### PR TITLE
paymentsservice: implement sendPayment to send `Circle->Circle` or `Circle->Stellar` payments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <log4j-core.version>2.17.1</log4j-core.version>
         <httpclient.version>4.5.13</httpclient.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
+        <jsonassert.version>1.5.0</jsonassert.version>
         <mockk.version>1.12.1</mockk.version>
         <reactor-netty.version>1.0.14</reactor-netty.version>
         <reactor-core.version>3.4.13</reactor-core.version>
@@ -166,6 +167,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${jsonassert.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -27,15 +27,15 @@ public class Account {
     @NonNull
     public Account.Capabilities capabilities;
 
+    @NonNull
+    public List<Balance> balances = new ArrayList<>();
+
     /**
      * The list of not-yet-available balances that are expected to settle shortly. These balances could be cancelled or
      * returned, in which cases they may never become available in the user account.
      */
     @NonNull
     public List<Balance> unsettledBalances = new ArrayList<>();
-
-    @NonNull
-    public List<Balance> balances = new ArrayList<>();
 
     public Account(@NonNull Network network, @NonNull String id, @Nullable String idTag, @NonNull Account.Capabilities capabilities) {
         this.network = network;
@@ -82,15 +82,7 @@ public class Account {
             this(List.of(sendAndReceive), List.of(sendAndReceive));
         }
 
-        public void setSendSupport(Network network, Boolean supportEnabled) {
-            this.send.put(network, supportEnabled);
-        }
-
-        public void setReceiveSupport(Network network, Boolean supportEnabled) {
-            this.receive.put(network, supportEnabled);
-        }
-
-        public void setFullSupport(Network network, Boolean supportEnabled) {
+        public void setCapabilities(Network network, Boolean supportEnabled) {
             this.send.put(network, supportEnabled);
             this.receive.put(network, supportEnabled);
         }

--- a/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -82,17 +82,20 @@ public class Account {
             this(List.of(sendAndReceive), List.of(sendAndReceive));
         }
 
-        public void setCapabilities(Network network, Boolean supportEnabled) {
-            this.send.put(network, supportEnabled);
-            this.receive.put(network, supportEnabled);
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Capabilities that = (Capabilities) o;
-            return this.send.keySet().equals(that.send.keySet()) && this.receive.keySet().equals(that.receive.keySet());
+            return this.send.equals(that.send) && this.receive.equals(that.receive);
+        }
+
+        @Override
+        public String toString() {
+            return "Capabilities{" +
+                    "send=" + send +
+                    ", receive=" + receive +
+                    '}';
         }
     }
 }

--- a/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -2,6 +2,8 @@ package org.stellar.anchor.paymentservice;
 
 import lombok.Data;
 import lombok.Getter;
+import reactor.util.annotation.Nullable;
+import reactor.util.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,27 +12,46 @@ import java.util.Map;
 
 @Data
 public class Account {
+    @NonNull
+    public Network network;
+
+    @NonNull
     public String id;
 
     /**
      * A complementary identifier of the account. It might be considered mandatory depending on the use case.
      */
+    @Nullable
     public String idTag;
-
-    public Network network;
-
-    public List<Balance> balances = new ArrayList<>();
 
     /**
      * An object indicating which networks this account can interact with for sending and/or receiving funds.
      */
-    public Capabilities capabilities;
+    @NonNull
+    public Account.Capabilities capabilities;
 
     /**
      * The list of not-yet-available balances that are expected to settle shortly. These balances could be cancelled or
      * returned, in which cases they may never become available in the user account.
      */
+    @NonNull
     public List<Balance> unsettledBalances = new ArrayList<>();
+
+    @NonNull
+    public List<Balance> balances = new ArrayList<>();
+
+    public Account(@NonNull Network network, @NonNull String id, @Nullable String idTag, @NonNull Account.Capabilities capabilities) {
+        this.network = network;
+        this.id = id;
+        this.idTag = idTag;
+        this.capabilities = capabilities;
+    }
+
+    public Account(@NonNull Network network, @NonNull String id, @NonNull Account.Capabilities capabilities) {
+        this.id = id;
+        this.network = network;
+        this.capabilities = capabilities;
+    }
 
     @Getter
     public static class Capabilities {
@@ -60,8 +81,21 @@ public class Account {
             }
         }
 
-        public Capabilities(List<Network> sendAndReceive) {
-            this(sendAndReceive, sendAndReceive);
+        public Capabilities(Network... sendAndReceive) {
+            this(List.of(sendAndReceive), List.of(sendAndReceive));
+        }
+
+        public void setSendSupport(Network network, Boolean supportEnabled) {
+            this.send.put(network, supportEnabled);
+        }
+
+        public void setReceiveSupport(Network network, Boolean supportEnabled) {
+            this.receive.put(network, supportEnabled);
+        }
+
+        public void setFullSupport(Network network, Boolean supportEnabled) {
+            this.send.put(network, supportEnabled);
+            this.receive.put(network, supportEnabled);
         }
     }
 }

--- a/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -5,10 +5,7 @@ import lombok.Getter;
 import reactor.util.annotation.Nullable;
 import reactor.util.annotation.NonNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Data
 public class Account {
@@ -96,6 +93,14 @@ public class Account {
         public void setFullSupport(Network network, Boolean supportEnabled) {
             this.send.put(network, supportEnabled);
             this.receive.put(network, supportEnabled);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Capabilities that = (Capabilities) o;
+            return this.send.keySet().equals(that.send.keySet()) && this.receive.keySet().equals(that.receive.keySet());
         }
     }
 }

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentsService.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentsService.java
@@ -358,24 +358,7 @@ public class CirclePaymentsService implements PaymentsService {
                 throw new RuntimeException("unsupported destination network '" + destinationAccount.network + "'");
         }
 
-        return Mono.zip(getDistributionAccountAddress(), sendPaymentMono).flatMap(args -> {
-            String distributionAccountAddress = args.getT1();
-            Payment payment = args.getT2();
-
-            // fill source account level
-            Account sourceAcc = payment.getSourceAccount();
-            Boolean isSourceEqualsDistribution = sourceAcc.id.equals(distributionAccountAddress);
-            sourceAcc.capabilities.setFullSupport(Network.BANK_WIRE, isSourceEqualsDistribution);
-            payment.setSourceAccount(sourceAcc);
-
-            // fill destination account level
-            Account destinationAcc = payment.getDestinationAccount();
-            Boolean isDestinationEqualsDistribution = destinationAcc.id.equals(distributionAccountAddress);
-            destinationAcc.capabilities.setFullSupport(Network.BANK_WIRE, isDestinationEqualsDistribution);
-            payment.setDestinationAccount(destinationAcc);
-
-            return Mono.just(payment);
-        });
+        return sendPaymentMono;
     }
 
     /**

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentsService.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentsService.java
@@ -10,11 +10,14 @@ import lombok.Setter;
 import org.stellar.anchor.exception.HttpException;
 import org.stellar.anchor.paymentservice.*;
 import org.stellar.anchor.paymentservice.circle.model.CircleBalance;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
 import org.stellar.anchor.paymentservice.circle.model.CircleWallet;
+import org.stellar.anchor.paymentservice.circle.model.response.CircleWalletResponse;
 import org.stellar.anchor.paymentservice.circle.model.response.CircleAccountBalancesResponse;
 import org.stellar.anchor.paymentservice.circle.model.response.CircleConfigurationResponse;
 import org.stellar.anchor.paymentservice.circle.model.response.CircleError;
-import org.stellar.anchor.paymentservice.circle.model.response.CircleWalletResponse;
+import org.stellar.anchor.paymentservice.circle.model.response.CircleTransferResponse;
+import org.stellar.anchor.paymentservice.circle.model.request.CircleSendTransactionRequest;
 import org.stellar.anchor.paymentservice.utils.NettyHttpClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufMono;
@@ -258,6 +261,73 @@ public class CirclePaymentsService implements PaymentsService {
     }
 
     /**
+     * Validates if the fields needed to send a payment are valid.
+     *
+     * @param sourceAccount      the account where the payment will be sent from.
+     * @param destinationAccount the account that will receive the payment.
+     * @param currencyName       the name of the currency used in the payment. It should obey the {scheme}:{identifier}
+     *                           format described in <a href="https://stellar.org/protocol/sep-38#asset-identification-format">SEP-38</a>.
+     *
+     * @throws HttpException if the source account network is not CIRCLE.
+     * @throws HttpException if the destination account network is not supported.
+     * @throws HttpException if the currencyName prefix does not reflect the destination account network.
+     */
+    private void validateSendPaymentInput(@NonNull Account sourceAccount, @NonNull Account destinationAccount, @NonNull String currencyName) throws HttpException {
+        if (sourceAccount.network != Network.CIRCLE) {
+            throw new HttpException(400, "the only supported network for the source account is circle");
+        }
+        if (!List.of(Network.CIRCLE, Network.STELLAR).contains(destinationAccount.network)) {
+            throw new HttpException(400, "the only supported networks for the destination account are circle and stellar");
+        }
+        if (!currencyName.startsWith(destinationAccount.network.getCurrencyPrefix())) {
+            throw new HttpException(400, "the currency to be sent must contain the destination network schema");
+        }
+    }
+
+    /**
+     * API request that sends a Circle transfer, i.e. a payment from a Circle account to another Circle account or to a
+     * blockchain wallet.
+     *
+     * @param sourceAccount      the account where the payment will be sent from.
+     * @param destinationAccount the account that will receive the payment, it can be an internal Circle account or a Stellar wallet.
+     * @param balance            the balance to be transferred.
+     * @return asynchronous stream with the payment object.
+     * @throws HttpException If the Circle http response status code is 4xx or 5xx.
+     * @throws HttpException If the destination network is not a Circle account nor a Stellar wallet.
+     */
+    private Mono<Payment> sendTransfer(Account sourceAccount, Account destinationAccount, CircleBalance balance) throws HttpException {
+        CircleTransactionParty source = CircleTransactionParty.wallet(sourceAccount.getId());
+        CircleTransactionParty destination;
+        switch (destinationAccount.network) {
+            case CIRCLE:
+                destination = CircleTransactionParty.wallet(destinationAccount.getId());
+                break;
+            case STELLAR:
+                destination = CircleTransactionParty.stellar(destinationAccount.id, destinationAccount.getIdTag());
+                break;
+            default:
+                throw new HttpException(400, "the destination network is not supported for Circle transfers");
+        }
+        CircleSendTransactionRequest req = CircleSendTransactionRequest.forTransfer(source, destination, balance);
+        String jsonBody = gson.toJson(req);
+
+        return getWebClient(true)
+                .post()
+                .uri("/v1/transfers")
+                .send(ByteBufMono.fromString(Mono.just(jsonBody)))
+                .responseSingle((postResponse, bodyBytesMono) -> {
+                    if (postResponse.status().code() >= 400) {
+                        return handleCircleError(postResponse, bodyBytesMono);
+                    }
+
+                    return bodyBytesMono.asString();
+                }).flatMap(body -> {
+                    CircleTransferResponse transfer = gson.fromJson(body, CircleTransferResponse.class);
+                    return Mono.just(transfer.getData().toPayment());
+                });
+    }
+
+    /**
      * API request that executes a payment between accounts. The APIKey needs to have access to the source account for
      * this request to succeed.
      *
@@ -272,8 +342,40 @@ public class CirclePaymentsService implements PaymentsService {
      * @throws HttpException If the http response status code is 4xx or 5xx.
      */
     public Mono<Payment> sendPayment(Account sourceAccount, Account destinationAccount, String currencyName, BigDecimal amount) throws HttpException {
-        // TODO: implement
-        return null;
+        // validate input
+        validateSendPaymentInput(sourceAccount, destinationAccount, currencyName);
+
+        String rawCurrencyName = currencyName.replace(destinationAccount.network.getCurrencyPrefix() + ":", "");
+        CircleBalance circleBalance = new CircleBalance(rawCurrencyName, amount.toString());
+
+        Mono<Payment> sendPaymentMono;
+        switch (destinationAccount.network) {
+            case CIRCLE:
+            case STELLAR:
+                sendPaymentMono = sendTransfer(sourceAccount, destinationAccount, circleBalance);
+                break;
+            default:
+                throw new RuntimeException("unsupported destination network '" + destinationAccount.network + "'");
+        }
+
+        return Mono.zip(getDistributionAccountAddress(), sendPaymentMono).flatMap(args -> {
+            String distributionAccountAddress = args.getT1();
+            Payment payment = args.getT2();
+
+            // fill source account level
+            Account sourceAcc = payment.getSourceAccount();
+            Boolean isSourceEqualsDistribution = sourceAcc.id.equals(distributionAccountAddress);
+            sourceAcc.capabilities.setFullSupport(Network.BANK_WIRE, isSourceEqualsDistribution);
+            payment.setSourceAccount(sourceAcc);
+
+            // fill destination account level
+            Account destinationAcc = payment.getDestinationAccount();
+            Boolean isDestinationEqualsDistribution = destinationAcc.id.equals(distributionAccountAddress);
+            destinationAcc.capabilities.setFullSupport(Network.BANK_WIRE, isDestinationEqualsDistribution);
+            payment.setDestinationAccount(destinationAcc);
+
+            return Mono.just(payment);
+        });
     }
 
     /**

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
@@ -9,6 +9,11 @@ public class CircleBalance {
     String amount;
     String currency;
 
+    public CircleBalance(String currency, String amount) {
+        this.currency = currency;
+        this.amount = amount;
+    }
+
     public Balance toBalance() {
         return new Balance(amount, Network.CIRCLE.getCurrencyPrefix() + ":" + currency);
     }

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePaymentStatus.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePaymentStatus.java
@@ -1,0 +1,41 @@
+package org.stellar.anchor.paymentservice.circle.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import org.stellar.anchor.paymentservice.Payment;
+
+@Getter
+public enum CirclePaymentStatus {
+    @SerializedName("pending")
+    PENDING("pending"),
+
+    @SerializedName("complete")
+    COMPLETE("complete"),
+
+    @SerializedName("failed")
+    FAILED("failed");
+
+    private final String name;
+
+    CirclePaymentStatus(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public Payment.Status toPaymentStatus() {
+        switch (this) {
+            case PENDING:
+                return Payment.Status.PENDING;
+            case COMPLETE:
+                return Payment.Status.SUCCESSFUL;
+            case FAILED:
+                return Payment.Status.FAILED;
+            default:
+                throw new RuntimeException("unsupported CirclePaymentStatus -> Payment.Status conversion");
+        }
+    }
+}

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
@@ -1,0 +1,88 @@
+package org.stellar.anchor.paymentservice.circle.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.stellar.anchor.paymentservice.Account;
+import org.stellar.anchor.paymentservice.Network;
+
+@lombok.Data
+public class CircleTransactionParty {
+    Type type;
+    String id;
+    String address;
+    String addressTag;
+    String name;
+    transient String email;
+    String chain;
+
+    public enum Type {
+        @SerializedName("wallet")
+        WALLET("wallet"),
+
+        @SerializedName("blockchain")
+        BLOCKCHAIN("blockchain"),
+
+        @SerializedName("wire")
+        WIRE("wire"),
+
+        @SerializedName("ach")
+        ACH("ach"),
+
+        @SerializedName("card")
+        CARD("card");
+
+        private final String name;
+
+        Type(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    public static CircleTransactionParty wallet(String id) {
+        CircleTransactionParty party = new CircleTransactionParty();
+        party.type = Type.WALLET;
+        party.id = id;
+        return party;
+    }
+
+    public static CircleTransactionParty stellar(String address, String addressTag) {
+        CircleTransactionParty party = new CircleTransactionParty();
+        party.type = Type.BLOCKCHAIN;
+        party.address = address;
+        party.addressTag = addressTag;
+        party.chain = "XLM";
+        return party;
+    }
+
+    public static CircleTransactionParty wire(String bankId, String email) {
+        CircleTransactionParty party = new CircleTransactionParty();
+        party.type = Type.WIRE;
+        party.id = bankId;
+        party.email = email;
+        return party;
+    }
+
+    public Account toAccount() {
+        switch (type) {
+            case BLOCKCHAIN:
+                if (!"XLM".equals(chain)) {
+                    throw new RuntimeException("the only supported chain is `XLM`");
+                }
+                return new Account(Network.STELLAR, address, addressTag, new Account.Capabilities(Network.STELLAR));
+
+            case WALLET:
+                return new Account(Network.CIRCLE, id, new Account.Capabilities(Network.CIRCLE, Network.STELLAR));
+
+            case WIRE:
+                return new Account(Network.BANK_WIRE, id, new Account.Capabilities(Network.BANK_WIRE));
+
+            default:
+                throw new RuntimeException("unsupported type");
+                // TODO: make sure to handle cards and ach as well
+        }
+    }
+}

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -1,0 +1,45 @@
+package org.stellar.anchor.paymentservice.circle.model;
+
+import com.google.gson.Gson;
+import lombok.Data;
+import org.stellar.anchor.paymentservice.Payment;
+import org.stellar.anchor.paymentservice.circle.util.CircleDateFormatter;
+import shadow.com.google.common.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.Map;
+
+@Data
+public class CircleTransfer {
+    String id;
+    CircleTransactionParty source;
+    CircleTransactionParty destination;
+    CircleBalance amount;
+    String transactionHash;
+    CirclePaymentStatus status;
+    String errorCode;
+    Date createDate;
+
+    public Payment toPayment() {
+        Payment p = new Payment();
+        p.setId(id);
+        p.setSourceAccount(source.toAccount());
+        p.setDestinationAccount(destination.toAccount());
+        p.setBalance(amount.toBalance());
+        p.setStatus(status.toPaymentStatus());
+        p.setErrorCode(errorCode);
+        p.setCreatedAt(createDate);
+        p.setUpdatedAt(createDate);
+
+        Gson gson = new Gson();
+        String jsonString = gson.toJson(this);
+        Type type = new TypeToken<Map<String, ?>>(){}.getType();
+        Map<String, Object> map = gson.fromJson(jsonString, type);
+        String createdDateStr = CircleDateFormatter.dateToString(createDate);
+        map.put("createDate", createdDateStr);
+        p.setOriginalResponse(map);
+
+        return p;
+    }
+}

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -21,16 +21,12 @@ public class CircleWallet {
         if ("merchant".equals(type)) {
             sendOrReceiveCapabilities.add(Network.BANK_WIRE);
         }
-        return new Account.Capabilities(sendOrReceiveCapabilities);
+        return new Account.Capabilities(sendOrReceiveCapabilities.toArray(new Network[0]));
     }
 
     public Account toAccount() {
-        Account account = new Account();
-        account.setId(walletId);
-        account.setIdTag(description);
-        account.setNetwork(Network.CIRCLE);
+        Account account = new Account(Network.CIRCLE, walletId, description, getCapabilities());
         account.setBalances(balances.stream().map(CircleBalance::toBalance).collect(Collectors.toList()));
-        account.setCapabilities(getCapabilities());
         return account;
     }
 }

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import org.stellar.anchor.paymentservice.Account;
 import org.stellar.anchor.paymentservice.Network;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,11 +16,7 @@ public class CircleWallet {
     List<CircleBalance> balances;
 
     public Account.Capabilities getCapabilities() {
-        List<Network> sendOrReceiveCapabilities = new ArrayList<>(List.of(Network.CIRCLE, Network.STELLAR));
-        if ("merchant".equals(type)) {
-            sendOrReceiveCapabilities.add(Network.BANK_WIRE);
-        }
-        return new Account.Capabilities(sendOrReceiveCapabilities.toArray(new Network[0]));
+        return new Account.Capabilities(Network.CIRCLE, Network.STELLAR);
     }
 
     public Account toAccount() {

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -1,0 +1,24 @@
+package org.stellar.anchor.paymentservice.circle.model.request;
+
+import lombok.Data;
+import org.stellar.anchor.paymentservice.circle.model.CircleBalance;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
+
+import java.util.HashMap;
+
+@Data
+public class CircleSendTransactionRequest {
+    CircleTransactionParty source;
+    CircleTransactionParty destination;
+    CircleBalance amount;
+    String idempotencyKey;
+    HashMap<String, Object> metadata;
+
+    public static CircleSendTransactionRequest forTransfer(CircleTransactionParty source, CircleTransactionParty destination, CircleBalance amount) {
+        CircleSendTransactionRequest req = new CircleSendTransactionRequest();
+        req.source = source;
+        req.destination = destination;
+        req.amount = amount;
+        return req;
+    }
+}

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferResponse.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferResponse.java
@@ -1,0 +1,9 @@
+package org.stellar.anchor.paymentservice.circle.model.response;
+
+import lombok.Data;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
+
+@Data
+public class CircleTransferResponse {
+    CircleTransfer data;
+}

--- a/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleDateFormatter.java
+++ b/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleDateFormatter.java
@@ -1,0 +1,25 @@
+package org.stellar.anchor.paymentservice.circle.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class CircleDateFormatter {
+    public static final SimpleDateFormat dateFormatter = _dateFormatter();
+
+    private static SimpleDateFormat _dateFormatter() {
+        SimpleDateFormat circleDateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH);
+        circleDateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return circleDateFormatter;
+    }
+
+    public static Date stringToDate(String dateStr) throws ParseException {
+        return dateFormatter.parse(dateStr);
+    }
+
+    public static String dateToString(Date date) {
+        return dateFormatter.format(date);
+    }
+}

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/AccountCapabilitiesTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/AccountCapabilitiesTest.kt
@@ -1,0 +1,25 @@
+package org.stellar.anchor.paymentservice
+
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+
+internal class AccountCapabilitiesTest {
+    @Test
+    fun testEquals() {
+        var capabilities1 = Account.Capabilities()
+        var capabilities2 = Account.Capabilities()
+        assertEquals(capabilities1, capabilities2)
+
+        capabilities1 = Account.Capabilities()
+        capabilities2 = Account.Capabilities(Network.STELLAR)
+        assertNotEquals(capabilities1, capabilities2)
+
+        capabilities1 = Account.Capabilities(Network.CIRCLE)
+        capabilities2 = Account.Capabilities(Network.STELLAR)
+        assertNotEquals(capabilities1, capabilities2)
+
+        capabilities1 = Account.Capabilities(Network.BANK_WIRE)
+        capabilities2 = Account.Capabilities(Network.BANK_WIRE)
+        assertEquals(capabilities1, capabilities2)
+    }
+}

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -680,7 +680,7 @@ class CirclePaymentsServiceTest {
                 Network.STELLAR,
                 "GBG7VGZFH4TU2GS7WL5LMPYFNP64ZFR23XEGAV7GPEEXKWOR2DKCYPCK",
                 "test tag",
-                Account.Capabilities(Network.CIRCLE, Network.STELLAR)
+                Account.Capabilities(Network.STELLAR)
             ), payment?.destinationAccount
         )
         assertEquals(Balance("0.91", "circle:USD"), payment?.balance)

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -573,31 +573,23 @@ class CirclePaymentsServiceTest {
         assertEquals(wantDate, payment?.createdAt)
         assertEquals(wantDate, payment?.updatedAt)
 
-        val wantOriginalResponse: Map<String, *> = object : HashMap<String, Any?>() {
-            init {
-                put("id", "c58e2613-a808-4075-956c-e576787afb3b")
-                put("source", object : HashMap<String, Any?>() {
-                    init {
-                        put("id", "1000066041")
-                        put("type", "wallet")
-                    }
-                })
-                put("destination", object : HashMap<String, Any?>() {
-                    init {
-                        put("id", "1000067536")
-                        put("type", "wallet")
-                    }
-                })
-                put("amount", object : HashMap<String, Any?>() {
-                    init {
-                        put("amount", "0.91")
-                        put("currency", "USD")
-                    }
-                })
-                put("status", "complete")
-                put("createDate", "2022-01-01T01:01:01.544Z")
-            }
-        }
+        val wantOriginalResponse = hashMapOf<String, Any>(
+            "id" to "c58e2613-a808-4075-956c-e576787afb3b",
+            "source" to hashMapOf<String, Any>(
+                "id" to "1000066041",
+                "type" to "wallet"
+            ),
+            "destination" to hashMapOf<String, Any>(
+                "id" to "1000067536",
+                "type" to "wallet",
+            ),
+            "amount" to hashMapOf<String, Any>(
+                "amount" to "0.91",
+                "currency" to "USD",
+            ),
+            "status" to "complete",
+            "createDate" to "2022-01-01T01:01:01.544Z",
+        )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
         assertEquals(2, server.requestCount)
@@ -704,33 +696,25 @@ class CirclePaymentsServiceTest {
         assertEquals(wantDate, payment?.createdAt)
         assertEquals(wantDate, payment?.updatedAt)
 
-        val wantOriginalResponse: Map<String, *> = object : HashMap<String, Any?>() {
-            init {
-                put("id", "c58e2613-a808-4075-956c-e576787afb3b")
-                put("source", object : HashMap<String, Any?>() {
-                    init {
-                        put("id", "1000066041")
-                        put("type", "wallet")
-                    }
-                })
-                put("destination", object : HashMap<String, Any?>() {
-                    init {
-                        put("address", "GBG7VGZFH4TU2GS7WL5LMPYFNP64ZFR23XEGAV7GPEEXKWOR2DKCYPCK")
-                        put("addressTag", "test tag")
-                        put("type", "blockchain")
-                        put("chain", "XLM")
-                    }
-                })
-                put("amount", object : HashMap<String, Any?>() {
-                    init {
-                        put("amount", "0.91")
-                        put("currency", "USD")
-                    }
-                })
-                put("status", "complete")
-                put("createDate", "2022-01-01T01:01:01.544Z")
-            }
-        }
+        val wantOriginalResponse = hashMapOf<String, Any>(
+            "id" to "c58e2613-a808-4075-956c-e576787afb3b",
+            "source" to hashMapOf<String, Any>(
+                "id" to "1000066041",
+                "type" to "wallet",
+            ),
+            "destination" to hashMapOf<String, Any>(
+                "address" to "GBG7VGZFH4TU2GS7WL5LMPYFNP64ZFR23XEGAV7GPEEXKWOR2DKCYPCK",
+                "addressTag" to "test tag",
+                "type" to "blockchain",
+                "chain" to "XLM",
+            ),
+            "amount" to hashMapOf<String, Any>(
+                "amount" to "0.91",
+                "currency" to "USD",
+            ),
+            "status" to "complete",
+            "createDate" to "2022-01-01T01:01:01.544Z",
+        )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
         assertEquals(2, server.requestCount)

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -288,7 +288,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { account = service.getAccount("1000223064").block() }
         assertEquals("1000223064", account?.id)
         assertEquals(Network.CIRCLE, account?.network)
-        val wantCapabilities = Account.Capabilities(listOf(Network.CIRCLE, Network.STELLAR))
+        val wantCapabilities = Account.Capabilities(Network.CIRCLE, Network.STELLAR)
         assertEquals(wantCapabilities.send, account?.capabilities?.send)
         assertEquals(wantCapabilities.receive, account?.capabilities?.receive)
         assertEquals("Treasury Wallet", account?.idTag)
@@ -373,7 +373,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { account = service.getAccount("1000066041").block() }
         assertEquals("1000066041", account?.id)
         assertEquals(Network.CIRCLE, account?.network)
-        val wantCapabilities = Account.Capabilities(listOf(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE))
+        val wantCapabilities = Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
         assertEquals(wantCapabilities.send, account?.capabilities?.send)
         assertEquals(wantCapabilities.receive, account?.capabilities?.receive)
         assertNull(account?.idTag)
@@ -432,7 +432,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { account = service.createAccount("Foo bar").block() }
         assertEquals("1000223064", account?.id)
         assertEquals(Network.CIRCLE, account?.network)
-        val wantCapabilities = Account.Capabilities(listOf(Network.CIRCLE, Network.STELLAR))
+        val wantCapabilities = Account.Capabilities(Network.CIRCLE, Network.STELLAR)
         assertEquals(wantCapabilities.send, account?.capabilities?.send)
         assertEquals(wantCapabilities.receive, account?.capabilities?.receive)
         assertEquals("Foo bar", account?.idTag)

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -410,7 +410,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { account = service.getAccount("1000066041").block() }
         assertEquals("1000066041", account?.id)
         assertEquals(Network.CIRCLE, account?.network)
-        assertEquals(Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE), account?.capabilities)
+        assertEquals(Account.Capabilities(Network.CIRCLE, Network.STELLAR), account?.capabilities)
         assertNull(account?.idTag)
         assertEquals(1, account?.balances?.size)
         assertEquals("29472389929.00", account!!.balances[0].amount)
@@ -563,7 +563,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { payment = service.sendPayment(source, destination, "circle:USD", BigDecimal.valueOf(0.91)).block() }
 
         assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)), payment?.sourceAccount)
+        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.sourceAccount)
         assertEquals(Account(Network.CIRCLE, "1000067536", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.destinationAccount)
         assertEquals(Balance("0.91", "circle:USD"), payment?.balance)
         assertEquals(Payment.Status.SUCCESSFUL, payment?.status)
@@ -592,13 +592,8 @@ class CirclePaymentsServiceTest {
         )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
-        assertEquals(2, server.requestCount)
-        val allRequests = arrayOf(server.takeRequest(), server.takeRequest())
-
-        val validateSecretKeyRequest = allRequests.find { request -> request.path!! == "/v1/configuration" }!!
-        assertEquals("GET", validateSecretKeyRequest.method)
-        assertEquals("application/json", validateSecretKeyRequest.headers["Content-Type"])
-        assertEquals("Bearer <secret-key>", validateSecretKeyRequest.headers["Authorization"])
+        assertEquals(1, server.requestCount)
+        val allRequests = arrayOf(server.takeRequest())
 
         val postTransferRequest = allRequests.find { request -> request.path!! == "/v1/transfers" }!!
         assertEquals("POST", postTransferRequest.method)
@@ -679,7 +674,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { payment = service.sendPayment(source, destination, "stellar:USD", BigDecimal.valueOf(0.91)).block() }
 
         assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)), payment?.sourceAccount)
+        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.sourceAccount)
         assertEquals(
             Account(
                 Network.STELLAR,
@@ -717,13 +712,8 @@ class CirclePaymentsServiceTest {
         )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
-        assertEquals(2, server.requestCount)
-        val allRequests = arrayOf(server.takeRequest(), server.takeRequest())
-
-        val validateSecretKeyRequest = allRequests.find { request -> request.path!! == "/v1/configuration" }!!
-        assertEquals("GET", validateSecretKeyRequest.method)
-        assertEquals("application/json", validateSecretKeyRequest.headers["Content-Type"])
-        assertEquals("Bearer <secret-key>", validateSecretKeyRequest.headers["Authorization"])
+        assertEquals(1, server.requestCount)
+        val allRequests = arrayOf(server.takeRequest())
 
         val postTransferRequest = allRequests.find { request -> request.path!! == "/v1/transfers" }!!
         assertEquals("POST", postTransferRequest.method)

--- a/src/test/kotlin/org/stellar/anchor/paymentservice/circle/util/CircleDateFormatterTest.kt
+++ b/src/test/kotlin/org/stellar/anchor/paymentservice/circle/util/CircleDateFormatterTest.kt
@@ -1,0 +1,30 @@
+package org.stellar.anchor.paymentservice.circle.util
+
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.*
+import org.junit.jupiter.api.Assertions.*
+
+internal class CircleDateFormatterTest {
+    @Test
+    fun testDateFormatterField() {
+        val wantDateFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
+        wantDateFormatter.timeZone = TimeZone.getTimeZone("UTC")
+        assertEquals(wantDateFormatter, CircleDateFormatter.dateFormatter)
+    }
+
+    @Test
+    fun testDateToString() {
+        val date = Date(1640998861544)
+        val gotDateStr = CircleDateFormatter.dateToString(Date.from(date.toInstant()))
+        val wantDateStr = "2022-01-01T01:01:01.544Z"
+        assertEquals(wantDateStr, gotDateStr)
+    }
+
+    @Test
+    fun testStringToDate() {
+        val gotDate = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+        val wantDate = Date(1640998861544)
+        assertEquals(wantDate, gotDate)
+    }
+}


### PR DESCRIPTION
### What
Implement `POST /v1/transfer` request that supports `Circle->Circle` and `Circle->Stellar` payments.