### PR TITLE
all: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
+template and use a short description, but in your description aim to include both what the
+change is, and why it is being made, with enough context for anyone to understand. -->
+
+<details>
+  <summary>PR Checklist</summary>
+
+### PR Structure
+
+* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
+* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
+  otherwise).
+* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
+  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
+  packages.
+
+### Thoroughness
+
+* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
+
+### What
+
+[TODO: Short statement about what is changing.]
+
+### Why
+
+[TODO: Why this change is being made. Include any context required to understand the why.]
+
+### Known limitations
+
+[TODO or N/A]


### PR DESCRIPTION
### What
Add a pull request template based on [stellar/go's](https://github.com/stellar/go/blob/master/.github/pull_request_template.md).

### Why
So we establish a clear way to communicate the pull request changes and create a better context for the code reviewers.