### PR TITLE
payment-circle: extend sendPayment functionality to allow sendding `Circle->BankWire` payments

### DIFF
--- a/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -83,6 +83,11 @@ public class Account {
       this(List.of(sendAndReceive), List.of(sendAndReceive));
     }
 
+    public void set(Network network, Boolean supportEnabled) {
+      this.send.put(network, supportEnabled);
+      this.receive.put(network, supportEnabled);
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;

--- a/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -70,12 +70,16 @@ public class Account {
         this.receive.put(network, false);
       }
 
-      for (Network network : send) {
-        this.send.put(network, true);
+      if (send != null) {
+        for (Network network : send) {
+          this.send.put(network, true);
+        }
       }
 
-      for (Network network : receive) {
-        this.receive.put(network, true);
+      if (receive != null) {
+        for (Network network : receive) {
+          this.receive.put(network, true);
+        }
       }
     }
 

--- a/payment-circle/build.gradle.kts
+++ b/payment-circle/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.log4j.core)
     implementation(libs.google.gson)
     implementation(libs.reactor.core)
+    implementation(libs.commons.validator)
     implementation(libs.slf4j.log4j12)
     implementation(libs.okhttp3.mockserver)
     implementation(libs.reactor.netty)

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
@@ -1,0 +1,58 @@
+package org.stellar.anchor.paymentservice.circle.model;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.Map;
+import lombok.Data;
+import org.stellar.anchor.paymentservice.Account;
+import org.stellar.anchor.paymentservice.Network;
+import org.stellar.anchor.paymentservice.Payment;
+import org.stellar.anchor.paymentservice.circle.util.CircleDateFormatter;
+import shadow.com.google.common.reflect.TypeToken;
+
+@Data
+public class CirclePayout {
+  String id;
+  String sourceWalletId;
+  CircleTransactionParty destination;
+  CircleBalance amount;
+  CircleBalance fees;
+  CirclePaymentStatus status;
+  String trackingRef;
+  String errorCode;
+  Date updateDate;
+  Date createDate;
+  Map<String, String> riskEvaluation;
+  Map<String, Map<String, String>> adjustments;
+
+  @SerializedName("return")
+  Map<String, ?> returnVal;
+
+  public Payment toPayment() {
+    Payment p = new Payment();
+    p.setId(id);
+    p.setSourceAccount(
+        new Account(
+            Network.CIRCLE,
+            sourceWalletId,
+            new Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)));
+    p.setDestinationAccount(destination.toAccount());
+    p.setBalance(amount.toBalance());
+    p.setStatus(status.toPaymentStatus());
+    p.setErrorCode(errorCode);
+    p.setCreatedAt(createDate);
+    p.setUpdatedAt(updateDate);
+
+    Gson gson = new Gson();
+    String jsonString = gson.toJson(this);
+    Type type = new TypeToken<Map<String, ?>>() {}.getType();
+    Map<String, Object> map = gson.fromJson(jsonString, type);
+    map.put("createDate", CircleDateFormatter.dateToString(createDate));
+    map.put("updateDate", CircleDateFormatter.dateToString(updateDate));
+    p.setOriginalResponse(map);
+
+    return p;
+  }
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.paymentservice.circle.model;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Data;
@@ -15,7 +16,12 @@ public class CircleWallet {
   List<CircleBalance> balances;
 
   public Account.Capabilities getCapabilities() {
-    return new Account.Capabilities(Network.CIRCLE, Network.STELLAR);
+    List<Network> sendOrReceiveCapabilities =
+        new ArrayList<>(List.of(Network.CIRCLE, Network.STELLAR));
+    if ("merchant".equals(type)) {
+      sendOrReceiveCapabilities.add(Network.BANK_WIRE);
+    }
+    return new Account.Capabilities(sendOrReceiveCapabilities.toArray(new Network[0]));
   }
 
   public Account toAccount() {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.paymentservice.circle.model;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Data;
@@ -16,12 +15,9 @@ public class CircleWallet {
   List<CircleBalance> balances;
 
   public Account.Capabilities getCapabilities() {
-    List<Network> sendOrReceiveCapabilities =
-        new ArrayList<>(List.of(Network.CIRCLE, Network.STELLAR));
-    if ("merchant".equals(type)) {
-      sendOrReceiveCapabilities.add(Network.BANK_WIRE);
-    }
-    return new Account.Capabilities(sendOrReceiveCapabilities.toArray(new Network[0]));
+    Account.Capabilities capabilities = new Account.Capabilities(Network.CIRCLE, Network.STELLAR);
+    capabilities.set(Network.BANK_WIRE, "merchant".equals(type));
+    return capabilities;
   }
 
   public Account toAccount() {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -21,4 +21,19 @@ public class CircleSendTransactionRequest {
     req.amount = amount;
     return req;
   }
+
+  public static CircleSendTransactionRequest forPayout(
+      CircleTransactionParty source,
+      CircleTransactionParty destination,
+      CircleBalance amount,
+      String idempotencyKey) {
+    CircleSendTransactionRequest req = new CircleSendTransactionRequest();
+    req.source = source;
+    req.destination = destination;
+    req.amount = amount;
+    req.idempotencyKey = idempotencyKey;
+    req.metadata = new HashMap<>();
+    req.metadata.put("beneficiaryEmail", destination.getEmail());
+    return req;
+  }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutResponse.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutResponse.java
@@ -1,0 +1,9 @@
+package org.stellar.anchor.paymentservice.circle.model.response;
+
+import lombok.Data;
+import org.stellar.anchor.paymentservice.circle.model.CirclePayout;
+
+@Data
+public class CirclePayoutResponse {
+  CirclePayout data;
+}

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -520,7 +520,7 @@ class CirclePaymentsServiceTest {
                                         "sourceWalletId":"1000066041",
                                         "destination":{
                                             "type":"wire",
-                                            "id":"8f6cd3bc-fd21-45ac-b1f0-7534d3b78949",
+                                            "id":"6c87da10-feb8-484f-822c-2083ed762d25",
                                             "name":"JPMORGAN CHASE BANK, NA ****6789"
                                         },
                                         "createDate":"2021-11-25T15:43:03.477Z",
@@ -535,13 +535,13 @@ class CirclePaymentsServiceTest {
         server.dispatcher = dispatcher
 
         val source = Account(Network.CIRCLE, "1000066041", Account.Capabilities())
-        val destination = Account(Network.BANK_WIRE, "8f6cd3bc-fd21-45ac-b1f0-7534d3b78949", "test@mail.com", Account.Capabilities())
+        val destination = Account(Network.BANK_WIRE, "6c87da10-feb8-484f-822c-2083ed762d25", "test@mail.com", Account.Capabilities())
         var payment: Payment? = null
         assertDoesNotThrow { payment = service.sendPayment(source, destination, "iso4217:USD", BigDecimal.valueOf(0.91)).block() }
 
         assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
         assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)), payment?.sourceAccount)
-        assertEquals(Account(Network.BANK_WIRE, "8f6cd3bc-fd21-45ac-b1f0-7534d3b78949", Account.Capabilities(Network.BANK_WIRE)), payment?.destinationAccount)
+        assertEquals(Account(Network.BANK_WIRE, "6c87da10-feb8-484f-822c-2083ed762d25", Account.Capabilities(Network.BANK_WIRE)), payment?.destinationAccount)
         assertEquals(Balance("0.91", "circle:USD"), payment?.balance)
         assertEquals(Payment.Status.SUCCESSFUL, payment?.status)
         assertNull(payment?.errorCode)
@@ -571,7 +571,7 @@ class CirclePaymentsServiceTest {
                 put("destination", object: HashMap<String, Any?>() {
                     init {
                         put("type", "wire")
-                        put("id", "8f6cd3bc-fd21-45ac-b1f0-7534d3b78949")
+                        put("id", "6c87da10-feb8-484f-822c-2083ed762d25")
                         put("name", "JPMORGAN CHASE BANK, NA ****6789")
                     }
                 })
@@ -601,7 +601,7 @@ class CirclePaymentsServiceTest {
             },
             "destination": {
                 "type": "wire",
-                "id": "8f6cd3bc-fd21-45ac-b1f0-7534d3b78949"
+                "id": "6c87da10-feb8-484f-822c-2083ed762d25"
             },
             "amount": {
                 "amount": "0.91",
@@ -1000,7 +1000,7 @@ class CirclePaymentsServiceTest {
             ErrorHandlingTestCase(
                 service.sendPayment(
                     Account(Network.CIRCLE, "1000066041", Account.Capabilities()),
-                    Account(Network.BANK_WIRE, "8f6cd3bc-fd21-45ac-b1f0-7534d3b78949", "test@mail.com", Account.Capabilities()),
+                    Account(Network.BANK_WIRE, "6c87da10-feb8-484f-822c-2083ed762d25", "test@mail.com", Account.Capabilities()),
                     "iso4217:USD",
                     BigDecimal(1)
                 ),

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentsServiceTest.kt
@@ -408,7 +408,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { account = service.getAccount("1000066041").block() }
         assertEquals("1000066041", account?.id)
         assertEquals(Network.CIRCLE, account?.network)
-        assertEquals(Account.Capabilities(Network.CIRCLE, Network.STELLAR), account?.capabilities)
+        assertEquals(Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE), account?.capabilities)
         assertNull(account?.idTag)
         assertEquals(1, account?.balances?.size)
         assertEquals("29472389929.00", account!!.balances[0].amount)
@@ -561,7 +561,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { payment = service.sendPayment(source, destination, "circle:USD", BigDecimal.valueOf(0.91)).block() }
 
         assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.sourceAccount)
+        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)), payment?.sourceAccount)
         assertEquals(Account(Network.CIRCLE, "1000067536", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.destinationAccount)
         assertEquals(Balance("0.91", "circle:USD"), payment?.balance)
         assertEquals(Payment.Status.SUCCESSFUL, payment?.status)
@@ -590,8 +590,13 @@ class CirclePaymentsServiceTest {
         )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
-        assertEquals(1, server.requestCount)
-        val allRequests = arrayOf(server.takeRequest())
+        assertEquals(2, server.requestCount)
+        val allRequests = arrayOf(server.takeRequest(), server.takeRequest())
+
+        val validateSecretKeyRequest = allRequests.find { request -> request.path!! == "/v1/configuration" }!!
+        assertEquals("GET", validateSecretKeyRequest.method)
+        assertEquals("application/json", validateSecretKeyRequest.headers["Content-Type"])
+        assertEquals("Bearer <secret-key>", validateSecretKeyRequest.headers["Authorization"])
 
         val postTransferRequest = allRequests.find { request -> request.path!! == "/v1/transfers" }!!
         assertEquals("POST", postTransferRequest.method)
@@ -672,7 +677,7 @@ class CirclePaymentsServiceTest {
         assertDoesNotThrow { payment = service.sendPayment(source, destination, "stellar:USD", BigDecimal.valueOf(0.91)).block() }
 
         assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR)), payment?.sourceAccount)
+        assertEquals(Account(Network.CIRCLE, "1000066041", Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)), payment?.sourceAccount)
         assertEquals(
             Account(
                 Network.STELLAR,
@@ -710,8 +715,13 @@ class CirclePaymentsServiceTest {
         )
         assertEquals(wantOriginalResponse, payment?.originalResponse)
 
-        assertEquals(1, server.requestCount)
-        val allRequests = arrayOf(server.takeRequest())
+        assertEquals(2, server.requestCount)
+        val allRequests = arrayOf(server.takeRequest(), server.takeRequest())
+
+        val validateSecretKeyRequest = allRequests.find { request -> request.path!! == "/v1/configuration" }!!
+        assertEquals("GET", validateSecretKeyRequest.method)
+        assertEquals("application/json", validateSecretKeyRequest.headers["Content-Type"])
+        assertEquals("Bearer <secret-key>", validateSecretKeyRequest.headers["Authorization"])
 
         val postTransferRequest = allRequests.find { request -> request.path!! == "/v1/transfers" }!!
         assertEquals("POST", postTransferRequest.method)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ dependencyResolutionManagement {
             alias("okhttp3.mockserver").to("com.squareup.okhttp3:mockwebserver:4.9.3")
             alias("reactor.netty").to("io.projectreactor.netty:reactor-netty:1.0.15")
             alias("java.stellar.sdk").to("com.github.stellar:java-stellar-sdk:0.29.0")
+            alias("commons.validator").to("commons-validator:commons-validator:1.7")
 
             alias("kotlin.mockk").to("io.mockk:mockk:1.12.2")
             alias("kotlin.stdlib").to("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Extend sendPayment functionality to allow sendding `Circle->BankWire` payments.

### Why

This is a feature that one of our potential adopters needs and it's likely most partners will need it too.

