### PR TITLE
payment-circle: implement getAccountHistory method

### DIFF
--- a/core/src/main/java/org/stellar/anchor/paymentservice/Payment.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/Payment.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 public class Payment {
   String id;
+  String txHash;
   Account sourceAccount;
   Account destinationAccount;
   /** The balance currency name contains the scheme of the destination network of the payment. */

--- a/core/src/main/java/org/stellar/anchor/paymentservice/Payment.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/Payment.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Data
 public class Payment {
   String id;
-  String txHash;
+  String idTag;
   Account sourceAccount;
   Account destinationAccount;
   /** The balance currency name contains the scheme of the destination network of the payment. */

--- a/core/src/main/java/org/stellar/anchor/paymentservice/PaymentHistory.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/PaymentHistory.java
@@ -1,11 +1,17 @@
 package org.stellar.anchor.paymentservice;
 
+import java.util.ArrayList;
 import java.util.List;
+import lombok.Data;
 
-@SuppressWarnings("unused")
+@Data
 public class PaymentHistory {
   Account account;
   String afterCursor;
   String beforeCursor;
-  List<Payment> payments;
+  List<Payment> payments = new ArrayList<>();
+
+  public PaymentHistory(Account account) {
+    this.account = account;
+  }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CircleGsonParsable.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CircleGsonParsable.java
@@ -1,0 +1,14 @@
+package org.stellar.anchor.paymentservice.circle;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.stellar.anchor.paymentservice.circle.model.CirclePayout;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
+
+public interface CircleGsonParsable {
+  Gson gson =
+      new GsonBuilder()
+          .registerTypeAdapter(CircleTransfer.class, new CircleTransfer.Serialization())
+          .registerTypeAdapter(CirclePayout.class, new CirclePayout.Deserializer())
+          .create();
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -276,14 +276,14 @@ public class CirclePaymentService implements PaymentService {
     queryParams.put("pageSize", _pageSize.toString());
     queryParams.put("walletId", accountID);
 
-    if (beforeCursor != null && !beforeCursor.isEmpty()) {
-      queryParams.put("pageBefore", beforeCursor);
-    } else if (afterCursor != null && !afterCursor.isEmpty()) {
-      // we can't use both pageBefore and pageAfter at once, that's why I'm using 'else if'
+    if (afterCursor != null && !afterCursor.isEmpty()) {
       queryParams.put("pageAfter", afterCursor);
+      // we can't use both pageBefore and pageAfter at the same time, that's why I'm using 'else if'
+    } else if (beforeCursor != null && !beforeCursor.isEmpty()) {
+      queryParams.put("pageBefore", beforeCursor);
     }
 
-    String url = NettyHttpClient.uriWithParams("/v1/transfer", queryParams);
+    String url = NettyHttpClient.uriWithParams("/v1/transfers", queryParams);
     return getWebClient(true)
         .get()
         .uri(url)

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -35,6 +35,8 @@ public class CirclePaymentService implements PaymentService, StellarReconciliati
 
   @Getter Server horizonServer;
 
+  private final org.stellar.sdk.Network stellarNetwork;
+
   private final Network network = Network.CIRCLE;
 
   private String url;
@@ -49,11 +51,13 @@ public class CirclePaymentService implements PaymentService, StellarReconciliati
    * For all service methods to work correctly, make sure your circle account has a valid business
    * wallet and a bank account configured.
    */
-  public CirclePaymentService(String url, String secretKey, String horizonUrl) {
+  public CirclePaymentService(
+      String url, String secretKey, String horizonUrl, org.stellar.sdk.Network stellarNetwork) {
     super();
     this.url = url;
     this.secretKey = secretKey;
     this.horizonServer = new Server(horizonUrl);
+    this.stellarNetwork = stellarNetwork;
   }
 
   public Network getNetwork() {
@@ -178,7 +182,7 @@ public class CirclePaymentService implements PaymentService, StellarReconciliati
 
               List<Balance> unsettledBalances = new ArrayList<>();
               for (CircleBalance uBalance : response.getData().unsettled) {
-                unsettledBalances.add(uBalance.toBalance());
+                unsettledBalances.add(uBalance.toBalance(Network.CIRCLE));
               }
 
               return unsettledBalances;
@@ -647,7 +651,8 @@ public class CirclePaymentService implements PaymentService, StellarReconciliati
 
     String rawCurrencyName =
         currencyName.replace(destinationAccount.network.getCurrencyPrefix() + ":", "");
-    CircleBalance circleBalance = new CircleBalance(rawCurrencyName, amount.toString());
+    CircleBalance circleBalance =
+        new CircleBalance(rawCurrencyName, amount.toString(), stellarNetwork);
 
     switch (destinationAccount.network) {
       case CIRCLE:

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -272,9 +272,9 @@ public class CirclePaymentService implements PaymentService {
       String accountID, String beforeCursor, String afterCursor, Integer pageSize)
       throws HttpException {
     // build query parameters for GET requests
-    Integer _pageSize = pageSize != null ? pageSize : 50;
+    int _pageSize = pageSize != null ? pageSize : 50;
     LinkedHashMap<String, String> queryParams = new LinkedHashMap<>();
-    queryParams.put("pageSize", _pageSize.toString());
+    queryParams.put("pageSize", Integer.toString(_pageSize));
     queryParams.put("walletId", accountID);
 
     if (afterCursor != null && !afterCursor.isEmpty()) {
@@ -400,14 +400,14 @@ public class CirclePaymentService implements PaymentService {
               allPayments.addAll(payoutsHistory.getPayments());
               allPayments =
                   allPayments.stream()
-                      .sorted(Comparator.comparing(Payment::getCreatedAt))
+                      .sorted((p1, p2) -> p2.getCreatedAt().compareTo(p1.getCreatedAt()))
                       .collect(Collectors.toList());
               for (Payment p : allPayments) {
                 updatePaymentWireCapability(p, distributionAccId);
               }
-              transfersHistory.setPayments(allPayments);
+              result.setPayments(allPayments);
 
-              return transfersHistory;
+              return result;
             });
   }
 

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.Getter;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.stellar.anchor.exception.HttpException;
 import org.stellar.anchor.paymentservice.*;
@@ -18,7 +17,6 @@ import org.stellar.anchor.paymentservice.circle.model.*;
 import org.stellar.anchor.paymentservice.circle.model.request.CircleSendTransactionRequest;
 import org.stellar.anchor.paymentservice.circle.model.response.*;
 import org.stellar.anchor.paymentservice.circle.util.NettyHttpClient;
-import org.stellar.sdk.Server;
 import reactor.core.publisher.Mono;
 import reactor.netty.ByteBufMono;
 import reactor.netty.http.client.HttpClient;
@@ -33,8 +31,6 @@ public class CirclePaymentService
           .registerTypeAdapter(CirclePayout.class, new CirclePayout.Deserializer())
           .create();
 
-  @Getter Server horizonServer;
-
   private final org.stellar.sdk.Network stellarNetwork;
 
   private final Network network = Network.CIRCLE;
@@ -42,6 +38,8 @@ public class CirclePaymentService
   private String url;
 
   private String secretKey;
+
+  private final String horizonUrl;
 
   private HttpClient webClient;
 
@@ -56,7 +54,7 @@ public class CirclePaymentService
     super();
     this.url = url;
     this.secretKey = secretKey;
-    this.horizonServer = new Server(horizonUrl);
+    this.horizonUrl = horizonUrl;
     this.stellarNetwork = stellarNetwork;
   }
 
@@ -81,7 +79,11 @@ public class CirclePaymentService
     this.mainAccountAddress = null;
   }
 
-  private HttpClient getWebClient(boolean authenticated) {
+  public String getHorizonUrl() {
+    return horizonUrl;
+  }
+
+  public HttpClient getWebClient(boolean authenticated) {
     if (webClient == null) {
       this.webClient = NettyHttpClient.withBaseUrl(getUrl());
     }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -303,6 +303,7 @@ public class CirclePaymentService implements PaymentService {
                           Network.CIRCLE,
                           accountID,
                           new Account.Capabilities(Network.CIRCLE, Network.STELLAR));
+                  // TODO: update stellar account when receiving Stellar->Wallet transfers
                   CircleTransferListResponse circleTransferListResponse =
                       gson.fromJson(body, CircleTransferListResponse.class);
                   return circleTransferListResponse.toPaymentHistory(_pageSize, account);
@@ -318,7 +319,7 @@ public class CirclePaymentService implements PaymentService {
     Integer _pageSize = pageSize != null ? pageSize : 50;
     LinkedHashMap<String, String> queryParams = new LinkedHashMap<>();
     queryParams.put("pageSize", _pageSize.toString());
-    queryParams.put("walletId", accountID);
+    queryParams.put("source", accountID);
 
     if (afterCursor != null && !afterCursor.isEmpty()) {
       queryParams.put("pageAfter", afterCursor);
@@ -368,6 +369,7 @@ public class CirclePaymentService implements PaymentService {
       String accountID, @Nullable String beforeCursor, @Nullable String afterCursor)
       throws HttpException {
     // TODO: implement
+    // TODO: implement /v1/payments as well
     return getTransfers(accountID, beforeCursor, afterCursor, null);
   }
 

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CircleResponseErrorHandler.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CircleResponseErrorHandler.java
@@ -1,0 +1,31 @@
+package org.stellar.anchor.paymentservice.circle;
+
+import java.util.function.BiFunction;
+import org.jetbrains.annotations.NotNull;
+import org.stellar.anchor.exception.HttpException;
+import org.stellar.anchor.paymentservice.circle.model.response.CircleError;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufMono;
+import reactor.netty.http.client.HttpClientResponse;
+
+public interface CircleResponseErrorHandler extends CircleGsonParsable {
+  @NotNull
+  default BiFunction<HttpClientResponse, ByteBufMono, Mono<String>> handleResponseSingle() {
+    return (response, bodyBytesMono) -> {
+      if (response.status().code() >= 400) {
+        return bodyBytesMono
+            .asString()
+            .map(
+                body -> {
+                  CircleError circleError = gson.fromJson(body, CircleError.class);
+                  throw new HttpException(
+                      response.status().code(),
+                      circleError.getMessage(),
+                      circleError.getCode().toString());
+                });
+      }
+
+      return bodyBytesMono.asString();
+    };
+  }
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
@@ -13,6 +13,7 @@ import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
 
 public interface StellarReconciliation {
+
   Server getHorizonServer();
 
   default void updateStellarSenderAddress(CircleTransfer transfer) throws HttpException {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
@@ -22,6 +22,8 @@ public interface StellarReconciliation {
   default void updateStellarSenderAddress(CircleTransfer transfer) throws HttpException {
     if (transfer.getSource().getId() != null) return;
 
+    // Only Stellar->CircleWallet transfers would arrive here with id == null, and they'd also have
+    // chain == "XLM" and type == BLOCKCHAIN
     if (!transfer.getSource().getChain().equals("XLM")
         || transfer.getSource().getType() != CircleTransactionParty.Type.BLOCKCHAIN) {
       throw new HttpException(500, "invalid source account");
@@ -29,8 +31,8 @@ public interface StellarReconciliation {
 
     Page<OperationResponse> responsePage;
     try {
-      responsePage =
-          getHorizonServer().payments().forTransaction(transfer.getTransactionHash()).execute();
+      String txHash = transfer.getTransactionHash();
+      responsePage = getHorizonServer().payments().forTransaction(txHash).execute();
     } catch (IOException e) {
       e.printStackTrace();
       throw new HttpException(500, e.getMessage());

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
@@ -1,0 +1,59 @@
+package org.stellar.anchor.paymentservice.circle;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import org.stellar.anchor.exception.HttpException;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
+import org.stellar.sdk.Server;
+import org.stellar.sdk.responses.Page;
+import org.stellar.sdk.responses.operations.OperationResponse;
+import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
+import org.stellar.sdk.responses.operations.PaymentOperationResponse;
+
+public interface StellarReconciliation {
+  Server getHorizonServer();
+
+  default void updateStellarSenderAddress(CircleTransfer transfer) throws HttpException {
+    if (transfer.getSource().getId() != null) return;
+
+    if (!transfer.getSource().getChain().equals("XLM")
+        || transfer.getSource().getType() != CircleTransactionParty.Type.BLOCKCHAIN) {
+      throw new HttpException(500, "invalid source account");
+    }
+
+    Page<OperationResponse> responsePage;
+    try {
+      responsePage =
+          getHorizonServer().payments().forTransaction(transfer.getTransactionHash()).execute();
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new HttpException(500, e.getMessage());
+    }
+
+    for (OperationResponse or : responsePage.getRecords()) {
+      if (!or.isTransactionSuccessful()) continue;
+
+      if (!List.of("payment", "path_payment_strict_send", "path_payment_strict_receive")
+          .contains(or.getType())) continue;
+
+      String amount, from;
+      if ("payment".equals(or.getType())) {
+        PaymentOperationResponse pr = (PaymentOperationResponse) or;
+        amount = pr.getAmount();
+        from = pr.getFrom();
+      } else {
+        PathPaymentBaseOperationResponse ppr = (PathPaymentBaseOperationResponse) or;
+        amount = ppr.getAmount();
+        from = ppr.getFrom();
+      }
+
+      BigDecimal wantAmount = new BigDecimal(transfer.getAmount().getAmount());
+      BigDecimal gotAmount = new BigDecimal(amount);
+      if (wantAmount.compareTo(gotAmount) != 0) continue;
+
+      transfer.getSource().setAddress(from);
+    }
+  }
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
@@ -1,79 +1,80 @@
 package org.stellar.anchor.paymentservice.circle;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import java.io.IOException;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.List;
 import org.stellar.anchor.exception.HttpException;
 import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
 import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
-import org.stellar.sdk.Server;
+import org.stellar.sdk.responses.GsonSingleton;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import shadow.com.google.common.reflect.TypeToken;
+import shadow.com.google.gson.Gson;
 
-public interface StellarReconciliation {
+public interface StellarReconciliation extends CircleResponseErrorHandler {
 
-  Server getHorizonServer();
+  HttpClient getWebClient(boolean authenticated);
 
-  default void updateStellarSenderAddress(CircleTransfer transfer) throws HttpException {
-    if (transfer.getSource().getId() != null) return;
-
-    // Only Stellar->CircleWallet transfers would arrive here with id == null, and they'd also have
-    // chain == "XLM" and type == BLOCKCHAIN
-    if (!transfer.getSource().getChain().equals("XLM")
-        || transfer.getSource().getType() != CircleTransactionParty.Type.BLOCKCHAIN) {
-      throw new HttpException(500, "invalid source account");
-    }
-
-    Page<OperationResponse> responsePage;
-    try {
-      String txHash = transfer.getTransactionHash();
-      responsePage = getHorizonServer().payments().forTransaction(txHash).execute();
-    } catch (IOException e) {
-      e.printStackTrace();
-      throw new HttpException(500, e.getMessage());
-    }
-
-    for (OperationResponse or : responsePage.getRecords()) {
-      if (!or.isTransactionSuccessful()) continue;
-
-      if (!List.of("payment", "path_payment_strict_send", "path_payment_strict_receive")
-          .contains(or.getType())) continue;
-
-      String amount, from;
-      if ("payment".equals(or.getType())) {
-        PaymentOperationResponse pr = (PaymentOperationResponse) or;
-        amount = pr.getAmount();
-        from = pr.getFrom();
-      } else {
-        PathPaymentBaseOperationResponse ppr = (PathPaymentBaseOperationResponse) or;
-        amount = ppr.getAmount();
-        from = ppr.getFrom();
-      }
-
-      BigDecimal wantAmount = new BigDecimal(transfer.getAmount().getAmount());
-      BigDecimal gotAmount = new BigDecimal(amount);
-      if (wantAmount.compareTo(gotAmount) != 0) continue;
-
-      transfer.getSource().setAddress(from);
-    }
-  }
+  String getHorizonUrl();
 
   default Mono<CircleTransfer> updatedStellarSenderAddress(CircleTransfer transfer)
       throws HttpException {
-    Gson gson =
-        new GsonBuilder()
-            .registerTypeAdapter(CircleTransfer.class, new CircleTransfer.Serialization())
-            .create();
-    CircleTransfer transferClone = gson.fromJson(gson.toJson(transfer), CircleTransfer.class);
-    return Mono.fromCallable(
-        () -> {
-          updateStellarSenderAddress(transferClone);
-          return transferClone;
-        });
+    CircleTransfer transferCopy = gson.fromJson(gson.toJson(transfer), CircleTransfer.class);
+
+    if (transferCopy.getSource().getId() != null) return Mono.just(transferCopy);
+
+    // Only Stellar->CircleWallet transfers should arrive here with id == null, and they should also
+    // have
+    // chain == "XLM" and type == BLOCKCHAIN. Let's validate if that's true:
+    if (!transferCopy.getSource().getChain().equals("XLM")
+        || transferCopy.getSource().getType() != CircleTransactionParty.Type.BLOCKCHAIN) {
+      throw new HttpException(500, "invalid source account");
+    }
+
+    String txHash = transferCopy.getTransactionHash();
+    return getWebClient(false)
+        .baseUrl(getHorizonUrl())
+        .get()
+        .uri("/transactions/" + txHash + "/payments")
+        .responseSingle(handleResponseSingle())
+        .mapNotNull(
+            body -> {
+              Type type = new TypeToken<Page<OperationResponse>>() {}.getType();
+              Gson stellarSdkGson = GsonSingleton.getInstance();
+              Page<OperationResponse> responsePage = stellarSdkGson.fromJson(body, type);
+
+              for (OperationResponse opResponse : responsePage.getRecords()) {
+                if (!opResponse.isTransactionSuccessful()) continue;
+
+                if (!List.of("payment", "path_payment_strict_send", "path_payment_strict_receive")
+                    .contains(opResponse.getType())) continue;
+
+                String amount, from;
+                if ("payment".equals(opResponse.getType())) {
+                  PaymentOperationResponse paymentResponse = (PaymentOperationResponse) opResponse;
+                  amount = paymentResponse.getAmount();
+                  from = paymentResponse.getFrom();
+                } else {
+                  PathPaymentBaseOperationResponse pathPaymentResponse =
+                      (PathPaymentBaseOperationResponse) opResponse;
+                  amount = pathPaymentResponse.getAmount();
+                  from = pathPaymentResponse.getFrom();
+                }
+
+                BigDecimal wantAmount = new BigDecimal(transferCopy.getAmount().getAmount());
+                BigDecimal gotAmount = new BigDecimal(amount);
+                if (wantAmount.compareTo(gotAmount) != 0) continue;
+
+                transferCopy.getSource().setAddress(from);
+                return transferCopy;
+              }
+
+              return null;
+            });
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/StellarReconciliation.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.paymentservice.circle;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
@@ -11,6 +13,7 @@ import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
+import reactor.core.publisher.Mono;
 
 public interface StellarReconciliation {
 
@@ -56,5 +59,19 @@ public interface StellarReconciliation {
 
       transfer.getSource().setAddress(from);
     }
+  }
+
+  default Mono<CircleTransfer> updatedStellarSenderAddress(CircleTransfer transfer)
+      throws HttpException {
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(CircleTransfer.class, new CircleTransfer.Serialization())
+            .create();
+    CircleTransfer transferClone = gson.fromJson(gson.toJson(transfer), CircleTransfer.class);
+    return Mono.fromCallable(
+        () -> {
+          updateStellarSenderAddress(transferClone);
+          return transferClone;
+        });
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
@@ -3,22 +3,36 @@ package org.stellar.anchor.paymentservice.circle.model;
 import lombok.Data;
 import org.stellar.anchor.paymentservice.Balance;
 import org.stellar.anchor.paymentservice.Network;
+import reactor.util.annotation.NonNull;
 
 @Data
 public class CircleBalance {
-  String amount;
-  String currency;
+  @NonNull String amount;
+  @NonNull String currency;
+  @NonNull org.stellar.sdk.Network stellarNetwork;
 
-  public CircleBalance(String currency, String amount) {
+  public CircleBalance(
+      @NonNull String currency,
+      @NonNull String amount,
+      @NonNull org.stellar.sdk.Network stellarNetwork) {
     this.currency = currency;
     this.amount = amount;
+    this.stellarNetwork = stellarNetwork;
   }
 
-  public Balance toBalance() {
-    return toBalance(Network.CIRCLE);
+  public Balance toBalance(@NonNull Network destinationNetwork) {
+    String currencyName = destinationNetwork.getCurrencyPrefix() + ":" + currency;
+    if (currencyName.equals("stellar:USD"))
+      currencyName = destinationNetwork.getCurrencyPrefix() + ":" + stellarUSDC();
+
+    return new Balance(amount, currencyName);
   }
 
-  public Balance toBalance(Network destinationNetwork) {
-    return new Balance(amount, destinationNetwork.getCurrencyPrefix() + ":" + currency);
+  @NonNull
+  private String stellarUSDC() {
+    if (stellarNetwork == org.stellar.sdk.Network.PUBLIC)
+      return "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+    return "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
@@ -29,7 +29,7 @@ public class CircleBalance {
   }
 
   @NonNull
-  private String stellarUSDC() {
+  public String stellarUSDC() {
     if (stellarNetwork == org.stellar.sdk.Network.PUBLIC)
       return "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
@@ -38,7 +38,8 @@ public class CirclePayout {
             Network.CIRCLE,
             sourceWalletId,
             new Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)));
-    Account destinationAccount = destination.toAccount();
+    // In Circle, only the source wallet can send a Payout:
+    Account destinationAccount = destination.toAccount(sourceWalletId);
     p.setDestinationAccount(destinationAccount);
     p.setBalance(amount.toBalance(destinationAccount.network));
     p.setStatus(status.toPaymentStatus());

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
@@ -53,10 +53,6 @@ public class CirclePayout {
   }
 
   public static class Deserializer implements JsonDeserializer<CirclePayout> {
-    public static CirclePayout.Deserializer getInstance() {
-      return new CirclePayout.Deserializer();
-    }
-
     @Override
     public CirclePayout deserialize(
         JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CirclePayout.java
@@ -39,8 +39,7 @@ public class CirclePayout {
             Network.CIRCLE,
             sourceWalletId,
             new Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)));
-    // In Circle, only the source wallet can send a Payout:
-    Account destinationAccount = destination.toAccount(sourceWalletId);
+    Account destinationAccount = destination.toAccount(null);
     p.setDestinationAccount(destinationAccount);
     p.setBalance(amount.toBalance(destinationAccount.network));
     p.setStatus(status.toPaymentStatus());
@@ -63,8 +62,10 @@ public class CirclePayout {
 
       Type type = new TypeToken<Map<String, ?>>() {}.getType();
       Map<String, Object> originalResponse = gson.fromJson(jsonObject, type);
-      String createdDateStr = CircleDateFormatter.dateToString(payout.getCreateDate());
-      originalResponse.put("createDate", createdDateStr);
+      String createDateStr = CircleDateFormatter.dateToString(payout.getCreateDate());
+      originalResponse.put("createDate", createDateStr);
+      String updateDateStr = CircleDateFormatter.dateToString(payout.getUpdateDate());
+      originalResponse.put("updateDate", updateDateStr);
       payout.setOriginalResponse(originalResponse);
       return payout;
     }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
@@ -66,7 +66,7 @@ public class CircleTransactionParty {
     return party;
   }
 
-  public Account toAccount() {
+  public Account toAccount(String distributionAccountId) {
     switch (type) {
       case BLOCKCHAIN:
         if (!"XLM".equals(chain)) {
@@ -76,8 +76,11 @@ public class CircleTransactionParty {
             Network.STELLAR, address, addressTag, new Account.Capabilities(Network.STELLAR));
 
       case WALLET:
-        return new Account(
-            Network.CIRCLE, id, new Account.Capabilities(Network.CIRCLE, Network.STELLAR));
+        Account account =
+            new Account(
+                Network.CIRCLE, id, new Account.Capabilities(Network.CIRCLE, Network.STELLAR));
+        account.capabilities.set(Network.BANK_WIRE, distributionAccountId.equals(id));
+        return account;
 
       case WIRE:
         return new Account(Network.BANK_WIRE, id, new Account.Capabilities(Network.BANK_WIRE));

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.paymentservice.circle.model;
 import com.google.gson.annotations.SerializedName;
 import org.stellar.anchor.paymentservice.Account;
 import org.stellar.anchor.paymentservice.Network;
+import reactor.util.annotation.Nullable;
 
 @lombok.Data
 public class CircleTransactionParty {
@@ -66,7 +67,14 @@ public class CircleTransactionParty {
     return party;
   }
 
-  public Account toAccount(String distributionAccountId) {
+  /**
+   * Transforms a Circle transaction party into an Account.
+   *
+   * @param distributionAccountId used to update the bank wire capability when this is a Circle
+   *     wallet.
+   * @return a new account instance.
+   */
+  public Account toAccount(@Nullable String distributionAccountId) {
     switch (type) {
       case BLOCKCHAIN:
         if (!"XLM".equals(chain)) {
@@ -79,7 +87,8 @@ public class CircleTransactionParty {
         Account account =
             new Account(
                 Network.CIRCLE, id, new Account.Capabilities(Network.CIRCLE, Network.STELLAR));
-        account.capabilities.set(Network.BANK_WIRE, distributionAccountId.equals(id));
+        boolean isWireEnabled = distributionAccountId != null && distributionAccountId.equals(id);
+        account.capabilities.set(Network.BANK_WIRE, isWireEnabled);
         return account;
 
       case WIRE:

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -28,6 +28,7 @@ public class CircleTransfer {
     Account destinationAccount = destination.toAccount();
     p.setDestinationAccount(destinationAccount);
     p.setBalance(amount.toBalance(destinationAccount.network));
+    p.setTxHash(transactionHash);
     p.setStatus(status.toPaymentStatus());
     p.setErrorCode(errorCode);
     p.setCreatedAt(createDate);

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -21,11 +21,11 @@ public class CircleTransfer {
   String errorCode;
   Date createDate;
 
-  public Payment toPayment() {
+  public Payment toPayment(String distributionAccountId) {
     Payment p = new Payment();
     p.setId(id);
-    p.setSourceAccount(source.toAccount());
-    Account destinationAccount = destination.toAccount();
+    p.setSourceAccount(source.toAccount(distributionAccountId));
+    Account destinationAccount = destination.toAccount(distributionAccountId);
     p.setDestinationAccount(destinationAccount);
     p.setBalance(amount.toBalance(destinationAccount.network));
     p.setTxHash(transactionHash);

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -39,7 +39,8 @@ public class CircleTransfer {
     return p;
   }
 
-  public static class Deserializer implements JsonDeserializer<CircleTransfer> {
+  public static class Serialization
+      implements JsonDeserializer<CircleTransfer>, JsonSerializer<CircleTransfer> {
     @Override
     public CircleTransfer deserialize(
         JsonElement json, Type typeOfT, JsonDeserializationContext context)
@@ -54,6 +55,14 @@ public class CircleTransfer {
       originalResponse.put("createDate", createdDateStr);
       transfer.setOriginalResponse(originalResponse);
       return transfer;
+    }
+
+    @Override
+    public JsonElement serialize(
+        CircleTransfer src, Type typeOfSrc, JsonSerializationContext context) {
+      Gson gson = new Gson();
+      JsonObject jsonObject = gson.toJsonTree(src.originalResponse).getAsJsonObject();
+      return jsonObject;
     }
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -29,7 +29,7 @@ public class CircleTransfer {
     Account destinationAccount = destination.toAccount(distributionAccountId);
     p.setDestinationAccount(destinationAccount);
     p.setBalance(amount.toBalance(destinationAccount.network));
-    p.setTxHash(transactionHash);
+    p.setIdTag(transactionHash);
     p.setStatus(status.toPaymentStatus());
     p.setErrorCode(errorCode);
     p.setCreatedAt(createDate);

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransfer.java
@@ -54,6 +54,7 @@ public class CircleTransfer {
       String createdDateStr = CircleDateFormatter.dateToString(transfer.getCreateDate());
       originalResponse.put("createDate", createdDateStr);
       transfer.setOriginalResponse(originalResponse);
+
       return transfer;
     }
 
@@ -61,8 +62,7 @@ public class CircleTransfer {
     public JsonElement serialize(
         CircleTransfer src, Type typeOfSrc, JsonSerializationContext context) {
       Gson gson = new Gson();
-      JsonObject jsonObject = gson.toJsonTree(src.originalResponse).getAsJsonObject();
-      return jsonObject;
+      return gson.toJsonTree(src.originalResponse).getAsJsonObject();
     }
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -23,7 +23,9 @@ public class CircleWallet {
   public Account toAccount() {
     Account account = new Account(Network.CIRCLE, walletId, description, getCapabilities());
     account.setBalances(
-        balances.stream().map(CircleBalance::toBalance).collect(Collectors.toList()));
+        balances.stream()
+            .map(circleBalance -> circleBalance.toBalance(Network.CIRCLE))
+            .collect(Collectors.toList()));
     return account;
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.paymentservice.circle.model.request;
 
 import java.util.HashMap;
+import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.paymentservice.circle.model.CircleBalance;
 import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
@@ -21,6 +22,12 @@ public class CircleSendTransactionRequest {
     CircleSendTransactionRequest req = new CircleSendTransactionRequest();
     req.source = source;
     req.destination = destination;
+    if (List.of(
+            "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+            "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN")
+        .contains(amount.getCurrency())) {
+      amount.setCurrency("USD");
+    }
     req.amount = amount;
     req.idempotencyKey = idempotencyKey;
     return req;

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.paymentservice.circle.model.request;
 
 import java.util.HashMap;
-import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.paymentservice.circle.model.CircleBalance;
 import org.stellar.anchor.paymentservice.circle.model.CircleTransactionParty;
@@ -22,12 +21,7 @@ public class CircleSendTransactionRequest {
     CircleSendTransactionRequest req = new CircleSendTransactionRequest();
     req.source = source;
     req.destination = destination;
-    if (List.of(
-            "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-            "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN")
-        .contains(amount.getCurrency())) {
-      amount.setCurrency("USD");
-    }
+    if (amount.stellarUSDC().equals(amount.getCurrency())) amount.setCurrency("USD");
     req.amount = amount;
     req.idempotencyKey = idempotencyKey;
     return req;

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutListResponse.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutListResponse.java
@@ -10,7 +10,7 @@ import org.stellar.anchor.paymentservice.circle.model.CirclePayout;
 public class CirclePayoutListResponse {
   List<CirclePayout> data;
 
-  public PaymentHistory toPaymentHistory(Integer pageSize, Account account) {
+  public PaymentHistory toPaymentHistory(int pageSize, Account account) {
     PaymentHistory ph = new PaymentHistory(account);
     if (data == null || data.size() == 0) {
       return ph;

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutListResponse.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CirclePayoutListResponse.java
@@ -1,0 +1,34 @@
+package org.stellar.anchor.paymentservice.circle.model.response;
+
+import java.util.List;
+import lombok.Data;
+import org.stellar.anchor.paymentservice.Account;
+import org.stellar.anchor.paymentservice.PaymentHistory;
+import org.stellar.anchor.paymentservice.circle.model.CirclePayout;
+
+@Data
+public class CirclePayoutListResponse {
+  List<CirclePayout> data;
+
+  public PaymentHistory toPaymentHistory(Integer pageSize, Account account) {
+    PaymentHistory ph = new PaymentHistory(account);
+    if (data == null || data.size() == 0) {
+      return ph;
+    }
+
+    for (int i = 0; i < data.size(); i++) {
+      CirclePayout payout = data.get(i);
+      ph.getPayments().add(payout.toPayment());
+
+      if (i == 0) {
+        ph.setBeforeCursor(payout.getId());
+      }
+
+      if (i + 1 == pageSize) {
+        ph.setAfterCursor(payout.getId());
+      }
+    }
+
+    return ph;
+  }
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferListResponse.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferListResponse.java
@@ -1,0 +1,34 @@
+package org.stellar.anchor.paymentservice.circle.model.response;
+
+import java.util.List;
+import lombok.Data;
+import org.stellar.anchor.paymentservice.Account;
+import org.stellar.anchor.paymentservice.PaymentHistory;
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
+
+@Data
+public class CircleTransferListResponse {
+  List<CircleTransfer> data;
+
+  public PaymentHistory toPaymentHistory(Integer pageSize, Account account) {
+    PaymentHistory ph = new PaymentHistory(account);
+    if (data == null || data.size() == 0) {
+      return ph;
+    }
+
+    for (int i = 0; i < data.size(); i++) {
+      CircleTransfer transfer = data.get(i);
+      ph.getPayments().add(transfer.toPayment());
+
+      if (i == 0) {
+        ph.setBeforeCursor(transfer.getId());
+      }
+
+      if (i + 1 == pageSize) {
+        ph.setAfterCursor(transfer.getId());
+      }
+    }
+
+    return ph;
+  }
+}

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferListResponse.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/response/CircleTransferListResponse.java
@@ -10,7 +10,8 @@ import org.stellar.anchor.paymentservice.circle.model.CircleTransfer;
 public class CircleTransferListResponse {
   List<CircleTransfer> data;
 
-  public PaymentHistory toPaymentHistory(Integer pageSize, Account account) {
+  public PaymentHistory toPaymentHistory(
+      int pageSize, Account account, String distributionAccountId) {
     PaymentHistory ph = new PaymentHistory(account);
     if (data == null || data.size() == 0) {
       return ph;
@@ -18,7 +19,7 @@ public class CircleTransferListResponse {
 
     for (int i = 0; i < data.size(); i++) {
       CircleTransfer transfer = data.get(i);
-      ph.getPayments().add(transfer.toPayment());
+      ph.getPayments().add(transfer.toPayment(distributionAccountId));
 
       if (i == 0) {
         ph.setBeforeCursor(transfer.getId());

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
@@ -6,6 +6,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import okhttp3.HttpUrl;
 import reactor.netty.http.client.HttpClient;
@@ -31,7 +32,7 @@ public class NettyHttpClient {
                     .addHandlerLast(new WriteTimeoutHandler(15)));
   }
 
-  public static String uriWithParams(String uri, Map<String, String> queryParams) {
+  public static String uriWithParams(String uri, LinkedHashMap<String, String> queryParams) {
     HttpUrl.Builder urlBuilder = new HttpUrl.Builder().scheme("https").host("example.com");
 
     if (uri != null && !uri.isEmpty()) {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
@@ -32,7 +32,7 @@ public class NettyHttpClient {
                     .addHandlerLast(new WriteTimeoutHandler(15)));
   }
 
-  public static String uriWithParams(String uri, LinkedHashMap<String, String> queryParams) {
+  public static String buildUri(String uri, LinkedHashMap<String, String> queryParams) {
     HttpUrl.Builder urlBuilder = new HttpUrl.Builder().scheme("https").host("example.com");
 
     if (uri != null && !uri.isEmpty()) {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/NettyHttpClient.java
@@ -6,6 +6,8 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.time.Duration;
+import java.util.Map;
+import okhttp3.HttpUrl;
 import reactor.netty.http.client.HttpClient;
 
 public class NettyHttpClient {
@@ -27,5 +29,23 @@ public class NettyHttpClient {
                 connection
                     .addHandlerLast(new ReadTimeoutHandler(15))
                     .addHandlerLast(new WriteTimeoutHandler(15)));
+  }
+
+  public static String uriWithParams(String uri, Map<String, String> queryParams) {
+    HttpUrl.Builder urlBuilder = new HttpUrl.Builder().scheme("https").host("example.com");
+
+    if (uri != null && !uri.isEmpty()) {
+      for (String pathSegment : uri.split("/")) {
+        urlBuilder = urlBuilder.addPathSegment(pathSegment);
+      }
+    }
+
+    if (queryParams != null && !queryParams.isEmpty()) {
+      for (Map.Entry<String, String> queryParam : queryParams.entrySet()) {
+        urlBuilder = urlBuilder.addQueryParameter(queryParam.getKey(), queryParam.getValue());
+      }
+    }
+
+    return urlBuilder.build().url().getFile();
   }
 }

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -1074,8 +1074,6 @@ class CirclePaymentServiceTest {
       mockStellarPaymentResponsePage
     (service as CirclePaymentService).horizonServer = mockHorizonServer
 
-    service.secretKey = "<secret-key>"
-
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -1102,7 +1100,7 @@ class CirclePaymentServiceTest {
 
     var paymentHistory: PaymentHistory? = null
     val getTransfersMono =
-      (service as CirclePaymentService)._getTransfers("1000066041", null, null, null)
+      (service as CirclePaymentService).getTransfers("1000066041", null, null, null)
     val merchantAccount =
       Account(
         Network.CIRCLE,
@@ -1175,8 +1173,6 @@ class CirclePaymentServiceTest {
 
   @Test
   fun test_getTransfers_paginationResponse() {
-    service.secretKey = "<secret-key>"
-
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -1208,7 +1204,7 @@ class CirclePaymentServiceTest {
         Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
       )
     val getTransfersMono =
-      (service as CirclePaymentService)._getTransfers("1000066041", null, null, 2)
+      (service as CirclePaymentService).getTransfers("1000066041", null, null, 2)
     var paymentHistory: PaymentHistory? = null
     assertDoesNotThrow {
       paymentHistory = getTransfersMono.block()!!.toPaymentHistory(2, merchantAccount, "1000066041")
@@ -1256,8 +1252,6 @@ class CirclePaymentServiceTest {
 
   @Test
   fun test_getPayouts() {
-    service.secretKey = "<secret-key>"
-
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -1286,7 +1280,7 @@ class CirclePaymentServiceTest {
         "1000066041",
         Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
       )
-    val getPayoutsMono = (service as CirclePaymentService)._getPayouts("1000066041", null, null, 50)
+    val getPayoutsMono = (service as CirclePaymentService).getPayouts("1000066041", null, null, 50)
     var paymentHistory: PaymentHistory? = null
     assertDoesNotThrow {
       paymentHistory = getPayoutsMono.block()!!.toPaymentHistory(50, merchantAccount)
@@ -1318,8 +1312,6 @@ class CirclePaymentServiceTest {
 
   @Test
   fun test_getPayouts_paginationResponse() {
-    service.secretKey = "<secret-key>"
-
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -1349,7 +1341,7 @@ class CirclePaymentServiceTest {
         Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
       )
 
-    val getPayoutsMono = (service as CirclePaymentService)._getPayouts("1000066041", null, null, 1)
+    val getPayoutsMono = (service as CirclePaymentService).getPayouts("1000066041", null, null, 1)
     var paymentHistory: PaymentHistory? = null
     assertDoesNotThrow {
       paymentHistory = getPayoutsMono.block()!!.toPaymentHistory(1, merchantAccount)
@@ -1400,8 +1392,6 @@ class CirclePaymentServiceTest {
     afterCursor: String?,
     expectedUri: String
   ) {
-    service.secretKey = "<secret-key>"
-
     val dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -1435,7 +1425,7 @@ class CirclePaymentServiceTest {
       assertDoesNotThrow {
         paymentHistory =
           (service as CirclePaymentService)
-              ._getTransfers("1000066041", beforeCursor, afterCursor, 1)
+              .getTransfers("1000066041", beforeCursor, afterCursor, 1)
               .block()!!
             .toPaymentHistory(1, merchantAccount, "1000066041")
       }
@@ -1443,7 +1433,7 @@ class CirclePaymentServiceTest {
       assertDoesNotThrow {
         paymentHistory =
           (service as CirclePaymentService)
-              ._getPayouts("1000066041", beforeCursor, afterCursor, 1)
+              .getPayouts("1000066041", beforeCursor, afterCursor, 1)
               .block()!!
             .toPaymentHistory(1, merchantAccount)
       }
@@ -1470,8 +1460,6 @@ class CirclePaymentServiceTest {
     every { mockHorizonServer.payments().forTransaction(any()).execute() } returns
       mockStellarPaymentResponsePage
     (service as CirclePaymentService).horizonServer = mockHorizonServer
-
-    service.secretKey = "<secret-key>"
 
     val dispatcher: Dispatcher =
       object : Dispatcher() {
@@ -1706,11 +1694,11 @@ class CirclePaymentServiceTest {
         ),
       ),
       ErrorHandlingTestCase(
-        (service as CirclePaymentService)._getTransfers("1000066041", null, null, null),
+        (service as CirclePaymentService).getTransfers("1000066041", null, null, null),
         hashMapOf("/v1/transfers?pageSize=50&walletId=1000066041" to badRequestResponse)
       ),
       ErrorHandlingTestCase(
-        (service as CirclePaymentService)._getPayouts("1000066041", null, null, null),
+        (service as CirclePaymentService).getPayouts("1000066041", null, null, null),
         hashMapOf("/v1/payouts?pageSize=50&source=1000066041" to badRequestResponse)
       ),
       ErrorHandlingTestCase(

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -32,53 +32,6 @@ import reactor.netty.ByteBufMono
 import reactor.netty.http.client.HttpClientResponse
 import shadow.com.google.common.reflect.TypeToken
 
-private class ErrorHandlingTestCase {
-  val requestMono: Mono<*>
-  var mockResponses: List<MockResponse>? = null
-    private set
-  var mockResponsesMap: Map<String, MockResponse>? = null
-    private set
-
-  constructor(_requestMono: Mono<*>, _mockResponses: List<MockResponse>) {
-    this.requestMono = _requestMono
-    this.mockResponses = _mockResponses
-  }
-
-  constructor(_requestMono: Mono<*>, _mockResponsesMap: Map<String, MockResponse>) {
-    this.requestMono = _requestMono
-    this.mockResponsesMap = _mockResponsesMap
-  }
-
-  private fun getDispatcher(): Dispatcher? {
-    if (mockResponsesMap == null) {
-      return null
-    }
-
-    val dispatcher: Dispatcher =
-      object : Dispatcher() {
-        @Throws(InterruptedException::class)
-        override fun dispatch(request: RecordedRequest): MockResponse {
-
-          if (!mockResponsesMap!!.containsKey(request.path)) {
-            return MockResponse().setResponseCode(404)
-          }
-
-          return mockResponsesMap!![request.path]!!
-        }
-      }
-    return dispatcher
-  }
-
-  fun prepareMockWebServer(server: MockWebServer) {
-    val dispatcher = getDispatcher()
-    if (dispatcher != null) {
-      server.dispatcher = dispatcher
-    } else if (mockResponses != null) {
-      mockResponses!!.forEach { mockResponse -> server.enqueue(mockResponse) }
-    }
-  }
-}
-
 class CirclePaymentServiceTest {
   private lateinit var server: MockWebServer
   private lateinit var service: PaymentService

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -37,6 +37,8 @@ import shadow.com.google.common.reflect.TypeToken
 
 class CirclePaymentServiceTest {
   companion object {
+    val TESTNET: org.stellar.sdk.Network = org.stellar.sdk.Network.TESTNET
+
     const val mockWalletToWalletTransferJson =
       """{
         "id":"c58e2613-a808-4075-956c-e576787afb3b",
@@ -199,7 +201,7 @@ class CirclePaymentServiceTest {
     val circleUrl = server.url("").toString()
     val horizonUrl = "https://horizon-testnet.stellar.org"
     val bearerToken = "<secret-key>"
-    service = CirclePaymentService(circleUrl, bearerToken, horizonUrl)
+    service = CirclePaymentService(circleUrl, bearerToken, horizonUrl, TESTNET)
   }
 
   @AfterEach
@@ -946,7 +948,14 @@ class CirclePaymentServiceTest {
     var payment: Payment? = null
     assertDoesNotThrow {
       payment =
-        service.sendPayment(source, destination, "stellar:USD", BigDecimal.valueOf(0.91)).block()
+        service
+          .sendPayment(
+            source,
+            destination,
+            "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+            BigDecimal.valueOf(0.91)
+          )
+          .block()
     }
 
     assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
@@ -967,7 +976,10 @@ class CirclePaymentServiceTest {
       ),
       payment?.destinationAccount
     )
-    assertEquals(Balance("0.91", "stellar:USD"), payment?.balance)
+    assertEquals(
+      Balance("0.91", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+      payment?.balance
+    )
     assertEquals(Payment.Status.PENDING, payment?.status)
     assertNull(payment?.errorCode)
 
@@ -1149,7 +1161,8 @@ class CirclePaymentServiceTest {
         "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
         Account.Capabilities(Network.STELLAR)
       )
-    p3.balance = Balance("1.00", "stellar:USD")
+    p3.balance =
+      Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
     p3.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p3.status = Payment.Status.SUCCESSFUL
     p3.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
@@ -1229,7 +1242,8 @@ class CirclePaymentServiceTest {
         "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
         Account.Capabilities(Network.STELLAR)
       )
-    p2.balance = Balance("1.00", "stellar:USD")
+    p2.balance =
+      Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
     p2.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
@@ -1568,7 +1582,8 @@ class CirclePaymentServiceTest {
         "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
         Account.Capabilities(Network.STELLAR)
       )
-    p4.balance = Balance("1.00", "stellar:USD")
+    p4.balance =
+      Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
     p4.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p4.status = Payment.Status.SUCCESSFUL
     p4.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
@@ -1665,7 +1680,7 @@ class CirclePaymentServiceTest {
             "test tag",
             Account.Capabilities(Network.CIRCLE, Network.STELLAR)
           ),
-          "stellar:USD",
+          "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           BigDecimal(1)
         ),
         hashMapOf(

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -33,6 +33,92 @@ import reactor.netty.http.client.HttpClientResponse
 import shadow.com.google.common.reflect.TypeToken
 
 class CirclePaymentServiceTest {
+  companion object {
+    const val mockWalletToWalletTransferJson =
+      """{
+        "id":"c58e2613-a808-4075-956c-e576787afb3b",
+        "source":{
+          "type":"wallet",
+          "id":"1000066041"
+        },
+        "destination":{
+          "type":"wallet",
+          "id":"1000067536"
+        },
+        "amount":{
+          "amount":"0.91",
+          "currency":"USD"
+        },
+        "status":"pending",
+        "createDate":"2022-01-01T01:01:01.544Z"
+      }"""
+
+    const val mockStellarToWalletTransferJson =
+      """{
+        "id":"7f131f58-a8a0-3dc2-be05-6a015c69de35",
+        "source":{
+          "type":"blockchain",
+          "chain":"XLM"
+        },
+        "destination":{
+          "type":"wallet",
+          "id":"1000066041",
+          "address":"GAYF33NNNMI2Z6VNRFXQ64D4E4SF77PM46NW3ZUZEEU5X7FCHAZCMHKU",
+          "addressTag":"8006436449031889621"
+        },
+        "amount":{
+          "amount":"1.50",
+          "currency":"USD"
+        },
+        "transactionHash":"fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1",
+        "status":"complete",
+        "createDate":"2022-02-07T18:02:17.999Z"
+      }"""
+
+    const val mockWalletToStellarTransferJson =
+      """{
+        "id":"a8997020-3da7-4543-bc4a-5ae8c7ce346d",
+        "source":{
+          "type":"wallet",
+          "id":"1000066041"
+        },
+        "destination":{
+          "type":"blockchain",
+          "address":"GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+          "chain":"XLM"
+        },
+        "amount":{
+          "amount":"1.00",
+          "currency":"USD"
+        },
+        "transactionHash":"5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
+        "status":"complete",
+        "createDate":"2022-02-07T19:50:23.408Z"
+      }"""
+
+    const val mockWalletToWirePayoutJson =
+      """{
+        "id":"6588a352-5131-4711-a264-e405f38d752d",
+        "amount":{
+          "amount":"3.00",
+          "currency":"USD"
+        },
+        "status":"complete",
+        "sourceWalletId":"1000066041",
+        "destination":{
+          "type":"wire",
+          "id":"6c87da10-feb8-484f-822c-2083ed762d25",
+          "name":"JPMORGAN CHASE BANK, NA ****6789"
+        },
+        "fees":{
+          "amount":"25.00",
+          "currency":"USD"
+        },
+        "createDate":"2022-02-03T15:41:25.286Z",
+        "updateDate":"2022-02-03T16:00:31.697Z"  
+      }"""
+  }
+
   private lateinit var server: MockWebServer
   private lateinit var service: PaymentService
 
@@ -635,68 +721,6 @@ class CirclePaymentServiceTest {
   fun test_getTransfers() {
     service.secretKey = "<secret-key>"
 
-    val mockWalletToWalletTransfer =
-      """{
-        "id":"c58e2613-a808-4075-956c-e576787afb3b",
-        "source":{
-          "type":"wallet",
-          "id":"1000066041"
-        },
-        "destination":{
-          "type":"wallet",
-          "id":"1000067536"
-        },
-        "amount":{
-          "amount":"0.91",
-          "currency":"USD"
-        },
-        "status":"pending",
-        "createDate":"2022-01-01T01:01:01.544Z"
-      }"""
-
-    val mockStellarToWalletTransfer =
-      """{
-        "id":"7f131f58-a8a0-3dc2-be05-6a015c69de35",
-        "source":{
-          "type":"blockchain",
-          "chain":"XLM"
-        },
-        "destination":{
-          "type":"wallet",
-          "id":"1000066041",
-          "address":"GAYF33NNNMI2Z6VNRFXQ64D4E4SF77PM46NW3ZUZEEU5X7FCHAZCMHKU",
-          "addressTag":"8006436449031889621"
-        },
-        "amount":{
-          "amount":"1.50",
-          "currency":"USD"
-        },
-        "transactionHash":"fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1",
-        "status":"complete",
-        "createDate":"2022-02-07T18:02:17.999Z"
-       }"""
-
-    val mockWalletToStellarTransfer =
-      """{
-        "id":"a8997020-3da7-4543-bc4a-5ae8c7ce346d",
-        "source":{
-          "type":"wallet",
-          "id":"1000066041"
-        },
-        "destination":{
-          "type":"blockchain",
-          "address":"GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
-          "chain":"XLM"
-        },
-        "amount":{
-          "amount":"1.00",
-          "currency":"USD"
-        },
-        "transactionHash":"5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
-        "status":"complete",
-        "createDate":"2022-02-07T19:50:23.408Z"
-       }"""
-
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -708,9 +732,9 @@ class CirclePaymentServiceTest {
                 .setBody(
                   """{    
                     "data": [
-                      $mockWalletToWalletTransfer,
-                      $mockStellarToWalletTransfer,
-                      $mockWalletToStellarTransfer
+                      $mockWalletToWalletTransferJson,
+                      $mockStellarToWalletTransferJson,
+                      $mockWalletToStellarTransferJson
                     ]
                   }""".trimIndent()
                 )
@@ -750,7 +774,7 @@ class CirclePaymentServiceTest {
     p1.status = Payment.Status.PENDING
     p1.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p1.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
-    p1.originalResponse = gson.fromJson(mockWalletToWalletTransfer, type)
+    p1.originalResponse = gson.fromJson(mockWalletToWalletTransferJson, type)
     wantPaymentHistory.payments.add(p1)
 
     val p2 = Payment()
@@ -762,7 +786,7 @@ class CirclePaymentServiceTest {
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
     p2.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
-    p2.originalResponse = gson.fromJson(mockStellarToWalletTransfer, type)
+    p2.originalResponse = gson.fromJson(mockStellarToWalletTransferJson, type)
     wantPaymentHistory.payments.add(p2)
 
     val p3 = Payment()
@@ -779,92 +803,8 @@ class CirclePaymentServiceTest {
     p3.status = Payment.Status.SUCCESSFUL
     p3.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
     p3.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
-    p3.originalResponse = gson.fromJson(mockWalletToStellarTransfer, type)
+    p3.originalResponse = gson.fromJson(mockWalletToStellarTransferJson, type)
     wantPaymentHistory.payments.add(p3)
-
-    assertEquals(wantPaymentHistory, paymentHistory)
-  }
-
-  @Test
-  fun test_getPayouts() {
-    service.secretKey = "<secret-key>"
-
-    val mockWalletToWirePayout =
-      """{
-      "id":"6588a352-5131-4711-a264-e405f38d752d",
-      "amount":{
-        "amount":"3.00",
-        "currency":"USD"
-      },
-      "status":"complete",
-      "sourceWalletId":"1000066041",
-      "destination":{
-        "type":"wire",
-        "id":"6c87da10-feb8-484f-822c-2083ed762d25",
-        "name":"JPMORGAN CHASE BANK, NA ****6789"
-      },
-      "fees":{
-        "amount":"25.00",
-        "currency":"USD"
-      },
-      "createDate":"2022-02-03T15:41:25.286Z",
-      "updateDate":"2022-02-03T16:00:31.697Z"  
-    }"""
-
-    val dispatcher: Dispatcher =
-      object : Dispatcher() {
-        @Throws(InterruptedException::class)
-        override fun dispatch(request: RecordedRequest): MockResponse {
-          when (request.path) {
-            "/v1/payouts?pageSize=50&source=1000066041" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{    
-                    "data": [
-                      $mockWalletToWirePayout
-                    ]
-                  }""".trimIndent()
-                )
-            "/v1/configuration" -> return getDistAccountIdMockResponse()
-          }
-          return MockResponse().setResponseCode(404)
-        }
-      }
-    server.dispatcher = dispatcher
-
-    val merchantAccount =
-      Account(
-        Network.CIRCLE,
-        "1000066041",
-        Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
-      )
-    val getPayoutsMono = (service as CirclePaymentService)._getPayouts("1000066041", null, null, 50)
-    var paymentHistory: PaymentHistory? = null
-    assertDoesNotThrow {
-      paymentHistory = getPayoutsMono.block()!!.toPaymentHistory(50, merchantAccount)
-    }
-
-    val wantPaymentHistory = PaymentHistory(merchantAccount)
-    wantPaymentHistory.beforeCursor = "6588a352-5131-4711-a264-e405f38d752d"
-
-    val p = Payment()
-    p.id = "6588a352-5131-4711-a264-e405f38d752d"
-    p.sourceAccount = merchantAccount
-    p.destinationAccount =
-      Account(
-        Network.BANK_WIRE,
-        "6c87da10-feb8-484f-822c-2083ed762d25",
-        Account.Capabilities(Network.BANK_WIRE)
-      )
-    p.balance = Balance("3.00", "iso4217:USD")
-    p.status = Payment.Status.SUCCESSFUL
-    p.createdAt = CircleDateFormatter.stringToDate("2022-02-03T15:41:25.286Z")
-    p.updatedAt = CircleDateFormatter.stringToDate("2022-02-03T16:00:31.697Z")
-    val gson = Gson()
-    val type = object : TypeToken<Map<String?, *>?>() {}.type
-    p.originalResponse = gson.fromJson(mockWalletToWirePayout, type)
-    wantPaymentHistory.payments.add(p)
 
     assertEquals(wantPaymentHistory, paymentHistory)
   }
@@ -872,46 +812,6 @@ class CirclePaymentServiceTest {
   @Test
   fun test_getTransfers_paginationResponse() {
     service.secretKey = "<secret-key>"
-
-    val mockWalletToWalletTransfer =
-      """{
-        "id":"c58e2613-a808-4075-956c-e576787afb3b",
-        "source":{
-          "type":"wallet",
-          "id":"1000066041"
-        },
-        "destination":{
-          "type":"wallet",
-          "id":"1000067536"
-        },
-        "amount":{
-          "amount":"0.91",
-          "currency":"USD"
-        },
-        "status":"pending",
-        "createDate":"2022-01-01T01:01:01.544Z"
-      }"""
-
-    val mockWalletToStellarTransfer =
-      """{
-        "id":"a8997020-3da7-4543-bc4a-5ae8c7ce346d",
-        "source":{
-          "type":"wallet",
-          "id":"1000066041"
-        },
-        "destination":{
-          "type":"blockchain",
-          "address":"GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
-          "chain":"XLM"
-        },
-        "amount":{
-          "amount":"1.00",
-          "currency":"USD"
-        },
-        "transactionHash":"5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
-        "status":"complete",
-        "createDate":"2022-02-07T19:50:23.408Z"
-       }"""
 
     val dispatcher: Dispatcher =
       object : Dispatcher() {
@@ -924,8 +824,8 @@ class CirclePaymentServiceTest {
                 .setBody(
                   """{    
                     "data": [
-                      $mockWalletToWalletTransfer,
-                      $mockWalletToStellarTransfer
+                      $mockWalletToWalletTransferJson,
+                      $mockWalletToStellarTransferJson
                     ]
                   }""".trimIndent()
                 )
@@ -966,7 +866,7 @@ class CirclePaymentServiceTest {
     p1.status = Payment.Status.PENDING
     p1.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p1.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
-    p1.originalResponse = gson.fromJson(mockWalletToWalletTransfer, type)
+    p1.originalResponse = gson.fromJson(mockWalletToWalletTransferJson, type)
     wantPaymentHistory.payments.add(p1)
 
     val p2 = Payment()
@@ -983,8 +883,70 @@ class CirclePaymentServiceTest {
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
     p2.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
-    p2.originalResponse = gson.fromJson(mockWalletToStellarTransfer, type)
+    p2.originalResponse = gson.fromJson(mockWalletToStellarTransferJson, type)
     wantPaymentHistory.payments.add(p2)
+
+    assertEquals(wantPaymentHistory, paymentHistory)
+  }
+
+  @Test
+  fun test_getPayouts() {
+    service.secretKey = "<secret-key>"
+
+    val dispatcher: Dispatcher =
+      object : Dispatcher() {
+        @Throws(InterruptedException::class)
+        override fun dispatch(request: RecordedRequest): MockResponse {
+          when (request.path) {
+            "/v1/payouts?pageSize=50&source=1000066041" ->
+              return MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                  """{    
+                    "data": [
+                      $mockWalletToWirePayoutJson
+                    ]
+                  }""".trimIndent()
+                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
+          }
+          return MockResponse().setResponseCode(404)
+        }
+      }
+    server.dispatcher = dispatcher
+
+    val merchantAccount =
+      Account(
+        Network.CIRCLE,
+        "1000066041",
+        Account.Capabilities(Network.CIRCLE, Network.STELLAR, Network.BANK_WIRE)
+      )
+    val getPayoutsMono = (service as CirclePaymentService)._getPayouts("1000066041", null, null, 50)
+    var paymentHistory: PaymentHistory? = null
+    assertDoesNotThrow {
+      paymentHistory = getPayoutsMono.block()!!.toPaymentHistory(50, merchantAccount)
+    }
+
+    val wantPaymentHistory = PaymentHistory(merchantAccount)
+    wantPaymentHistory.beforeCursor = "6588a352-5131-4711-a264-e405f38d752d"
+
+    val p = Payment()
+    p.id = "6588a352-5131-4711-a264-e405f38d752d"
+    p.sourceAccount = merchantAccount
+    p.destinationAccount =
+      Account(
+        Network.BANK_WIRE,
+        "6c87da10-feb8-484f-822c-2083ed762d25",
+        Account.Capabilities(Network.BANK_WIRE)
+      )
+    p.balance = Balance("3.00", "iso4217:USD")
+    p.status = Payment.Status.SUCCESSFUL
+    p.createdAt = CircleDateFormatter.stringToDate("2022-02-03T15:41:25.286Z")
+    p.updatedAt = CircleDateFormatter.stringToDate("2022-02-03T16:00:31.697Z")
+    val gson = Gson()
+    val type = object : TypeToken<Map<String?, *>?>() {}.type
+    p.originalResponse = gson.fromJson(mockWalletToWirePayoutJson, type)
+    wantPaymentHistory.payments.add(p)
 
     assertEquals(wantPaymentHistory, paymentHistory)
   }
@@ -992,28 +954,6 @@ class CirclePaymentServiceTest {
   @Test
   fun test_getPayouts_paginationResponse() {
     service.secretKey = "<secret-key>"
-
-    val mockWalletToWirePayout =
-      """{
-        "id":"6588a352-5131-4711-a264-e405f38d752d",
-        "amount":{
-          "amount":"3.00",
-          "currency":"USD"
-        },
-        "status":"complete",
-        "sourceWalletId":"1000066041",
-        "destination":{
-          "type":"wire",
-          "id":"6c87da10-feb8-484f-822c-2083ed762d25",
-          "name":"JPMORGAN CHASE BANK, NA ****6789"
-        },
-        "fees":{
-          "amount":"25.00",
-          "currency":"USD"
-        },
-        "createDate":"2022-02-03T15:41:25.286Z",
-        "updateDate":"2022-02-03T16:00:31.697Z"  
-      }"""
 
     val dispatcher: Dispatcher =
       object : Dispatcher() {
@@ -1026,7 +966,7 @@ class CirclePaymentServiceTest {
                 .setBody(
                   """{    
                     "data": [
-                      $mockWalletToWirePayout
+                      $mockWalletToWirePayoutJson
                     ]
                   }""".trimIndent()
                 )
@@ -1069,7 +1009,7 @@ class CirclePaymentServiceTest {
     p.updatedAt = CircleDateFormatter.stringToDate("2022-02-03T16:00:31.697Z")
     val gson = Gson()
     val type = object : TypeToken<Map<String?, *>?>() {}.type
-    p.originalResponse = gson.fromJson(mockWalletToWirePayout, type)
+    p.originalResponse = gson.fromJson(mockWalletToWirePayoutJson, type)
     wantPaymentHistory.payments.add(p)
 
     assertEquals(wantPaymentHistory, paymentHistory)

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -50,7 +50,7 @@ class CirclePaymentServiceTest {
           "currency":"USD"
         },
         "status":"pending",
-        "createDate":"2022-01-01T01:01:01.544Z"
+        "createDate":"2022-02-07T19:50:23.408Z"
       }"""
 
     const val mockStellarToWalletTransferJson =
@@ -93,7 +93,7 @@ class CirclePaymentServiceTest {
         },
         "transactionHash":"5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
         "status":"complete",
-        "createDate":"2022-02-07T19:50:23.408Z"
+        "createDate":"2022-01-01T01:01:01.544Z"
       }"""
 
     const val mockWalletToWirePayoutJson =
@@ -1031,8 +1031,8 @@ class CirclePaymentServiceTest {
       Account(Network.CIRCLE, "1000067536", Account.Capabilities(Network.CIRCLE, Network.STELLAR))
     p1.balance = Balance("0.91", "circle:USD")
     p1.status = Payment.Status.PENDING
-    p1.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
-    p1.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    p1.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
+    p1.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
     p1.originalResponse = gson.fromJson(mockWalletToWalletTransferJson, type)
     wantPaymentHistory.payments.add(p1)
 
@@ -1060,8 +1060,8 @@ class CirclePaymentServiceTest {
     p3.balance = Balance("1.00", "stellar:USD")
     p3.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p3.status = Payment.Status.SUCCESSFUL
-    p3.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
-    p3.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
+    p3.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    p3.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p3.originalResponse = gson.fromJson(mockWalletToStellarTransferJson, type)
     wantPaymentHistory.payments.add(p3)
 
@@ -1123,8 +1123,8 @@ class CirclePaymentServiceTest {
       Account(Network.CIRCLE, "1000067536", Account.Capabilities(Network.CIRCLE, Network.STELLAR))
     p1.balance = Balance("0.91", "circle:USD")
     p1.status = Payment.Status.PENDING
-    p1.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
-    p1.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    p1.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
+    p1.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
     p1.originalResponse = gson.fromJson(mockWalletToWalletTransferJson, type)
     wantPaymentHistory.payments.add(p1)
 
@@ -1140,8 +1140,8 @@ class CirclePaymentServiceTest {
     p2.balance = Balance("1.00", "stellar:USD")
     p2.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p2.status = Payment.Status.SUCCESSFUL
-    p2.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
-    p2.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
+    p2.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    p2.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p2.originalResponse = gson.fromJson(mockWalletToStellarTransferJson, type)
     wantPaymentHistory.payments.add(p2)
 

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -1203,7 +1203,7 @@ class CirclePaymentServiceTest {
       )
     p2.destinationAccount = merchantAccount
     p2.balance = Balance("1.50", "circle:USD")
-    p2.txHash = "fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1"
+    p2.idTag = "fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1"
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
     p2.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
@@ -1221,7 +1221,7 @@ class CirclePaymentServiceTest {
       )
     p3.balance =
       Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
-    p3.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
+    p3.idTag = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p3.status = Payment.Status.SUCCESSFUL
     p3.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p3.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
@@ -1300,7 +1300,7 @@ class CirclePaymentServiceTest {
       )
     p2.balance =
       Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
-    p2.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
+    p2.idTag = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p2.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
@@ -1598,7 +1598,7 @@ class CirclePaymentServiceTest {
       )
     p2.destinationAccount = merchantAccount
     p2.balance = Balance("1.50", "circle:USD")
-    p2.txHash = "fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1"
+    p2.idTag = "fb8947c67856d8eb444211c1927d92bcf14abcfb34cdd27fc9e604b15d208fd1"
     p2.status = Payment.Status.SUCCESSFUL
     p2.createdAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
     p2.updatedAt = CircleDateFormatter.stringToDate("2022-02-07T18:02:17.999Z")
@@ -1632,7 +1632,7 @@ class CirclePaymentServiceTest {
       )
     p4.balance =
       Balance("1.00", "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
-    p4.txHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
+    p4.idTag = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
     p4.status = Payment.Status.SUCCESSFUL
     p4.createdAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
     p4.updatedAt = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -82,6 +82,20 @@ class CirclePaymentServiceTest {
   private lateinit var server: MockWebServer
   private lateinit var service: PaymentService
 
+  private fun getDistAccountIdMockResponse(masterWalletId: String = "1000066041"): MockResponse {
+    return MockResponse()
+      .addHeader("Content-Type", "application/json")
+      .setBody(
+        """{
+          "data":{
+            "payments":{
+              "masterWalletId":"$masterWalletId"
+            }
+          }
+        }"""
+      )
+  }
+
   @BeforeEach
   @Throws(IOException::class)
   fun setUp() {
@@ -141,19 +155,7 @@ class CirclePaymentServiceTest {
 
   @Test
   fun testGetDistributionAccountAddress() {
-    val response =
-      MockResponse()
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-          """{
-                        "data":{
-                            "payments":{
-                                "masterWalletId":"1000066041"
-                            }
-                        }
-                    }"""
-        )
-    server.enqueue(response)
+    server.enqueue(getDistAccountIdMockResponse())
 
     var masterWalletId: String? = null
     assertDoesNotThrow { masterWalletId = service.distributionAccountAddress.block() }
@@ -166,7 +168,6 @@ class CirclePaymentServiceTest {
     assertThat(request.path, CoreMatchers.endsWith("/v1/configuration"))
 
     // check if cached version doesn't freeze the thread
-    server.enqueue(response)
     assertDoesNotThrow { masterWalletId = service.distributionAccountAddress.block() }
     assertEquals("1000066041", masterWalletId)
   }
@@ -339,18 +340,7 @@ class CirclePaymentServiceTest {
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
           when (request.path) {
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                                    "data":{
-                                        "payments":{
-                                            "masterWalletId":"1000066041"
-                                        }
-                                    }
-                            }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
             "/v1/businessAccount/balances" ->
               return MockResponse()
                 .addHeader("Content-Type", "application/json")
@@ -481,18 +471,7 @@ class CirclePaymentServiceTest {
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
           when (request.path) {
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                                    "data":{
-                                        "payments":{
-                                            "masterWalletId":"1000066041"
-                                        }
-                                    }
-                            }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
             "/v1/payouts" ->
               return MockResponse()
                 .addHeader("Content-Type", "application/json")
@@ -781,18 +760,7 @@ class CirclePaymentServiceTest {
                     ]
                   }""".trimIndent()
                 )
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                    "data":{
-                      "payments":{
-                        "masterWalletId":"1000066041"
-                      }
-                    }
-                  }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
           }
           return MockResponse().setResponseCode(404)
         }
@@ -913,18 +881,7 @@ class CirclePaymentServiceTest {
                     ]
                   }""".trimIndent()
                 )
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                    "data":{
-                      "payments":{
-                        "masterWalletId":"1000066041"
-                      }
-                    }
-                  }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
           }
           return MockResponse().setResponseCode(404)
         }
@@ -1039,18 +996,7 @@ class CirclePaymentServiceTest {
                     ]
                   }""".trimIndent()
                 )
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                    "data":{
-                      "payments":{
-                        "masterWalletId":"1000066041"
-                      }
-                    }
-                  }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
           }
           return MockResponse().setResponseCode(404)
         }
@@ -1148,17 +1094,7 @@ class CirclePaymentServiceTest {
           }
 
           if (request.path.equals("/v1/configuration")) {
-            return MockResponse()
-              .addHeader("Content-Type", "application/json")
-              .setBody(
-                """{
-                  "data":{
-                    "payments":{
-                      "masterWalletId":"1000066041"
-                    }
-                  }
-                }"""
-              )
+            return getDistAccountIdMockResponse()
           }
 
           return MockResponse().setResponseCode(404)
@@ -1208,18 +1144,7 @@ class CirclePaymentServiceTest {
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
           when (request.path) {
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                                    "data":{
-                                        "payments":{
-                                            "masterWalletId":"1000066041"
-                                        }
-                                    }
-                            }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
             "/v1/transfers" ->
               return MockResponse()
                 .addHeader("Content-Type", "application/json")
@@ -1339,18 +1264,7 @@ class CirclePaymentServiceTest {
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
           when (request.path) {
-            "/v1/configuration" ->
-              return MockResponse()
-                .addHeader("Content-Type", "application/json")
-                .setBody(
-                  """{
-                                    "data":{
-                                        "payments":{
-                                            "masterWalletId":"1000066041"
-                                        }
-                                    }
-                            }"""
-                )
+            "/v1/configuration" -> return getDistAccountIdMockResponse()
             "/v1/transfers" ->
               return MockResponse()
                 .addHeader("Content-Type", "application/json")
@@ -1489,18 +1403,7 @@ class CirclePaymentServiceTest {
         .setResponseCode(400)
         .addHeader("Content-Type", "application/json")
         .setBody("{\"code\":2,\"message\":\"Request body contains unprocessable entity.\"}")
-    val validateSecretKeyResponse =
-      MockResponse()
-        .addHeader("Content-Type", "application/json")
-        .setBody(
-          """{
-                        "data":{
-                            "payments":{
-                                "masterWalletId":"1000066041"
-                            }
-                        }
-                    }"""
-        )
+    val validateSecretKeyResponse = getDistAccountIdMockResponse()
     val mainAccountResponse =
       MockResponse()
         .addHeader("Content-Type", "application/json")

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CircleResponseErrorHandlerTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CircleResponseErrorHandlerTest.kt
@@ -1,0 +1,54 @@
+package org.stellar.anchor.paymentservice.circle
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.netty.handler.codec.http.HttpResponseStatus
+import java.io.IOException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.exception.HttpException
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer
+import reactor.core.publisher.Mono
+import reactor.netty.ByteBufMono
+import reactor.netty.http.client.HttpClientResponse
+
+class CircleResponseErrorHandlerTest {
+  internal class CircleResponseErrorHandlerImpl : CircleResponseErrorHandler {}
+
+  private lateinit var gson: Gson
+
+  @BeforeEach
+  @Throws(IOException::class)
+  fun setUp() {
+    gson =
+      GsonBuilder()
+        .registerTypeAdapter(CircleTransfer::class.java, CircleTransfer.Serialization())
+        .create()
+  }
+
+  @Test
+  fun test_private_handleCircleError() {
+    // mock objects
+    val response = mockk<HttpClientResponse>()
+    every { response.status() } returns HttpResponseStatus.BAD_REQUEST
+
+    val bodyBytesMono = mockk<ByteBufMono>()
+    every { bodyBytesMono.asString() } returns
+      Mono.just("{\"code\":2,\"message\":\"Request body contains unprocessable entity.\"}")
+
+    // run and test
+    val impl = CircleResponseErrorHandlerImpl()
+    val ex =
+      assertThrows<HttpException> {
+        impl.handleResponseSingle().apply(response, bodyBytesMono).block()
+      }
+    verify { response.status() }
+    verify { bodyBytesMono.asString() }
+    assertEquals(HttpException(400, "Request body contains unprocessable entity.", "2"), ex)
+  }
+}

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/ErrorHandlingTestCase.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/ErrorHandlingTestCase.kt
@@ -1,0 +1,53 @@
+package org.stellar.anchor.paymentservice.circle
+
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import reactor.core.publisher.Mono
+
+class ErrorHandlingTestCase {
+  val requestMono: Mono<*>
+  private var mockResponses: List<MockResponse>? = null
+  var mockResponsesMap: Map<String, MockResponse>? = null
+    private set
+
+  constructor(_requestMono: Mono<*>, _mockResponses: List<MockResponse>) {
+    this.requestMono = _requestMono
+    this.mockResponses = _mockResponses
+  }
+
+  constructor(_requestMono: Mono<*>, _mockResponsesMap: Map<String, MockResponse>) {
+    this.requestMono = _requestMono
+    this.mockResponsesMap = _mockResponsesMap
+  }
+
+  private fun getDispatcher(): Dispatcher? {
+    if (mockResponsesMap == null) {
+      return null
+    }
+
+    val dispatcher: Dispatcher =
+      object : Dispatcher() {
+        @Throws(InterruptedException::class)
+        override fun dispatch(request: RecordedRequest): MockResponse {
+
+          if (!mockResponsesMap!!.containsKey(request.path)) {
+            return MockResponse().setResponseCode(404)
+          }
+
+          return mockResponsesMap!![request.path]!!
+        }
+      }
+    return dispatcher
+  }
+
+  fun prepareMockWebServer(server: MockWebServer) {
+    val dispatcher = getDispatcher()
+    if (dispatcher != null) {
+      server.dispatcher = dispatcher
+    } else if (mockResponses != null) {
+      mockResponses!!.forEach { mockResponse -> server.enqueue(mockResponse) }
+    }
+  }
+}

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/StellarReconciliationTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/StellarReconciliationTest.kt
@@ -1,0 +1,94 @@
+package org.stellar.anchor.paymentservice.circle
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import io.mockk.every
+import io.mockk.mockk
+import java.io.IOException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.stellar.anchor.paymentservice.circle.model.CircleTransfer
+import org.stellar.sdk.Server
+import org.stellar.sdk.responses.GsonSingleton
+import org.stellar.sdk.responses.Page
+import org.stellar.sdk.responses.operations.OperationResponse
+import shadow.com.google.common.reflect.TypeToken
+
+class StellarReconciliationTest {
+  internal class StellarReconciliationImpl : StellarReconciliation {
+
+    private var horizonServer: Server? = null
+
+    override fun getHorizonServer(): Server {
+      if (horizonServer == null) {
+        val type = (object : TypeToken<Page<OperationResponse>>() {}).type
+        val mockStellarPaymentResponsePage: Page<OperationResponse> =
+          GsonSingleton.getInstance()
+            .fromJson(CirclePaymentServiceTest.mockStellarPaymentResponsePageBody, type)
+        horizonServer = mockk<Server>()
+        every { horizonServer!!.payments().forTransaction(any()).execute() } returns
+          mockStellarPaymentResponsePage
+      }
+
+      return horizonServer!!
+    }
+  }
+
+  private lateinit var gson: Gson
+
+  @BeforeEach
+  @Throws(IOException::class)
+  fun setUp() {
+    gson =
+      GsonBuilder()
+        .registerTypeAdapter(CircleTransfer::class.java, CircleTransfer.Serialization())
+        .create()
+  }
+
+  @Test
+  fun test_updateTransferStellarSender() {
+    val originalTransfer =
+      gson.fromJson(
+        CirclePaymentServiceTest.mockStellarToWalletTransferJson,
+        CircleTransfer::class.java
+      )
+
+    assertNull(originalTransfer.source.address)
+
+    val updatedTransfer = gson.fromJson(gson.toJson(originalTransfer), CircleTransfer::class.java)
+    val impl = StellarReconciliationImpl()
+    impl.updateStellarSenderAddress(updatedTransfer)
+    assertEquals(
+      "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+      updatedTransfer.source.address
+    )
+
+    assertNull(originalTransfer.source.address)
+  }
+
+  @Test
+  fun test_updatedTransferStellarSender() {
+    val originalTransfer =
+      gson.fromJson(
+        CirclePaymentServiceTest.mockStellarToWalletTransferJson,
+        CircleTransfer::class.java
+      )
+
+    assertNull(originalTransfer.source.address)
+
+    val impl = StellarReconciliationImpl()
+    var updatedTransfer: CircleTransfer? = null
+    assertDoesNotThrow {
+      updatedTransfer = impl.updatedStellarSenderAddress(originalTransfer).block()
+    }
+    assertEquals(
+      "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+      updatedTransfer?.source?.address
+    )
+
+    assertNull(originalTransfer.source.address)
+  }
+}

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/model/CircleTransferSerializationTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/model/CircleTransferSerializationTest.kt
@@ -1,0 +1,123 @@
+package org.stellar.anchor.paymentservice.circle.model
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.IOException
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.stellar.anchor.paymentservice.circle.util.CircleDateFormatter
+
+class CircleTransferSerializationTest {
+  private lateinit var gson: Gson
+
+  companion object {
+    const val mockCircleTransferJson =
+      """{
+        "id":"a8997020-3da7-4543-bc4a-5ae8c7ce346d",
+        "source":{
+          "type":"wallet",
+          "id":"1000066041"
+        },
+        "destination":{
+          "type":"blockchain",
+          "address":"GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+          "chain":"XLM"
+        },
+        "amount":{
+          "amount":"1.00",
+          "currency":"USD"
+        },
+        "transactionHash":"5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
+        "status":"complete",
+        "createDate":"2022-01-01T01:01:01.544Z"
+      }"""
+  }
+
+  @BeforeEach
+  @Throws(IOException::class)
+  fun setUp() {
+    gson =
+      GsonBuilder()
+        .registerTypeAdapter(CircleTransfer::class.java, CircleTransfer.Serialization())
+        .create()
+  }
+
+  @Test
+  fun testDeserialize() {
+    val wantTransfer = CircleTransfer()
+    wantTransfer.id = "a8997020-3da7-4543-bc4a-5ae8c7ce346d"
+    wantTransfer.source = CircleTransactionParty.wallet("1000066041")
+    wantTransfer.destination =
+      CircleTransactionParty.stellar(
+        "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+        null
+      )
+    wantTransfer.amount = CircleBalance("USD", "1.00", null)
+    wantTransfer.transactionHash =
+      "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
+    wantTransfer.status = CirclePaymentStatus.COMPLETE
+    wantTransfer.createDate = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    wantTransfer.originalResponse =
+      hashMapOf<String, Any>(
+        "id" to "a8997020-3da7-4543-bc4a-5ae8c7ce346d",
+        "source" to hashMapOf<String, Any>("id" to "1000066041", "type" to "wallet"),
+        "destination" to
+          hashMapOf<String, Any>(
+            "type" to "blockchain",
+            "address" to "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+            "chain" to "XLM"
+          ),
+        "amount" to
+          hashMapOf<String, Any>(
+            "amount" to "1.00",
+            "currency" to "USD",
+          ),
+        "transactionHash" to "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
+        "status" to "complete",
+        "createDate" to "2022-01-01T01:01:01.544Z"
+      )
+
+    val transfer = gson.fromJson(mockCircleTransferJson, CircleTransfer::class.java)
+    assertEquals(wantTransfer, transfer)
+  }
+
+  @Test
+  fun testSerialize() {
+    val transfer = CircleTransfer()
+    transfer.id = "a8997020-3da7-4543-bc4a-5ae8c7ce346d"
+    transfer.source = CircleTransactionParty.wallet("1000066041")
+    transfer.destination =
+      CircleTransactionParty.stellar(
+        "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+        null
+      )
+    transfer.amount = CircleBalance("USD", "1.00", null)
+    transfer.transactionHash = "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef"
+    transfer.status = CirclePaymentStatus.COMPLETE
+    transfer.createDate = CircleDateFormatter.stringToDate("2022-01-01T01:01:01.544Z")
+    transfer.originalResponse =
+      hashMapOf<String, Any>(
+        "id" to "a8997020-3da7-4543-bc4a-5ae8c7ce346d",
+        "source" to hashMapOf<String, Any>("id" to "1000066041", "type" to "wallet"),
+        "destination" to
+          hashMapOf<String, Any>(
+            "type" to "blockchain",
+            "address" to "GAC2OWWDD75GCP4II35UCLYA7JB6LDDZUBZQLYANAVIHIRJAAQBSCL2S",
+            "chain" to "XLM"
+          ),
+        "amount" to
+          hashMapOf<String, Any>(
+            "amount" to "1.00",
+            "currency" to "USD",
+          ),
+        "transactionHash" to "5239ee055b1083231c6bdaaa921d3e4b3bc090577fbd909815bd5d7fe68091ef",
+        "status" to "complete",
+        "createDate" to "2022-01-01T01:01:01.544Z"
+      )
+
+    val transferJson = gson.toJson(transfer)
+    JSONAssert.assertEquals(mockCircleTransferJson, transferJson, true)
+  }
+}

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
@@ -1,45 +1,21 @@
 package org.stellar.anchor.paymentservice.utils
 
-internal class NettyHttpClientTest {
-  //    private lateinit var server: MockWebServer
-  //    private lateinit var httpClient: HttpClient
-  //
-  //    @BeforeEach
-  //    @Throws(IOException::class)
-  //    fun setUp() {
-  //        server = MockWebServer()
-  //        server.start()
-  //        val baseUrl = server.url("").toString()
-  //        httpClient = NettyHttpClient.withBaseUrl(baseUrl)
-  //    }
-  //
-  //    @AfterEach
-  //    fun tearDown() {
-  //        server.shutdown()
-  //    }
-  //
-  //    @Test
-  //    fun testHttpClient_readTimeoutResponse() {
-  //        val timeoutResponse = MockResponse()
-  //            .setBody("{\"foo\": \"bar\"}")
-  //            .setBodyDelay(16, TimeUnit.SECONDS)
-  //        server.enqueue(timeoutResponse)
-  //
-  //        assertThrows<ReadTimeoutException> {
-  // httpClient.get().responseContent().aggregate().asString().block() }
-  //    }
-  //
-  //    @Test
-  //    @Timeout(value = 5500, unit = TimeUnit.MILLISECONDS)
-  //    fun testHttpClient_connectionTimeout() {
-  //
-  // server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.SHUTDOWN_SERVER_AFTER_RESPONSE))
-  //
-  //        // throws from the second time onwards because of the option
-  // SocketPolicy.SHUTDOWN_SERVER_AFTER_RESPONSE
-  //        assertDoesNotThrow { httpClient.get().responseContent().aggregate().asString().block() }
-  //        val ex = assertThrows<RuntimeException> {
-  // httpClient.get().responseContent().aggregate().asString().block() }
-  //        assertNotEquals(-1, ExceptionUtils.indexOfThrowable(ex, ConnectException::class.java))
-  //    }
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.paymentservice.circle.util.NettyHttpClient
+
+class NettyHttpClientTest {
+  @Test
+  fun testUriWithParams() {
+    assertEquals("/", NettyHttpClient.uriWithParams(null, null))
+    assertEquals("/foo", NettyHttpClient.uriWithParams("/foo", null))
+    assertEquals("/foo", NettyHttpClient.uriWithParams("foo", null))
+    assertEquals("/foo/bar", NettyHttpClient.uriWithParams("foo/bar", null))
+    assertEquals("/foo/bar", NettyHttpClient.uriWithParams("/foo/bar", null))
+
+    assertEquals("/?key1=val1", NettyHttpClient.uriWithParams(null, mapOf("key1" to "val1")))
+    assertEquals("/foo?key1=val1", NettyHttpClient.uriWithParams("/foo", mapOf("key1" to "val1")))
+    val queryParams = mapOf("key1" to "val1", "key2" to "val2")
+    assertEquals("/foo?key1=val1&key2=val2", NettyHttpClient.uriWithParams("/foo", queryParams))
+  }
 }

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
@@ -13,9 +13,14 @@ class NettyHttpClientTest {
     assertEquals("/foo/bar", NettyHttpClient.uriWithParams("foo/bar", null))
     assertEquals("/foo/bar", NettyHttpClient.uriWithParams("/foo/bar", null))
 
-    assertEquals("/?key1=val1", NettyHttpClient.uriWithParams(null, mapOf("key1" to "val1")))
-    assertEquals("/foo?key1=val1", NettyHttpClient.uriWithParams("/foo", mapOf("key1" to "val1")))
-    val queryParams = mapOf("key1" to "val1", "key2" to "val2")
+    assertEquals("/?key1=val1", NettyHttpClient.uriWithParams(null, linkedMapOf("key1" to "val1")))
+    assertEquals(
+      "/foo?key1=val1",
+      NettyHttpClient.uriWithParams("/foo", linkedMapOf("key1" to "val1"))
+    )
+    var queryParams = linkedMapOf("key1" to "val1", "key2" to "val2")
     assertEquals("/foo?key1=val1&key2=val2", NettyHttpClient.uriWithParams("/foo", queryParams))
+    queryParams = linkedMapOf("key2" to "val2", "key1" to "val1")
+    assertEquals("/foo?key2=val2&key1=val1", NettyHttpClient.uriWithParams("/foo", queryParams))
   }
 }

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/utils/NettyHttpClientTest.kt
@@ -6,21 +6,18 @@ import org.stellar.anchor.paymentservice.circle.util.NettyHttpClient
 
 class NettyHttpClientTest {
   @Test
-  fun testUriWithParams() {
-    assertEquals("/", NettyHttpClient.uriWithParams(null, null))
-    assertEquals("/foo", NettyHttpClient.uriWithParams("/foo", null))
-    assertEquals("/foo", NettyHttpClient.uriWithParams("foo", null))
-    assertEquals("/foo/bar", NettyHttpClient.uriWithParams("foo/bar", null))
-    assertEquals("/foo/bar", NettyHttpClient.uriWithParams("/foo/bar", null))
+  fun testBuildUri() {
+    assertEquals("/", NettyHttpClient.buildUri(null, null))
+    assertEquals("/foo", NettyHttpClient.buildUri("/foo", null))
+    assertEquals("/foo", NettyHttpClient.buildUri("foo", null))
+    assertEquals("/foo/bar", NettyHttpClient.buildUri("foo/bar", null))
+    assertEquals("/foo/bar", NettyHttpClient.buildUri("/foo/bar", null))
 
-    assertEquals("/?key1=val1", NettyHttpClient.uriWithParams(null, linkedMapOf("key1" to "val1")))
-    assertEquals(
-      "/foo?key1=val1",
-      NettyHttpClient.uriWithParams("/foo", linkedMapOf("key1" to "val1"))
-    )
+    assertEquals("/?key1=val1", NettyHttpClient.buildUri(null, linkedMapOf("key1" to "val1")))
+    assertEquals("/foo?key1=val1", NettyHttpClient.buildUri("/foo", linkedMapOf("key1" to "val1")))
     var queryParams = linkedMapOf("key1" to "val1", "key2" to "val2")
-    assertEquals("/foo?key1=val1&key2=val2", NettyHttpClient.uriWithParams("/foo", queryParams))
+    assertEquals("/foo?key1=val1&key2=val2", NettyHttpClient.buildUri("/foo", queryParams))
     queryParams = linkedMapOf("key2" to "val2", "key1" to "val1")
-    assertEquals("/foo?key2=val2&key1=val1", NettyHttpClient.uriWithParams("/foo", queryParams))
+    assertEquals("/foo?key2=val2&key1=val1", NettyHttpClient.buildUri("/foo", queryParams))
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Implement `CirclePaymentService#getAccountHistory` as part of the `PaymentService` implementation. This implementation is a bit non conventional because it aggregates results from multiple endpoints into one, since Circle history is distributed across multiple endpoints:
* `GET /v1/transfers` returns CircleWallet->CircleWallet, CircleWallet->Stellar and Stellar->CircleWallet results.
* `GET /v1/payouts` returns CircleWallet->BankWire results.
* (not implemented) `GET /v1/payments` returns BankWire->CircleWallet and CreditCard->CircleWallet

### Further discussion

When we aggregate results from multiple endpoints, we mess with the consistency of page sizes: if one of the endpoints has more pages than the other, the page sizes will look like this:
* Page 1: 100 results
* Page 2: 53 results
* Page 3...(n-1): 50 results
* Page n: x<50 results

Instead of aggregating the results from multiple endpoints, we could alternatively change the signature of [`getAccountPaymentHistory`](https://github.com/stellar/java-stellar-anchor-sdk/blob/a72b81518d3ca290734f2b76f5e7eece73aed8a1/core/src/main/java/org/stellar/anchor/paymentservice/PaymentService.java#L68-L70) to contemplate which network we want to read status from, something like:

```java
Mono<PaymentHistory> getAccountPaymentHistory(
      String accountID, 
      Network networkOfInterest,
      @Nullable String beforeCursor,
      @Nullable String afterCursor
) throws HttpException;
```

This would increase the complexity on the Anchor side though.