### PR TITLE
payment-circle: polish responses and code

### DIFF
--- a/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
+++ b/core/src/main/java/org/stellar/anchor/paymentservice/Account.java
@@ -24,14 +24,14 @@ public class Account {
    */
   @NonNull public Account.Capabilities capabilities;
 
-  @NonNull public List<Balance> balances = new ArrayList<>();
+  @Nullable public List<Balance> balances;
 
   /**
    * The list of not-yet-available balances that are expected to settle shortly. These balances
    * could be cancelled or returned, in which cases they may never become available in the user
    * account.
    */
-  @NonNull public List<Balance> unsettledBalances = new ArrayList<>();
+  @Nullable public List<Balance> unsettledBalances;
 
   public Account(
       @NonNull PaymentNetwork paymentNetwork,

--- a/docs/payment-circle.md
+++ b/docs/payment-circle.md
@@ -157,7 +157,7 @@ Usage:
 // CircleWallet->CircleWallet
 Account source = new Account(PaymentNetwork.CIRCLE, "1000066041", Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR));
 Account destination = new Account(PaymentNetwork.CIRCLE, "1000067536", Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR));
-String currencyName = "circle:USD";
+String currencyName = CircleAsset.circleUSD();
 Payment payment = service.sendPayment(source, destination, currencyName, BigDecimal.valueOf(0.91)).block();
 System.out.println(payment);
 
@@ -172,7 +172,7 @@ System.out.println(payment);
 Account source = new Account(PaymentNetwork.CIRCLE, "1000066041", Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR));
 // The bank wire account should have been created in advance directly in Circle
 Account destination = new Account(PaymentNetwork.BANK_WIRE, "6c87da10-feb8-484f-822c-2083ed762d25", "test@mail.com", Account.Capabilities());
-String currencyName = "iso4217:USD";
+String currencyName = CircleAsset.fiatUSD();
 Payment payment = service.sendPayment(source, destination, currencyName, BigDecimal.valueOf(0.91)).block();
 System.out.println(payment);
 ```
@@ -186,17 +186,17 @@ Usage:
 
 ```java
 // Deposit requirements to receive CircleWallet<-CircleWallet payments
-DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.CIRCLE, "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.CIRCLE, CircleAsset.circleUSD());
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 
 // Deposit requirements to receive CircleWallet<-Stellar payments
-DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.STELLAR, "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.STELLAR, CircleAsset.circleUSD());
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 
 // Deposit requirements to receive CircleWallet<-BankWire payments
-DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, "a4e76642-81c5-47ca-9229-ebd64efd74a7", "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, "a4e76642-81c5-47ca-9229-ebd64efd74a7", CircleAsset.circleUSD());
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 ```

--- a/docs/payment-circle.md
+++ b/docs/payment-circle.md
@@ -186,17 +186,17 @@ Usage:
 
 ```java
 // Deposit requirements to receive CircleWallet<-CircleWallet payments
-DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.CIRCLE, "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.CIRCLE, "circle:USD");
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 
 // Deposit requirements to receive CircleWallet<-Stellar payments
-DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.STELLAR, "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", PaymentNetwork.STELLAR, "circle:USD");
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 
 // Deposit requirements to receive CircleWallet<-BankWire payments
-DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, "circle:USD");
+DepositRequirements config = DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, "a4e76642-81c5-47ca-9229-ebd64efd74a7", "circle:USD");
 DepositInstructions instructions = service.getDepositInstructions(config).block();
 System.out.println(instructions);
 ```

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -335,7 +335,7 @@ public class CirclePaymentService
     String afterTransfer = null, afterPayout = null, afterPayment = null;
     if (beforeCursor != null) {
       String[] beforeCursors = beforeCursor.split(":");
-      if (beforeCursors.length < 2) {
+      if (beforeCursors.length < 3) {
         throw new HttpException(400, "invalid before cursor");
       }
       beforeTransfer = beforeCursors[0];
@@ -344,7 +344,7 @@ public class CirclePaymentService
     }
     if (afterCursor != null) {
       String[] afterCursors = afterCursor.split(":");
-      if (afterCursors.length < 2) {
+      if (afterCursors.length < 3) {
         throw new HttpException(400, "invalid after cursor");
       }
       afterTransfer = afterCursors[0];
@@ -374,17 +374,17 @@ public class CirclePaymentService
               PaymentHistory paymentsHistory = args.getT4().toPaymentHistory(pageSize, account);
               PaymentHistory result = new PaymentHistory(account);
 
-              String befTransfer = transfersHistory.getBeforeCursor();
-              String befPayout = payoutsHistory.getBeforeCursor();
-              String befPayment = paymentsHistory.getBeforeCursor();
-              if (befTransfer != null || befPayout != null || befPayment != null) {
+              String befTransfer = Objects.toString(transfersHistory.getBeforeCursor(), "");
+              String befPayout = Objects.toString(payoutsHistory.getBeforeCursor(), "");
+              String befPayment = Objects.toString(paymentsHistory.getBeforeCursor(), "");
+              if (!befTransfer.isEmpty() || !befPayout.isEmpty() || !befPayment.isEmpty()) {
                 result.setBeforeCursor(befTransfer + ":" + befPayout + ":" + befPayment);
               }
 
-              String aftTransfer = transfersHistory.getAfterCursor();
-              String aftPayout = payoutsHistory.getAfterCursor();
-              String aftPayment = paymentsHistory.getAfterCursor();
-              if (aftTransfer != null || aftPayout != null || aftPayment != null) {
+              String aftTransfer = Objects.toString(transfersHistory.getAfterCursor(), "");
+              String aftPayout = Objects.toString(payoutsHistory.getAfterCursor(), "");
+              String aftPayment = Objects.toString(paymentsHistory.getAfterCursor(), "");
+              if (!aftTransfer.isEmpty() || !aftPayout.isEmpty() || !aftPayment.isEmpty()) {
                 result.setAfterCursor(aftTransfer + ":" + aftPayout + ":" + aftPayment);
               }
 

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -444,6 +444,13 @@ public class CirclePaymentService
       throw new HttpException(
           400, "the currency to be sent must contain the destination network schema");
     }
+    if (!CircleAsset.isSupported(currencyName, stellarNetwork)) {
+      throw new HttpException(
+          400,
+          String.format(
+              "the only supported currencies are %s, %s and %s.",
+              "circle:USD", "iso4217:USD", CircleAsset.stellarUSDC(stellarNetwork)));
+    }
   }
 
   /**
@@ -580,10 +587,7 @@ public class CirclePaymentService
     // validate input
     validateSendPaymentInput(sourceAccount, destinationAccount, currencyName);
 
-    String rawCurrencyName =
-        currencyName.replace(destinationAccount.paymentNetwork.getCurrencyPrefix() + ":", "");
-    CircleBalance circleBalance =
-        new CircleBalance(rawCurrencyName, amount.toString(), stellarNetwork);
+    CircleBalance circleBalance = new CircleBalance("USD", amount.toString(), stellarNetwork);
 
     switch (destinationAccount.paymentNetwork) {
       case CIRCLE:

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/CirclePaymentService.java
@@ -15,6 +15,7 @@ import org.stellar.anchor.paymentservice.circle.config.CirclePaymentConfig;
 import org.stellar.anchor.paymentservice.circle.model.*;
 import org.stellar.anchor.paymentservice.circle.model.request.CircleSendTransactionRequest;
 import org.stellar.anchor.paymentservice.circle.model.response.*;
+import org.stellar.anchor.paymentservice.circle.util.CircleAsset;
 import org.stellar.anchor.paymentservice.circle.util.NettyHttpClient;
 import org.stellar.sdk.Network;
 import reactor.core.publisher.Mono;
@@ -677,7 +678,7 @@ public class CirclePaymentService
       throw new HttpException(400, "beneficiary account id cannot be empty");
     }
 
-    if (!"circle:USD".equals(config.getBeneficiaryCurrencyName())) {
+    if (!CircleAsset.circleUSD().equals(config.getBeneficiaryCurrencyName())) {
       throw new HttpException(
           400, "the only receiving currency in a circle account is \"circle:USD\"");
     }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBalance.java
@@ -28,8 +28,7 @@ public class CircleBalance {
 
   public Balance toBalance(@NonNull PaymentNetwork destinationPaymentNetwork) {
     String currencyName = destinationPaymentNetwork.getCurrencyPrefix() + ":" + currency;
-    if (currencyName.equals("stellar:USD"))
-      currencyName = destinationPaymentNetwork.getCurrencyPrefix() + ":" + stellarUSDC();
+    if (currencyName.equals("stellar:USD")) currencyName = stellarUSDC();
 
     return new Balance(amount, currencyName);
   }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBlockchainAddress.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleBlockchainAddress.java
@@ -28,8 +28,6 @@ public class CircleBlockchainAddress {
 
   public DepositInstructions toDepositInstructions(
       String beneficiaryAccountId, Network stellarNetwork) {
-    String intermediaryCurrencyName =
-        PaymentNetwork.STELLAR.getCurrencyPrefix() + ":" + CircleAsset.stellarUSDC(stellarNetwork);
     return new DepositInstructions(
         beneficiaryAccountId,
         null,
@@ -37,7 +35,7 @@ public class CircleBlockchainAddress {
         address,
         addressTag,
         PaymentNetwork.STELLAR,
-        intermediaryCurrencyName,
+        CircleAsset.stellarUSDC(stellarNetwork),
         null);
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleTransactionParty.java
@@ -87,14 +87,13 @@ public class CircleTransactionParty {
             new Account.Capabilities(PaymentNetwork.STELLAR));
 
       case WALLET:
-        Account account =
-            new Account(
-                PaymentNetwork.CIRCLE,
-                id,
-                new Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR));
-        boolean isWireEnabled = distributionAccountId != null && distributionAccountId.equals(id);
-        account.capabilities.set(PaymentNetwork.BANK_WIRE, isWireEnabled);
-        return account;
+        boolean isMerchantAccount =
+            distributionAccountId != null && distributionAccountId.equals(id);
+        Account.Capabilities capabilities =
+            isMerchantAccount
+                ? CircleWallet.merchantAccountCapabilities()
+                : CircleWallet.defaultCapabilities();
+        return new Account(PaymentNetwork.CIRCLE, id, capabilities);
 
       case WIRE:
         return new Account(

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.paymentservice.circle.model;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Data;
@@ -41,6 +42,7 @@ public class CircleWallet {
         balances.stream()
             .map(circleBalance -> circleBalance.toBalance(PaymentNetwork.CIRCLE))
             .collect(Collectors.toList()));
+    account.setUnsettledBalances(new ArrayList<>());
     return account;
   }
 

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -15,17 +15,24 @@ public class CircleWallet {
   String description;
   List<CircleBalance> balances;
 
-  public CircleWallet() {}
-
   public CircleWallet(String walletId) {
     this.walletId = walletId;
   }
 
   public Account.Capabilities getCapabilities() {
+    return "merchant".equals(type) ? merchantAccountCapabilities() : defaultCapabilities();
+  }
+
+  public static Account.Capabilities defaultCapabilities() {
     Account.Capabilities capabilities =
         new Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR);
-    capabilities.set(PaymentNetwork.BANK_WIRE, "merchant".equals(type));
+    capabilities.getSend().put(PaymentNetwork.BANK_WIRE, true);
     return capabilities;
+  }
+
+  public static Account.Capabilities merchantAccountCapabilities() {
+    return new Account.Capabilities(
+        PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR, PaymentNetwork.BANK_WIRE);
   }
 
   public Account toAccount() {

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWallet.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import org.stellar.anchor.paymentservice.Account;
 import org.stellar.anchor.paymentservice.DepositInstructions;
 import org.stellar.anchor.paymentservice.PaymentNetwork;
+import org.stellar.anchor.paymentservice.circle.util.CircleAsset;
 
 @Data
 public class CircleWallet {
@@ -54,7 +55,7 @@ public class CircleWallet {
         walletId,
         null,
         PaymentNetwork.CIRCLE,
-        "circle:USD",
+        CircleAsset.circleUSD(),
         null);
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWireDepositInstructions.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/CircleWireDepositInstructions.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import lombok.Data;
 import org.stellar.anchor.paymentservice.DepositInstructions;
 import org.stellar.anchor.paymentservice.PaymentNetwork;
+import org.stellar.anchor.paymentservice.circle.util.CircleAsset;
 import org.stellar.sdk.responses.GsonSingleton;
 import shadow.com.google.common.reflect.TypeToken;
 import shadow.com.google.gson.Gson;
@@ -45,7 +46,7 @@ public class CircleWireDepositInstructions {
         trackingRef,
         null,
         PaymentNetwork.BANK_WIRE,
-        "iso4217:USD",
+        CircleAsset.fiatUSD(),
         originalResponse);
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -21,7 +21,7 @@ public class CircleSendTransactionRequest {
     CircleSendTransactionRequest req = new CircleSendTransactionRequest();
     req.source = source;
     req.destination = destination;
-    if (amount.stellarUSDC().equals(amount.getCurrency())) amount.setCurrency("USD");
+    if (amount.stellarUSDC().equals("stellar:" + amount.getCurrency())) amount.setCurrency("USD");
     req.amount = amount;
     req.idempotencyKey = idempotencyKey;
     return req;

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/model/request/CircleSendTransactionRequest.java
@@ -21,7 +21,6 @@ public class CircleSendTransactionRequest {
     CircleSendTransactionRequest req = new CircleSendTransactionRequest();
     req.source = source;
     req.destination = destination;
-    if (amount.stellarUSDC().equals("stellar:" + amount.getCurrency())) amount.setCurrency("USD");
     req.amount = amount;
     req.idempotencyKey = idempotencyKey;
     return req;

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleAsset.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleAsset.java
@@ -7,8 +7,16 @@ public class CircleAsset {
   @NonNull
   public static String stellarUSDC(Network stellarNetwork) {
     if (stellarNetwork == org.stellar.sdk.Network.PUBLIC)
-      return "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+      return "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 
-    return "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    return "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+  }
+
+  public static String circleUSD() {
+    return "circle:USD";
+  }
+
+  public static String fiatUSD() {
+    return "iso4217:USD";
   }
 }

--- a/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleAsset.java
+++ b/payment-circle/src/main/java/org/stellar/anchor/paymentservice/circle/util/CircleAsset.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.paymentservice.circle.util;
 
+import java.util.List;
 import org.stellar.sdk.Network;
 import reactor.util.annotation.NonNull;
 
@@ -18,5 +19,11 @@ public class CircleAsset {
 
   public static String fiatUSD() {
     return "iso4217:USD";
+  }
+
+  public static boolean isSupported(String currencyName, Network stellarNetwork) {
+    return List.of(
+            CircleAsset.circleUSD(), CircleAsset.fiatUSD(), CircleAsset.stellarUSDC(stellarNetwork))
+        .contains(currencyName);
   }
 }

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -587,7 +587,12 @@ class CirclePaymentServiceTest {
     assertDoesNotThrow {
       payment =
         service
-          .sendPayment(merchantAccount, destination, "circle:USD", BigDecimal.valueOf(0.91))
+          .sendPayment(
+            merchantAccount,
+            destination,
+            CircleAsset.circleUSD(),
+            BigDecimal.valueOf(0.91)
+          )
           .block()
     }
 
@@ -850,7 +855,9 @@ class CirclePaymentServiceTest {
     var payment: Payment? = null
     assertDoesNotThrow {
       payment =
-        service.sendPayment(source, destination, "iso4217:USD", BigDecimal.valueOf(0.91)).block()
+        service
+          .sendPayment(source, destination, CircleAsset.fiatUSD(), BigDecimal.valueOf(0.91))
+          .block()
     }
 
     assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
@@ -1845,7 +1852,8 @@ class CirclePaymentServiceTest {
     )
 
     // missing bank id
-    config = DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, "circle:USD")
+    config =
+      DepositRequirements("1000066041", null, PaymentNetwork.BANK_WIRE, CircleAsset.circleUSD())
     ex = assertThrows { service.getDepositInstructions(config).block() }
     assertEquals(
       HttpException(
@@ -1867,7 +1875,7 @@ class CirclePaymentServiceTest {
     paymentNetwork: PaymentNetwork?
   ) {
     // unsupported intermediary payment network
-    val config = DepositRequirements("1000066041", null, paymentNetwork, "circle:USD")
+    val config = DepositRequirements("1000066041", null, paymentNetwork, CircleAsset.circleUSD())
     val ex: HttpException = assertThrows { service.getDepositInstructions(config).block() }
     assertEquals(
       HttpException(
@@ -1881,7 +1889,8 @@ class CirclePaymentServiceTest {
   @Test
   fun test_getDepositInstructions_circle() {
     var instructions: DepositInstructions? = null
-    val config = DepositRequirements("1000066041", null, PaymentNetwork.CIRCLE, "circle:USD")
+    val config =
+      DepositRequirements("1000066041", null, PaymentNetwork.CIRCLE, CircleAsset.circleUSD())
     assertDoesNotThrow { instructions = service.getDepositInstructions(config).block() }
 
     val wantInstructions =
@@ -1924,7 +1933,8 @@ class CirclePaymentServiceTest {
     server.dispatcher = dispatcher
 
     var instructions: DepositInstructions? = null
-    val config = DepositRequirements("1000066041", null, PaymentNetwork.STELLAR, "circle:USD")
+    val config =
+      DepositRequirements("1000066041", null, PaymentNetwork.STELLAR, CircleAsset.circleUSD())
     assertDoesNotThrow { instructions = service.getDepositInstructions(config).block() }
 
     val wantInstructions =
@@ -1935,7 +1945,7 @@ class CirclePaymentServiceTest {
         "GAYF33NNNMI2Z6VNRFXQ64D4E4SF77PM46NW3ZUZEEU5X7FCHAZCMHKU",
         "2454278437550473431",
         PaymentNetwork.STELLAR,
-        "stellar:" + CircleAsset.stellarUSDC(Network.TESTNET),
+        CircleAsset.stellarUSDC(Network.TESTNET),
         null
       )
     assertEquals(wantInstructions, instructions)
@@ -1983,7 +1993,7 @@ class CirclePaymentServiceTest {
         null,
         PaymentNetwork.BANK_WIRE,
         "bank-id-here",
-        "circle:USD"
+        CircleAsset.circleUSD()
       )
     assertDoesNotThrow { instructions = service.getDepositInstructions(config).block() }
 
@@ -2111,7 +2121,7 @@ class CirclePaymentServiceTest {
       ),
       ErrorHandlingTestCase(
         service.getDepositInstructions(
-          DepositRequirements("1000066041", PaymentNetwork.STELLAR, "circle:USD")
+          DepositRequirements("1000066041", PaymentNetwork.STELLAR, CircleAsset.circleUSD())
         ),
         listOf(badRequestResponse)
       ),
@@ -2122,7 +2132,7 @@ class CirclePaymentServiceTest {
             null,
             PaymentNetwork.BANK_WIRE,
             "bank-id-here",
-            "circle:USD"
+            CircleAsset.circleUSD()
           )
         ),
         listOf(badRequestResponse)
@@ -2144,7 +2154,7 @@ class CirclePaymentServiceTest {
         service.sendPayment(
           Account(PaymentNetwork.CIRCLE, "1000066041", Account.Capabilities()),
           Account(PaymentNetwork.CIRCLE, "1000067536", Account.Capabilities()),
-          "circle:USD",
+          CircleAsset.circleUSD(),
           BigDecimal.valueOf(1)
         ),
         hashMapOf(
@@ -2178,7 +2188,7 @@ class CirclePaymentServiceTest {
             "test@mail.com",
             Account.Capabilities()
           ),
-          "iso4217:USD",
+          CircleAsset.fiatUSD(),
           BigDecimal(1)
         ),
         hashMapOf(

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -77,6 +77,12 @@ class CirclePaymentServiceTest {
 
   private lateinit var server: MockWebServer
   private lateinit var service: PaymentService
+  private val merchantAccount =
+    Account(
+      PaymentNetwork.CIRCLE,
+      "1000066041",
+      Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR, PaymentNetwork.BANK_WIRE)
+    )
 
   private fun getDistAccountIdMockResponse(masterWalletId: String = "1000066041"): MockResponse {
     return MockResponse()
@@ -532,18 +538,7 @@ class CirclePaymentServiceTest {
     }
 
     assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-    assertEquals(
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      ),
-      payment?.sourceAccount
-    )
+    assertEquals(merchantAccount, payment?.sourceAccount)
     assertEquals(
       Account(
         PaymentNetwork.BANK_WIRE,
@@ -724,12 +719,6 @@ class CirclePaymentServiceTest {
       }
     server.dispatcher = dispatcher
 
-    val source =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR)
-      )
     val destination =
       Account(
         PaymentNetwork.CIRCLE,
@@ -739,22 +728,13 @@ class CirclePaymentServiceTest {
     var payment: Payment? = null
     assertDoesNotThrow {
       payment =
-        service.sendPayment(source, destination, "circle:USD", BigDecimal.valueOf(0.91)).block()
+        service
+          .sendPayment(merchantAccount, destination, "circle:USD", BigDecimal.valueOf(0.91))
+          .block()
     }
 
     assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-    assertEquals(
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      ),
-      payment?.sourceAccount
-    )
+    assertEquals(merchantAccount, payment?.sourceAccount)
     assertEquals(
       Account(PaymentNetwork.CIRCLE, "1000067536", CircleWallet.defaultCapabilities()),
       payment?.destinationAccount
@@ -880,18 +860,7 @@ class CirclePaymentServiceTest {
     }
 
     assertEquals("c58e2613-a808-4075-956c-e576787afb3b", payment?.id)
-    assertEquals(
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      ),
-      payment?.sourceAccount
-    )
+    assertEquals(merchantAccount, payment?.sourceAccount)
     assertEquals(
       Account(
         PaymentNetwork.STELLAR,
@@ -1027,16 +996,6 @@ class CirclePaymentServiceTest {
 
     var paymentHistory: PaymentHistory? = null
     val getTransfersMono = service.getTransfers("1000066041", null, null, null)
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     assertDoesNotThrow {
       paymentHistory =
         getTransfersMono.block()!!.toPaymentHistory(50, merchantAccount, "1000066041")
@@ -1126,16 +1085,6 @@ class CirclePaymentServiceTest {
     server.dispatcher = dispatcher
 
     // Let's use reflection to access the private method
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     val getTransfersMono =
       (service as CirclePaymentService).getTransfers("1000066041", null, null, 2)
     var paymentHistory: PaymentHistory? = null
@@ -1207,16 +1156,6 @@ class CirclePaymentServiceTest {
       }
     server.dispatcher = dispatcher
 
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     val getPayoutsMono = (service as CirclePaymentService).getPayouts("1000066041", null, null, 50)
     var paymentHistory: PaymentHistory? = null
     assertDoesNotThrow {
@@ -1270,17 +1209,6 @@ class CirclePaymentServiceTest {
         }
       }
     server.dispatcher = dispatcher
-
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
 
     val getPayoutsMono = (service as CirclePaymentService).getPayouts("1000066041", null, null, 1)
     var paymentHistory: PaymentHistory? = null
@@ -1337,16 +1265,6 @@ class CirclePaymentServiceTest {
       }
     server.dispatcher = dispatcher
 
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     val getPaymentsMono =
       (service as CirclePaymentService).getIncomingPayments("1000066041", null, null, 50)
     var paymentHistory: PaymentHistory? = null
@@ -1402,16 +1320,6 @@ class CirclePaymentServiceTest {
       }
     server.dispatcher = dispatcher
 
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     val getPaymentsMono =
       (service as CirclePaymentService).getIncomingPayments("1000066041", null, null, 1)
     var paymentHistory: PaymentHistory? = null
@@ -1488,17 +1396,6 @@ class CirclePaymentServiceTest {
         }
       }
     server.dispatcher = dispatcher
-
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
 
     var paymentHistory: PaymentHistory? = null
     if (uri == "transfers") {
@@ -1601,16 +1498,6 @@ class CirclePaymentServiceTest {
     // validate Stellar call was executed
     verify { serviceClient.baseUrl(any()) }
 
-    val merchantAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000066041",
-        Account.Capabilities(
-          PaymentNetwork.CIRCLE,
-          PaymentNetwork.STELLAR,
-          PaymentNetwork.BANK_WIRE
-        )
-      )
     val wantPaymentHistory = PaymentHistory(merchantAccount)
     wantPaymentHistory.beforeCursor =
       "c58e2613-a808-4075-956c-e576787afb3b:6588a352-5131-4711-a264-e405f38d752d:acc622bf-89e1-447c-8588-1bdead8e41a3"

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -322,10 +322,7 @@ class CirclePaymentServiceTest {
     assertDoesNotThrow { account = service.getAccount("1000223064").block() }
     assertEquals("1000223064", account?.id)
     assertEquals(PaymentNetwork.CIRCLE, account?.paymentNetwork)
-    assertEquals(
-      Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR),
-      account?.capabilities
-    )
+    assertEquals(CircleWallet.defaultCapabilities(), account?.capabilities)
     assertEquals("Treasury Wallet", account?.idTag)
     assertEquals(1, account?.balances?.size)
     assertEquals("29472389929.00", account!!.balances[0].amount)
@@ -462,10 +459,7 @@ class CirclePaymentServiceTest {
     assertDoesNotThrow { account = service.createAccount("Foo bar").block() }
     assertEquals("1000223064", account?.id)
     assertEquals(PaymentNetwork.CIRCLE, account?.paymentNetwork)
-    assertEquals(
-      Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR),
-      account?.capabilities
-    )
+    assertEquals(CircleWallet.defaultCapabilities(), account?.capabilities)
     assertEquals("Foo bar", account?.idTag)
     assertEquals(1, account?.balances?.size)
     assertEquals("123.45", account!!.balances[0].amount)
@@ -762,11 +756,7 @@ class CirclePaymentServiceTest {
       payment?.sourceAccount
     )
     assertEquals(
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000067536",
-        Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR)
-      ),
+      Account(PaymentNetwork.CIRCLE, "1000067536", CircleWallet.defaultCapabilities()),
       payment?.destinationAccount
     )
     assertEquals(Balance("0.91", "circle:USD"), payment?.balance)
@@ -1064,11 +1054,7 @@ class CirclePaymentServiceTest {
     p1.id = "c58e2613-a808-4075-956c-e576787afb3b"
     p1.sourceAccount = merchantAccount
     p1.destinationAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000067536",
-        Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR)
-      )
+      Account(PaymentNetwork.CIRCLE, "1000067536", CircleWallet.defaultCapabilities())
     p1.balance = Balance("0.91", "circle:USD")
     p1.status = Payment.Status.PENDING
     p1.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
@@ -1168,11 +1154,7 @@ class CirclePaymentServiceTest {
     p1.id = "c58e2613-a808-4075-956c-e576787afb3b"
     p1.sourceAccount = merchantAccount
     p1.destinationAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000067536",
-        Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR)
-      )
+      Account(PaymentNetwork.CIRCLE, "1000067536", CircleWallet.defaultCapabilities())
     p1.balance = Balance("0.91", "circle:USD")
     p1.status = Payment.Status.PENDING
     p1.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")
@@ -1656,11 +1638,7 @@ class CirclePaymentServiceTest {
     p1.id = "c58e2613-a808-4075-956c-e576787afb3b"
     p1.sourceAccount = merchantAccount
     p1.destinationAccount =
-      Account(
-        PaymentNetwork.CIRCLE,
-        "1000067536",
-        Account.Capabilities(PaymentNetwork.CIRCLE, PaymentNetwork.STELLAR)
-      )
+      Account(PaymentNetwork.CIRCLE, "1000067536", CircleWallet.defaultCapabilities())
     p1.balance = Balance("0.91", "circle:USD")
     p1.status = Payment.Status.PENDING
     p1.createdAt = CircleDateFormatter.stringToDate("2022-02-07T19:50:23.408Z")

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -331,8 +331,8 @@ class CirclePaymentServiceTest {
     assertEquals(CircleWallet.defaultCapabilities(), account?.capabilities)
     assertEquals("Treasury Wallet", account?.idTag)
     assertEquals(1, account?.balances?.size)
-    assertEquals("29472389929.00", account!!.balances[0].amount)
-    assertEquals("circle:USD", account!!.balances[0].currencyName)
+    assertEquals("29472389929.00", account!!.balances!![0].amount)
+    assertEquals("circle:USD", account!!.balances!![0].currencyName)
     assertEquals(0, account?.unsettledBalances?.size)
 
     assertEquals(2, server.requestCount)
@@ -409,11 +409,11 @@ class CirclePaymentServiceTest {
     )
     assertNull(account?.idTag)
     assertEquals(1, account?.balances?.size)
-    assertEquals("29472389929.00", account!!.balances[0].amount)
-    assertEquals("circle:USD", account!!.balances[0].currencyName)
+    assertEquals("29472389929.00", account!!.balances!![0].amount)
+    assertEquals("circle:USD", account!!.balances!![0].currencyName)
     assertEquals(1, account?.unsettledBalances?.size)
-    assertEquals("100.00", account!!.unsettledBalances[0].amount)
-    assertEquals("circle:USD", account!!.unsettledBalances[0].currencyName)
+    assertEquals("100.00", account!!.unsettledBalances!![0].amount)
+    assertEquals("circle:USD", account!!.unsettledBalances!![0].currencyName)
 
     assertEquals(3, server.requestCount)
 
@@ -468,8 +468,8 @@ class CirclePaymentServiceTest {
     assertEquals(CircleWallet.defaultCapabilities(), account?.capabilities)
     assertEquals("Foo bar", account?.idTag)
     assertEquals(1, account?.balances?.size)
-    assertEquals("123.45", account!!.balances[0].amount)
-    assertEquals("circle:USD", account!!.balances[0].currencyName)
+    assertEquals("123.45", account!!.balances!![0].amount)
+    assertEquals("circle:USD", account!!.balances!![0].currencyName)
     assertEquals(0, account?.unsettledBalances?.size)
 
     val request = server.takeRequest()
@@ -1398,32 +1398,37 @@ class CirclePaymentServiceTest {
     server.dispatcher = dispatcher
 
     var paymentHistory: PaymentHistory? = null
-    if (uri == "transfers") {
-      assertDoesNotThrow {
-        paymentHistory =
-          (service as CirclePaymentService)
-              .getTransfers("1000066041", beforeCursor, afterCursor, 1)
-              .block()!!
-            .toPaymentHistory(1, merchantAccount, "1000066041")
+    when (uri) {
+      "transfers" -> {
+        assertDoesNotThrow {
+          paymentHistory =
+            (service as CirclePaymentService)
+                .getTransfers("1000066041", beforeCursor, afterCursor, 1)
+                .block()!!
+              .toPaymentHistory(1, merchantAccount, "1000066041")
+        }
       }
-    } else if (uri == "payouts") {
-      assertDoesNotThrow {
-        paymentHistory =
-          (service as CirclePaymentService)
-              .getPayouts("1000066041", beforeCursor, afterCursor, 1)
-              .block()!!
-            .toPaymentHistory(1, merchantAccount)
+      "payouts" -> {
+        assertDoesNotThrow {
+          paymentHistory =
+            (service as CirclePaymentService)
+                .getPayouts("1000066041", beforeCursor, afterCursor, 1)
+                .block()!!
+              .toPaymentHistory(1, merchantAccount)
+        }
       }
-    } else if (uri == "payments") {
-      assertDoesNotThrow {
-        paymentHistory =
-          (service as CirclePaymentService)
-              .getIncomingPayments("1000066041", beforeCursor, afterCursor, 1)
-              .block()!!
-            .toPaymentHistory(1, merchantAccount)
+      "payments" -> {
+        assertDoesNotThrow {
+          paymentHistory =
+            (service as CirclePaymentService)
+                .getIncomingPayments("1000066041", beforeCursor, afterCursor, 1)
+                .block()!!
+              .toPaymentHistory(1, merchantAccount)
+        }
       }
-    } else {
-      throw RuntimeException("INVALID URI FOR TEST")
+      else -> {
+        throw RuntimeException("INVALID URI FOR TEST")
+      }
     }
 
     val wantPaymentHistory = PaymentHistory(merchantAccount)

--- a/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
+++ b/payment-circle/src/test/kotlin/org/stellar/anchor/paymentservice/circle/CirclePaymentServiceTest.kt
@@ -157,7 +157,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testCirclePing() {
+  fun test_ping() {
     val response =
       MockResponse()
         .addHeader("Content-Type", "application/json")
@@ -172,7 +172,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testGetDistributionAccountAddress() {
+  fun test_getDistributionAccountAddress() {
     server.enqueue(getDistAccountIdMockResponse())
 
     var masterWalletId: String? = null
@@ -281,7 +281,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testGetAccount_isNotMainAccount() {
+  fun test_getAccount_isNotMainAccount() {
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -352,7 +352,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testGetAccount_isMainAccount() {
+  fun test_getAccount_isMainAccount() {
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -483,7 +483,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testSendPayment_circleToWire() {
+  fun test_sendPayment_circleToWire() {
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -625,7 +625,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testSendPayment_parameterValidation() {
+  fun test_sendPayment_parameterValidation() {
     // invalid source account network
     var ex =
       assertThrows<HttpException> {
@@ -682,7 +682,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testSendPayment_circleToCircle() {
+  fun test_sendPayment_circleToCircle() {
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -799,7 +799,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testSendPayment_circleToStellar() {
+  fun test_sendPayment_circleToStellar() {
     val dispatcher: Dispatcher =
       object : Dispatcher() {
         @Throws(InterruptedException::class)
@@ -2038,7 +2038,7 @@ class CirclePaymentServiceTest {
   }
 
   @Test
-  fun testErrorHandling() {
+  fun test_errorHandling() {
     val badRequestResponse =
       MockResponse()
         .setResponseCode(400)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Code polishes and small fixes. Changes details:
* Add `CircleWallet.defaultCapabilities()` and `CircleWallet.merchantAccountCapabilities()` to avoid hardcoding the capabilities every time.
* Update Account default `balances` and `unsettledBalances` values to null, so the JSON response works better when we don't have the balances. Otherwise, returning an empty list passes the impression the balances are empty when that might not be the case.
* Fix paginated responses cursors.
* Updated docs on how to get the bank deposit instructions.
* Solve warnings
* Update `CirclePaymentServiceTest` to reduce code repetition and standardize method names.
* Add all Circle asset names to the `CircleAsset` class, so we don't need to hardcode the string names.
