### PR TITLE
Sep38 config

### DIFF
--- a/config-spring-property/src/main/java/org/stellar/anchor/server/config/PropertySep38Config.java
+++ b/config-spring-property/src/main/java/org/stellar/anchor/server/config/PropertySep38Config.java
@@ -1,0 +1,10 @@
+package org.stellar.anchor.server.config;
+
+import lombok.Data;
+import org.stellar.anchor.config.Sep38Config;
+
+@Data
+public class PropertySep38Config implements Sep38Config {
+  boolean enabled = false;
+  String customerIntegrationEndPoint;
+}

--- a/core/src/main/java/org/stellar/anchor/config/ConfigProvider.java
+++ b/core/src/main/java/org/stellar/anchor/config/ConfigProvider.java
@@ -8,4 +8,6 @@ public interface ConfigProvider {
   Sep10Config sep10Config();
 
   Sep24Config sep24Config();
+
+  Sep38Config sep38Config();
 }

--- a/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
@@ -1,0 +1,7 @@
+package org.stellar.anchor.config;
+
+public interface Sep38Config {
+  boolean isEnabled();
+
+  String getCustomerIntegrationEndPoint();
+}

--- a/core/src/main/java/org/stellar/anchor/dto/sep24/AssetResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep24/AssetResponse.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.dto.sep24;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import lombok.Data;
 
 @SuppressWarnings("unused")
@@ -8,6 +9,7 @@ import lombok.Data;
 public class AssetResponse {
   String code;
   String issuer;
+  Schema schema;
 
   @SerializedName("significant_decimals")
   Integer significantDecimals;
@@ -15,6 +17,7 @@ public class AssetResponse {
   AssetOperation deposit;
   AssetOperation withdraw;
   SendOperation send;
+  Sep38Operation sep38;
 
   @SerializedName("sep24_enabled")
   Boolean sep24Enabled;
@@ -24,6 +27,28 @@ public class AssetResponse {
 
   @SerializedName("sep31_enabled")
   Boolean sep31Enabled;
+
+  @SerializedName("sep38_enabled")
+  Boolean sep38Enabled;
+
+  public enum Schema {
+    @SerializedName("stellar")
+    STELLAR("stellar"),
+
+    @SerializedName("iso4217")
+    ISO4217("iso4217");
+
+    private final String name;
+
+    Schema(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
 
   @Data
   public static class AssetOperation {
@@ -58,5 +83,27 @@ public class AssetResponse {
 
     @SerializedName("max_amount")
     Long maxAmount;
+  }
+
+  @Data
+  public static class Sep38Operation {
+    @SerializedName("supported_exchanges")
+    List<String> supportedExchanges;
+
+    @SerializedName("country_codes")
+    List<String> countryCodes;
+
+    @SerializedName("sell_delivery_methods")
+    List<DeliveryMethod> sellDeliveryMethods;
+
+    @SerializedName("buy_delivery_methods")
+    List<DeliveryMethod> buyDeliveryMethods;
+
+    @Data
+    public static class DeliveryMethod {
+      String name;
+
+      String description;
+    }
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep24/AssetService.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/AssetService.java
@@ -8,7 +8,7 @@ public interface AssetService {
   /**
    * Returns all assets supported by the anchor.
    *
-   * @return assets.
+   * @return a list of assets.
    */
   List<AssetResponse> listAllAssets();
 
@@ -17,7 +17,7 @@ public interface AssetService {
    *
    * @param code The asset code
    * @param issuer The account ID of the issuer
-   * @return
+   * @return an asset with the given code and issuer.
    */
   AssetResponse getAsset(String code, String issuer);
 }

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -1,0 +1,13 @@
+package org.stellar.anchor.sep38;
+
+import org.stellar.anchor.config.Sep38Config;
+import org.stellar.anchor.util.Log;
+
+public class Sep38Service {
+  final Sep38Config sep38Config;
+
+  public Sep38Service(Sep38Config sep38Config) {
+    this.sep38Config = sep38Config;
+    Log.info("Initializing sep38 service.");
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -1,13 +1,16 @@
 package org.stellar.anchor.sep38;
 
 import org.stellar.anchor.config.Sep38Config;
+import org.stellar.anchor.sep24.AssetService;
 import org.stellar.anchor.util.Log;
 
 public class Sep38Service {
   final Sep38Config sep38Config;
+  final AssetService assetService;
 
-  public Sep38Service(Sep38Config sep38Config) {
+  public Sep38Service(Sep38Config sep38Config, AssetService assetService) {
     this.sep38Config = sep38Config;
+    this.assetService = assetService;
     Log.info("Initializing sep38 service.");
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/plugins/asset/ResourceJsonAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/plugins/asset/ResourceJsonAssetServiceTest.kt
@@ -12,10 +12,10 @@ internal class ResourceJsonAssetServiceTest {
   @Test
   fun getListAllAssets() {
     val rjas = ResourceJsonAssetService("test_assets.json")
-    assertEquals(rjas.assets.getAssets().size, 2)
+    assertEquals(3, rjas.assets.getAssets().size)
 
     val assets = rjas.listAllAssets()
-    assertTrue(assets.size == 2)
+    assertEquals(3, assets.size)
 
     val asset = rjas.getAsset(TEST_ASSET, TEST_ASSET_ISSUER_ACCOUNT_ID)
     assertEquals(asset.code, TEST_ASSET)

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -384,8 +384,8 @@ internal class Sep24ServiceTest {
   fun testGetInfo() {
     val response = sep24Service.info
 
-    assertEquals(response.deposit.size, 2)
-    assertEquals(response.withdraw.size, 1)
+    assertEquals(3, response.deposit.size)
+    assertEquals(1, response.withdraw.size)
     assertNotNull(response.deposit["USDC"])
     assertNotNull(response.withdraw["USDC"])
     assertTrue(response.fee.enabled)

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -1,6 +1,7 @@
 {
   "assets": [
     {
+      "schema": "stellar",
       "code": "USDC",
       "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
       "significant_decimals": 2,
@@ -24,11 +25,19 @@
         "min_amount": 1,
         "max_amount": 10000
       },
+      "sep38": {
+        "supported_exchanges": [
+          "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          "iso4217:USD"
+        ]
+      },
       "sep24_enabled": true,
       "sep6_enabled": false,
-      "sep31_enabled": false
+      "sep31_enabled": false,
+      "sep38_enabled": true
     },
     {
+      "schema": "stellar",
       "code": "JPYC",
       "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
       "significant_decimals": 0,
@@ -52,9 +61,62 @@
         "min_amount": 1,
         "max_amount": 1000000
       },
+      "sep38": {
+        "supported_exchanges": [
+          "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          "iso4217:USD"
+        ]
+      },
       "sep24_enabled": true,
       "sep6_enabled": true,
-      "sep31_enabled": true
+      "sep31_enabled": true,
+      "sep38_enabled": true
+    },
+    {
+      "schema": "iso4217",
+      "code": "USD",
+      "deposit" : {
+        "enabled": true,
+        "fee_minimum": 0,
+        "fee_percent": 0,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "withdraw": {
+        "enabled": false,
+        "fee_fixed": 0,
+        "fee_percent": 0,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "send": {
+        "fee_fixed": 0,
+        "fee_percent": 0,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "sep38": {
+        "supported_exchanges": [
+          "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+        ],
+        "country_codes": ["USA"],
+        "sell_delivery_methods": [
+          {
+            "name": "WIRE",
+            "description": "Send USD directly to the Anchor's bank account."
+          }
+        ],
+        "buy_delivery_methods": [
+          {
+            "name": "WIRE",
+            "description": "Have WIRE sent directly to your bank account."
+          }
+        ]
+      },
+      "sep6_enabled": false,
+      "sep31_enabled": false,
+      "sep38_enabled": true
     }
   ]
 }

--- a/platform/example.anchor-config.yaml
+++ b/platform/example.anchor-config.yaml
@@ -42,6 +42,11 @@ app-config:
     jwtTimeout: 86400
     signingSeed: SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X
 
+  # sep-38
+  sep38:
+    enabled: true
+    customerIntegrationEndpoint: localhost:8082
+
   payment-gateway:
     #
     # Payment Circle configurations

--- a/platform/src/main/java/org/stellar/anchor/server/ConfigManagementConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/server/ConfigManagementConfig.java
@@ -6,11 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.config.Sep1Config;
+import org.stellar.anchor.config.Sep38Config;
 import org.stellar.anchor.paymentservice.circle.config.CirclePaymentConfig;
 import org.stellar.anchor.paymentservice.circle.config.StellarPaymentConfig;
 import org.stellar.anchor.server.config.PropertyAppConfig;
 import org.stellar.anchor.server.config.PropertySep10Config;
 import org.stellar.anchor.server.config.PropertySep1Config;
+import org.stellar.anchor.server.config.PropertySep38Config;
 import org.stellar.anchor.server.config.payment.PropertyCirclePaymentConfig;
 import org.stellar.anchor.server.config.payment.PropertyStellarPaymentConfig;
 
@@ -32,6 +34,12 @@ public class ConfigManagementConfig {
   @ConfigurationProperties(prefix = "sep10")
   Sep10Config sep10Config() {
     return new PropertySep10Config();
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "sep38")
+  Sep38Config sep38Config() {
+    return new PropertySep38Config();
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
@@ -64,7 +64,7 @@ public class SepConfig {
   }
 
   @Bean
-  Sep38Service sep38Service(Sep38Config sep38Config) {
-    return new Sep38Service(sep38Config);
+  Sep38Service sep38Service(Sep38Config sep38Config, AssetService assetService) {
+    return new Sep38Service(sep38Config, assetService);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.config.Sep1Config;
+import org.stellar.anchor.config.Sep38Config;
 import org.stellar.anchor.exception.SepNotFoundException;
 import org.stellar.anchor.filter.Sep10TokenFilter;
 import org.stellar.anchor.horizon.Horizon;
@@ -16,6 +17,7 @@ import org.stellar.anchor.sep1.Sep1Service;
 import org.stellar.anchor.sep10.JwtService;
 import org.stellar.anchor.sep10.Sep10Service;
 import org.stellar.anchor.sep24.AssetService;
+import org.stellar.anchor.sep38.Sep38Service;
 
 /** SEP configurations */
 @Configuration
@@ -59,5 +61,10 @@ public class SepConfig {
   Sep10Service sep10Service(
       AppConfig appConfig, Sep10Config sep10Config, Horizon horizon, JwtService jwtService) {
     return new Sep10Service(appConfig, sep10Config, horizon, jwtService);
+  }
+
+  @Bean
+  Sep38Service sep38Service(Sep38Config sep38Config) {
+    return new Sep38Service(sep38Config);
   }
 }

--- a/platform/src/main/resources/assets-prod.json
+++ b/platform/src/main/resources/assets-prod.json
@@ -1,6 +1,7 @@
 {
     "assets": [
         {
+            "schema": "stellar",
             "code": "USDC",
             "issuer": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
             "significant_decimals": 2,
@@ -24,8 +25,59 @@
                 "min_amount": 0,
                 "max_amount": 10000
             },
+            "sep38": {
+                "supported_exchanges": [
+                    "iso4217:USD"
+                ]
+            },
             "sep6_enabled": false,
-            "sep31_enabled": false
+            "sep31_enabled": false,
+            "sep38_enabled": true
+        },
+        {
+            "schema": "iso4217",
+            "code": "USD",
+            "deposit" : {
+                "enabled": true,
+                "fee_minimum": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "withdraw": {
+                "enabled": true,
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "sep38": {
+                "supported_exchanges": [
+                    "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+                ],
+                "country_codes": ["USA"],
+                "sell_delivery_methods": [
+                    {
+                        "name": "WIRE",
+                        "description": "Send USD directly to the Anchor's bank account."
+                    }
+                ],
+                "buy_delivery_methods": [
+                    {
+                        "name": "WIRE",
+                        "description": "Have WIRE sent directly to your bank account."
+                    }
+                ]
+            },
+            "sep6_enabled": false,
+            "sep31_enabled": false,
+            "sep38_enabled": true
         }
     ]
 }

--- a/platform/src/main/resources/assets-test.json
+++ b/platform/src/main/resources/assets-test.json
@@ -1,6 +1,7 @@
 {
     "assets": [
         {
+            "schema": "stellar",
             "code": "USDC",
             "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
             "significant_decimals": 2,
@@ -24,7 +25,57 @@
                 "min_amount": 0,
                 "max_amount": 10000
             },
-            "sep31_enabled": false
+            "sep38": {
+                "supported_exchanges": [
+                    "iso4217:USD"
+                ]
+            },
+            "sep31_enabled": false,
+            "sep38_enabled": true
+        },
+        {
+            "schema": "iso4217",
+            "code": "USD",
+            "deposit" : {
+                "enabled": true,
+                "fee_minimum": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "withdraw": {
+                "enabled": true,
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 0,
+                "max_amount": 10000
+            },
+            "sep38": {
+                "supported_exchanges": [
+                    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+                ],
+                "country_codes": ["USA"],
+                "sell_delivery_methods": [
+                    {
+                        "name": "WIRE",
+                        "description": "Send USD directly to the Anchor's bank account."
+                    }
+                ],
+                "buy_delivery_methods": [
+                    {
+                        "name": "WIRE",
+                        "description": "Have WIRE sent directly to your bank account."
+                    }
+                ]
+            },
+            "sep31_enabled": false,
+            "sep38_enabled": true
         }
     ]
 }

--- a/platform/src/main/resources/default-config.yaml
+++ b/platform/src/main/resources/default-config.yaml
@@ -43,6 +43,11 @@ config-spring-property-settings:
     jwtTimeout: 86400
     signingSeed:
 
+  # sep-38
+  sep38:
+    enabled: true
+    customerIntegrationEndpoint: localhost:8082
+
 #
 # Payment Circle configurations
 #

--- a/platform/src/test/kotlin/org/stellar/anchor/server/configurator/ConfiguratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/server/configurator/ConfiguratorTest.kt
@@ -70,6 +70,8 @@ open class ConfiguratorTest {
         "sep10.enabled" to "true",
         "sep10.homeDomain" to "localhost:8080",
         "sep10.signingSeed" to "SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X",
+        "sep38.enabled" to "true",
+        "sep38.customerIntegrationEndpoint" to "localhost:8082",
         "payment-gateway.circle.name" to "circle",
         "payment-gateway.circle.stellarNetwork" to "TESTNET",
         "spring.jpa.database-platform" to "org.stellar.anchor.server.sqlite.SQLiteDialect",

--- a/platform/src/test/kotlin/org/stellar/anchor/server/configurator/SpringBootConfiguratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/server/configurator/SpringBootConfiguratorTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.Sep10Config
 import org.stellar.anchor.config.Sep1Config
+import org.stellar.anchor.config.Sep38Config
 import org.stellar.anchor.paymentservice.circle.config.CirclePaymentConfig
 import org.stellar.anchor.server.ConfigManagementConfig
 
@@ -46,6 +47,7 @@ open class SpringBootConfiguratorTest {
   @Autowired lateinit var appConfig: AppConfig
   @Autowired lateinit var sep1Config: Sep1Config
   @Autowired lateinit var sep10Config: Sep10Config
+  @Autowired lateinit var sep38Config: Sep38Config
 
   @Test
   fun testYamlProperties() {
@@ -55,6 +57,8 @@ open class SpringBootConfiguratorTest {
         "sep10.enabled" to "true",
         "sep10.homeDomain" to "localhost:8080",
         "sep10.signingSeed" to "SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X",
+        "sep38.enabled" to "true",
+        "sep38.customerIntegrationEndpoint" to "localhost:8082",
         "payment-gateway.circle.name" to "circle",
         "payment-gateway.circle.stellarNetwork" to "TESTNET",
         "spring.jpa.database-platform" to "org.stellar.anchor.server.sqlite.SQLiteDialect",
@@ -103,5 +107,11 @@ open class SpringBootConfiguratorTest {
       "SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X",
       sep10Config.signingSeed
     )
+  }
+
+  @Test
+  fun testSep38Config() {
+    assertEquals(true, sep38Config.isEnabled)
+    assertEquals("localhost:8082", sep38Config.customerIntegrationEndPoint)
   }
 }

--- a/platform/src/test/resources/test-anchor-config.yaml
+++ b/platform/src/test/resources/test-anchor-config.yaml
@@ -42,6 +42,11 @@ app-config:
     jwtTimeout: 86400
     signingSeed: SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X
 
+  # sep-38
+  sep38:
+    enabled: true
+    customerIntegrationEndpoint: localhost:8082
+
   payment-gateway:
     #
     # Payment Circle configurations


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add Sep48Config to read sep38-related configurations from yaml file and serve them to the Sep38Service.

The SEP-38 service is currently a dummy file that doesn't have any method yet but will be incremented in the next SEP-38 pull requests.

Additionally, updated the assets json files and AssetResponse with SEP-38 data,

### Why

Closes #74 
