### PR TITLE
core: move AssetService, AssetResponse and ResourceJsonAssetService to a different folder

### DIFF
--- a/core/src/main/java/org/stellar/anchor/asset/AssetResponse.java
+++ b/core/src/main/java/org/stellar/anchor/asset/AssetResponse.java
@@ -1,4 +1,4 @@
-package org.stellar.anchor.dto.sep24;
+package org.stellar.anchor.asset;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.List;

--- a/core/src/main/java/org/stellar/anchor/asset/AssetService.java
+++ b/core/src/main/java/org/stellar/anchor/asset/AssetService.java
@@ -1,7 +1,6 @@
-package org.stellar.anchor.sep24;
+package org.stellar.anchor.asset;
 
 import java.util.List;
-import org.stellar.anchor.dto.sep24.AssetResponse;
 
 public interface AssetService {
 

--- a/core/src/main/java/org/stellar/anchor/asset/ResourceJsonAssetService.java
+++ b/core/src/main/java/org/stellar/anchor/asset/ResourceJsonAssetService.java
@@ -1,13 +1,11 @@
-package org.stellar.anchor.plugins.asset;
+package org.stellar.anchor.asset;
 
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
-import org.stellar.anchor.dto.sep24.AssetResponse;
 import org.stellar.anchor.exception.SepNotFoundException;
-import org.stellar.anchor.sep24.AssetService;
 import org.stellar.anchor.util.FileUtil;
 import org.stellar.anchor.util.Log;
 

--- a/core/src/main/java/org/stellar/anchor/dto/sep24/InfoResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep24/InfoResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
+import org.stellar.anchor.asset.AssetResponse;
 
 @Data
 public class InfoResponse {

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -15,6 +15,8 @@ import java.time.Instant;
 import java.util.*;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.http.client.utils.URIBuilder;
+import org.stellar.anchor.asset.AssetResponse;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep24Config;
 import org.stellar.anchor.dto.sep24.*;

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -1,7 +1,7 @@
 package org.stellar.anchor.sep38;
 
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.config.Sep38Config;
-import org.stellar.anchor.sep24.AssetService;
 import org.stellar.anchor.util.Log;
 
 public class Sep38Service {

--- a/core/src/test/kotlin/org/stellar/anchor/asset/ResourceJsonAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/ResourceJsonAssetServiceTest.kt
@@ -1,4 +1,4 @@
-package org.stellar.anchor.plugins.asset
+package org.stellar.anchor.asset
 
 import com.google.gson.JsonSyntaxException
 import org.junit.jupiter.api.Assertions.*

--- a/core/src/test/kotlin/org/stellar/anchor/dto/sep24/Sep24DtoTests.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/dto/sep24/Sep24DtoTests.kt
@@ -1,6 +1,7 @@
 package org.stellar.anchor.dto.sep24
 
 import org.junit.jupiter.api.Test
+import org.stellar.anchor.asset.AssetResponse
 
 internal class Sep24DtoTests {
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -19,6 +19,8 @@ import org.stellar.anchor.Constants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.Constants.Companion.TEST_CLIENT_DOMAIN
 import org.stellar.anchor.Constants.Companion.TEST_TRANSACTION_ID_0
 import org.stellar.anchor.Constants.Companion.TEST_TRANSACTION_ID_1
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.asset.ResourceJsonAssetService
 import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.Sep24Config
 import org.stellar.anchor.dto.sep24.GetTransactionRequest
@@ -27,7 +29,6 @@ import org.stellar.anchor.exception.SepException
 import org.stellar.anchor.exception.SepNotFoundException
 import org.stellar.anchor.exception.SepValidationException
 import org.stellar.anchor.model.Sep24Transaction
-import org.stellar.anchor.plugins.asset.ResourceJsonAssetService
 import org.stellar.anchor.sep10.JwtService
 import org.stellar.anchor.sep10.JwtToken
 import org.stellar.anchor.util.DateUtil

--- a/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/server/SepConfig.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.asset.ResourceJsonAssetService;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.config.Sep1Config;
@@ -12,11 +14,9 @@ import org.stellar.anchor.config.Sep38Config;
 import org.stellar.anchor.exception.SepNotFoundException;
 import org.stellar.anchor.filter.Sep10TokenFilter;
 import org.stellar.anchor.horizon.Horizon;
-import org.stellar.anchor.plugins.asset.ResourceJsonAssetService;
 import org.stellar.anchor.sep1.Sep1Service;
 import org.stellar.anchor.sep10.JwtService;
 import org.stellar.anchor.sep10.Sep10Service;
-import org.stellar.anchor.sep24.AssetService;
 import org.stellar.anchor.sep38.Sep38Service;
 
 /** SEP configurations */


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Move AssetService, AssetResponse and ResourceJsonAssetService to a different folder so they are decoupled from SEP-24 and can be used across other SEPs.

### Why

These files are relevant for SEP-6, SEP-24, SEP-31 and SEP-38 and shouldn't be confined to the `*/sep24/*` folder.
