### PR TITLE
core: platform: Read SEP1 stellar.toml from external resource

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep1/ResourceReader.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/ResourceReader.java
@@ -1,0 +1,12 @@
+package org.stellar.anchor.sep1;
+
+/** The interface to reads resource external to the application. */
+public interface ResourceReader {
+  /**
+   * Reads the specified resource as a string.
+   *
+   * @param path The location of the resource.
+   * @return The content of the resource.
+   */
+  String readResourceAsString(String path);
+}

--- a/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
@@ -6,12 +6,33 @@ import org.stellar.anchor.util.FileUtil;
 
 public class Sep1Service {
   private final Sep1Config sep1Config;
+  private ResourceReader resourceReader;
 
+  /**
+   * Construct the Sep1Service that reads the stellar.toml content from Java resource.
+   *
+   * @param sep1Config The Sep1 configuration.
+   */
   public Sep1Service(Sep1Config sep1Config) {
     this.sep1Config = sep1Config;
   }
 
+  /**
+   * Construct the Sep1Service that reads the stellar.toml content by the resourceReader.
+   *
+   * @param sep1Config The Sep1 configuration.
+   * @param resourceReader The resource reader that reads the sep1 contents.
+   */
+  public Sep1Service(Sep1Config sep1Config, ResourceReader resourceReader) {
+    this.sep1Config = sep1Config;
+    this.resourceReader = resourceReader;
+  }
+
   public String getStellarToml() throws IOException {
-    return FileUtil.getResourceFileAsString(sep1Config.getStellarFile());
+    if (resourceReader == null) {
+      return FileUtil.getResourceFileAsString(sep1Config.getStellarFile());
+    }
+
+    return resourceReader.readResourceAsString(sep1Config.getStellarFile());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -3,7 +3,6 @@ package org.stellar.anchor.sep10;
 import static org.stellar.anchor.util.Log.infoF;
 import static org.stellar.anchor.util.Log.shorter;
 
-import com.moandjiezana.toml.Toml;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,7 +21,8 @@ import org.stellar.anchor.exception.SepException;
 import org.stellar.anchor.exception.SepValidationException;
 import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.util.Log;
-import org.stellar.anchor.util.NetUtil;
+import org.stellar.anchor.util.Sep1Helper;
+import org.stellar.anchor.util.Sep1Helper.TomlContent;
 import org.stellar.sdk.*;
 import org.stellar.sdk.requests.ErrorResponse;
 import org.stellar.sdk.responses.AccountResponse;
@@ -244,10 +244,7 @@ public class Sep10Service {
     String clientSigningKey = "";
     String url = "https://" + clientDomain + "/.well-known/stellar.toml";
     try {
-      String tomlValue = NetUtil.fetch(url);
-      Log.debug("Fetched client_domain's stellar.toml.", tomlValue);
-
-      Toml toml = new Toml().read(tomlValue);
+      TomlContent toml = Sep1Helper.readToml(url);
       clientSigningKey = toml.getString("SIGNING_KEY");
       if (clientSigningKey == null) {
         throw new SepException("SIGNING_KEY not present in 'client_domain' TOML");

--- a/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
+++ b/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
@@ -1,0 +1,27 @@
+package org.stellar.anchor.util;
+
+import com.moandjiezana.toml.Toml;
+import java.io.IOException;
+
+public class Sep1Helper {
+  public static TomlContent readToml(String url) throws IOException {
+    return new TomlContent(url);
+  }
+
+  public static class TomlContent {
+    private Toml toml;
+
+    TomlContent(String url) throws IOException {
+      String tomlValue = NetUtil.fetch(url);
+      toml = new Toml().read(tomlValue);
+    }
+
+    public String getString(String key) {
+      return toml.getString(key);
+    }
+
+    public String getString(String key, String defaultValue) {
+      return toml.getString(key, defaultValue);
+    }
+  }
+}

--- a/platform/example.anchor-config.yaml
+++ b/platform/example.anchor-config.yaml
@@ -29,7 +29,14 @@ app-config:
   # sep-1
   sep1:
     enabled: true
-    stellarFile: sep1/stellar-wks.toml
+    #
+    # The stellarFile is the location where to retrieve the content as the return value
+    # of the `/.well-known/stellar.toml`.
+    #
+    # The format of the resource is specified as Table 6.1 of the Spring document located at:
+    # https://docs.spring.io/spring-framework/docs/3.2.x/spring-framework-reference/html/resources.html
+    #
+    stellarFile: classpath://sep1/stellar-wks.toml
 
   # sep-10
   sep10:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -21,6 +21,7 @@ import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator
 import org.stellar.anchor.reference.AnchorReferenceServer
 import org.stellar.anchor.sep10.JwtService
 import org.stellar.anchor.sep10.JwtToken
+import org.stellar.anchor.util.OkHttpUtil
 
 @SpringBootTest(
   classes = [AnchorPlatformServer::class],
@@ -35,7 +36,7 @@ import org.stellar.anchor.sep10.JwtToken
       DataAccessConfigurator::class,
       SpringFrameworkConfigurator::class]
 )
-class Sep12IntegrationTest {
+class AnchorPlatformIntegrationTest {
   @Autowired lateinit var restTemplate: TestRestTemplate
   @Autowired lateinit var jwtService: JwtService
   @Autowired lateinit var appConfig: AppConfig
@@ -66,7 +67,6 @@ class Sep12IntegrationTest {
 
   @Test
   fun runTest() {
-    //    val port = applicationContext.environment.getProperty("server.port")
     val jwtToken = createJwtToken()
     val request =
       Request.Builder()
@@ -75,6 +75,12 @@ class Sep12IntegrationTest {
         .get()
         .build()
 
+    client.newCall(request).execute().use { response -> println(response.body!!.string()) }
+  }
+
+  @Test
+  fun runSep1Test() {
+    val request = OkHttpUtil.buildGetRequest("http://localhost:$port/.well-known/stellar.toml")
     client.newCall(request).execute().use { response -> println(response.body!!.string()) }
   }
 


### PR DESCRIPTION
closes #105
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This PR reads SEP1 content from resource external to the application.

