### PR TITLE
core: SEP-38's number of decimals can now be set in the assets.json configuration file

### DIFF
--- a/core/src/main/java/org/stellar/anchor/asset/AssetInfo.java
+++ b/core/src/main/java/org/stellar/anchor/asset/AssetInfo.java
@@ -99,6 +99,8 @@ public class AssetInfo {
     @SerializedName("buy_delivery_methods")
     List<DeliveryMethod> buyDeliveryMethods;
 
+    Integer decimals;
+
     @Data
     public static class DeliveryMethod {
       String name;

--- a/core/src/main/java/org/stellar/anchor/dto/sep38/GetPricesResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep38/GetPricesResponse.java
@@ -12,9 +12,18 @@ public class GetPricesResponse {
   @SerializedName("buy_assets")
   List<Asset> buyAssets = new ArrayList<>();
 
-  public void addAsset(@NonNull String assetName, @NonNull String price) {
-    int decimals = assetName.startsWith("iso4217") ? 4 : 7;
-    buyAssets.add(Asset.builder().asset(assetName).price(price).decimals(decimals).build());
+  public void addAsset(
+      @NonNull String buyAssetName, Integer buyAssetDecimals, @NonNull String price) {
+    int decimals = 7;
+    if (!buyAssetName.startsWith("stellar") && buyAssetDecimals != null) {
+      decimals = buyAssetDecimals;
+    }
+
+    buyAssets.add(Asset.builder().asset(buyAssetName).price(price).decimals(decimals).build());
+  }
+
+  public void addAsset(@NonNull String buyAssetName, @NonNull String price) {
+    addAsset(buyAssetName, null, price);
   }
 
   @Data

--- a/core/src/main/java/org/stellar/anchor/dto/sep38/GetPricesResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep38/GetPricesResponse.java
@@ -14,16 +14,8 @@ public class GetPricesResponse {
 
   public void addAsset(
       @NonNull String buyAssetName, Integer buyAssetDecimals, @NonNull String price) {
-    int decimals = 7;
-    if (!buyAssetName.startsWith("stellar") && buyAssetDecimals != null) {
-      decimals = buyAssetDecimals;
-    }
-
-    buyAssets.add(Asset.builder().asset(buyAssetName).price(price).decimals(decimals).build());
-  }
-
-  public void addAsset(@NonNull String buyAssetName, @NonNull String price) {
-    addAsset(buyAssetName, null, price);
+    buyAssets.add(
+        Asset.builder().asset(buyAssetName).price(price).decimals(buyAssetDecimals).build());
   }
 
   @Data

--- a/core/src/main/java/org/stellar/anchor/dto/sep38/InfoResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep38/InfoResponse.java
@@ -26,7 +26,12 @@ public class InfoResponse {
           newAsset.setSellDeliveryMethods(sep38Info.getSellDeliveryMethods());
           newAsset.setBuyDeliveryMethods(sep38Info.getBuyDeliveryMethods());
           newAsset.setExchangeableAssetNames(sep38Info.getExchangeableAssets());
-          newAsset.setDecimals(sep38Info.getDecimals());
+
+          int decimals = 7;
+          if (!assetName.startsWith("stellar") && sep38Info.getDecimals() != null) {
+            decimals = sep38Info.getDecimals();
+          }
+          newAsset.setDecimals(decimals);
 
           assets.add(newAsset);
         });

--- a/core/src/main/java/org/stellar/anchor/dto/sep38/InfoResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep38/InfoResponse.java
@@ -26,6 +26,7 @@ public class InfoResponse {
           newAsset.setSellDeliveryMethods(sep38Info.getSellDeliveryMethods());
           newAsset.setBuyDeliveryMethods(sep38Info.getBuyDeliveryMethods());
           newAsset.setExchangeableAssetNames(sep38Info.getExchangeableAssets());
+          newAsset.setDecimals(sep38Info.getDecimals());
 
           assets.add(newAsset);
         });
@@ -45,6 +46,8 @@ public class InfoResponse {
     private List<AssetInfo.Sep38Operation.DeliveryMethod> buyDeliveryMethods;
 
     private transient List<String> exchangeableAssetNames;
+
+    private transient Integer decimals;
 
     public boolean supportsSellDeliveryMethod(String deliveryMethod) {
       return supportsDeliveryMethod(sellDeliveryMethods, deliveryMethod);

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -198,21 +198,22 @@ public class Sep38Service {
     BigDecimal bSellAmount, bBuyAmount;
     if (sellAmount != null) {
       bSellAmount = new BigDecimal(sellAmount);
-      bBuyAmount = bSellAmount.divide(bPrice, buyAsset.getDecimals(), RoundingMode.HALF_UP);
+      bBuyAmount = bSellAmount.divide(bPrice, buyAsset.getDecimals(), RoundingMode.DOWN);
     } else {
       bBuyAmount = new BigDecimal(buyAmount);
       bSellAmount = bBuyAmount.multiply(bPrice);
     }
     builder =
         builder
-            .sellAmount(formatAmount(bSellAmount, sellAsset.getDecimals()))
-            .buyAmount(formatAmount(bBuyAmount, buyAsset.getDecimals()));
+            .sellAmount(formatAmount(bSellAmount, sellAsset.getDecimals(), RoundingMode.UP))
+            .buyAmount(formatAmount(bBuyAmount, buyAsset.getDecimals(), RoundingMode.DOWN));
 
     return builder.build();
   }
 
-  private String formatAmount(BigDecimal amount, Integer decimals) throws NumberFormatException {
-    BigDecimal newAmount = amount.setScale(decimals, RoundingMode.HALF_UP);
+  private String formatAmount(BigDecimal amount, Integer decimals, RoundingMode roundingMode)
+      throws NumberFormatException {
+    BigDecimal newAmount = amount.setScale(decimals, roundingMode);
 
     DecimalFormat df = new DecimalFormat();
     df.setMaximumFractionDigits(decimals);

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -198,8 +198,7 @@ public class Sep38Service {
     BigDecimal bSellAmount, bBuyAmount;
     if (sellAmount != null) {
       bSellAmount = new BigDecimal(sellAmount);
-      int buyDecimals = buyAsset.getDecimals() != null ? buyAsset.getDecimals() : 7;
-      bBuyAmount = bSellAmount.divide(bPrice, buyDecimals, RoundingMode.HALF_UP);
+      bBuyAmount = bSellAmount.divide(bPrice, buyAsset.getDecimals(), RoundingMode.HALF_UP);
     } else {
       bBuyAmount = new BigDecimal(buyAmount);
       bSellAmount = bBuyAmount.multiply(bPrice);
@@ -213,11 +212,10 @@ public class Sep38Service {
   }
 
   private String formatAmount(BigDecimal amount, Integer decimals) throws NumberFormatException {
-    int newDecimals = decimals != null ? decimals : 7;
-    BigDecimal newAmount = amount.setScale(newDecimals, RoundingMode.HALF_UP);
+    BigDecimal newAmount = amount.setScale(decimals, RoundingMode.HALF_UP);
 
     DecimalFormat df = new DecimalFormat();
-    df.setMaximumFractionDigits(newDecimals);
+    df.setMaximumFractionDigits(decimals);
     df.setMinimumFractionDigits(0);
     df.setGroupingUsed(false);
 

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -198,22 +198,21 @@ public class Sep38Service {
     BigDecimal bSellAmount, bBuyAmount;
     if (sellAmount != null) {
       bSellAmount = new BigDecimal(sellAmount);
-      bBuyAmount = bSellAmount.divide(bPrice, buyAsset.getDecimals(), RoundingMode.DOWN);
+      bBuyAmount = bSellAmount.divide(bPrice, buyAsset.getDecimals(), RoundingMode.HALF_DOWN);
     } else {
       bBuyAmount = new BigDecimal(buyAmount);
       bSellAmount = bBuyAmount.multiply(bPrice);
     }
     builder =
         builder
-            .sellAmount(formatAmount(bSellAmount, sellAsset.getDecimals(), RoundingMode.UP))
-            .buyAmount(formatAmount(bBuyAmount, buyAsset.getDecimals(), RoundingMode.DOWN));
+            .sellAmount(formatAmount(bSellAmount, sellAsset.getDecimals()))
+            .buyAmount(formatAmount(bBuyAmount, buyAsset.getDecimals()));
 
     return builder.build();
   }
 
-  private String formatAmount(BigDecimal amount, Integer decimals, RoundingMode roundingMode)
-      throws NumberFormatException {
-    BigDecimal newAmount = amount.setScale(decimals, roundingMode);
+  private String formatAmount(BigDecimal amount, Integer decimals) throws NumberFormatException {
+    BigDecimal newAmount = amount.setScale(decimals, RoundingMode.HALF_DOWN);
 
     DecimalFormat df = new DecimalFormat();
     df.setMaximumFractionDigits(decimals);

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -174,9 +174,10 @@ class Sep38ServiceTest {
     val wantResponse = GetPricesResponse()
     wantResponse.addAsset(
       "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      7,
       "1"
     )
-    wantResponse.addAsset(stellarUSDC, "2")
+    wantResponse.addAsset(stellarUSDC, 7, "2")
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -213,9 +214,10 @@ class Sep38ServiceTest {
     val wantResponse = GetPricesResponse()
     wantResponse.addAsset(
       "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      7,
       "1.1"
     )
-    wantResponse.addAsset(stellarUSDC, "2.1")
+    wantResponse.addAsset(stellarUSDC, 7, "2.1")
     assertEquals(wantResponse, gotResponse)
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -390,7 +390,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrice("iso4217:USD", "100", null, stellarUSDC, null, null, null)
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392156").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -442,7 +442,7 @@ class Sep38ServiceTest {
         sep38Service.getPrice("iso4217:USD", "100", "WIRE", stellarUSDC, null, null, "USA")
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392156").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -458,7 +458,7 @@ class Sep38ServiceTest {
         .countryCode("USA")
         .sellDeliveryMethod("WIRE")
         .build()
-    every { mockRateIntegration.getRate(getRateReq) } returns GetRateResponse("1.02")
+    every { mockRateIntegration.getRate(getRateReq) } returns GetRateResponse("1.02345678901")
     sep38Service =
       Sep38Service(sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration)
 
@@ -470,7 +470,11 @@ class Sep38ServiceTest {
         sep38Service.getPrice("iso4217:USD", null, "WIRE", stellarUSDC, "100", null, "USA")
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("102").buyAmount("100").build()
+      GetPriceResponse.builder()
+        .price("1.02345678901")
+        .sellAmount("102.3457")
+        .buyAmount("100")
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -390,7 +390,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrice("iso4217:USD", "100", null, stellarUSDC, null, null, null)
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392156").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -442,7 +442,7 @@ class Sep38ServiceTest {
         sep38Service.getPrice("iso4217:USD", "100", "WIRE", stellarUSDC, null, null, "USA")
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392156").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
     assertEquals(wantResponse, gotResponse)
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -240,7 +240,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrices(stellarUSDC, "100", null, "WIRE", null)
     }
     val wantResponse = GetPricesResponse()
-    wantResponse.addAsset("iso4217:USD", "1")
+    wantResponse.addAsset("iso4217:USD", 4, "1")
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -388,7 +388,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrice("iso4217:USD", "100", null, stellarUSDC, null, null, null)
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -412,7 +412,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrice("iso4217:USD", null, null, stellarUSDC, "100", null, null)
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("102.00").buyAmount("100").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("102").buyAmount("100").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -440,7 +440,7 @@ class Sep38ServiceTest {
         sep38Service.getPrice("iso4217:USD", "100", "WIRE", stellarUSDC, null, null, "USA")
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("100").buyAmount("98.0392157").build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -468,7 +468,7 @@ class Sep38ServiceTest {
         sep38Service.getPrice("iso4217:USD", null, "WIRE", stellarUSDC, "100", null, "USA")
     }
     val wantResponse =
-      GetPriceResponse.builder().price("1.02").sellAmount("102.00").buyAmount("100").build()
+      GetPriceResponse.builder().price("1.02").sellAmount("102").buyAmount("100").build()
     assertEquals(wantResponse, gotResponse)
   }
 }

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -101,6 +101,7 @@
           "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
         ],
         "country_codes": ["USA"],
+        "decimals": 4,
         "sell_delivery_methods": [
           {
             "name": "WIRE",

--- a/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
@@ -1,5 +1,8 @@
 package org.stellar.anchor.platform;
 
+import static org.springframework.boot.Banner.Mode.OFF;
+
+import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -10,10 +13,6 @@ import org.stellar.anchor.platform.configurator.DataAccessConfigurator;
 import org.stellar.anchor.platform.configurator.PlatformAppConfigurator;
 import org.stellar.anchor.platform.configurator.PropertiesReader;
 import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator;
-
-import java.util.Map;
-
-import static org.springframework.boot.Banner.Mode.OFF;
 
 @SpringBootApplication
 @EnableConfigurationProperties

--- a/platform/src/main/resources/assets-prod.json
+++ b/platform/src/main/resources/assets-prod.json
@@ -62,6 +62,7 @@
                     "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
                 ],
                 "country_codes": ["USA"],
+                "decimals": 4,
                 "sell_delivery_methods": [
                     {
                         "name": "WIRE",

--- a/platform/src/main/resources/assets-test.json
+++ b/platform/src/main/resources/assets-test.json
@@ -61,6 +61,7 @@
                     "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                 ],
                 "country_codes": ["USA"],
+                "decimals": 4,
                 "sell_delivery_methods": [
                     {
                         "name": "WIRE",

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -101,6 +101,7 @@
           "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
         ],
         "country_codes": ["USA"],
+        "decimals": 4,
         "sell_delivery_methods": [
           {
             "name": "WIRE",

--- a/platform/src/test/resources/test_sep38_get_info.json
+++ b/platform/src/test/resources/test_sep38_get_info.json
@@ -9,6 +9,7 @@
     {
       "asset": "iso4217:USD",
       "country_codes": ["USA"],
+      "decimals": 4,
       "sell_delivery_methods": [
         {
           "name": "WIRE",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The number of decimals returned in SEP-38's [`GET /prices`], [`POST /quote`] and [`GET /quote/:id`] requests now defaults to **7** and can be configured to a different value in the assets.json config file.

### Why

Addressing Jake's comment in https://github.com/stellar/java-stellar-anchor-sdk/pull/113#discussion_r826102562.

[`GET /prices`]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-prices
[`POST /quote`]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#post-quote
[`GET /quote/:id`]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-quote
