### PR TITLE
ci: add script to validate SEP-1 and SEP-38

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,18 +71,22 @@ jobs:
           # Can be "open", "closed", or "all".  Defaults to "open".
           state: open
 
-      # This will echo "Your PR is 7", or be skipped if there is no current PR.
-      - name: Check if `findPr` worked
+      - name: Wait for preview endpoint to be up and running
+        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
         env:
           PR: ${{ steps.findPr.outputs.pr }}
-        run: echo "Your PR is ${PR}"
+        with:
+          url: https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml
+          responseCode: 200
+          timeout: 30000
+          interval: 1000
 
       - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: 14
 
-      - name: Install & run stellar-anchor-tests for SEPs 1 and 38
+      - name: Validate SEPs (1, 38)
         env:
           PR: ${{ steps.findPr.outputs.pr }}
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
     if: github.event.pull_request != null
     needs: [build_and_test]
     runs-on: ubuntu-latest
-    name: Run [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) for SEP-38
+    name: Validate SEPs (1, 38)
     steps:
       - uses: actions/checkout@v1
 
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version: 14
 
-      - name: Validate SEPs (1, 38)
+      - name: Run Validation Tool
         env:
           PR: ${{ steps.findPr.outputs.pr }}
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,7 +57,7 @@ jobs:
 
   sep_validation_suite:
     if: github.event.pull_request != null
-    needs: [build_and_push_anchor_platform]
+    needs: [build_and_test]
     runs-on: ubuntu-latest
     name: Run [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) for SEP-38
     steps:
@@ -73,16 +73,29 @@ jobs:
 
       # This will echo "Your PR is 7", or be skipped if there is no current PR.
       - name: Check if `findPr` worked
-        run: echo "Your PR is ${PR}"
         env:
           PR: ${{ steps.findPr.outputs.pr }}
+        run: echo "Your PR is ${PR}"
 
       - name: Wait for preview endpoint to be up and running
         uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
         env:
           PR: ${{ steps.findPr.outputs.pr }}
         with:
-          url: 'https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml'
+          url: https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml
           responseCode: 200
-          timeout: 240000
+          timeout: 30000
           interval: 1000
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests)
+        run: yarn global add @stellar/anchor-tests
+
+      - name: Execute [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) in the preview instance.
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+        run: yarn stellar-anchor-tests --home-domain https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml --seps 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,6 +86,4 @@ jobs:
         run: yarn global add @stellar/anchor-tests
 
       - name: Execute [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) in the preview instance.
-        env:
-          PR: ${{ steps.findPr.outputs.pr }}
-        run: yarn stellar-anchor-tests --home-domain https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml --seps 38
+        run: yarn stellar-anchor-tests --home-domain https://anchor-sep-pr${{ steps.findPr.outputs.pr }}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml --seps 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,7 @@ jobs:
         cat /home/runner/work/java-stellar-anchor-sdk/java-stellar-anchor-sdk/platform/build/reports/tests/test/index.html
         echo *** Anchor reference server test report ***
         cat /home/runner/work/java-stellar-anchor-sdk/java-stellar-anchor-sdk/anchor-reference-server/build/reports/tests/test/index.html
+
   build_and_push_anchor_platform:
     needs: [build_and_test]
     runs-on: ubuntu-latest
@@ -53,3 +54,35 @@ jobs:
         push: true
         tags: stellar/anchor-platform:${{ steps.get_tag.outputs.TAG }}
         file: Dockerfile
+
+  sep_validation_suite:
+    if: github.event.pull_request != null
+    needs: [build_and_push_anchor_platform]
+    runs-on: ubuntu-latest
+    name: Run [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) for SEP-38
+    steps:
+      - uses: actions/checkout@v1
+
+      # Find the PR associated with this push, if there is one.
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@465461f2b0e83dd1a57b3a04e7c81050705f7391
+        id: findPr
+        with:
+          # Can be "open", "closed", or "all".  Defaults to "open".
+          state: open
+
+      # This will echo "Your PR is 7", or be skipped if there is no current PR.
+      - name: Check if `findPr` worked
+        run: echo "Your PR is ${PR}"
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+
+      - name: Wait for preview endpoint to be up and running
+        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+        with:
+          url: 'https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml'
+          responseCode: 200
+          timeout: 240000
+          interval: 1000

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,6 +83,8 @@ jobs:
           node-version: 14
 
       - name: Install & run stellar-anchor-tests for SEPs 1 and 38
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
         run: |
           npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain https://anchor-sep-pr165.previews.kube001.services.stellar-ops.com --seps 1 38
+          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,16 +77,6 @@ jobs:
           PR: ${{ steps.findPr.outputs.pr }}
         run: echo "Your PR is ${PR}"
 
-      - name: Wait for preview endpoint to be up and running
-        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
-        env:
-          PR: ${{ steps.findPr.outputs.pr }}
-        with:
-          url: https://anchor-sep-pr${PR}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml
-          responseCode: 200
-          timeout: 30000
-          interval: 1000
-
       - name: Install Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,7 +83,9 @@ jobs:
           node-version: 14
 
       - name: Install [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests)
-        run: yarn global add @stellar/anchor-tests
+        run: |
+          yarn global add @stellar/anchor-tests
+          echo "$(yarn global bin)" >> $GITHUB_PATH
 
       - name: Execute [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) in the preview instance.
         run: yarn stellar-anchor-tests --home-domain https://anchor-sep-pr${{ steps.findPr.outputs.pr }}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml --seps 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,10 +82,7 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests)
+      - name: Install & run stellar-anchor-tests for SEPs 1 and 38
         run: |
-          yarn global add @stellar/anchor-tests
-          echo "$(yarn global bin)" >> $GITHUB_PATH
-
-      - name: Execute [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) in the preview instance.
-        run: yarn stellar-anchor-tests --home-domain https://anchor-sep-pr${{ steps.findPr.outputs.pr }}.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml --seps 38
+          npm install -g @stellar/anchor-tests
+          stellar-anchor-tests --home-domain https://anchor-sep-pr165.previews.kube001.services.stellar-ops.com --seps 1 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,16 +71,6 @@ jobs:
           # Can be "open", "closed", or "all".  Defaults to "open".
           state: open
 
-      - name: Wait for preview endpoint to be up and running
-        uses: nev7n/wait_for_response@7fef3c1a6e8939d0b09062f14fec50d3c5d15fa1
-        env:
-          PR: ${{ steps.findPr.outputs.pr }}
-        with:
-          url: https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com/.well-known/stellar.toml
-          responseCode: 200
-          timeout: 30000
-          interval: 1000
-
       - name: Install Node
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

</details>

### What

Add a Github Action that runs the [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) script in the preview instance to validate SEPs 1 and 38.

### Why

To make sure our SEP implementations are fully compliant.

Close #116 

### Known limitations

There's also a Jenkins job attempting to run this same script but it's failing, so please nevermind the following Jenkins status:

![Screen Shot 2022-03-31 at 16 46 28](https://user-images.githubusercontent.com/1952597/161136799-f59568da-cc88-4c31-b4a0-814ef53bd088.png)

Will be following up about that in this issue: https://github.com/stellar/java-stellar-anchor-sdk/issues/171