### PR TITLE
platform: Integrate payment observer with SEP-31

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
@@ -145,6 +145,10 @@ public class CustomerService {
   }
 
   private void updateCustomer(Customer customer, PutCustomerRequest request) {
+    customer.setStellarAccount(request.getAccount());
+    customer.setMemo(request.getMemo());
+    customer.setMemoType(request.getMemoType());
+
     if (request.getFirstName() != null) {
       customer.setFirstName(request.getFirstName());
     }

--- a/core/src/main/java/org/stellar/anchor/dto/sep31/Sep31InfoResponse.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep31/Sep31InfoResponse.java
@@ -11,6 +11,8 @@ public class Sep31InfoResponse {
 
   @Data
   public static class AssetResponse {
+    Boolean enabled = true;
+
     @SerializedName("quotes_supported")
     Boolean quotesSupported;
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionStore.java
@@ -33,6 +33,15 @@ public interface Sep31TransactionStore {
       throws SepException;
 
   /**
+   * Find the transactions by the transaction memo.
+   *
+   * @param memo transaction memo.
+   * @return The matching transaction.
+   * @throws SepException if error happens.
+   */
+  Sep31Transaction findByStellarMemo(@NonNull String memo) throws SepException;
+
+  /**
    * Save a transaction.
    *
    * @param sep31Transaction The transaction to be saved.

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -95,7 +95,7 @@ public class Sep38Service {
     GetPricesResponse response = new GetPricesResponse();
     for (String buyAssetName : sellAsset.getExchangeableAssetNames()) {
       InfoResponse.Asset buyAsset = this.assetMap.get(buyAssetName);
-      if (!buyAsset.supportsBuyDeliveryMethod(buyDeliveryMethod)) {
+      if (buyAsset == null || !buyAsset.supportsBuyDeliveryMethod(buyDeliveryMethod)) {
         continue;
       }
 

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -38,6 +38,23 @@ public class MemoHelper {
     return makeMemo(memo, mt);
   }
 
+  public static String memoType(MemoType memoType) {
+    switch (memoType) {
+      case MEMO_ID:
+        return "id";
+      case MEMO_TEXT:
+        return "text";
+      case MEMO_HASH:
+        return "hash";
+      case MEMO_NONE:
+        return "none";
+      case MEMO_RETURN:
+        return "return";
+      default:
+        throw new RuntimeException("Unsupported value: " + memoType);
+    }
+  }
+
   public static Memo makeMemo(String memo, MemoType memoType) throws SepException {
     try {
       switch (memoType) {

--- a/data-spring-jdbc/src/main/java/org/stellar/anchor/server/data/JdbcSep31TransactionRepo.java
+++ b/data-spring-jdbc/src/main/java/org/stellar/anchor/server/data/JdbcSep31TransactionRepo.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.stellar.anchor.model.Sep31Transaction;
 
 public interface JdbcSep31TransactionRepo extends CrudRepository<JdbcSep31Transaction, String> {
   Optional<JdbcSep31Transaction> findById(@NonNull String id);
@@ -15,4 +16,6 @@ public interface JdbcSep31TransactionRepo extends CrudRepository<JdbcSep31Transa
   List<JdbcSep31Transaction> findByIds(@Param("ids") Collection<String> ids);
 
   Optional<JdbcSep31Transaction> findByStellarAccountId(@NonNull String stellarAccountId);
+
+  Optional<Sep31Transaction> findByStellarMemo(String stellarMemo);
 }

--- a/data-spring-jdbc/src/main/java/org/stellar/anchor/server/data/JdbcSep31TransactionStore.java
+++ b/data-spring-jdbc/src/main/java/org/stellar/anchor/server/data/JdbcSep31TransactionStore.java
@@ -43,6 +43,11 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
   }
 
   @Override
+  public Sep31Transaction findByStellarMemo(@NonNull String memo) throws SepException {
+    return transactionRepo.findByStellarMemo(memo).orElse(null);
+  }
+
+  @Override
   public Sep31Transaction save(Sep31Transaction transaction) throws SepException {
     if (!(transaction instanceof JdbcSep31Transaction)) {
       throw new SepException(

--- a/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/requests/PutCustomerRequest.java
+++ b/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/requests/PutCustomerRequest.java
@@ -1,7 +1,7 @@
 package org.stellar.platform.apis.callbacks.requests;
 
 import com.google.gson.annotations.SerializedName;
-import java.time.LocalDate;
+import java.time.Instant;
 import lombok.Data;
 
 @Data
@@ -44,10 +44,10 @@ public class PutCustomerRequest {
   String emailAddress;
 
   @SerializedName("birth_date")
-  LocalDate birthDate;
+  Instant birthDate;
 
   @SerializedName("birth_place")
-  LocalDate birthPlace;
+  Instant birthPlace;
 
   @SerializedName("birth_country_code")
   String birthCountryCode;
@@ -88,10 +88,10 @@ public class PutCustomerRequest {
   String idCountryCode;
 
   @SerializedName("id_issue_date")
-  LocalDate idIssueDate;
+  Instant idIssueDate;
 
   @SerializedName("id_expiration_date")
-  LocalDate idExpirationDate;
+  Instant idExpirationDate;
 
   @SerializedName("id_number")
   String idNumber;

--- a/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
@@ -1,9 +1,6 @@
 package org.stellar.anchor.platform;
 
-import static org.springframework.boot.Banner.Mode.OFF;
-
 import com.google.gson.Gson;
-import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -18,6 +15,10 @@ import org.stellar.anchor.platform.configurator.PlatformAppConfigurator;
 import org.stellar.anchor.platform.configurator.PropertiesReader;
 import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator;
 import org.stellar.anchor.util.GsonUtils;
+
+import java.util.Map;
+
+import static org.springframework.boot.Banner.Mode.OFF;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"org.stellar.anchor.server.data"})

--- a/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
@@ -1,6 +1,9 @@
 package org.stellar.anchor.platform;
 
+import static org.springframework.boot.Banner.Mode.OFF;
+
 import com.google.gson.Gson;
+import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -15,10 +18,6 @@ import org.stellar.anchor.platform.configurator.PlatformAppConfigurator;
 import org.stellar.anchor.platform.configurator.PropertiesReader;
 import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator;
 import org.stellar.anchor.util.GsonUtils;
-
-import java.util.Map;
-
-import static org.springframework.boot.Banner.Mode.OFF;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"org.stellar.anchor.server.data"})

--- a/platform/src/main/java/org/stellar/anchor/platform/SepConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/SepConfig.java
@@ -53,7 +53,8 @@ public class SepConfig {
     FilterRegistrationBean<Sep10TokenFilter> registrationBean = new FilterRegistrationBean<>();
     registrationBean.setFilter(new Sep10TokenFilter(sep10Config, jwtService));
     registrationBean.addUrlPatterns("/sep12/*");
-    registrationBean.addUrlPatterns("/sep31/*");
+    registrationBean.addUrlPatterns("/sep31/transactions");
+    registrationBean.addUrlPatterns("/sep31/transactions/*");
     registrationBean.addUrlPatterns("/sep38/quote");
     registrationBean.addUrlPatterns("/sep38/quote/*");
     return registrationBean;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -2,6 +2,9 @@ package org.stellar.anchor.platform.controller;
 
 import static org.stellar.anchor.platform.controller.Sep10Helper.getSep10Token;
 
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.dto.sep12.*;
 import org.stellar.anchor.sep10.JwtToken;
 import org.stellar.anchor.sep12.Sep12Service;
+import org.stellar.anchor.util.GsonUtils;
 
 @RestController
 @CrossOrigin(origins = "*")
@@ -57,6 +61,25 @@ public class Sep12Controller {
       method = {RequestMethod.PUT})
   public Sep12PutCustomerResponse putCustomer(
       HttpServletRequest request, @RequestBody Sep12PutCustomerRequest putCustomerRequest) {
+    JwtToken jwtToken = getSep10Token(request);
+    return sep12Service.putCustomer(jwtToken, putCustomerRequest);
+  }
+
+  @SneakyThrows
+  @CrossOrigin(origins = "*")
+  @ResponseStatus(code = HttpStatus.ACCEPTED)
+  @RequestMapping(
+      value = "/customer",
+      method = {RequestMethod.POST, RequestMethod.PUT},
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+  public Sep12PutCustomerResponse putCustomerMultipart(HttpServletRequest request) {
+    Gson gson = GsonUtils.getInstance();
+    Map<String, String> requestData = new HashMap<>();
+    for (Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
+      requestData.put(entry.getKey(), entry.getValue()[0]);
+    }
+    Sep12PutCustomerRequest putCustomerRequest =
+        gson.fromJson(gson.toJson(requestData), Sep12PutCustomerRequest.class);
     JwtToken jwtToken = getSep10Token(request);
     return sep12Service.putCustomer(jwtToken, putCustomerRequest);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.service;
 
 import com.google.gson.Gson;
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.stereotype.Component;
 import org.stellar.anchor.exception.SepException;
 import org.stellar.anchor.model.Sep31Transaction;
@@ -12,6 +13,7 @@ import org.stellar.anchor.server.data.JdbcSep31TransactionStore;
 import org.stellar.anchor.util.Log;
 import org.stellar.platform.apis.shared.Amount;
 import org.stellar.sdk.AssetTypeCreditAlphaNum;
+import org.stellar.sdk.MemoHash;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
 
 @Component
@@ -24,15 +26,29 @@ public class PaymentOperationToEventListener implements PaymentListener {
 
   @Override
   public void onReceived(PaymentOperationResponse payment) {
+    if (!payment.getTransaction().isPresent()) {
+      return;
+    }
+
+    MemoHash memoHash = (MemoHash) payment.getTransaction().get().getMemo();
+    String hash = new String(Base64.encodeBase64(memoHash.getBytes()));
+
     // Find the matching transaction
-    Sep31Transaction txn = transactionStore.findByStellarAccountId(payment.getTo());
+    Sep31Transaction txn = null;
+    try {
+      txn = transactionStore.findByStellarMemo(hash);
+    } catch (SepException e) {
+      Log.info(String.format("error finding transaction that matches the memo (%s).", hash));
+    }
+
     if (txn == null) {
-      Log.error(String.format("no transaction(stellarAccountId=%s) is found.", payment.getTo()));
+      Log.info(String.format("no transaction(stellarAccountId=%s) is found.", payment.getTo()));
       return;
     }
 
     if (!(payment.getAsset() instanceof AssetTypeCreditAlphaNum)) {
-      // Asset does not match
+      // Asset does not match. Ignore.
+      Log.info(String.format("unexpected payment type %s", payment.getAsset().getClass()));
       return;
     }
 
@@ -50,6 +66,8 @@ public class PaymentOperationToEventListener implements PaymentListener {
     // Set the transaction status.
     if (txn.getStatus().equals(TransactionStatus.PENDING_SENDER.toString())) {
       txn.setStatus(TransactionStatus.PENDING_RECEIVER.toString());
+      txn.setStatus(
+          TransactionStatus.COMPLETED.toString()); // TODO: remove after event API is implemented.
       try {
         transactionStore.save(txn);
       } catch (SepException ex) {

--- a/platform/src/main/kotlin/org/stellar/anchor/platform/Sep38Tests.kt
+++ b/platform/src/main/kotlin/org/stellar/anchor/platform/Sep38Tests.kt
@@ -31,7 +31,7 @@ fun sep38TestHappyPath() {
     sep38.getPrice(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
     )
   printResponse(price)
 
@@ -41,7 +41,7 @@ fun sep38TestHappyPath() {
     sep38.postQuote(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
     )
   printResponse(postQuote)
 
@@ -52,7 +52,7 @@ fun sep38TestHappyPath() {
     sep38.postQuote(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
       expiresAfter
     )
   printResponse(postQuote)

--- a/platform/src/main/kotlin/org/stellar/anchor/platform/SepClient.kt
+++ b/platform/src/main/kotlin/org/stellar/anchor/platform/SepClient.kt
@@ -28,7 +28,13 @@ open class SepClient {
     println("responseBody: $responseBody")
     if (response.code == HttpStatus.FORBIDDEN.value()) {
       throw SepNotAuthorizedException("Forbidden")
-    } else if (!listOf(HttpStatus.OK.value(), HttpStatus.CREATED.value()).contains(response.code)) {
+    } else if (!listOf(
+          HttpStatus.OK.value(),
+          HttpStatus.CREATED.value(),
+          HttpStatus.ACCEPTED.value()
+        )
+        .contains(response.code)
+    ) {
       throw SepException(responseBody)
     }
 

--- a/platform/src/main/resources/assets-test.json
+++ b/platform/src/main/resources/assets-test.json
@@ -3,8 +3,8 @@
         {
             "schema": "stellar",
             "code": "USDC",
-            "issuer": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-            "distribution_account": "GBJDTHT4562X2H37JMOE6IUTZZSDU6RYGYUNFYCHVFG3J4MYJIMU33HK",
+            "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+            "distribution_account": "GDVARAZQD3B5QKKQG2AE455HXLD3NYFWRMPBGXSH2VE3L3CF23CAZDUB",
             "significant_decimals": 2,
             "deposit" : {
                 "enabled": true,
@@ -105,7 +105,7 @@
             },
             "sep38": {
                 "exchangeable_assets": [
-                    "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+                    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                 ],
                 "country_codes": ["USA"],
                 "decimals": 4,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Integrate PaymentObserver with SEP-31. 

### Why

N/A.
### Known limitations

The transaction status is changed to COMPLETED after the payment is received. When event queue is implemented, the reference server should call `PATCH /transactions` to update the status from PENDING_RECEIVER to COMPLETED.