### PR TITLE
all: update the `stellar-anchor-tests` CI command to also validate SEP-10, SEP-12 and SEP-31

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,7 @@ jobs:
         cat /home/runner/work/java-stellar-anchor-sdk/java-stellar-anchor-sdk/anchor-reference-server/build/reports/tests/test/index.html
 
   build_and_push_anchor_platform:
+    if: github.event.pull_request == null
     needs: [build_and_test]
     runs-on: ubuntu-latest
     name: Push stellar/anchor-platform:sha to DockerHub

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -81,4 +81,4 @@ jobs:
           PR: ${{ steps.findPr.outputs.pr }}
         run: |
           npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 38
+          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 10 38

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,4 +82,4 @@ jobs:
           PR: ${{ steps.findPr.outputs.pr }}
         run: |
           npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 10 12 38 --sep-config platform/src/test/resources/stellar-anchor-tests-sep-config.json
+          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 10 12 31 38 --sep-config platform/src/test/resources/stellar-anchor-tests-sep-config.json

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate SEPs (1, 38)
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       # Find the PR associated with this push, if there is one.
       - name: Find PR number
@@ -82,4 +82,4 @@ jobs:
           PR: ${{ steps.findPr.outputs.pr }}
         run: |
           npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 10 38
+          stellar-anchor-tests --home-domain https://anchor-sep-pr$PR.previews.kube001.services.stellar-ops.com --seps 1 10 12 38 --sep-config platform/src/test/resources/stellar-anchor-tests-sep-config.json

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/CustomerController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/CustomerController.java
@@ -4,10 +4,8 @@ import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.exception.NotFoundException;
 import org.stellar.anchor.reference.config.AppSettings;
 import org.stellar.anchor.reference.service.CustomerService;
-import org.stellar.platform.apis.callbacks.requests.DeleteCustomerRequest;
 import org.stellar.platform.apis.callbacks.requests.GetCustomerRequest;
 import org.stellar.platform.apis.callbacks.requests.PutCustomerRequest;
-import org.stellar.platform.apis.callbacks.responses.DeleteCustomerResponse;
 import org.stellar.platform.apis.callbacks.responses.GetCustomerResponse;
 import org.stellar.platform.apis.callbacks.responses.PutCustomerResponse;
 
@@ -41,9 +39,7 @@ public class CustomerController {
   @RequestMapping(
       value = "/customer/{id}",
       method = {RequestMethod.DELETE})
-  public DeleteCustomerResponse deleteCustomer(@PathVariable String id) throws NotFoundException {
-    DeleteCustomerRequest request = new DeleteCustomerRequest();
-    request.setId(id);
-    return customerService.delete(request);
+  public void deleteCustomer(@PathVariable String id) {
+    customerService.delete(id);
   }
 }

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/GlobalControllerExceptionHandler.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/GlobalControllerExceptionHandler.java
@@ -4,29 +4,43 @@ import static org.stellar.anchor.util.Log.errorEx;
 
 import java.io.IOException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.stellar.anchor.dto.SepExceptionResponse;
-import org.stellar.anchor.exception.BadRequestException;
-import org.stellar.anchor.exception.NotFoundException;
-import org.stellar.anchor.exception.ServerErrorException;
-import org.stellar.anchor.exception.UnprocessableEntityException;
+import org.stellar.anchor.exception.*;
 
 @RestControllerAdvice
 public class GlobalControllerExceptionHandler {
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  @ExceptionHandler({NotFoundException.class})
-  public SepExceptionResponse handleNotFoundError(Exception ex) {
+  @ExceptionHandler({SepNotFoundException.class, NotFoundException.class})
+  public SepExceptionResponse handleNotFoundError(AnchorException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
   }
 
   @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
   @ExceptionHandler({BadRequestException.class, UnprocessableEntityException.class})
-  public SepExceptionResponse handleUnprocessableEntityError(Exception ex) {
+  public SepExceptionResponse handleUnprocessableEntityError(AnchorException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
+  }
+
+  @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public SepExceptionResponse handleMissingParams(MissingServletRequestParameterException ex) {
+    errorEx(ex);
+    String name = ex.getParameterName();
+    return new SepExceptionResponse(String.format("The \"%s\" parameter is missing.", name));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(value = HttpStatus.UNPROCESSABLE_ENTITY)
+  public SepExceptionResponse handleRandomException(HttpMessageNotReadableException ex) {
+    errorEx(ex);
+    return new SepExceptionResponse("Your request body is wrong in some way.");
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -34,7 +48,8 @@ public class GlobalControllerExceptionHandler {
     IOException.class,
     NullPointerException.class,
     RuntimeException.class,
-    ServerErrorException.class
+    ServerErrorException.class,
+    Exception.class
   })
   public SepExceptionResponse handleInternalError(Exception ex) {
     errorEx(ex);

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.reference.service;
 
+import static org.stellar.anchor.reference.model.Customer.Status.*;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -133,7 +135,8 @@ public class CustomerService {
     response.setId(customer.getId());
     response.setFields(fields);
     response.setProvidedFields(providedFields);
-    response.setStatus(getStatusForCustomer(customer, type));
+    Customer.Status status = (fields.size() > 0) ? NEEDS_INFO : ACCEPTED;
+    response.setStatus(status.toString());
     return response;
   }
 
@@ -167,28 +170,6 @@ public class CustomerService {
       }
     }
     customerRepo.save(customer);
-  }
-
-  public String getStatusForCustomer(Customer customer, String type) {
-    if (Customer.Type.SEP31_SENDER.toString().equals(type)) {
-      if (customer.getFirstName() != null
-          && customer.getLastName() != null
-          && customer.getEmail() != null) {
-        return Customer.Status.ACCEPTED.toString();
-      } else {
-        return Customer.Status.NEEDS_INFO.toString();
-      }
-    } else {
-      if (customer.getFirstName() == null
-          || customer.getLastName() == null
-          || customer.getEmail() == null
-          || customer.getBankAccountNumber() == null
-          || customer.getBankRoutingNumber() == null) {
-        return Customer.Status.NEEDS_INFO.toString();
-      } else {
-        return Customer.Status.ACCEPTED.toString();
-      }
-    }
   }
 
   public Map<String, Field> getBasicFields() {

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
@@ -10,10 +10,8 @@ import org.springframework.stereotype.Service;
 import org.stellar.anchor.exception.NotFoundException;
 import org.stellar.anchor.reference.model.Customer;
 import org.stellar.anchor.reference.repo.CustomerRepo;
-import org.stellar.platform.apis.callbacks.requests.DeleteCustomerRequest;
 import org.stellar.platform.apis.callbacks.requests.GetCustomerRequest;
 import org.stellar.platform.apis.callbacks.requests.PutCustomerRequest;
-import org.stellar.platform.apis.callbacks.responses.DeleteCustomerResponse;
 import org.stellar.platform.apis.callbacks.responses.GetCustomerResponse;
 import org.stellar.platform.apis.callbacks.responses.PutCustomerResponse;
 import org.stellar.platform.apis.shared.Field;
@@ -73,11 +71,8 @@ public class CustomerService {
     return response;
   }
 
-  public DeleteCustomerResponse delete(DeleteCustomerRequest request) {
-    customerRepo.deleteById(request.getId());
-    DeleteCustomerResponse response = new DeleteCustomerResponse();
-    response.setId(request.getId());
-    return response;
+  public void delete(String customerId) {
+    customerRepo.deleteById(customerId);
   }
 
   private Customer getCustomerByRequestId(String id) throws NotFoundException {

--- a/core/src/main/java/org/stellar/anchor/dto/sep12/Sep12DeleteCustomerRequest.java
+++ b/core/src/main/java/org/stellar/anchor/dto/sep12/Sep12DeleteCustomerRequest.java
@@ -1,9 +1,11 @@
 package org.stellar.anchor.dto.sep12;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class Sep12DeleteCustomerRequest {
   String account;
   String memo;

--- a/core/src/main/java/org/stellar/anchor/integration/customer/CustomerIntegration.java
+++ b/core/src/main/java/org/stellar/anchor/integration/customer/CustomerIntegration.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.integration.customer;
 
-import org.stellar.anchor.dto.sep12.Sep12DeleteCustomerRequest;
 import org.stellar.anchor.dto.sep12.Sep12GetCustomerRequest;
 import org.stellar.anchor.dto.sep12.Sep12GetCustomerResponse;
 import org.stellar.anchor.dto.sep12.Sep12PutCustomerRequest;
@@ -29,10 +28,10 @@ public interface CustomerIntegration {
   /**
    * Deletes a customer.
    *
-   * @param request The request to delete a customer.
+   * @param id The id of the customer to be deleted.
    * @throws AnchorException if error happens
    */
-  void deleteCustomer(Sep12DeleteCustomerRequest request) throws AnchorException;
+  void deleteCustomer(String id) throws AnchorException;
 
   /**
    * The request for verification.

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -6,10 +6,7 @@ import static org.stellar.anchor.util.Log.shorter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep10Config;
@@ -108,7 +105,7 @@ public class Sep10Service {
     //
     try {
       String clientSigningKey = null;
-      if (challengeRequest.getClientDomain() != null) {
+      if (!Objects.toString(challengeRequest.getClientDomain(), "").isEmpty()) {
         clientSigningKey = getClientAccountId(challengeRequest.getClientDomain());
       }
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -31,6 +31,9 @@ public class Sep12Service {
     request.setMemo(getMemoForCustomerIntegration(request.getMemo(), token.getAccountMemo()));
     request.setMemoType(
         getMemoTypeForCustomerIntegration(request.getMemo(), request.getMemoType()));
+    if (request.getId() == null && request.getAccount() == null && token.getAccount() != null) {
+      request.setAccount(token.getAccount());
+    }
     return customerIntegration.getCustomer(request);
   }
 
@@ -47,6 +50,9 @@ public class Sep12Service {
     request.setMemo(getMemoForCustomerIntegration(request.getMemo(), token.getAccountMemo()));
     request.setMemoType(
         getMemoTypeForCustomerIntegration(request.getMemo(), request.getMemoType()));
+    if (request.getAccount() == null && token.getAccount() != null) {
+      request.setAccount(token.getAccount());
+    }
     return customerIntegration.putCustomer(request);
   }
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -26,10 +26,7 @@ import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.event.models.Amount;
 import org.stellar.anchor.event.models.StellarId;
 import org.stellar.anchor.event.models.TransactionEvent;
-import org.stellar.anchor.exception.AnchorException;
-import org.stellar.anchor.exception.BadRequestException;
-import org.stellar.anchor.exception.NotFoundException;
-import org.stellar.anchor.exception.SepException;
+import org.stellar.anchor.exception.*;
 import org.stellar.anchor.integration.customer.CustomerIntegration;
 import org.stellar.anchor.integration.fee.FeeIntegration;
 import org.stellar.anchor.model.Sep31Transaction;
@@ -274,7 +271,15 @@ public class Sep31Service {
       throw new BadRequestException("'fields' field must have one 'transaction' field");
     }
 
+    if (assetCode == null) {
+      throw new BadRequestException("Missing asset code.");
+    }
+
     AssetResponse fieldSpecs = this.infoResponse.getReceive().get(assetCode);
+    if (fieldSpecs == null) {
+      throw new SepNotFoundException("Asset not found.");
+    }
+
     Map<String, AssetInfo.Sep31TxnFieldSpec> missingFields =
         fieldSpecs.getFields().getTransaction().entrySet().stream()
             .filter(

--- a/docs/docker-examples/kafka/docker-compose.yaml
+++ b/docs/docker-examples/kafka/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   zookeeper:
+    platform: linux/x86_64
     image: confluentinc/cp-zookeeper:latest
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -9,6 +10,7 @@ services:
       - 22181:2181
 
   kafka:
+    platform: linux/x86_64
     image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper

--- a/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/requests/DeleteCustomerRequest.java
+++ b/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/requests/DeleteCustomerRequest.java
@@ -1,8 +1,0 @@
-package org.stellar.platform.apis.callbacks.requests;
-
-import lombok.Data;
-
-@Data
-public class DeleteCustomerRequest {
-  String id;
-}

--- a/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/responses/DeleteCustomerResponse.java
+++ b/platform-apis/src/main/java/org/stellar/platform/apis/callbacks/responses/DeleteCustomerResponse.java
@@ -1,8 +1,0 @@
-package org.stellar.platform.apis.callbacks.responses;
-
-import lombok.Data;
-
-@Data
-public class DeleteCustomerResponse {
-  String id;
-}

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
@@ -101,9 +101,17 @@ public class RestCustomerIntegration implements CustomerIntegration {
 
   @SneakyThrows
   @Override
-  public void deleteCustomer(Sep12DeleteCustomerRequest sep12DeleteCustomerRequest) {
-    //    DeleteCustomerRequest deleteRequest = fromSep12(sep12DeleteCustomerRequest);
-    throw new UnsupportedOperationException("not implemented");
+  public void deleteCustomer(String id) {
+    HttpUrl url = getCustomerUrlBuilder().addPathSegment(id).build();
+    Request callbackRequest = new Request.Builder().url(url).delete().build();
+
+    // Call anchor
+    Response response = call(httpClient, callbackRequest);
+    String responseContent = getContent(response);
+
+    if (response.code() != HttpStatus.OK.value()) {
+      throw httpError(responseContent, response.code(), gson);
+    }
   }
 
   @SneakyThrows

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.errorEx;
 
 import javax.transaction.NotSupportedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -18,6 +19,13 @@ public class GlobalControllerExceptionHandler {
   public SepExceptionResponse handleBadRequest(AnchorException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public SepExceptionResponse handleMissingParams(MissingServletRequestParameterException ex) {
+    String name = ex.getParameterName();
+    return new SepExceptionResponse(String.format("The \"%s\" parameter is missing.", name));
   }
 
   @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -46,7 +46,7 @@ public class GlobalControllerExceptionHandler {
 
   @ExceptionHandler({SepNotFoundException.class, NotFoundException.class})
   @ResponseStatus(value = HttpStatus.NOT_FOUND)
-  SepExceptionResponse handleNotFound(Exception ex) {
+  SepExceptionResponse handleNotFound(AnchorException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.errorEx;
 
 import javax.transaction.NotSupportedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -24,8 +25,16 @@ public class GlobalControllerExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public SepExceptionResponse handleMissingParams(MissingServletRequestParameterException ex) {
+    errorEx(ex);
     String name = ex.getParameterName();
     return new SepExceptionResponse(String.format("The \"%s\" parameter is missing.", name));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+  public SepExceptionResponse handleRandomException(HttpMessageNotReadableException ex) {
+    errorEx(ex);
+    return new SepExceptionResponse("Your request body is wrong in some way.");
   }
 
   @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -39,7 +39,7 @@ public class GlobalControllerExceptionHandler {
 
   @ResponseStatus(HttpStatus.FORBIDDEN)
   @ExceptionHandler({SepNotAuthorizedException.class})
-  public SepExceptionResponse handleAuthError(SepValidationException ex) {
+  public SepExceptionResponse handleAuthError(SepException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
@@ -79,8 +79,8 @@ public class Sep10Controller {
     InvalidSep10ChallengeException.class,
     URISyntaxException.class
   })
-  @ResponseStatus(value = org.springframework.http.HttpStatus.BAD_REQUEST)
-  public SepExceptionResponse handleSepValidationException(SepException ex) {
+  @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+  public SepExceptionResponse handleSepValidationException(Exception ex) {
     return new SepExceptionResponse(ex.getMessage());
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
@@ -81,6 +81,7 @@ public class Sep10Controller {
   })
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
   public SepExceptionResponse handleSepValidationException(Exception ex) {
+    errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -95,11 +95,9 @@ public class Sep12Controller {
       @PathVariable String account,
       @RequestBody(required = false) Sep12DeleteCustomerRequest body) {
     JwtToken jwtToken = getSep10Token(request);
-    if (body == null) {
-      sep12Service.deleteCustomer(jwtToken, account, null, null);
-      return;
-    }
-    sep12Service.deleteCustomer(jwtToken, account, body.getMemo(), body.getMemoType());
+    String memo = body != null ? body.getMemo() : null;
+    String memoType = body != null ? body.getMemoType() : null;
+    sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 
   @SneakyThrows

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -93,8 +93,9 @@ public class Sep12Controller {
   public void deleteCustomer(
       HttpServletRequest request,
       @PathVariable String account,
-      @RequestBody Sep12DeleteCustomerRequest deleteCustomerRequest) {
+      @RequestParam(required = false) String memo,
+      @RequestParam(required = false, name = "memo_type") String memoType) {
     JwtToken jwtToken = getSep10Token(request);
-    sep12Service.deleteCustomer(jwtToken, deleteCustomerRequest);
+    sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -93,6 +93,24 @@ public class Sep12Controller {
   public void deleteCustomer(
       HttpServletRequest request,
       @PathVariable String account,
+      @RequestBody(required = false) Sep12DeleteCustomerRequest body) {
+    JwtToken jwtToken = getSep10Token(request);
+    if (body == null) {
+      sep12Service.deleteCustomer(jwtToken, account, null, null);
+      return;
+    }
+    sep12Service.deleteCustomer(jwtToken, account, body.getMemo(), body.getMemoType());
+  }
+
+  @SneakyThrows
+  @CrossOrigin(origins = "*")
+  @RequestMapping(
+      value = "/customer/{account}",
+      consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+      method = {RequestMethod.DELETE})
+  public void deleteCustomer(
+      HttpServletRequest request,
+      @PathVariable String account,
       @RequestParam(required = false) String memo,
       @RequestParam(required = false, name = "memo_type") String memoType) {
     JwtToken jwtToken = getSep10Token(request);

--- a/platform/src/main/kotlin/org/stellar/anchor/platform/Sep12Client.kt
+++ b/platform/src/main/kotlin/org/stellar/anchor/platform/Sep12Client.kt
@@ -49,8 +49,7 @@ class Sep12Client(private val endpoint: String, private val jwt: String) : SepCl
   }
 
   fun deleteCustomer(account: String): Int {
-    val deleteCustomerRequest = Sep12DeleteCustomerRequest()
-    deleteCustomerRequest.account = account
+    val deleteCustomerRequest = Sep12DeleteCustomerRequest.builder().account(account).build()
 
     val request =
       Request.Builder()

--- a/platform/src/main/kotlin/org/stellar/anchor/platform/Sep12Tests.kt
+++ b/platform/src/main/kotlin/org/stellar/anchor/platform/Sep12Tests.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform
 
+import org.junit.jupiter.api.Assertions.*
 import org.stellar.anchor.dto.sep12.Sep12PutCustomerRequest
 import org.stellar.anchor.dto.sep12.Sep12Status
 import org.stellar.anchor.util.GsonUtils
@@ -40,8 +41,8 @@ fun sep12TestHappyPath() {
   var gr = sep12Client.getCustomer(pr!!.id)
   printResponse(gr)
 
-  assert(gr!!.id.equals(pr.id))
-  assert(gr.status.equals(Sep12Status.NEEDS_INFO))
+  assertEquals(Sep12Status.NEEDS_INFO, gr?.status)
+  assertEquals(pr.id, gr?.id)
 
   customer.emailAddress = "john.doe@stellar.org"
   customer.bankAccountNumber = "1234"
@@ -58,13 +59,16 @@ fun sep12TestHappyPath() {
   gr = sep12Client.getCustomer(pr!!.id)
   printResponse(gr)
 
-  assert(gr!!.id.equals(pr.id))
-  assert(gr.status.equals(Sep12Status.ACCEPTED))
+  assertEquals(pr.id, gr?.id)
+  assertEquals(Sep12Status.ACCEPTED, gr?.status)
 
   // Delete the customer
   printRequest("Calling DELETE /customer/${CLIENT_WALLET_ACCOUNT}")
   val code = sep12Client.deleteCustomer(CLIENT_WALLET_ACCOUNT)
   printResponse(code)
   // currently, not implemented
-  assert(code == 500)
+  assertEquals(200, code)
+
+  gr = sep12Client.getCustomer(pr.id)
+  assertNull(gr!!.id)
 }

--- a/platform/src/main/resources/default-config.yaml
+++ b/platform/src/main/resources/default-config.yaml
@@ -80,6 +80,17 @@ app-config:
       horizonUrl: https://horizon-testnet.stellar.org
       secretKey: secret # stellar account secret key
 
+  event:
+    enabled: true
+    kafkaBootstrapServer: localhost:29092
+    useSingleQueue: false
+    queues:
+      all: ap_event_single_queue
+      quote_created: ap_event_quote_created
+      transaction_created: ap_event_transaction_created
+      transaction_payment_received: ap_event_transaction_payment_received
+      transaction_error: ap_event_transaction_error
+
 #
 # Spring Data JDBC settings
 #

--- a/platform/src/test/resources/stellar-anchor-tests-sep-config.json
+++ b/platform/src/test/resources/stellar-anchor-tests-sep-config.json
@@ -1,0 +1,31 @@
+{
+  "12": {
+    "customers": {
+      "toBeCreated": {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email_address": "john@email.com",
+        "bank_number": "123",
+        "bank_account_number": "456"
+      },
+      "sendingClient": {
+        "first_name": "Allie",
+        "last_name": "Grater",
+        "email_address": "allie@email.com"
+      },
+      "receivingClient": {
+        "first_name": "Lee",
+        "last_name": "Sun",
+        "email_address": "lee@email.com"
+      },
+      "toBeDeleted": {
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "email_address": "jane@email.com"
+      }
+    },
+    "createCustomer": "toBeCreated",
+    "deleteCustomer": "toBeDeleted",
+    "sameAccountDifferentMemos": ["sendingClient", "receivingClient"]
+  }
+}

--- a/platform/src/test/resources/stellar-anchor-tests-sep-config.json
+++ b/platform/src/test/resources/stellar-anchor-tests-sep-config.json
@@ -27,5 +27,15 @@
     "createCustomer": "toBeCreated",
     "deleteCustomer": "toBeDeleted",
     "sameAccountDifferentMemos": ["sendingClient", "receivingClient"]
+  },
+  "31": {
+    "sendingAnchorClientSecret": "SB7E7M6VLBXXIEDJ4RXP7E4SS4CFDMFMIMWERJVY3MSRGNN5ROANA5OJ",
+    "sendingClientName": "sendingClient",
+    "receivingClientName": "receivingClient",
+    "transactionFields": {
+      "receiver_account_number": "123",
+      "receiver_routing_number": "456",
+      "type": "SWIFT"
+    }
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Increase the number of SEPs our CI script [stellar-anchor-tests](https://github.com/stellar/stellar-anchor-tests) is testing. We were only covering SEP-1 and SEP-38, and this PR adds coverage for SEP-10, SEP-12, and SEP-31 as well.

This PR also includes:
* Fixes for those SEPs to make sure they pass the tests and thus are compliant with the industry standards.
* Implement SEP-12 `DELETE /customer`.
* Fix exception handlers (and add missing ones), mostly in `GlobalControllerExceptionHandler`.
* Add missing SEP-12 controller handler for different deletion content types

### Why

To improve our test coverage and make sure our code is compliant with the network standards.

### Future work

Implement internal tests to make sure these flows are being validated internally.