### PR TITLE
anchor-reference-server: Add Yaml configuration support to the reference server.

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
@@ -13,7 +13,9 @@ import org.stellar.anchor.util.GsonUtils;
 
 @SpringBootApplication
 @EnableConfigurationProperties
-@PropertySource("/anchor-reference-server.yaml")
+@PropertySource(
+    value = "classpath:anchor-reference-server.yaml",
+    factory = YamlPropertySourceFactory.class)
 public class AnchorReferenceServer implements WebMvcConfigurer {
   public static void start(int port, String contextPath) {
     SpringApplicationBuilder builder =

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/YamlPropertySourceFactory.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/YamlPropertySourceFactory.java
@@ -1,0 +1,24 @@
+package org.stellar.anchor.reference;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class YamlPropertySourceFactory implements PropertySourceFactory {
+
+  @Override
+  public PropertySource<?> createPropertySource(String name, EncodedResource encodedResource)
+      throws IOException {
+    YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+    factory.setResources(encodedResource.getResource());
+
+    Properties properties = factory.getObject();
+
+    return new PropertiesPropertySource(encodedResource.getResource().getFilename(), properties);
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The reference server does not read from anchor-reference-server.yaml. This is the fix that can read YAML file.

### Why

N/A

### Known limitations

N/A