### PR TITLE
Improve the REFERENCE_SERVER_CONFIG import mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=build /code/platform/build/libs/platform*.jar /app/anchor-platform.j
 RUN mkdir /config
 ENV STELLAR_ANCHOR_CONFIG=file:/config/anchor-config.yaml
 
-ENV REFERENCE_CONFIG=file:/config/reference-config.yaml
+ENV REFERENCE_SERVER_CONFIG_ENV=file:/config/reference-config.yaml
 
 EXPOSE 8080 8081
 

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceConfig.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceConfig.java
@@ -1,9 +1,14 @@
 package org.stellar.anchor.reference;
 
+import com.google.gson.Gson;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.util.GsonUtils;
 
-/** SEP configurations */
 @Configuration
 public class AnchorReferenceConfig {
-  public AnchorReferenceConfig() {}
+  @Bean
+  public Gson gson() {
+    return GsonUtils.builder().create();
+  }
 }

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.reference;
 
-import com.google.gson.Gson;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,10 +8,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.env.YamlPropertySourceLoader;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.stellar.anchor.util.GsonUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,7 +35,6 @@ public class AnchorReferenceServer implements WebMvcConfigurer {
     app.addInitializers(new PropertySourceInitializer());
     app.run();
   }
-
 
   public static class PropertySourceInitializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/AnchorReferenceServer.java
@@ -1,20 +1,31 @@
 package org.stellar.anchor.reference;
 
-import static org.springframework.boot.Banner.Mode.OFF;
-
 import com.google.gson.Gson;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.io.Resource;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.stellar.anchor.util.GsonUtils;
 
+import java.io.IOException;
+import java.util.List;
+
+import static org.springframework.boot.Banner.Mode.OFF;
+
 @SpringBootApplication
 @EnableConfigurationProperties
-@PropertySource(value = "${REFERENCE_CONFIG}", factory = YamlPropertySourceFactory.class)
 public class AnchorReferenceServer implements WebMvcConfigurer {
+  static final String REFERENCE_SERVER_CONFIG_ENV = "REFERENCE_SERVER_CONFIG_ENV";
+  static final String REFERENCE_SERVER_PORT = "REFERENCE_SERVER_PORT";
+  static final String REFERENCE_SERVER_CONTEXT_PATH = "REFERENCE_SERVER_CONTEXT_PATH";
+
   public static void start(int port, String contextPath) {
     SpringApplicationBuilder builder =
         new SpringApplicationBuilder(AnchorReferenceServer.class)
@@ -23,15 +34,49 @@ public class AnchorReferenceServer implements WebMvcConfigurer {
                 String.format("server.port=%d", port),
                 String.format("server.contextPath=%s", contextPath));
 
-    builder.build().run();
+    SpringApplication app = builder.build();
+    app.addInitializers(new PropertySourceInitializer());
+    app.run();
   }
 
-  @Bean
-  public Gson gson() {
-    return GsonUtils.builder().create();
+
+  public static class PropertySourceInitializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+      String referenceServerConfig =
+          AnchorReferenceServer.getProperty(
+              REFERENCE_SERVER_CONFIG_ENV, "classpath:/anchor-reference-server.yaml");
+
+      Resource resource = applicationContext.getResource(referenceServerConfig);
+      try {
+        List<org.springframework.core.env.PropertySource<?>> sources =
+            new YamlPropertySourceLoader().load("yaml", resource);
+        for (org.springframework.core.env.PropertySource<?> source : sources) {
+          applicationContext.getEnvironment().getPropertySources().addFirst(source);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(
+            String.format("Error reading configuration from %s", referenceServerConfig));
+      }
+    }
+  }
+
+  static String getProperty(String name, String defaultValue) {
+    String value = System.getenv().get(name);
+    if (value == null) {
+      value = System.getProperty(name);
+    }
+    if (value == null) {
+      value = defaultValue;
+    }
+    return value;
   }
 
   public static void main(String[] args) {
-    start(8081, "/");
+    start(
+        Integer.parseInt(getProperty(REFERENCE_SERVER_PORT, "8081")),
+        getProperty(REFERENCE_SERVER_CONTEXT_PATH, "/"));
   }
 }

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/CustomerController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/CustomerController.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.reference.controller;
 
 import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.exception.NotFoundException;
-import org.stellar.anchor.reference.config.AppSettings;
 import org.stellar.anchor.reference.service.CustomerService;
 import org.stellar.platform.apis.callbacks.requests.GetCustomerRequest;
 import org.stellar.platform.apis.callbacks.requests.PutCustomerRequest;
@@ -13,7 +12,7 @@ import org.stellar.platform.apis.callbacks.responses.PutCustomerResponse;
 public class CustomerController {
   private final CustomerService customerService;
 
-  public CustomerController(AppSettings appSettings, CustomerService customerService) {
+  public CustomerController(CustomerService customerService) {
     this.customerService = customerService;
   }
 

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/FeeController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/FeeController.java
@@ -15,8 +15,8 @@ import java.util.Map;
 
 @RestController
 public class FeeController {
-  private FeeService feeService;
-  private static final Gson gson = GsonUtils.builder().create();
+  final FeeService feeService;
+  static final Gson gson = GsonUtils.builder().create();
 
   public FeeController(FeeService feeService) {
     this.feeService = feeService;

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/FeeController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/FeeController.java
@@ -1,21 +1,24 @@
 package org.stellar.anchor.reference.controller;
 
 import com.google.gson.Gson;
-import java.util.Map;
 import lombok.SneakyThrows;
-import org.springframework.web.bind.annotation.*;
-import org.stellar.anchor.reference.config.AppSettings;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.stellar.anchor.reference.service.FeeService;
 import org.stellar.anchor.util.GsonUtils;
-import org.stellar.platform.apis.callbacks.requests.*;
+import org.stellar.platform.apis.callbacks.requests.GetFeeRequest;
 import org.stellar.platform.apis.callbacks.responses.GetFeeResponse;
+
+import java.util.Map;
 
 @RestController
 public class FeeController {
   private FeeService feeService;
   private static final Gson gson = GsonUtils.builder().create();
 
-  public FeeController(AppSettings appSettings, FeeService feeService) {
+  public FeeController(FeeService feeService) {
     this.feeService = feeService;
   }
 

--- a/anchor-reference-server/src/test/kotlin/org/stellar/anchor/server/AnchorReferenceServerIntegrationTest.kt
+++ b/anchor-reference-server/src/test/kotlin/org/stellar/anchor/server/AnchorReferenceServerIntegrationTest.kt
@@ -39,7 +39,7 @@ class AnchorReferenceServerIntegrationTest {
 
     init {
       val props = System.getProperties()
-      props.setProperty("REFERENCE_CONFIG", "classpath:/anchor-reference-server.yaml")
+      props.setProperty("REFERENCE_SERVER_CONFIG_ENV", "classpath:/anchor-reference-server.yaml")
     }
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -15,7 +15,7 @@ class AnchorPlatformIntegrationTest {
     lateinit var jwt: String
     init {
       val props = System.getProperties()
-      props.setProperty("REFERENCE_CONFIG", "classpath:/anchor-reference-server.yaml")
+      props.setProperty("REFERENCE_SERVER_CONFIG_ENV", "classpath:/anchor-reference-server.yaml")
     }
     @BeforeAll
     @JvmStatic


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Currently, the REFERENCE_SERVER_CONFIG (previously REFERENCE_CONFIG) is read from the environment. If it does not exist, the application won't start. This is to improve the import mechanism.

### Why

N/A

### Known limitations

N/A