### PR TITLE
all: add health check endpoints at `/health` for both the SEP and Reference servers

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/HealthController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/HealthController.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.stellar.anchor.util.HealthCheck;
 
-import java.util.Map;
-
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping(value = "/health")

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/HealthController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/HealthController.java
@@ -1,0 +1,19 @@
+package org.stellar.anchor.reference.controller;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.stellar.anchor.util.HealthCheck;
+
+import java.util.Map;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping(value = "/health")
+public class HealthController {
+  @RequestMapping(method = {RequestMethod.GET})
+  public HealthCheck health() {
+    return new HealthCheck(true);
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/util/HealthCheck.java
+++ b/core/src/main/java/org/stellar/anchor/util/HealthCheck.java
@@ -1,0 +1,8 @@
+package org.stellar.anchor.util;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class HealthCheck {
+  boolean live = false;
+}

--- a/core/src/main/java/org/stellar/anchor/util/HealthCheck.java
+++ b/core/src/main/java/org/stellar/anchor/util/HealthCheck.java
@@ -1,8 +1,10 @@
 package org.stellar.anchor.util;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @AllArgsConstructor
+@Data
 public class HealthCheck {
-  boolean live = false;
+  boolean live;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.stellar.anchor.util.HealthCheck;
 
-import java.util.Map;
-
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping(value = "/health")

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
@@ -1,0 +1,19 @@
+package org.stellar.anchor.platform.controller;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.stellar.anchor.util.HealthCheck;
+
+import java.util.Map;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping(value = "/health")
+public class HealthController {
+  @RequestMapping(method = {RequestMethod.GET})
+  public HealthCheck health() {
+    return new HealthCheck(true);
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add health check endpoints at `/health` for both the SEP and Reference servers.

### Why

So we can have endpoints to check the status of the servers and their sub-services.

### Future work

Add coverage to all sub-services, like kafka, stellar watcher, circle watcher, etc.