### PR TITLE
core: Fix NullPointerException when the asset in the SEP-31 request not valid

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -81,6 +81,8 @@ public class Sep31Service {
     Context.get().setRequest(request);
     Context.get().setJwtToken(jwtToken);
 
+    validateAsset();
+
     String assetName =
         assetService.getAsset(request.getAssetCode(), request.getAssetIssuer()).getAssetName();
 
@@ -88,7 +90,6 @@ public class Sep31Service {
     validateAmount(request.getAmount());
     validateLanguage(appConfig, request.getLang());
     validateRequiredFields(assetName, request.getFields().getTransaction());
-    validateAsset();
     validateSenderAndReceiver();
     validateKyc();
     preValidateQuote();

--- a/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep31Client.kt
+++ b/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep31Client.kt
@@ -1,9 +1,9 @@
 package org.stellar.anchor.platform
 
+import com.google.gson.reflect.TypeToken
 import org.stellar.anchor.api.sep.sep31.Sep31InfoResponse
 import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest
 import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionResponse
-import shadow.com.google.common.reflect.TypeToken
 
 class Sep31Client(private val endpoint: String, private val jwt: String) : SepClient() {
   fun getInfo(): Sep31InfoResponse {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep31Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep31Tests.kt
@@ -1,6 +1,8 @@
 package org.stellar.anchor.platform
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
 import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest
 import org.stellar.anchor.util.GsonUtils
@@ -31,6 +33,7 @@ fun sep31TestAll(toml: Sep1Helper.TomlContent, jwt: String) {
 
   testSep31TestInfo()
   testSep31PostTransaction()
+  testBadAsset()
 }
 
 fun testSep31TestInfo() {
@@ -50,4 +53,16 @@ fun testSep31PostTransaction() {
   val txnRequest = gson.fromJson(postTxnJson, Sep31PostTransactionRequest::class.java)
   txnRequest.receiverId = pr!!.id
   sep31Client.postTransaction(txnRequest)
+}
+
+fun testBadAsset() {
+  val customer =
+    GsonUtils.getInstance().fromJson(testCustomerJson, Sep12PutCustomerRequest::class.java)
+  val pr = sep12Client.putCustomer(customer)
+
+  // Post Sep31 transaction.
+  val txnRequest = gson.fromJson(postTxnJson, Sep31PostTransactionRequest::class.java)
+  txnRequest.assetCode = "bad-asset-code"
+  txnRequest.receiverId = pr!!.id
+  assertThrows<SepException> { sep31Client.postTransaction(txnRequest) }
 }


### PR DESCRIPTION
… found

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix issue #254 . 

When the asset code is invalid, we should return 400 instead of status code 500, which is caused by an NullPointerException.

### Why

N/A

### Known limitations

N/A