### PR TITLE
bugfix: add NoArgsConstructor to RateFeeDetail so it can be parsed by kafka

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/RateFeeDetail.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/RateFeeDetail.java
@@ -2,9 +2,11 @@ package org.stellar.anchor.api.sep.sep38;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class RateFeeDetail {
   String name;
   String description;


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add `@NoArgsConstructor` to `RateFeeDetail` so it can be parsed by kafka.

### Why

Otherwise, kafka would throw errors.