### PR TITLE
docs: Add more details of the `client_id` field of the fee callback API.

### DIFF
--- a/docs/03 - Implementing the Anchor Server/Callbacks API.yml
+++ b/docs/03 - Implementing the Anchor Server/Callbacks API.yml
@@ -69,9 +69,12 @@ paths:
           description: |
             An identifier for the client application making the request. This ID can be used to offer different fees to different clients.
 
-            Client IDs will be Stellar public keys when the client is initiating a SEP-31 transaction. In this case the client should be a 
-            known SEP-31 sending anchor and the public key will be the Stellar address used to authenticate via SEP-10. Anchors must ensure
-            that the public key specified in the request matches a public key known to belong to the sending anchor.
+            A client ID can be one of the following:
+            1. the `client_domain` if the transaction is initiated from a non-custodial wallet. 
+            2. the Stellar custodial/omnibus account if the transaction is initiated from a custodian, such as Wyre.
+            3. The Stellar account of a SEP-31 sending anchor. In this case the client should be a known SEP-31 sending 
+               anchor and the public key will be the Stellar address used to authenticate via SEP-10. Anchors must ensure
+               that the public key specified in the request matches a public key known to belong to the sending anchor.
           schema:
             type: string
           required: true

--- a/docs/03 - Implementing the Anchor Server/Callbacks API.yml
+++ b/docs/03 - Implementing the Anchor Server/Callbacks API.yml
@@ -68,13 +68,10 @@ paths:
           name: client_id
           description: |
             An identifier for the client application making the request. This ID can be used to offer different fees to different clients.
-
             A client ID can be one of the following:
-            1. the `client_domain` if the transaction is initiated from a non-custodial wallet. 
-            2. the Stellar custodial/omnibus account if the transaction is initiated from a custodian, such as Wyre.
-            3. The Stellar account of a SEP-31 sending anchor. In this case the client should be a known SEP-31 sending 
-               anchor and the public key will be the Stellar address used to authenticate via SEP-10. Anchors must ensure
-               that the public key specified in the request matches a public key known to belong to the sending anchor.
+            1. the `client_domain`: In SEP-24, if the transaction is initiated from a non-custodial wallet, the `client_id` must match the `client_domain` if wallet attribution is required. 
+            2. the Stellar custodial/omnibus account: In SEP-24, if the transaction is initiated from a custodian, such as Wyre, the `client_id` should match a known pooled/omnibus account configured in the [`omnibusAccountList`] of the YAML file](https://github.com/stellar/java-stellar-anchor-sdk/blob/main/platform/src/main/resources/anchor-config-defaults.yaml).  
+            3. The Stellar account of a sending anchor: In SEP-31, the `client_id` should match the account of a known SEP-31 sending anchor match the one used to authenticate via SEP-10.
           schema:
             type: string
           required: true
@@ -555,10 +552,10 @@ components:
         rate:
           type: object
           properties:
-            id: 
+            id:
               type: string
               description: Id of the firm quote. NOT USED when `type=indicative*`.
-            expires_at: 
+            expires_at:
               type: string
               format: date-time
               description: Expirations are NOT USED when `type=indicative*`.


### PR DESCRIPTION
The `client_id` field description is good only for SEP-31. This PR adds more descriptions for SEP-6 and SEP-24 and custodial account. 

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add more details of the client_id field of the fee callback API

### Why

adds more descriptions for SEP-6 and SEP-24 and custodial account. 

### Known limitations
The code should be modified to reflect the change.