### PR TITLE
bugfix: replace usage of `client_domain` with `client_id` in the GET /fee callback API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 */out/**
 *.class
 .jpb
+*/bin/*

--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/GetFeeRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/GetFeeRequest.java
@@ -19,8 +19,8 @@ public class GetFeeRequest {
   @SerializedName("receive_amount")
   String receiveAmount;
 
-  @SerializedName("client_domain")
-  String clientDomain;
+  @SerializedName("client_id")
+  String clientId;
 
   @SerializedName("sender_id")
   String senderId;

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.sep12;
 
+import static org.stellar.anchor.util.Log.infoF;
+
 import java.util.stream.Stream;
 import org.stellar.anchor.api.callback.CustomerIntegration;
 import org.stellar.anchor.api.exception.*;
@@ -10,9 +12,6 @@ import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerResponse;
 import org.stellar.anchor.sep10.JwtToken;
 import org.stellar.anchor.util.MemoHelper;
 import org.stellar.sdk.xdr.MemoType;
-
-import static org.stellar.anchor.util.Log.debugF;
-import static org.stellar.anchor.util.Log.infoF;
 
 public class Sep12Service {
   private final CustomerIntegration customerIntegration;
@@ -75,7 +74,8 @@ public class Sep12Service {
                 .memoType(memoType)
                 .build());
     if (existingCustomer.getId() == null) {
-      infoF("No existing customer found for account={} memo={} memoType={}", account, memo, memoType);
+      infoF(
+          "No existing customer found for account={} memo={} memoType={}", account, memo, memoType);
       throw new SepNotFoundException("User not found.");
     }
 
@@ -139,14 +139,20 @@ public class Sep12Service {
       throws SepException {
     if (requestAccount != null
         && Stream.of(tokenAccount, tokenMuxedAccount).noneMatch(requestAccount::equals)) {
-      infoF("Neither tokenAccount ({}) nor tokenMuxedAccount ({}) match requestAccount ({})", tokenAccount,
-              tokenMuxedAccount, requestAccount);
+      infoF(
+          "Neither tokenAccount ({}) nor tokenMuxedAccount ({}) match requestAccount ({})",
+          tokenAccount,
+          tokenMuxedAccount,
+          requestAccount);
       throw new SepNotAuthorizedException(
           "The account specified does not match authorization token");
     }
     if (tokenMemo != null && requestMemo != null) {
       if (!tokenMemo.equals(requestMemo) || !requestMemoType.equals(MemoType.MEMO_ID.name())) {
-        infoF("request memo ({}) does not match token memo ID ({}) authorized via SEP-10", requestMemo, tokenMemo);
+        infoF(
+            "request memo ({}) does not match token memo ID ({}) authorized via SEP-10",
+            requestMemo,
+            tokenMemo);
         throw new SepNotAuthorizedException(
             "The memo specified does not match the memo ID authorized via SEP-10");
       }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -1,6 +1,24 @@
 package org.stellar.anchor.sep24;
 
+import static org.stellar.anchor.api.sep.SepTransactionStatus.INCOMPLETE;
+import static org.stellar.anchor.sep24.Sep24Transaction.Kind.DEPOSIT;
+import static org.stellar.anchor.sep24.Sep24Transaction.Kind.WITHDRAWAL;
+import static org.stellar.anchor.sep9.Sep9Fields.extractSep9Fields;
+import static org.stellar.anchor.util.Log.shorter;
+import static org.stellar.anchor.util.MathHelper.decimal;
+import static org.stellar.anchor.util.MemoHelper.makeMemo;
+import static org.stellar.anchor.util.MemoHelper.memoType;
+import static org.stellar.anchor.util.SepHelper.generateSepTransactionId;
+import static org.stellar.anchor.util.SepHelper.memoTypeString;
+import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
+
 import com.google.gson.Gson;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.exception.SepNotAuthorizedException;
@@ -16,25 +34,6 @@ import org.stellar.anchor.sep10.JwtToken;
 import org.stellar.anchor.util.Log;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.Memo;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.time.Instant;
-import java.util.*;
-
-import static org.stellar.anchor.api.sep.SepTransactionStatus.INCOMPLETE;
-import static org.stellar.anchor.sep24.Sep24Transaction.Kind.DEPOSIT;
-import static org.stellar.anchor.sep24.Sep24Transaction.Kind.WITHDRAWAL;
-import static org.stellar.anchor.sep9.Sep9Fields.extractSep9Fields;
-import static org.stellar.anchor.util.Log.shorter;
-import static org.stellar.anchor.util.MathHelper.decimal;
-import static org.stellar.anchor.util.MemoHelper.memoType;
-import static org.stellar.anchor.util.MemoHelper.makeMemo;
-import static org.stellar.anchor.util.SepHelper.generateSepTransactionId;
-import static org.stellar.anchor.util.SepHelper.memoTypeString;
-import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
 public class Sep24Service {
   final Gson gson;

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -396,7 +396,7 @@ public class Sep31Service {
                     .receiveAmount(null)
                     .senderId(request.getSenderId())
                     .receiverId(request.getReceiverId())
-                    .clientDomain(token.getClientDomain())
+                    .clientId(token.getAccount())
                     .build())
             .getFee();
     infoF("Fee for request ({}) is ({})", request, fee);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -94,7 +94,8 @@ public class Sep31Service {
     validateAmount(request.getAmount());
     validateLanguage(appConfig, request.getLang());
     if (request.getFields() == null) {
-      infoF("POST /transaction with id ({}) cannot have empty `fields`", jwtToken.getTransactionId());
+      infoF(
+          "POST /transaction with id ({}) cannot have empty `fields`", jwtToken.getTransactionId());
       throw new BadRequestException("'fields' field cannot be empty");
     }
     validateRequiredFields(assetInfo.getCode(), request.getFields().getTransaction());
@@ -200,10 +201,7 @@ public class Sep31Service {
     }
 
     Sep31Transaction txn = Context.get().getTransaction();
-    debugF("Updating transaction ({}) with quote ({})",
-            txn.getId(),
-            quote.getId()
-    );
+    debugF("Updating transaction ({}) with quote ({})", txn.getId(), quote.getId());
     txn.setAmountInAsset(quote.getSellAsset());
     txn.setAmountIn(quote.getSellAmount());
     txn.setAmountOutAsset(quote.getBuyAsset());
@@ -234,11 +232,7 @@ public class Sep31Service {
       amountIn = reqAmount.add(fee);
       amountOut = reqAmount;
     }
-    debugF("Updating transaction ({}) with fee ({}) - reqAsset ({})",
-            txn.getId(),
-            fee,
-            reqAsset
-    );
+    debugF("Updating transaction ({}) with fee ({}) - reqAsset ({})", txn.getId(), fee, reqAsset);
 
     // Update transaction
     txn.setAmountIn(formatAmount(amountIn, scale));
@@ -343,10 +337,11 @@ public class Sep31Service {
 
     // Check quote amounts: `post_transaction.amount == quote.sell_amount`
     if (!amountEquals(request.getAmount(), quote.getSellAmount())) {
-      infoF("Quote ({}) - sellAmount ({}) is different from the SEP-31 transaction amount ({})",
-              request.getQuoteId(),
-              quote.getSellAmount(),
-              request.getAmount());
+      infoF(
+          "Quote ({}) - sellAmount ({}) is different from the SEP-31 transaction amount ({})",
+          request.getQuoteId(),
+          quote.getSellAmount(),
+          request.getAmount());
       throw new BadRequestException(
           String.format(
               "Quote sell amount [%s] is different from the SEP-31 transaction amount [%s]",
@@ -357,10 +352,11 @@ public class Sep31Service {
     String assetName =
         assetService.getAsset(request.getAssetCode(), request.getAssetIssuer()).getAssetName();
     if (!assetName.equals(quote.getSellAsset())) {
-      infoF("Quote ({}) - sellAsset ({}) is different from the SEP-31 transaction asset ({})",
-              request.getQuoteId(),
-              quote.getSellAsset(),
-              assetName);
+      infoF(
+          "Quote ({}) - sellAsset ({}) is different from the SEP-31 transaction asset ({})",
+          request.getQuoteId(),
+          quote.getSellAsset(),
+          assetName);
       throw new BadRequestException(
           String.format(
               "Quote sell asset [%s] is different from the SEP-31 transaction asset [%s]",
@@ -437,7 +433,9 @@ public class Sep31Service {
 
   void validateRequiredFields(String assetCode, Map<String, String> fields) throws AnchorException {
     if (fields == null) {
-      infoF("'fields' field must have one 'transaction' field for request ({})", Context.get().getRequest());
+      infoF(
+          "'fields' field must have one 'transaction' field for request ({})",
+          Context.get().getRequest());
       throw new BadRequestException("'fields' field must have one 'transaction' field");
     }
 
@@ -466,7 +464,10 @@ public class Sep31Service {
     sep31MissingTxnFields.setTransaction(missingFields);
 
     if (missingFields.size() > 0) {
-      infoF("Missing SEP-31 fields ({}) for request ({})", sep31MissingTxnFields, Context.get().getRequest());
+      infoF(
+          "Missing SEP-31 fields ({}) for request ({})",
+          sep31MissingTxnFields,
+          Context.get().getRequest());
       throw new Sep31MissingFieldException(sep31MissingTxnFields);
     }
   }

--- a/core/src/main/java/org/stellar/anchor/util/SepHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepHelper.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 import java.util.UUID;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
-import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.sdk.*;
 import org.stellar.sdk.xdr.MemoType;
@@ -47,7 +46,6 @@ public class SepHelper {
 
     return result;
   }
-
 
   public static boolean amountEquals(String amount1, String amount2) {
     return decimal(amount1).compareTo(decimal(amount2)) == 0;

--- a/core/src/main/java/org/stellar/anchor/util/SepLanguageHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepLanguageHelper.java
@@ -72,8 +72,8 @@ public class SepLanguageHelper {
 }
 
 /**
- * The representation class of RFC-4646 to identify a language.
- * <a href="https://www.ietf.org/rfc/rfc4646.txt">https://www.ietf.org/rfc/rfc4646.txt</a>
+ * The representation class of RFC-4646 to identify a language. <a
+ * href="https://www.ietf.org/rfc/rfc4646.txt">https://www.ietf.org/rfc/rfc4646.txt</a>
  */
 @Getter
 @AllArgsConstructor

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -57,6 +57,7 @@ class AnchorPlatformIntegrationTest {
       val props = System.getProperties()
       props.setProperty("REFERENCE_SERVER_CONFIG", "classpath:/anchor-reference-server.yaml")
     }
+
     @BeforeAll
     @JvmStatic
     fun setup() {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -40,13 +40,13 @@ public class Sep12Controller {
       @RequestParam(required = false, name = "memo_type") String memoType,
       @RequestParam(required = false) String lang) {
     debugF(
-            "GET /customer type={} id={} account={} memo={}, memoType={}, lang={}",
-            type,
-            id,
-            account,
-            memo,
-            memoType,
-            lang);
+        "GET /customer type={} id={} account={} memo={}, memoType={}, lang={}",
+        type,
+        id,
+        account,
+        memo,
+        memoType,
+        lang);
     JwtToken jwtToken = getSep10Token(request);
     Sep12GetCustomerRequest getCustomerRequest =
         Sep12GetCustomerRequest.builder()
@@ -70,8 +70,7 @@ public class Sep12Controller {
       method = {RequestMethod.PUT})
   public Sep12PutCustomerResponse putCustomer(
       HttpServletRequest request, @RequestBody Sep12PutCustomerRequest putCustomerRequest) {
-    debug(
-            "PUT /customer details:", putCustomerRequest);
+    debug("PUT /customer details:", putCustomerRequest);
     JwtToken jwtToken = getSep10Token(request);
     return sep12Service.putCustomer(jwtToken, putCustomerRequest);
   }
@@ -84,8 +83,7 @@ public class Sep12Controller {
       method = {RequestMethod.POST, RequestMethod.PUT},
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public Sep12PutCustomerResponse putCustomerMultipart(HttpServletRequest request) {
-    debug(
-            "PUT /customer multipart details:", request);
+    debug("PUT /customer multipart details:", request);
     Gson gson = GsonUtils.getInstance();
     Map<String, String> requestData = new HashMap<>();
     for (Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
@@ -110,8 +108,7 @@ public class Sep12Controller {
     JwtToken jwtToken = getSep10Token(request);
     String memo = body != null ? body.getMemo() : null;
     String memoType = body != null ? body.getMemoType() : null;
-    debugF(
-            "DELETE /customer request={} account={} body={}", request, account, body);
+    debugF("DELETE /customer request={} account={} body={}", request, account, body);
     sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 
@@ -127,8 +124,7 @@ public class Sep12Controller {
       @RequestParam(required = false) String memo,
       @RequestParam(required = false, name = "memo_type") String memoType) {
     JwtToken jwtToken = getSep10Token(request);
-    debugF(
-            "DELETE /customer request={} account={}", request, account);
+    debugF("DELETE /customer request={} account={}", request, account);
     sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep31Controller.java
@@ -44,8 +44,7 @@ public class Sep31Controller {
       HttpServletRequest servletRequest, @RequestBody Sep31PostTransactionRequest request)
       throws AnchorException {
     JwtToken jwtToken = getSep10Token(servletRequest);
-    debugF(
-            "POST /transactions request={}", request);
+    debugF("POST /transactions request={}", request);
     return sep31Service.postTransaction(jwtToken, request);
   }
 
@@ -58,8 +57,7 @@ public class Sep31Controller {
       HttpServletRequest servletRequest, @PathVariable(name = "id") String txnId)
       throws AnchorException {
     JwtToken jwtToken = getSep10Token(servletRequest);
-    debugF(
-            "GET /transactions id={}", txnId);
+    debugF("GET /transactions id={}", txnId);
     return sep31Service.getTransaction(txnId);
   }
 
@@ -74,8 +72,7 @@ public class Sep31Controller {
       @RequestBody Sep31PatchTransactionRequest request)
       throws AnchorException {
     JwtToken jwtToken = getSep10Token(servletRequest);
-    debugF(
-            "PATCH /transactions id={} request={}", txnId, request);
+    debugF("PATCH /transactions id={} request={}", txnId, request);
     return sep31Service.patchTransaction(request);
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -50,13 +50,13 @@ public class Sep38Controller {
       @RequestParam(name = "buy_delivery_method", required = false) String buyDeliveryMethod,
       @RequestParam(name = "country_code", required = false) String countryCode) {
     debugF(
-            "GET /prices sell_asset={} sell_amount={} sell_delivery_method={} " +
-                    "buyDeliveryMethod={} countryCode={}",
-            sellAssetName,
-            sellAmount,
-            sellDeliveryMethod,
-            buyDeliveryMethod,
-            countryCode);
+        "GET /prices sell_asset={} sell_amount={} sell_delivery_method={} "
+            + "buyDeliveryMethod={} countryCode={}",
+        sellAssetName,
+        sellAmount,
+        sellDeliveryMethod,
+        buyDeliveryMethod,
+        countryCode);
     return sep38Service.getPrices(
         sellAssetName, sellAmount, sellDeliveryMethod, buyDeliveryMethod, countryCode);
   }
@@ -67,8 +67,7 @@ public class Sep38Controller {
       value = "/price",
       method = {RequestMethod.GET})
   public GetPriceResponse getPrice(@RequestParam Map<String, String> params) {
-    debugF(
-            "GET /price params={}", params);
+    debugF("GET /price params={}", params);
     Sep38GetPriceRequest getPriceRequest =
         gson.fromJson(gson.toJson(params), Sep38GetPriceRequest.class);
     return sep38Service.getPrice(getPriceRequest);
@@ -84,8 +83,7 @@ public class Sep38Controller {
   public Sep38QuoteResponse postQuote(
       HttpServletRequest request, @RequestBody Sep38PostQuoteRequest postQuoteRequest) {
     JwtToken jwtToken = getSep10Token(request);
-    debugF(
-            "POSTS /quote request={}", postQuoteRequest);
+    debugF("POSTS /quote request={}", postQuoteRequest);
     return sep38Service.postQuote(jwtToken, postQuoteRequest);
   }
 
@@ -98,8 +96,7 @@ public class Sep38Controller {
   public Sep38QuoteResponse getQuote(
       HttpServletRequest request, @PathVariable(name = "quote_id") String quoteId) {
     JwtToken jwtToken = getSep10Token(request);
-    debugF(
-            "GET /quote id={}", quoteId);
+    debugF("GET /quote id={}", quoteId);
     return sep38Service.getQuote(jwtToken, quoteId);
   }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Replace usage of ~`client_domain`~ with `client_id` in the `GET /fee` callback API

### Why

This change was made in the documentation in https://github.com/stellar/stellar-anchor-platform/pull/25 but wasn't updated in the code.

Closes #325.

> Note: we need to make sure we're more thorough next time and create tickets for the changes that need to be performed across other repos and the code.
