### PR TITLE
hotfix: fix `gson` reference cycle triggered by a print

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/PlatformTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/PlatformTests.kt
@@ -23,7 +23,7 @@ fun testHappyPath() {
   // Create sender customer
   val senderCustomerRequest =
     GsonUtils.getInstance().fromJson(testCustomer1Json, Sep12PutCustomerRequest::class.java)
-  val senderCustomer = sep12Client.putCustomer(senderCustomerRequest)
+  val senderCustomer = sep12Client.putCustomer(senderCustomerRequest, TYPE_MULTIPART_FORM_DATA)
 
   // Create receiver customer
   val receiverCustomerRequest =

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -108,7 +108,11 @@ public class Sep12Controller {
     JwtToken jwtToken = getSep10Token(request);
     String memo = body != null ? body.getMemo() : null;
     String memoType = body != null ? body.getMemoType() : null;
-    debugF("DELETE /customer requestURI={} account={} body={}", request.getRequestURI(), account, body);
+    debugF(
+        "DELETE /customer requestURI={} account={} body={}",
+        request.getRequestURI(),
+        account,
+        body);
     sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -83,7 +83,7 @@ public class Sep12Controller {
       method = {RequestMethod.POST, RequestMethod.PUT},
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public Sep12PutCustomerResponse putCustomerMultipart(HttpServletRequest request) {
-    debug("PUT /customer multipart details:", request);
+    debug("PUT /customer multipart body:", request.getParameterMap());
     Gson gson = GsonUtils.getInstance();
     Map<String, String> requestData = new HashMap<>();
     for (Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
@@ -108,7 +108,7 @@ public class Sep12Controller {
     JwtToken jwtToken = getSep10Token(request);
     String memo = body != null ? body.getMemo() : null;
     String memoType = body != null ? body.getMemoType() : null;
-    debugF("DELETE /customer request={} account={} body={}", request, account, body);
+    debugF("DELETE /customer requestURI={} account={} body={}", request.getRequestURI(), account, body);
     sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 
@@ -124,7 +124,7 @@ public class Sep12Controller {
       @RequestParam(required = false) String memo,
       @RequestParam(required = false, name = "memo_type") String memoType) {
     JwtToken jwtToken = getSep10Token(request);
-    debugF("DELETE /customer request={} account={}", request, account);
+    debugF("DELETE /customer requestURI={} account={}", request.getRequestURI(), account);
     sep12Service.deleteCustomer(jwtToken, account, memo, memoType);
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix reference cycle caused by print.

### Why

For some reason, when we printed the request, it caused a reference cycle that went on until the computer memory is over, to finally throw a 500.

The reference cycle happened in:
https://github.com/stellar/java-stellar-anchor-sdk/blob/c6bfc92f9499f9efec4ec10cca6933a6c3088ac9/core/src/main/java/org/stellar/anchor/filter/BaseTokenFilter.java#L84

The error:

<img width="1331" alt="Screen Shot 2022-06-13 at 6 57 51 PM" src="https://user-images.githubusercontent.com/1952597/173477151-a1c5f237-b116-49e3-977a-f26c1d06085c.png">

> Note: these lines repeat in a loop, the full stack trace has hundreds of lines.