### PR TITLE
core: Fix issue-331 memo value is being dropped when generating SEP-24 interactive URL JWT and more_info_url JWT

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
@@ -48,7 +48,9 @@ public class Sep24Helper {
     JwtToken token =
         JwtToken.of(
             "moreInfoUrl",
-            txn.getSep10Account(),
+            (txn.getSep10AccountMemo() == null || txn.getSep10AccountMemo().length() == 0)
+                ? txn.getSep10Account()
+                : txn.getSep10Account() + ":" + txn.getSep10AccountMemo(),
             Instant.now().getEpochSecond(),
             Instant.now().getEpochSecond() + sep24Config.getInteractiveJwtExpiration(),
             txn.getTransactionId(),

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -361,7 +361,7 @@ public class Sep24Service {
   JwtToken buildRedirectJwtToken(String fullRequestUrl, JwtToken token, Sep24Transaction txn) {
     return JwtToken.of(
         fullRequestUrl,
-        token.getAccount(),
+        token.getSub(),
         Instant.now().getEpochSecond(),
         Instant.now().getEpochSecond() + sep24Config.getInteractiveJwtExpiration(),
         txn.getTransactionId(),

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
@@ -216,7 +216,8 @@ public interface Sep24Transaction {
   void setAmountInAsset(String amountInAsset);
 
   /**
-   * Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
+   * Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes
+   * amount converted to XLM to fund account and any external fees.
    *
    * @return <code>amount_out</code> field of the SEP-24 transaction history.
    */

--- a/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
@@ -7,24 +7,15 @@ class TestHelper {
     private const val TEST_ACCOUNT = "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
 
     fun createJwtToken(
-      publicKey: String = TEST_ACCOUNT,
-      hostUrl: String = "",
-      clientDomain: String = "vibrant.stellar.org"
-    ): JwtToken {
-      val issuedAt: Long = System.currentTimeMillis() / 1000L
-      return JwtToken.of("$hostUrl/auth", publicKey, issuedAt, issuedAt + 60, "", clientDomain)
-    }
-
-    fun createJwtWithMemo(
       account: String = TEST_ACCOUNT,
-      memo: String = "1234",
+      accountMemo: String? = null,
       hostUrl: String = "",
       clientDomain: String = "vibrant.stellar.org"
     ): JwtToken {
       val issuedAt: Long = System.currentTimeMillis() / 1000L
       return JwtToken.of(
         "$hostUrl/auth",
-        "$account:$memo",
+        if (accountMemo == null) account else "$account:$accountMemo",
         issuedAt,
         issuedAt + 60,
         "",

--- a/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
@@ -4,15 +4,32 @@ import org.stellar.anchor.sep10.JwtToken
 
 class TestHelper {
   companion object {
-    private const val PUBLIC_KEY = "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
+    private const val TEST_ACCOUNT = "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
 
     fun createJwtToken(
-      publicKey: String = PUBLIC_KEY,
+      publicKey: String = TEST_ACCOUNT,
       hostUrl: String = "",
       clientDomain: String = "vibrant.stellar.org"
     ): JwtToken {
       val issuedAt: Long = System.currentTimeMillis() / 1000L
       return JwtToken.of("$hostUrl/auth", publicKey, issuedAt, issuedAt + 60, "", clientDomain)
+    }
+
+    fun createJwtWithMemo(
+      account: String = TEST_ACCOUNT,
+      memo: String = "1234",
+      hostUrl: String = "",
+      clientDomain: String = "vibrant.stellar.org"
+    ): JwtToken {
+      val issuedAt: Long = System.currentTimeMillis() / 1000L
+      return JwtToken.of(
+        "$hostUrl/auth",
+        "$account:$memo",
+        issuedAt,
+        issuedAt + 60,
+        "",
+        clientDomain
+      )
     }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/filter/Sep10TokenFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/Sep10TokenFilterTest.kt
@@ -47,7 +47,7 @@ internal class Sep10TokenFilterTest {
     this.mockFilterChain = mockk(relaxed = true)
 
     every { sep10Config.enabled } returns true
-    this.jwtToken = jwtService.encode(createJwtToken(PUBLIC_KEY, appConfig.hostUrl))
+    this.jwtToken = jwtService.encode(createJwtToken(PUBLIC_KEY, null, appConfig.hostUrl))
     every { request.getHeader("Authorization") } returns "Bearer $jwtToken"
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -17,6 +17,7 @@ import org.stellar.anchor.Constants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.Constants.Companion.TEST_ASSET
 import org.stellar.anchor.Constants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.Constants.Companion.TEST_CLIENT_DOMAIN
+import org.stellar.anchor.Constants.Companion.TEST_MEMO
 import org.stellar.anchor.Constants.Companion.TEST_TRANSACTION_ID_0
 import org.stellar.anchor.Constants.Companion.TEST_TRANSACTION_ID_1
 import org.stellar.anchor.TestHelper
@@ -85,13 +86,22 @@ internal class Sep24ServiceTest {
     return TestHelper.createJwtToken(TEST_ACCOUNT, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
   }
 
+  private fun createJwtWithMemo(): JwtToken {
+    return TestHelper.createJwtWithMemo(
+      TEST_ACCOUNT,
+      TEST_MEMO,
+      appConfig.hostUrl,
+      TEST_CLIENT_DOMAIN
+    )
+  }
+
   @Test
   fun testWithdraw() {
     val slotTxn = slot<Sep24Transaction>()
 
     every { txnStore.save(capture(slotTxn)) } returns null
 
-    val response =
+    var response =
       sep24Service.withdraw("/sep24/withdraw", createJwtToken(), createTestTransactionRequest())
 
     verify(exactly = 1) { txnStore.save(any()) }
@@ -113,13 +123,28 @@ internal class Sep24ServiceTest {
     assertEquals(slotTxn.captured.amountIn, "123.4")
     assertEquals(slotTxn.captured.amountOut, "123.4")
 
-    val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
-    val tokenStrings = params.filter { pair -> pair.name.equals("token") }
+    var params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
+    var tokenStrings = params.filter { pair -> pair.name.equals("token") }
     assertEquals(tokenStrings.size, 1)
-    val tokenString = tokenStrings[0].value
-    val decodedToken = jwtService.decode(tokenString)
+    var tokenString = tokenStrings[0].value
+    var decodedToken = jwtService.decode(tokenString)
     assertEquals(decodedToken.sub, TEST_ACCOUNT)
     assertEquals(decodedToken.clientDomain, TEST_CLIENT_DOMAIN)
+
+    // Now test with a memo
+    response =
+      sep24Service.withdraw("/sep24/withdraw", createJwtWithMemo(), createTestTransactionRequest())
+
+    params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
+    tokenStrings = params.filter { pair -> pair.name.equals("token") }
+    assertEquals(tokenStrings.size, 1)
+    tokenString = tokenStrings[0].value
+    decodedToken = jwtService.decode(tokenString)
+    assertEquals(
+      "$TEST_ACCOUNT:$TEST_MEMO",
+      decodedToken.sub,
+    )
+    assertEquals(TEST_CLIENT_DOMAIN, decodedToken.clientDomain)
   }
 
   private fun createTestTransactionRequest(): MutableMap<String, String> {
@@ -202,7 +227,7 @@ internal class Sep24ServiceTest {
 
     val request = createTestTransactionRequest()
     request["claimable_balance_supported"] = claimable_balance_supported
-    val response = sep24Service.deposit("/sep24/deposit", createJwtToken(), request)
+    var response = sep24Service.deposit("/sep24/deposit", createJwtToken(), request)
 
     verify(exactly = 1) { txnStore.save(any()) }
 
@@ -219,6 +244,21 @@ internal class Sep24ServiceTest {
     assertEquals(slotTxn.captured.clientDomain, TEST_CLIENT_DOMAIN)
     assertEquals(slotTxn.captured.amountIn, "123.4")
     assertEquals(slotTxn.captured.amountOut, "123.4")
+
+    // Now test with a memo
+    response =
+      sep24Service.withdraw("/sep24/withdraw", createJwtWithMemo(), createTestTransactionRequest())
+
+    val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
+    val tokenStrings = params.filter { pair -> pair.name.equals("token") }
+    assertEquals(tokenStrings.size, 1)
+    val tokenString = tokenStrings[0].value
+    val decodedToken = jwtService.decode(tokenString)
+    assertEquals(
+      "$TEST_ACCOUNT:$TEST_MEMO",
+      decodedToken.sub,
+    )
+    assertEquals(TEST_CLIENT_DOMAIN, decodedToken.clientDomain)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -83,16 +83,11 @@ internal class Sep24ServiceTest {
   }
 
   private fun createJwtToken(): JwtToken {
-    return TestHelper.createJwtToken(TEST_ACCOUNT, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
+    return TestHelper.createJwtToken(TEST_ACCOUNT, null, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
   }
 
   private fun createJwtWithMemo(): JwtToken {
-    return TestHelper.createJwtWithMemo(
-      TEST_ACCOUNT,
-      TEST_MEMO,
-      appConfig.hostUrl,
-      TEST_CLIENT_DOMAIN
-    )
+    return TestHelper.createJwtToken(TEST_ACCOUNT, TEST_MEMO, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfiguratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfiguratorTest.kt
@@ -58,6 +58,7 @@ open class ConfiguratorTest {
     val applicationContext = AnnotationConfigApplicationContext()
     val propertiesReader = spyk<PropertiesReader>(recordPrivateCalls = true)
 
+    every { propertiesReader.fromUserFolder } returns File("not exist")
     every { propertiesReader.getFromSystemEnv() } returns "classpath:test-read.yaml"
     assertDoesNotThrow { propertiesReader.initialize(applicationContext) }
     verify(exactly = 1) { propertiesReader.getFromSystemEnv() }


### PR DESCRIPTION
Closes #331

https://github.com/stellar/java-stellar-anchor-sdk/issues/331 

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fixed the memo value is being dropped when generating SEP-24 interactive URL JWT and more_info_url JWT

### Why

Bug

### Known limitations

N/A