### PR TITLE
bugfix: remove duplicate USDC asset that was causing USDC transfer to not work

### DIFF
--- a/end-to-end-tests/end_to_end_tests.py
+++ b/end-to-end-tests/end_to_end_tests.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
             TRANSACTION_PAYLOAD = {
                 "amount": "10.0",
                 "asset_code": "USDC",
-                "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                "asset_issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "fields": {
                     "transaction": {
                         "receiver_routing_number": "r0123",
@@ -232,7 +232,7 @@ if __name__ == "__main__":
             test_sep_31_flow(endpoints, keypair, TRANSACTION_PAYLOAD)
         elif test == "sep31_flow_with_sep38":
             QUOTE_PAYLOAD_USDC_TO_JPYC = {
-                "sell_asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                "sell_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "sell_amount": "10",
                 "buy_asset": "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "context": "sep31"
@@ -241,7 +241,7 @@ if __name__ == "__main__":
             TRANSACTION_PAYLOAD_USDC_TO_JPYC = {
                 "amount": "10.0",
                 "asset_code": "USDC",
-                "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                "asset_issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "fields": {
                     "transaction": {
                         "receiver_routing_number": "r0123",
@@ -281,7 +281,7 @@ if __name__ == "__main__":
         elif test == "sep38_create_quote":
             print("####################### Testing POST Quote #######################")
             QUOTE_PAYLOAD_USDC_TO_JPYC = {
-                "sell_asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                "sell_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "sell_amount": "10",
                 "buy_asset": "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
                 "context": "sep31"

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -51,7 +51,7 @@ class AnchorPlatformIntegrationTest {
     private val rfi =
       RestFeeIntegration("http://localhost:$REFERENCE_SERVER_PORT", httpClient, gson)
     const val fiatUSD = "iso4217:USD"
-    const val stellarUSDC = "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+    const val stellarUSDC = "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     private lateinit var platformServerContext: ConfigurableApplicationContext
     init {
       val props = System.getProperties()

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep31Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep31Tests.kt
@@ -14,7 +14,7 @@ const val postTxnJson =
   """{
     "amount": "10",
     "asset_code": "USDC",
-    "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    "asset_issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
     "receiver_id": "MOCK_RECEIVER_ID",
     "sender_id": "MOCK_SENDER_ID",
     "fields": {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep38Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep38Tests.kt
@@ -32,7 +32,7 @@ fun sep38TestHappyPath() {
     sep38.getPrice(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
       SEP31
     )
   printResponse(price)
@@ -43,7 +43,7 @@ fun sep38TestHappyPath() {
     sep38.postQuote(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
       SEP31
     )
   printResponse(postQuote)
@@ -55,7 +55,7 @@ fun sep38TestHappyPath() {
     sep38.postQuote(
       "iso4217:USD",
       "100",
-      "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
       SEP31,
       expireAfter = expireAfter
     )

--- a/platform/src/main/resources/assets-test.json
+++ b/platform/src/main/resources/assets-test.json
@@ -3,8 +3,8 @@
         {
             "schema": "stellar",
             "code": "USDC",
-            "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-            "distribution_account": "GD5CC2OLKMW3ZMAFVS2F5J4MGIPANJS3E25E5D5Z4CLS4DHRZTWISTPD",
+            "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+            "distribution_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
             "significant_decimals": 2,
             "deposit" : {
                 "enabled": true,
@@ -86,7 +86,7 @@
             "schema": "stellar",
             "code": "JPYC",
             "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-            "distribution_account": "GD5CC2OLKMW3ZMAFVS2F5J4MGIPANJS3E25E5D5Z4CLS4DHRZTWISTPD",
+            "distribution_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
             "significant_decimals": 4,
             "deposit" : {
                 "enabled": true,
@@ -157,7 +157,7 @@
             "sep38": {
                 "exchangeable_assets": [
                     "iso4217:USD",
-                    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
                 ]
             },
             "sep24_enabled": false,
@@ -189,7 +189,7 @@
             },
             "sep38": {
                 "exchangeable_assets": [
-                    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
                 ],
                 "country_codes": ["USA"],
                 "decimals": 4,

--- a/platform/src/main/resources/assets-test.json
+++ b/platform/src/main/resources/assets-test.json
@@ -84,88 +84,6 @@
         },
         {
             "schema": "stellar",
-            "code": "USDC",
-            "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-            "distribution_account": "GD5CC2OLKMW3ZMAFVS2F5J4MGIPANJS3E25E5D5Z4CLS4DHRZTWISTPD",
-            "significant_decimals": 2,
-            "deposit" : {
-                "enabled": true,
-                "fee_minimum": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-            },
-            "withdraw": {
-                "enabled": true,
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-            },
-            "send": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-            },
-            "sep31" : {
-                "quotes_supported": true,
-                "quotes_required": true,
-                "sep12": {
-                    "sender": {
-                        "types": {
-                            "sep31-sender": {
-                                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-                            },
-                            "sep31-large-sender": {
-                                "description": "U.S. citizens that do not have sending limits"
-                            },
-                            "sep31-foreign-sender": {
-                                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-                            }
-                        }
-                    },
-                    "receiver": {
-                        "types": {
-                            "sep31-receiver": {
-                                "description": "U.S. citizens receiving USD"
-                            },
-                            "sep31-foreign-receiver": {
-                                "description": "non-U.S. citizens receiving USD"
-                            }
-                        }
-                    }
-                },
-                "fields": {
-                    "transaction": {
-                        "receiver_routing_number": {
-                            "description": "routing number of the destination bank account"
-                        },
-                        "receiver_account_number": {
-                            "description": "bank account number of the destination"
-                        },
-                        "type": {
-                            "description": "type of deposit to make",
-                            "choices": [
-                                "SEPA",
-                                "SWIFT"
-                            ]
-                        }
-                    }
-                }
-            },
-            "sep38": {
-                "exchangeable_assets": [
-                    "iso4217:USD",
-                    "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-                ]
-            },
-            "sep24_enabled": true,
-            "sep31_enabled": true,
-            "sep38_enabled": true
-        },
-        {
-            "schema": "stellar",
             "code": "JPYC",
             "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
             "distribution_account": "GD5CC2OLKMW3ZMAFVS2F5J4MGIPANJS3E25E5D5Z4CLS4DHRZTWISTPD",
@@ -238,8 +156,7 @@
             },
             "sep38": {
                 "exchangeable_assets": [
-                    "iso4217:USD",,
-                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+                    "iso4217:USD",
                     "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                 ]
             },
@@ -272,7 +189,7 @@
             },
             "sep38": {
                 "exchangeable_assets": [
-                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+                    "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                 ],
                 "country_codes": ["USA"],
                 "decimals": 4,

--- a/platform/src/main/resources/sep1/stellar-wks.toml
+++ b/platform/src/main/resources/sep1/stellar-wks.toml
@@ -11,11 +11,11 @@ ANCHOR_QUOTE_SERVER = "http://localhost:8080/sep38"
 
 [[CURRENCIES]]
 code = "USDC"
-issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"
 is_asset_anchored = true
 anchor_asset_type = "fiat"
-desc = "A test USDC issued by Circle."
+desc = "A test USDC issued by Stellar."
 
 [[CURRENCIES]]
 code = "JPYC"

--- a/platform/src/main/resources/sep1/stellar-wks.toml
+++ b/platform/src/main/resources/sep1/stellar-wks.toml
@@ -18,14 +18,6 @@ anchor_asset_type = "fiat"
 desc = "A test USDC issued by Circle."
 
 [[CURRENCIES]]
-code = "USDC"
-issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-status = "test"
-is_asset_anchored = true
-anchor_asset_type = "fiat"
-desc = "A test USDC issued by Stellar."
-
-[[CURRENCIES]]
 code = "JPYC"
 issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Remove duplicate USDC asset that was causing USDC transfer to not work.

Also, use a different USDC (issued by our account) so we can have more control over it.
