### PR TITLE
Swap out hardcoded customer type values in SEP-12

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -70,7 +70,7 @@ public class Sep12Service {
 
     // TODO: Move this into configuration instead of hardcoding customer type values.
     boolean existingCustomerMatch = false;
-    String customerTypes[] = {"sep31-sender", "sep31-receiver"};
+    String customerTypes[] = {"sending_user", "receiving_user"};
     for (String customerType: customerTypes) {
       Sep12GetCustomerResponse existingCustomer =
           customerIntegration.getCustomer(


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Swap out hardcoded customer type values in SEP-12 to `receiving_user` and `sending_user`

### Why

These are the values currently used by bitso's e2e test

### Known limitations

We should remove the hardcoded values and make customer type configurable across SEPs