### PR TITLE
Let /customer DELETE calls expect 204 on success instead of 200

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
@@ -111,7 +111,8 @@ public class RestCustomerIntegration implements CustomerIntegration {
     Response response = call(httpClient, callbackRequest);
     String responseContent = getContent(response);
 
-    if (response.code() != HttpStatus.NO_CONTENT.value()) {
+    if (response.code() != HttpStatus.NO_CONTENT.value()
+        && response.code() != HttpStatus.OK.value()) {
       throw httpError(responseContent, response.code(), gson);
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestCustomerIntegration.java
@@ -111,7 +111,7 @@ public class RestCustomerIntegration implements CustomerIntegration {
     Response response = call(httpClient, callbackRequest);
     String responseContent = getContent(response);
 
-    if (response.code() != HttpStatus.OK.value()) {
+    if (response.code() != HttpStatus.NO_CONTENT.value()) {
       throw httpError(responseContent, response.code(), gson);
     }
   }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Let '/customer' DELETE calls expect 204 on success, instead of 200.

### Why

This is in line with the OpenAPI spec for anchor platform

