### PR TITLE
api schema: Make PutCustomerRequest field birth_place a string instea…

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
@@ -47,7 +47,7 @@ public class PutCustomerRequest {
   Instant birthDate;
 
   @SerializedName("birth_place")
-  Instant birthPlace;
+  String birthPlace;
 
   @SerializedName("birth_country_code")
   String birthCountryCode;


### PR DESCRIPTION
`birth_place` is currently declared as a time, but it should be a string.

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Make `PutCustomerRequest` field `birth_place` a string

### Why

Birth place is not a time.

### Known limitations

N/A