### PR TITLE
events: update `TransactionEvent#refunds` to mirror the design outlined in the events schema

### DIFF
--- a/core/src/main/java/org/stellar/anchor/event/models/Refund.java
+++ b/core/src/main/java/org/stellar/anchor/event/models/Refund.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.event.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
-import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,16 +11,16 @@ import org.stellar.anchor.api.shared.Amount;
 @Builder
 @AllArgsConstructor
 public class Refund {
-  String type;
-  Amount amount;
 
-  @JsonProperty("requested_at")
-  @SerializedName("requested_at")
-  Instant requestedAt;
+  @JsonProperty("amount_refunded")
+  @SerializedName("amount_refunded")
+  Amount amountRefunded;
 
-  @JsonProperty("refunded_at")
-  @SerializedName("refunded_at")
-  Instant refundedAt;
+  @JsonProperty("amount_fee")
+  @SerializedName("amount_fee")
+  Amount amountFee;
+
+  RefundPayment[] payments;
 
   public Refund() {}
 }

--- a/core/src/main/java/org/stellar/anchor/event/models/RefundPayment.java
+++ b/core/src/main/java/org/stellar/anchor/event/models/RefundPayment.java
@@ -1,0 +1,53 @@
+package org.stellar.anchor.event.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.stellar.anchor.api.shared.Amount;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class RefundPayment {
+  String id;
+
+  @JsonProperty("id_type")
+  @SerializedName("id_type")
+  IdType idType;
+
+  Amount amount;
+
+  Amount fee;
+
+  @JsonProperty("requested_at")
+  @SerializedName("requested_at")
+  Instant requestedAt;
+
+  @JsonProperty("refunded_at")
+  @SerializedName("refunded_at")
+  Instant refundedAt;
+
+  public RefundPayment() {}
+
+  public enum IdType {
+    @SerializedName("stellar")
+    STELLAR("stellar"),
+
+    @SerializedName("external")
+    EXTERNAL("external");
+
+    private final String name;
+
+    IdType(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/event/models/TransactionEvent.java
+++ b/core/src/main/java/org/stellar/anchor/event/models/TransactionEvent.java
@@ -74,7 +74,7 @@ public class TransactionEvent implements AnchorEvent {
 
   String message;
 
-  Refund[] refunds;
+  Refund refunds;
 
   @JsonProperty("stellar_transactions")
   @SerializedName("stellar_transactions")

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -46,7 +46,7 @@ import org.stellar.anchor.sep38.PojoSep38Quote
 import org.stellar.anchor.sep38.Sep38QuoteStore
 import org.stellar.anchor.util.GsonUtils
 
-internal class Sep31ServiceTest {
+class Sep31ServiceTest {
   companion object {
     val gson: Gson = GsonUtils.getInstance()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update the `TransactionEvent#refunds` model to mirror the design in:

The design says it should be an object similar to [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#refunds-object-schema):
https://github.com/stellar/java-stellar-anchor-sdk/blob/c5d0e233198db49c803879906372d9f9108598fe/docs/03%20-%20Implementing%20the%20Anchor%20Server/Communication/Events%20Schema.yml#L188-L216

### Why

Close #353.
