### PR TITLE
docs: add high-level database sizing information

### DIFF
--- a/docs/00 - Stellar Anchor Platform.md
+++ b/docs/00 - Stellar Anchor Platform.md
@@ -166,6 +166,8 @@ sequenceDiagram
     Client-->>Client: notifies sender
 ```
 
+> Note: in terms of database usage for SEP-31, our tests indicate that each SEP-31 (with SEP-38) transaction occupies ~2KB of space in the database. The tests also indicate the data space usage tends to decrease as the number of SEP-31 transactions increases. These results were achieved by executing 500 SEP-31 transactions on a Postgres database.
+
 ## Subprojects
 
 The Stellar Anchor SDK is a collection of projects that make easy to build financial applications on Stellar:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update documentation with a high-level estimate of database storage usage for the Anchor Platform, considering the SEP-31 (with SEP-38) flow.

Our tests indicate that **each SEP-31 (with SEP-38) transaction occupies ~2KB of space in the database**. The tests also indicate that the data space usage tends to decrease as the number of SEP-31 transactions increases. These results were achieved by executing 500 SEP-31 transactions on a Postgres database.

### Why

Close #304.

### Known limitations

This is not a real-world scenario, but it's a good estimate of the amount of data that will be used by SEP-31 transactions.