### PR TITLE
bugfix: fix auth header when the authorization type is NONE

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/client/PlatformApiClient.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/client/PlatformApiClient.java
@@ -72,9 +72,12 @@ public class PlatformApiClient extends BaseApiClient {
   }
 
   Request.Builder getRequestBuilder() {
+    Request.Builder requestBuilder =
+        new Request.Builder().header("Content-Type", "application/json");
+
     AuthHeader<String, String> authHeader = authHelper.createAuthHeader();
-    return new Request.Builder()
-        .header("Content-Type", "application/json")
-        .header(authHeader.getName(), authHeader.getValue());
+    return authHeader == null
+        ? requestBuilder
+        : requestBuilder.header(authHeader.getName(), authHeader.getValue());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/auth/AuthHelper.java
+++ b/core/src/main/java/org/stellar/anchor/auth/AuthHelper.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.auth;
 
 import java.util.Calendar;
+import javax.annotation.Nullable;
 import org.stellar.anchor.config.IntegrationAuthConfig.AuthType;
 import org.stellar.anchor.util.AuthHeader;
 
@@ -34,6 +35,7 @@ public class AuthHelper {
     return new AuthHelper(AuthType.NONE);
   }
 
+  @Nullable
   public AuthHeader<String, String> createAuthHeader() {
     switch (authType) {
       case JWT_TOKEN:
@@ -46,7 +48,7 @@ public class AuthHelper {
         return new AuthHeader<>("X-Api-Key", apiKey);
 
       default:
-        return new AuthHeader<>("Authorization", null);
+        return null;
     }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -1,0 +1,65 @@
+package org.stellar.anchor.auth
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.stellar.anchor.config.IntegrationAuthConfig.AuthType
+import org.stellar.anchor.util.AuthHeader
+
+class AuthHelperTest {
+  companion object {
+    const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
+  }
+
+  @ParameterizedTest
+  @EnumSource(AuthType::class)
+  fun test_createAuthHeader(authType: AuthType) {
+    when (authType) {
+      AuthType.JWT_TOKEN -> {
+        // Mock calendar to guarantee the jwt token format
+        val calendarSingleton = Calendar.getInstance()
+        val currentTimeMilliseconds = calendarSingleton.getTimeInMillis()
+        mockkObject(calendarSingleton)
+        every { calendarSingleton.getTimeInMillis() } returns currentTimeMilliseconds
+        every { calendarSingleton.setTimeInMillis(any()) } answers { callOriginal() }
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns calendarSingleton
+
+        // mock jwt token based on the mocked calendar
+        val wantJwtToken =
+          JwtToken.of(
+            "http://localhost:8080",
+            currentTimeMilliseconds / 1000L,
+            (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+          )
+
+        val jwtService = JwtService("secret")
+        val authHelper =
+          AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS, "http://localhost:8080")
+        val gotAuthHeader = authHelper.createAuthHeader()
+        val wantAuthHeader =
+          AuthHeader("Authorization", "Bearer ${jwtService.encode(wantJwtToken)}")
+        assertEquals(wantAuthHeader, gotAuthHeader)
+      }
+      AuthType.API_KEY -> {
+        val authHelper = AuthHelper.forApiKey("secret")
+        val gotAuthHeader = authHelper.createAuthHeader()
+        val wantAuthHeader = AuthHeader("X-Api-Key", "secret")
+        assertEquals(wantAuthHeader, gotAuthHeader)
+      }
+      AuthType.NONE -> {
+        val authHelper = AuthHelper.forNone()
+        val authHeader = authHelper.createAuthHeader()
+        assertNull(authHeader)
+      }
+      else -> {
+        throw Exception("Unsupported new AuthType!!!")
+      }
+    }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -23,10 +23,10 @@ class AuthHelperTest {
       AuthType.JWT_TOKEN -> {
         // Mock calendar to guarantee the jwt token format
         val calendarSingleton = Calendar.getInstance()
-        val currentTimeMilliseconds = calendarSingleton.getTimeInMillis()
+        val currentTimeMilliseconds = calendarSingleton.timeInMillis
         mockkObject(calendarSingleton)
-        every { calendarSingleton.getTimeInMillis() } returns currentTimeMilliseconds
-        every { calendarSingleton.setTimeInMillis(any()) } answers { callOriginal() }
+        every { calendarSingleton.timeInMillis } returns currentTimeMilliseconds
+        every { calendarSingleton.timeInMillis = any() } answers { callOriginal() }
         mockkStatic(Calendar::class)
         every { Calendar.getInstance() } returns calendarSingleton
 

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -1,11 +1,10 @@
 package org.stellar.anchor.auth
 
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
+import io.mockk.*
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.stellar.anchor.config.IntegrationAuthConfig.AuthType
@@ -14,6 +13,12 @@ import org.stellar.anchor.util.AuthHeader
 class AuthHelperTest {
   companion object {
     const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
+  }
+
+  @AfterEach
+  fun teardown() {
+    clearAllMocks()
+    unmockkAll()
   }
 
   @ParameterizedTest

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -24,7 +24,7 @@ internal class JwtServiceTest {
   }
 
   @Test
-  fun testcodec() {
+  fun testCodec() {
     val appConfig = mockk<AppConfig>()
     every { appConfig.jwtSecretKey } returns "jwt_secret"
 

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -15,10 +15,13 @@ import org.stellar.anchor.util.Log;
 
 public class PlatformIntegrationHelper {
   public static Request.Builder getRequestBuilder(AuthHelper authHelper) {
+    Request.Builder requestBuilder =
+        new Request.Builder().header("Content-Type", "application/json");
+
     AuthHeader<String, String> authHeader = authHelper.createAuthHeader();
-    return new Request.Builder()
-        .header("Content-Type", "application/json")
-        .header(authHeader.getName(), authHeader.getValue());
+    return authHeader == null
+        ? requestBuilder
+        : requestBuilder.header(authHeader.getName(), authHeader.getValue());
   }
 
   public static Response call(OkHttpClient httpClient, Request request)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -1,11 +1,10 @@
 package org.stellar.anchor.platform.callback
 
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
+import io.mockk.*
 import java.util.*
 import kotlin.test.assertEquals
 import okhttp3.Request
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.stellar.anchor.auth.AuthHelper
@@ -17,6 +16,12 @@ class PlatformIntegrationHelperTest {
   companion object {
     const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
     const val TEST_HOME_DOMAIN = "http://localhost:8080"
+  }
+
+  @AfterEach
+  fun teardown() {
+    clearAllMocks()
+    unmockkAll()
   }
 
   @ParameterizedTest

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -16,6 +16,7 @@ import org.stellar.anchor.config.IntegrationAuthConfig.AuthType
 class PlatformIntegrationHelperTest {
   companion object {
     const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
+    const val TEST_HOME_DOMAIN = "http://localhost:8080"
   }
 
   @ParameterizedTest
@@ -35,40 +36,40 @@ class PlatformIntegrationHelperTest {
         // mock jwt token based on the mocked calendar
         val wantJwtToken =
           JwtToken.of(
-            "http://localhost:8080",
+            TEST_HOME_DOMAIN,
             currentTimeMilliseconds / 1000L,
             (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
           )
 
         val jwtService = JwtService("secret")
         val authHelper =
-          AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS, "http://localhost:8080")
+          AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS, TEST_HOME_DOMAIN)
 
         val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         val wantRequestBuilder: Request.Builder =
           Request.Builder()
             .header("Content-Type", "application/json")
             .header("Authorization", "Bearer ${jwtService.encode(wantJwtToken)}")
-        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         assertEquals(wantRequest.headers, gotRequest.headers)
       }
       AuthType.API_KEY -> {
         val authHelper = AuthHelper.forApiKey("secret")
         val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         val wantRequestBuilder: Request.Builder =
           Request.Builder().header("Content-Type", "application/json").header("X-Api-Key", "secret")
-        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         assertEquals(wantRequest.headers, gotRequest.headers)
       }
       AuthType.NONE -> {
         val authHelper = AuthHelper.forNone()
         val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         val wantRequestBuilder: Request.Builder =
           Request.Builder().header("Content-Type", "application/json")
-        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
         assertEquals(wantRequest.headers, gotRequest.headers)
       }
       else -> {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -1,0 +1,3 @@
+package org.stellar.anchor.platform.callback
+
+class PlatformIntegrationHelperTest {}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -1,3 +1,79 @@
 package org.stellar.anchor.platform.callback
 
-class PlatformIntegrationHelperTest {}
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import java.util.*
+import kotlin.test.assertEquals
+import okhttp3.Request
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.stellar.anchor.auth.AuthHelper
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.JwtToken
+import org.stellar.anchor.config.IntegrationAuthConfig.AuthType
+
+class PlatformIntegrationHelperTest {
+  companion object {
+    const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
+  }
+
+  @ParameterizedTest
+  @EnumSource(AuthType::class)
+  fun test_getRequestBuilder(authType: AuthType) {
+    when (authType) {
+      AuthType.JWT_TOKEN -> {
+        // Mock calendar to guarantee the jwt token format
+        val calendarSingleton = Calendar.getInstance()
+        val currentTimeMilliseconds = calendarSingleton.timeInMillis
+        mockkObject(calendarSingleton)
+        every { calendarSingleton.timeInMillis } returns currentTimeMilliseconds
+        every { calendarSingleton.timeInMillis = any() } answers { callOriginal() }
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns calendarSingleton
+
+        // mock jwt token based on the mocked calendar
+        val wantJwtToken =
+          JwtToken.of(
+            "http://localhost:8080",
+            currentTimeMilliseconds / 1000L,
+            (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+          )
+
+        val jwtService = JwtService("secret")
+        val authHelper =
+          AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS, "http://localhost:8080")
+
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder()
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer ${jwtService.encode(wantJwtToken)}")
+        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      AuthType.API_KEY -> {
+        val authHelper = AuthHelper.forApiKey("secret")
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder().header("Content-Type", "application/json").header("X-Api-Key", "secret")
+        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      AuthType.NONE -> {
+        val authHelper = AuthHelper.forNone()
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url("http://localhost:8080").get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder().header("Content-Type", "application/json")
+        val wantRequest = wantRequestBuilder.url("http://localhost:8080").get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      else -> {
+        throw Exception("Unsupported new AuthType!!!")
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix auth header when the authorization type is NONE.

### Why

When trying to set the RequestBuilder header to Authorization: null, we were getting a NullPointerException in:

https://github.com/stellar/java-stellar-anchor-sdk/blob/be4095414e6201e2ab7779cea1621e7d1f07881a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java#L17-L22
