### PR TITLE
bugfix: update TransactionEvent by attaching the memo to the receiver instead of the sender

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -140,13 +140,13 @@ public class PaymentOperationToEventListener implements PaymentListener {
     TransactionEvent.StatusChange statusChange =
         new TransactionEvent.StatusChange(oldStatus, newStatus);
 
-    StellarId senderStellarId =
+    StellarId senderStellarId = StellarId.builder().account(payment.getFrom()).build();
+    StellarId receiverStellarId =
         StellarId.builder()
-            .account(payment.getFrom())
+            .account(payment.getTo())
             .memo(txn.getStellarMemo())
             .memoType(txn.getStellarMemoType())
             .build();
-    StellarId receiverStellarId = StellarId.builder().account(payment.getTo()).build();
 
     TransactionEvent event =
         TransactionEvent.builder()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -146,13 +146,13 @@ class PaymentOperationToEventListenerTest {
 
     every { transactionStore.findByStellarMemo(capture(slotMemo)) } returns sep31TxMock
 
-    val wantSenderStellarId =
+    val wantSenderStellarId = StellarId.builder().account(p.from).build()
+    val wantReceiverStellarId =
       StellarId.builder()
-        .account(p.from)
+        .account(p.to)
         .memo("OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=")
         .memoType("hash")
         .build()
-    val wantReceiverStellarId = StellarId.builder().account(p.to).build()
     val wantEvent =
       TransactionEvent.builder()
         .type(TransactionEvent.Type.TRANSACTION_STATUS_CHANGED)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update the TransactionEvent sender and receiver.

Close #387.

### Why

The transaction memo was being added to the sender object when it actually refers to the receiver object instead.
