### PR TITLE
core: Improve SEP-31 unit test coverage

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep31/RefundPaymentBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/RefundPaymentBuilder.java
@@ -1,0 +1,30 @@
+package org.stellar.anchor.sep31;
+
+import org.stellar.anchor.sep31.Sep31Transaction.RefundPayment;
+
+public class RefundPaymentBuilder {
+  RefundPayment refundPayment;
+
+  public RefundPaymentBuilder(Sep31TransactionStore factory) {
+    refundPayment = factory.newRefundPayment();
+  }
+
+  public RefundPaymentBuilder id(String id) {
+    refundPayment.setId(id);
+    return this;
+  }
+
+  public RefundPaymentBuilder amount(String amount) {
+    refundPayment.setAmount(amount);
+    return this;
+  }
+
+  public RefundPaymentBuilder fee(String fee) {
+    refundPayment.setFee(fee);
+    return this;
+  }
+
+  public RefundPayment build() {
+    return refundPayment;
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/sep31/RefundsBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/RefundsBuilder.java
@@ -1,0 +1,30 @@
+package org.stellar.anchor.sep31;
+
+import java.util.List;
+
+public class RefundsBuilder {
+  Sep31Transaction.Refunds refunds;
+
+  RefundsBuilder(Sep31TransactionStore factory) {
+    refunds = factory.newRefunds();
+  }
+
+  RefundsBuilder amountRefunded(String amountRefunded) {
+    refunds.setAmountRefunded(amountRefunded);
+    return this;
+  }
+
+  RefundsBuilder amountFee(String amountFee) {
+    refunds.setAmountFee(amountFee);
+    return this;
+  }
+
+  RefundsBuilder payments(List<Sep31Transaction.RefundPayment> payments) {
+    refunds.setRefundPayments(payments);
+    return this;
+  }
+
+  Sep31Transaction.Refunds build() {
+    return refunds;
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -1,5 +1,17 @@
 package org.stellar.anchor.sep31;
 
+import static org.stellar.anchor.api.sep.sep31.Sep31InfoResponse.AssetResponse;
+import static org.stellar.anchor.config.Sep31Config.PaymentType.STRICT_SEND;
+import static org.stellar.anchor.util.Log.*;
+import static org.stellar.anchor.util.MathHelper.decimal;
+import static org.stellar.anchor.util.MathHelper.formatAmount;
+import static org.stellar.anchor.util.SepHelper.*;
+import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.stellar.anchor.api.callback.CustomerIntegration;
@@ -25,19 +37,6 @@ import org.stellar.anchor.event.models.TransactionEvent;
 import org.stellar.anchor.sep38.Sep38Quote;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
 import org.stellar.anchor.util.Log;
-
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.stellar.anchor.api.sep.sep31.Sep31InfoResponse.AssetResponse;
-import static org.stellar.anchor.config.Sep31Config.PaymentType.STRICT_SEND;
-import static org.stellar.anchor.util.Log.*;
-import static org.stellar.anchor.util.MathHelper.decimal;
-import static org.stellar.anchor.util.MathHelper.formatAmount;
-import static org.stellar.anchor.util.SepHelper.*;
-import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
 public class Sep31Service {
   private final AppConfig appConfig;

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -111,11 +111,7 @@ public class Sep31Service {
     Context.get().setAsset(assetInfo);
     Context.get().setTransactionFields(request.getFields().getTransaction());
 
-    // TODO: When there are missing required fields, we should catch Sep31MissingFieldException and
-    // set the status to pending_transaction_info_update
     validateRequiredFields();
-    // TODO: When there are missing customer information, we should catch
-    // Sep31CustomerInfoNeededException and the status to pending_customer_info_update
     validateSenderAndReceiver();
     preValidateQuote();
 
@@ -277,13 +273,8 @@ public class Sep31Service {
   }
 
   public Sep31GetTransactionResponse getTransaction(String id) throws AnchorException {
-    if (id == null) {
-      info("Unable to get transaction, 'id' is not provided");
-      throw new BadRequestException("'id' is not provided");
-    }
-
-    if (id.length() == 0) {
-      info("Empty transaction ID is not allowed");
+    if (Objects.toString(id, "").isEmpty()) {
+      info("Empty 'id'");
       throw new BadRequestException("'id' is empty");
     }
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -221,6 +221,8 @@ public class Sep31Service {
     txn.setAmountIn(quote.getSellAmount());
     txn.setAmountOutAsset(quote.getBuyAsset());
     txn.setAmountOut(quote.getBuyAmount());
+    txn.setAmountFee(quote.getFee().getTotal());
+    txn.setAmountFeeAsset(quote.getFee().getAsset());
   }
 
   void updateTxAmountsWhenNoQuoteWasUsed() {
@@ -258,6 +260,7 @@ public class Sep31Service {
     // Update fee
     String feeStr = formatAmount(fee, scale);
     txn.setAmountFee(feeStr);
+    txn.setAmountFeeAsset(feeResponse.getAsset());
     Context.get().getFee().setAmount(feeStr);
   }
 
@@ -274,6 +277,7 @@ public class Sep31Service {
       info("Unable to get transaction, 'id' is not provided");
       throw new BadRequestException("'id' is not provided");
     }
+
     Sep31Transaction txn = sep31TransactionStore.findByTransactionId(id);
     if (txn == null) {
       infoF("Transaction ({}) not found", id);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -114,7 +114,7 @@ public class Sep31Service {
     // TODO: When there are missing required fields, we should catch Sep31MissingFieldException and
     // set the status to pending_transaction_info_update
     validateRequiredFields();
-    // TODO: When there are missing customer infroamtion, we should catch
+    // TODO: When there are missing customer information, we should catch
     // Sep31CustomerInfoNeededException and the status to pending_customer_info_update
     validateSenderAndReceiver();
     preValidateQuote();

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -294,7 +294,7 @@ public class Sep31Service {
       throw new BadRequestException("request cannot be null");
     }
 
-    if (request.getId() == null || request.getId().isEmpty()) {
+    if (Objects.toString(request.getId(), "").isEmpty()) {
       infoF("id cannot be null or empty");
       throw new BadRequestException("id cannot be null or empty");
     }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -278,6 +278,11 @@ public class Sep31Service {
       throw new BadRequestException("'id' is not provided");
     }
 
+    if (id.length() == 0) {
+      info("Empty transaction ID is not allowed");
+      throw new BadRequestException("'id' is empty");
+    }
+
     Sep31Transaction txn = sep31TransactionStore.findByTransactionId(id);
     if (txn == null) {
       infoF("Transaction ({}) not found", id);
@@ -543,7 +548,7 @@ public class Sep31Service {
                 .stellarTransactionId(txn.getStellarTransactionId())
                 .externalTransactionId(txn.getExternalTransactionId())
                 .refunded(txn.getRefunded())
-                // TODO: handle this post-mvp
+                // TODO: handle refund after mvp
                 // .refunds(txn.getRefunds())
                 .requiredInfoMessage(txn.getRequiredInfoMessage())
                 .requiredInfoUpdates(txn.getRequiredInfoUpdates())

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.sep31;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import org.stellar.anchor.api.sep.AssetInfo;
 
@@ -142,51 +141,5 @@ public class Sep31TransactionBuilder {
 
   public Sep31Transaction build() {
     return txn;
-  }
-
-  public class RefundsBuilder {
-    Sep31Transaction.Refunds refunds;
-
-    RefundsBuilder() {
-      refunds = factory.newRefunds();
-    }
-
-    RefundsBuilder amountRefunded(String amountRefunded) {
-      refunds.setAmountRefunded(amountRefunded);
-      return this;
-    }
-
-    RefundsBuilder amountFee(String amountFee) {
-      refunds.setAmountFee(amountFee);
-      return this;
-    }
-
-    RefundsBuilder payments(List<Sep31Transaction.RefundPayment> payments) {
-      refunds.setRefundPayments(payments);
-      return this;
-    }
-  }
-
-  public class RefundPaymentBuilder {
-    Sep31Transaction.RefundPayment refundPayment;
-
-    RefundPaymentBuilder() {
-      refundPayment = factory.newRefundPayment();
-    }
-
-    RefundPaymentBuilder id(String id) {
-      refundPayment.setId(id);
-      return this;
-    }
-
-    RefundPaymentBuilder amount(String amount) {
-      refundPayment.setAmount(amount);
-      return this;
-    }
-
-    RefundPaymentBuilder fee(String fee) {
-      refundPayment.setFee(fee);
-      return this;
-    }
   }
 }

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31RefundPayment.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31RefundPayment.java
@@ -1,0 +1,10 @@
+package org.stellar.anchor.sep31;
+
+import lombok.Data;
+
+@Data
+public class PojoSep31RefundPayment implements Sep31Transaction.RefundPayment {
+  String id;
+  String amount;
+  String fee;
+}

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Refunds.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Refunds.java
@@ -1,0 +1,13 @@
+package org.stellar.anchor.sep31;
+
+import lombok.Data;
+import org.stellar.anchor.sep31.Sep31Transaction.RefundPayment;
+
+import java.util.List;
+
+@Data
+public class PojoSep31Refunds implements Sep31Transaction.Refunds {
+  String amountRefunded;
+  String amountFee;
+  List<RefundPayment> refundPayments;
+}

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Refunds.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Refunds.java
@@ -1,9 +1,8 @@
 package org.stellar.anchor.sep31;
 
+import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.sep31.Sep31Transaction.RefundPayment;
-
-import java.util.List;
 
 @Data
 public class PojoSep31Refunds implements Sep31Transaction.Refunds {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
@@ -1,0 +1,56 @@
+package org.stellar.anchor.sep31
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.api.exception.BadRequestException
+
+class Sep31HelperTest {
+  @Test
+  fun test_allAmountAvailable() {
+    val txn = PojoSep31Transaction()
+    txn.amountIn = "100"
+    assertFalse(Sep31Helper.allAmountAvailable(txn))
+    txn.amountInAsset = "USDC"
+    assertFalse(Sep31Helper.allAmountAvailable(txn))
+    txn.amountOut = "500"
+    assertFalse(Sep31Helper.allAmountAvailable(txn))
+    txn.amountOutAsset = "BRL"
+    assertFalse(Sep31Helper.allAmountAvailable(txn))
+    txn.amountFee = "5"
+    assertFalse(Sep31Helper.allAmountAvailable(txn))
+    txn.amountFeeAsset = "USDC"
+    assertTrue(Sep31Helper.allAmountAvailable(txn))
+  }
+
+  @Test
+  fun test_validateStatus() {
+    val txn = PojoSep31Transaction()
+    txn.status = "pending_stellar"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "pending_sender"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "pending_customer_info_update"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "pending_transaction_info_update"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "pending_receiver"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "pending_sender"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "completed"
+    Sep31Helper.validateStatus(txn)
+    txn.status = "error"
+    Sep31Helper.validateStatus(txn)
+
+    txn.status = "Error"
+    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+    txn.status = "erroR"
+    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+    txn.status = ""
+    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+    txn.status = null
+    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
@@ -28,16 +28,17 @@ class Sep31HelperTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings =
-          [
-              "pending_stellar",
-              "pending_sender",
-              "pending_customer_info_update",
-              "pending_transaction_info_update",
-              "pending_receiver",
-              "pending_sender",
-              "completed",
-              "error"])
+    strings =
+      [
+        "pending_stellar",
+        "pending_sender",
+        "pending_customer_info_update",
+        "pending_transaction_info_update",
+        "pending_receiver",
+        "pending_sender",
+        "completed",
+        "error"]
+  )
   fun test_validateStatus(status: String) {
     val txn = PojoSep31Transaction()
     txn.status = status
@@ -49,7 +50,7 @@ class Sep31HelperTest {
   @ValueSource(strings = ["Error", "erroR", ""])
   fun test_validateStatus_failure(status: String?) {
     val txn = PojoSep31Transaction()
-      txn.status = status
+    txn.status = status
     val ex = assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
     assertEquals("'$status' is not a valid status of SEP31.", ex.message)
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31HelperTest.kt
@@ -1,9 +1,11 @@
 package org.stellar.anchor.sep31
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.api.exception.BadRequestException
 
 class Sep31HelperTest {
@@ -24,33 +26,31 @@ class Sep31HelperTest {
     assertTrue(Sep31Helper.allAmountAvailable(txn))
   }
 
-  @Test
-  fun test_validateStatus() {
+  @ParameterizedTest
+  @ValueSource(
+      strings =
+          [
+              "pending_stellar",
+              "pending_sender",
+              "pending_customer_info_update",
+              "pending_transaction_info_update",
+              "pending_receiver",
+              "pending_sender",
+              "completed",
+              "error"])
+  fun test_validateStatus(status: String) {
     val txn = PojoSep31Transaction()
-    txn.status = "pending_stellar"
+    txn.status = status
     Sep31Helper.validateStatus(txn)
-    txn.status = "pending_sender"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "pending_customer_info_update"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "pending_transaction_info_update"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "pending_receiver"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "pending_sender"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "completed"
-    Sep31Helper.validateStatus(txn)
-    txn.status = "error"
-    Sep31Helper.validateStatus(txn)
+  }
 
-    txn.status = "Error"
-    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
-    txn.status = "erroR"
-    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
-    txn.status = ""
-    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
-    txn.status = null
-    assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["Error", "erroR", ""])
+  fun test_validateStatus_failure(status: String?) {
+    val txn = PojoSep31Transaction()
+      txn.status = status
+    val ex = assertThrows<BadRequestException> { Sep31Helper.validateStatus(txn) }
+    assertEquals("'$status' is not a valid status of SEP31.", ex.message)
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -49,13 +49,13 @@ class Sep31ServiceTest {
     val gson: Gson = GsonUtils.getInstance()
 
     private const val stellarUSDC =
-      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 
     private const val stellarJPYC =
-      "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+        "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
 
     private const val requestJson =
-      """
+        """
         {
           "amount": "500",
           "asset_code": "USDC",
@@ -72,7 +72,7 @@ class Sep31ServiceTest {
     """
 
     private const val feeJson =
-      """
+        """
         {
           "amount": "2",
           "asset": "USDC"
@@ -80,7 +80,7 @@ class Sep31ServiceTest {
     """
 
     private const val assetJson =
-      """
+        """
             {
               "code": "USDC",
               "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
@@ -169,7 +169,7 @@ class Sep31ServiceTest {
         """
 
     private const val txnJson =
-      """
+        """
     {
       "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
       "status": "pending_sender",
@@ -199,7 +199,7 @@ class Sep31ServiceTest {
     """
 
     private const val quoteJson =
-      """
+        """
       {
         "id": "de762cda-a193-4961-861e-57b31fed6eb3",
         "expires_at": "2021-04-30T07:42:23",
@@ -216,7 +216,7 @@ class Sep31ServiceTest {
       }
   """
     private const val patchTxnRequestJson =
-      """
+        """
       {
         "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
         "fields": {
@@ -262,17 +262,17 @@ class Sep31ServiceTest {
     jwtService = spyk(JwtService(appConfig))
 
     sep31Service =
-      Sep31Service(
-        appConfig,
-        sep31Config,
-        txnStore,
-        sep31DepositInfoGenerator,
-        quoteStore,
-        assetService,
-        feeIntegration,
-        customerIntegration,
-        eventPublishService,
-      )
+        Sep31Service(
+            appConfig,
+            sep31Config,
+            txnStore,
+            sep31DepositInfoGenerator,
+            quoteStore,
+            assetService,
+            feeIntegration,
+            customerIntegration,
+            eventPublishService,
+        )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
     txn = gson.fromJson(txnJson, PojoSep31Transaction::class.java)
@@ -311,26 +311,26 @@ class Sep31ServiceTest {
   @Test
   fun test_quotesSupportedAndRequiredValidation() {
     val assetServiceQuotesNotSupported: AssetService =
-      ResourceJsonAssetService(
-        "test_assets.json.quotes_required_but_not_supported",
-      )
+        ResourceJsonAssetService(
+            "test_assets.json.quotes_required_but_not_supported",
+        )
     val ex: AnchorException = assertThrows {
       Sep31Service(
-        appConfig,
-        sep31Config,
-        txnStore,
-        sep31DepositInfoGenerator,
-        quoteStore,
-        assetServiceQuotesNotSupported,
-        feeIntegration,
-        customerIntegration,
-        eventPublishService,
+          appConfig,
+          sep31Config,
+          txnStore,
+          sep31DepositInfoGenerator,
+          quoteStore,
+          assetServiceQuotesNotSupported,
+          feeIntegration,
+          customerIntegration,
+          eventPublishService,
       )
     }
     assertInstanceOf(SepValidationException::class.java, ex)
     assertEquals(
-      "if quotes_required is true, quotes_supported must also be true",
-      ex.message,
+        "if quotes_required is true, quotes_supported must also be true",
+        ex.message,
     )
   }
 
@@ -351,8 +351,8 @@ class Sep31ServiceTest {
     // TODO: Add fee validation.
     assertEquals("100", txn.amountIn)
     assertEquals(
-      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-      txn.amountInAsset,
+        "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        txn.amountInAsset,
     )
     assertEquals("12500", txn.amountOut)
     assertEquals(stellarJPYC, txn.amountOutAsset)
@@ -404,9 +404,9 @@ class Sep31ServiceTest {
     assertEquals("request cannot be null", ex1.message)
 
     val ex2 =
-      assertThrows<BadRequestException> {
-        sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
-      }
+        assertThrows<BadRequestException> {
+          sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
+        }
     assertEquals("id cannot be null or empty", ex2.message)
 
     every { txnStore.findByTransactionId(any()) } returns null
@@ -496,24 +496,24 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31MissingFieldException::class.java, ex)
     val wantMissingFieldsNames =
-      listOf("receiver_account_number", "type", "receiver_routing_number")
+        listOf("receiver_account_number", "type", "receiver_routing_number")
     val gotMissingFieldsNames = (ex as Sep31MissingFieldException).missingFields.transaction.keys
     assertTrue(
-      wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
-      "missing field names don't match",
+        wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
+        "missing field names don't match",
     )
     assertTrue(
-      gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
-      "missing field names don't match",
+        gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
+        "missing field names don't match",
     )
 
     // missing receiver_id
     val fields =
-      hashMapOf(
-        "receiver_account_number" to "1",
-        "type" to "1",
-        "receiver_routing_number" to "SWIFT",
-      )
+        hashMapOf(
+            "receiver_account_number" to "1",
+            "type" to "1",
+            "receiver_routing_number" to "SWIFT",
+        )
     postTxRequest.fields = Sep31TxnFields(fields)
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -565,8 +565,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-      "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
-      ex.message,
+        "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
+        ex.message,
     )
 
     // quote and tx assets don't match (quote.sell_asset is null)
@@ -575,8 +575,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-      "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-      ex.message,
+        "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+        ex.message,
     )
 
     // quote and tx assets don't match
@@ -585,8 +585,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-      "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-      ex.message,
+        "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+        ex.message,
     )
 
     // quote is missing the `fee` field
@@ -622,13 +622,13 @@ class Sep31ServiceTest {
     postTxRequest.receiverId = receiverId
     postTxRequest.quoteId = "my_quote_id"
     postTxRequest.fields =
-      Sep31TxnFields(
-        hashMapOf(
-          "receiver_account_number" to "1",
-          "type" to "1",
-          "receiver_routing_number" to "SWIFT",
-        ),
-      )
+        Sep31TxnFields(
+            hashMapOf(
+                "receiver_account_number" to "1",
+                "type" to "1",
+                "receiver_routing_number" to "SWIFT",
+            ),
+        )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -638,13 +638,13 @@ class Sep31ServiceTest {
     every {
       sep31DepositInfoGenerator.getSep31DepositInfo(capture(txForDepositInfoGenerator))
     } answers
-      {
-        val tx: Sep31Transaction = txForDepositInfoGenerator.captured
-        var memo = StringUtils.truncate(tx.id, 32)
-        memo = StringUtils.leftPad(memo, 32, '0')
-        memo = String(Base64.getEncoder().encode(memo.toByteArray()))
-        Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
-      }
+        {
+          val tx: Sep31Transaction = txForDepositInfoGenerator.captured
+          var memo = StringUtils.truncate(tx.id, 32)
+          memo = StringUtils.leftPad(memo, 32, '0')
+          memo = String(Base64.getEncoder().encode(memo.toByteArray()))
+          Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
+        }
 
     // mock eventService
     val txEventSlot = slot<TransactionEvent>()
@@ -676,7 +676,7 @@ class Sep31ServiceTest {
     memo = String(Base64.getEncoder().encode(memo.toByteArray()))
     val txStartedAt = slotTxn.captured.startedAt
     val wantTx =
-      """{
+        """{
       "id": "$txId",
       "status": "pending_sender",
       "amountFee": "10",
@@ -704,48 +704,49 @@ class Sep31ServiceTest {
 
     // validate event response
     val wantEvent: TransactionEvent =
-      TransactionEvent.builder()
-        .eventId(txEventSlot.captured.eventId)
-        .type(TransactionEvent.Type.TRANSACTION_CREATED)
-        .id(txId)
-        .sep(TransactionEvent.Sep.SEP_31)
-        .kind(TransactionEvent.Kind.RECEIVE)
-        .status(TransactionEvent.Status.PENDING_SENDER)
-        .statusChange(TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
-        .amountExpected(Amount("100", stellarUSDC))
-        .amountIn(Amount("100", stellarUSDC))
-        .amountOut(Amount("12500", stellarJPYC))
-        .amountFee(Amount("10", stellarUSDC))
-        .quoteId("my_quote_id")
-        .startedAt(txStartedAt)
-        .updatedAt(txStartedAt)
-        .completedAt(null)
-        .transferReceivedAt(null)
-        .message(null)
-        .refunds(null)
-        .stellarTransactions(null)
-        .externalTransactionId(null)
-        .custodialTransactionId(null)
-        .sourceAccount(senderId)
-        .destinationAccount(receiverId)
-        .creator(
-          StellarId.builder()
-            .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-            .memo(memo)
-            .memoType("hash")
-            .build(),
-        )
-        .build()
+        TransactionEvent.builder()
+            .eventId(txEventSlot.captured.eventId)
+            .type(TransactionEvent.Type.TRANSACTION_CREATED)
+            .id(txId)
+            .sep(TransactionEvent.Sep.SEP_31)
+            .kind(TransactionEvent.Kind.RECEIVE)
+            .status(TransactionEvent.Status.PENDING_SENDER)
+            .statusChange(
+                TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
+            .amountExpected(Amount("100", stellarUSDC))
+            .amountIn(Amount("100", stellarUSDC))
+            .amountOut(Amount("12500", stellarJPYC))
+            .amountFee(Amount("10", stellarUSDC))
+            .quoteId("my_quote_id")
+            .startedAt(txStartedAt)
+            .updatedAt(txStartedAt)
+            .completedAt(null)
+            .transferReceivedAt(null)
+            .message(null)
+            .refunds(null)
+            .stellarTransactions(null)
+            .externalTransactionId(null)
+            .custodialTransactionId(null)
+            .sourceAccount(senderId)
+            .destinationAccount(receiverId)
+            .creator(
+                StellarId.builder()
+                    .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+                    .memo(memo)
+                    .memoType("hash")
+                    .build(),
+            )
+            .build()
     assertEquals(wantEvent, txEventSlot.captured)
 
     // validate the final response
     val wantResponse =
-      Sep31PostTransactionResponse.builder()
-        .id(txId)
-        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-        .stellarMemo(memo)
-        .stellarMemoType("hash")
-        .build()
+        Sep31PostTransactionResponse.builder()
+            .id(txId)
+            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+            .stellarMemo(memo)
+            .stellarMemoType("hash")
+            .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -761,13 +762,13 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-      Sep31TxnFields(
-        hashMapOf(
-          "receiver_account_number" to "1",
-          "type" to "1",
-          "receiver_routing_number" to "SWIFT",
-        ),
-      )
+        Sep31TxnFields(
+            hashMapOf(
+                "receiver_account_number" to "1",
+                "type" to "1",
+                "receiver_routing_number" to "SWIFT",
+            ),
+        )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -788,21 +789,21 @@ class Sep31ServiceTest {
   @Test
   fun test_postTransaction_quoteNotSupported() {
     val assetServiceQuotesNotSupported: AssetService =
-      ResourceJsonAssetService(
-        "test_assets.json.quotes_not_supported",
-      )
+        ResourceJsonAssetService(
+            "test_assets.json.quotes_not_supported",
+        )
     sep31Service =
-      Sep31Service(
-        appConfig,
-        sep31Config,
-        txnStore,
-        sep31DepositInfoGenerator,
-        quoteStore,
-        assetServiceQuotesNotSupported,
-        feeIntegration,
-        customerIntegration,
-        eventPublishService,
-      )
+        Sep31Service(
+            appConfig,
+            sep31Config,
+            txnStore,
+            sep31DepositInfoGenerator,
+            quoteStore,
+            assetServiceQuotesNotSupported,
+            feeIntegration,
+            customerIntegration,
+            eventPublishService,
+        )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
     val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
@@ -813,22 +814,22 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-      Sep31TxnFields(
-        hashMapOf(
-          "receiver_account_number" to "1",
-          "type" to "1",
-          "receiver_routing_number" to "SWIFT",
-        ),
-      )
+        Sep31TxnFields(
+            hashMapOf(
+                "receiver_account_number" to "1",
+                "type" to "1",
+                "receiver_routing_number" to "SWIFT",
+            ),
+        )
 
     // Provide fee response.
     every { feeIntegration.getFee(any()) } returns
-      GetFeeResponse(
-        Amount(
-          "2",
-          "stellar:USDC",
-        ),
-      )
+        GetFeeResponse(
+            Amount(
+                "2",
+                "stellar:USDC",
+            ),
+        )
 
     // POST transaction
     val jwtToken = TestHelper.createJwtToken()
@@ -836,12 +837,12 @@ class Sep31ServiceTest {
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
     val wantResponse =
-      Sep31PostTransactionResponse.builder()
-        .id(gotResponse!!.id)
-        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-        .stellarMemo("")
-        .stellarMemoType("")
-        .build()
+        Sep31PostTransactionResponse.builder()
+            .id(gotResponse!!.id)
+            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+            .stellarMemo("")
+            .stellarMemoType("")
+            .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -907,5 +908,44 @@ class Sep31ServiceTest {
     Context.get().setTransactionFields(null)
     val ex3 = assertThrows<BadRequestException> { sep31Service.validateRequiredFields() }
     assertEquals("'fields' field must have one 'transaction' field", ex3.message)
+  }
+
+  @Test
+  fun test_updateFee() {
+    val jwtToken = TestHelper.createJwtToken()
+    Context.get().setRequest(request)
+    Context.get().setJwtToken(jwtToken)
+
+    // With quote
+    Context.get().setQuote(quote)
+    request.destinationAsset = "USDC"
+    sep31Service.updateFee()
+
+    // No quote
+    every { feeIntegration.getFee(any()) } returns GetFeeResponse(Amount("10", "USDC"))
+    Context.get().setQuote(null)
+    request.destinationAsset = "USDC"
+    sep31Service.updateFee()
+    var fee = Context.get().getFee()
+    assertEquals("10", fee.amount)
+    assertEquals("USDC", fee.asset)
+
+    request.destinationAsset = null
+    sep31Service.updateFee()
+    fee = Context.get().getFee()
+    assertEquals("10", fee.amount)
+    assertEquals("USDC", fee.asset)
+  }
+
+  @Test
+  fun test_updateFee_failure() {
+    val jwtToken = TestHelper.createJwtToken()
+    Context.get().setRequest(request)
+    Context.get().setJwtToken(jwtToken)
+
+    // With quote
+    Context.get().setQuote(quote)
+    quote.fee = null
+    assertThrows<SepValidationException> { sep31Service.updateFee() }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -49,13 +49,13 @@ class Sep31ServiceTest {
     val gson: Gson = GsonUtils.getInstance()
 
     private const val stellarUSDC =
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 
     private const val stellarJPYC =
-        "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
 
     private const val requestJson =
-        """
+      """
         {
           "amount": "500",
           "asset_code": "USDC",
@@ -72,7 +72,7 @@ class Sep31ServiceTest {
     """
 
     private const val feeJson =
-        """
+      """
         {
           "amount": "2",
           "asset": "USDC"
@@ -80,7 +80,7 @@ class Sep31ServiceTest {
     """
 
     private const val assetJson =
-        """
+      """
             {
               "code": "USDC",
               "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
@@ -169,7 +169,7 @@ class Sep31ServiceTest {
         """
 
     private const val txnJson =
-        """
+      """
     {
       "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
       "status": "pending_sender",
@@ -199,7 +199,7 @@ class Sep31ServiceTest {
     """
 
     private const val quoteJson =
-        """
+      """
       {
         "id": "de762cda-a193-4961-861e-57b31fed6eb3",
         "expires_at": "2021-04-30T07:42:23",
@@ -216,7 +216,7 @@ class Sep31ServiceTest {
       }
   """
     private const val patchTxnRequestJson =
-        """
+      """
       {
         "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
         "fields": {
@@ -262,17 +262,17 @@ class Sep31ServiceTest {
     jwtService = spyk(JwtService(appConfig))
 
     sep31Service =
-        Sep31Service(
-            appConfig,
-            sep31Config,
-            txnStore,
-            sep31DepositInfoGenerator,
-            quoteStore,
-            assetService,
-            feeIntegration,
-            customerIntegration,
-            eventPublishService,
-        )
+      Sep31Service(
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetService,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
+      )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
     txn = gson.fromJson(txnJson, PojoSep31Transaction::class.java)
@@ -311,26 +311,26 @@ class Sep31ServiceTest {
   @Test
   fun test_quotesSupportedAndRequiredValidation() {
     val assetServiceQuotesNotSupported: AssetService =
-        ResourceJsonAssetService(
-            "test_assets.json.quotes_required_but_not_supported",
-        )
+      ResourceJsonAssetService(
+        "test_assets.json.quotes_required_but_not_supported",
+      )
     val ex: AnchorException = assertThrows {
       Sep31Service(
-          appConfig,
-          sep31Config,
-          txnStore,
-          sep31DepositInfoGenerator,
-          quoteStore,
-          assetServiceQuotesNotSupported,
-          feeIntegration,
-          customerIntegration,
-          eventPublishService,
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetServiceQuotesNotSupported,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
       )
     }
     assertInstanceOf(SepValidationException::class.java, ex)
     assertEquals(
-        "if quotes_required is true, quotes_supported must also be true",
-        ex.message,
+      "if quotes_required is true, quotes_supported must also be true",
+      ex.message,
     )
   }
 
@@ -351,8 +351,8 @@ class Sep31ServiceTest {
     // TODO: Add fee validation.
     assertEquals("100", txn.amountIn)
     assertEquals(
-        "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        txn.amountInAsset,
+      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      txn.amountInAsset,
     )
     assertEquals("12500", txn.amountOut)
     assertEquals(stellarJPYC, txn.amountOutAsset)
@@ -404,9 +404,9 @@ class Sep31ServiceTest {
     assertEquals("request cannot be null", ex1.message)
 
     val ex2 =
-        assertThrows<BadRequestException> {
-          sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
-        }
+      assertThrows<BadRequestException> {
+        sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
+      }
     assertEquals("id cannot be null or empty", ex2.message)
 
     every { txnStore.findByTransactionId(any()) } returns null
@@ -496,24 +496,24 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31MissingFieldException::class.java, ex)
     val wantMissingFieldsNames =
-        listOf("receiver_account_number", "type", "receiver_routing_number")
+      listOf("receiver_account_number", "type", "receiver_routing_number")
     val gotMissingFieldsNames = (ex as Sep31MissingFieldException).missingFields.transaction.keys
     assertTrue(
-        wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
-        "missing field names don't match",
+      wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
+      "missing field names don't match",
     )
     assertTrue(
-        gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
-        "missing field names don't match",
+      gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
+      "missing field names don't match",
     )
 
     // missing receiver_id
     val fields =
-        hashMapOf(
-            "receiver_account_number" to "1",
-            "type" to "1",
-            "receiver_routing_number" to "SWIFT",
-        )
+      hashMapOf(
+        "receiver_account_number" to "1",
+        "type" to "1",
+        "receiver_routing_number" to "SWIFT",
+      )
     postTxRequest.fields = Sep31TxnFields(fields)
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -565,8 +565,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
-        ex.message,
+      "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
+      ex.message,
     )
 
     // quote and tx assets don't match (quote.sell_asset is null)
@@ -575,8 +575,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-        ex.message,
+      "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+      ex.message,
     )
 
     // quote and tx assets don't match
@@ -585,8 +585,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-        ex.message,
+      "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+      ex.message,
     )
 
     // quote is missing the `fee` field
@@ -622,13 +622,13 @@ class Sep31ServiceTest {
     postTxRequest.receiverId = receiverId
     postTxRequest.quoteId = "my_quote_id"
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -638,13 +638,13 @@ class Sep31ServiceTest {
     every {
       sep31DepositInfoGenerator.getSep31DepositInfo(capture(txForDepositInfoGenerator))
     } answers
-        {
-          val tx: Sep31Transaction = txForDepositInfoGenerator.captured
-          var memo = StringUtils.truncate(tx.id, 32)
-          memo = StringUtils.leftPad(memo, 32, '0')
-          memo = String(Base64.getEncoder().encode(memo.toByteArray()))
-          Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
-        }
+      {
+        val tx: Sep31Transaction = txForDepositInfoGenerator.captured
+        var memo = StringUtils.truncate(tx.id, 32)
+        memo = StringUtils.leftPad(memo, 32, '0')
+        memo = String(Base64.getEncoder().encode(memo.toByteArray()))
+        Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
+      }
 
     // mock eventService
     val txEventSlot = slot<TransactionEvent>()
@@ -676,7 +676,7 @@ class Sep31ServiceTest {
     memo = String(Base64.getEncoder().encode(memo.toByteArray()))
     val txStartedAt = slotTxn.captured.startedAt
     val wantTx =
-        """{
+      """{
       "id": "$txId",
       "status": "pending_sender",
       "amountFee": "10",
@@ -704,49 +704,48 @@ class Sep31ServiceTest {
 
     // validate event response
     val wantEvent: TransactionEvent =
-        TransactionEvent.builder()
-            .eventId(txEventSlot.captured.eventId)
-            .type(TransactionEvent.Type.TRANSACTION_CREATED)
-            .id(txId)
-            .sep(TransactionEvent.Sep.SEP_31)
-            .kind(TransactionEvent.Kind.RECEIVE)
-            .status(TransactionEvent.Status.PENDING_SENDER)
-            .statusChange(
-                TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
-            .amountExpected(Amount("100", stellarUSDC))
-            .amountIn(Amount("100", stellarUSDC))
-            .amountOut(Amount("12500", stellarJPYC))
-            .amountFee(Amount("10", stellarUSDC))
-            .quoteId("my_quote_id")
-            .startedAt(txStartedAt)
-            .updatedAt(txStartedAt)
-            .completedAt(null)
-            .transferReceivedAt(null)
-            .message(null)
-            .refunds(null)
-            .stellarTransactions(null)
-            .externalTransactionId(null)
-            .custodialTransactionId(null)
-            .sourceAccount(senderId)
-            .destinationAccount(receiverId)
-            .creator(
-                StellarId.builder()
-                    .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-                    .memo(memo)
-                    .memoType("hash")
-                    .build(),
-            )
-            .build()
+      TransactionEvent.builder()
+        .eventId(txEventSlot.captured.eventId)
+        .type(TransactionEvent.Type.TRANSACTION_CREATED)
+        .id(txId)
+        .sep(TransactionEvent.Sep.SEP_31)
+        .kind(TransactionEvent.Kind.RECEIVE)
+        .status(TransactionEvent.Status.PENDING_SENDER)
+        .statusChange(TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
+        .amountExpected(Amount("100", stellarUSDC))
+        .amountIn(Amount("100", stellarUSDC))
+        .amountOut(Amount("12500", stellarJPYC))
+        .amountFee(Amount("10", stellarUSDC))
+        .quoteId("my_quote_id")
+        .startedAt(txStartedAt)
+        .updatedAt(txStartedAt)
+        .completedAt(null)
+        .transferReceivedAt(null)
+        .message(null)
+        .refunds(null)
+        .stellarTransactions(null)
+        .externalTransactionId(null)
+        .custodialTransactionId(null)
+        .sourceAccount(senderId)
+        .destinationAccount(receiverId)
+        .creator(
+          StellarId.builder()
+            .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+            .memo(memo)
+            .memoType("hash")
+            .build(),
+        )
+        .build()
     assertEquals(wantEvent, txEventSlot.captured)
 
     // validate the final response
     val wantResponse =
-        Sep31PostTransactionResponse.builder()
-            .id(txId)
-            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-            .stellarMemo(memo)
-            .stellarMemoType("hash")
-            .build()
+      Sep31PostTransactionResponse.builder()
+        .id(txId)
+        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+        .stellarMemo(memo)
+        .stellarMemoType("hash")
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -762,13 +761,13 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -789,21 +788,21 @@ class Sep31ServiceTest {
   @Test
   fun test_postTransaction_quoteNotSupported() {
     val assetServiceQuotesNotSupported: AssetService =
-        ResourceJsonAssetService(
-            "test_assets.json.quotes_not_supported",
-        )
+      ResourceJsonAssetService(
+        "test_assets.json.quotes_not_supported",
+      )
     sep31Service =
-        Sep31Service(
-            appConfig,
-            sep31Config,
-            txnStore,
-            sep31DepositInfoGenerator,
-            quoteStore,
-            assetServiceQuotesNotSupported,
-            feeIntegration,
-            customerIntegration,
-            eventPublishService,
-        )
+      Sep31Service(
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetServiceQuotesNotSupported,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
+      )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
     val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
@@ -814,22 +813,22 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Provide fee response.
     every { feeIntegration.getFee(any()) } returns
-        GetFeeResponse(
-            Amount(
-                "2",
-                "stellar:USDC",
-            ),
-        )
+      GetFeeResponse(
+        Amount(
+          "2",
+          "stellar:USDC",
+        ),
+      )
 
     // POST transaction
     val jwtToken = TestHelper.createJwtToken()
@@ -837,12 +836,12 @@ class Sep31ServiceTest {
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
     val wantResponse =
-        Sep31PostTransactionResponse.builder()
-            .id(gotResponse!!.id)
-            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-            .stellarMemo("")
-            .stellarMemoType("")
-            .build()
+      Sep31PostTransactionResponse.builder()
+        .id(gotResponse!!.id)
+        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+        .stellarMemo("")
+        .stellarMemoType("")
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -262,7 +262,7 @@ class Sep31ServiceTest {
     clearAllMocks()
     unmockkAll()
   }
-
+  
   @Test
   fun test_updateTxAmountsWhenNoQuoteWasUsed() {
     Sep31Service.Context.get().setTransaction(txn)
@@ -745,5 +745,50 @@ class Sep31ServiceTest {
         .stellarMemoType("")
         .build()
     assertEquals(wantResponse, gotResponse)
+  }
+
+  @Test
+  fun test_info_response() {
+    val info = sep31Service.info
+    val jpyc = info.receive.get("JPYC")!!
+    val usdc = info.receive.get("USDC")!!
+
+    // Test correctness of reading test_assets.json
+    assertTrue(jpyc.enabled)
+    assertTrue(jpyc.quotesSupported)
+    assertTrue(jpyc.quotesRequired)
+    assertEquals(0, jpyc.feeFixed)
+    assertEquals(0, jpyc.feePercent)
+    assertEquals(1, jpyc.minAmount)
+    assertEquals(1000000, jpyc.maxAmount)
+    assertNotNull(jpyc.sep12)
+    assertNotNull(jpyc.sep12.sender)
+    assertNotNull(jpyc.sep12.sender.types)
+    assertEquals(1, jpyc.sep12.sender.types.size)
+    assertNotNull(jpyc.sep12.receiver)
+    assertNotNull(jpyc.sep12.receiver.types)
+    assertEquals(1, jpyc.sep12.receiver.types.size)
+    assertNotNull(jpyc.fields.transaction)
+    assertEquals(3, jpyc.fields.transaction.size)
+
+    assertTrue(usdc.enabled)
+    assertTrue(usdc.quotesSupported)
+    assertTrue(usdc.quotesRequired)
+    assertEquals(0, usdc.feeFixed)
+    assertEquals(0, usdc.feePercent)
+    assertEquals(1, usdc.minAmount)
+    assertEquals(1000000, usdc.maxAmount)
+    assertNotNull(usdc.sep12)
+    assertNotNull(usdc.sep12.sender)
+    assertNotNull(usdc.sep12.sender.types)
+    assertEquals(3, usdc.sep12.sender.types.size)
+    assertNotNull(usdc.sep12.receiver)
+    assertNotNull(usdc.sep12.receiver.types)
+    assertEquals(2, usdc.sep12.receiver.types.size)
+    assertNotNull(usdc.fields.transaction)
+    assertEquals(3, usdc.fields.transaction.size)
+
+
+    print(info)
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -897,13 +897,16 @@ class Sep31ServiceTest {
     Context.get().setQuote(quote)
     request.destinationAsset = "USDC"
     sep31Service.updateFee()
+    var fee = Context.get().getFee()
+    assertEquals(quote.fee.total, fee.amount)
+    assertEquals(quote.fee.asset, fee.asset)
 
     // No quote
     every { feeIntegration.getFee(any()) } returns GetFeeResponse(Amount("10", "USDC"))
     Context.get().setQuote(null)
     request.destinationAsset = "USDC"
     sep31Service.updateFee()
-    var fee = Context.get().getFee()
+    fee = Context.get().getFee()
     assertEquals("10", fee.amount)
     assertEquals("USDC", fee.asset)
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -367,7 +367,8 @@ class Sep31ServiceTest {
     assertThrows<BadRequestException> { sep31Service.getTransaction("") }
 
     every { txnStore.findByTransactionId("not_found") } returns null
-    assertThrows<NotFoundException> { sep31Service.getTransaction("not_found") }
+    val ex = assertThrows<NotFoundException> { sep31Service.getTransaction("not_found") }
+    assertEquals("transaction (id=not_found) not found", ex.message)
 
     every { txnStore.findByTransactionId("found") } returns txn
     val getTransactionResponse = sep31Service.getTransaction("found")

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -22,11 +22,8 @@ import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.sep.AssetInfo
 import org.stellar.anchor.api.sep.sep12.Sep12GetCustomerRequest
 import org.stellar.anchor.api.sep.sep12.Sep12GetCustomerResponse
-import org.stellar.anchor.api.sep.sep31.Sep31DepositInfo
-import org.stellar.anchor.api.sep.sep31.Sep31PatchTransactionRequest
-import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest
+import org.stellar.anchor.api.sep.sep31.*
 import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest.Sep31TxnFields
-import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionResponse
 import org.stellar.anchor.api.sep.sep38.RateFee
 import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.asset.AssetService
@@ -847,48 +844,27 @@ class Sep31ServiceTest {
     assertEquals(wantResponse, gotResponse)
   }
 
+  val jpycJson =
+      """
+    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"Japanese citizens"}}},"receiver":{"types":{"sep31-receiver":{"description":"Japanese citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["ACH","SWIFT","WIRE"],"optional":false}}}}
+  """.trimIndent()
+
+  val usdcJson =
+      """
+    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"},"sep31-large-sender":{"description":"U.S. citizens that do not have sending limits"},"sep31-foreign-sender":{"description":"non-U.S. citizens sending payments of less than ${'$'}10,000 in value"}}},"receiver":{"types":{"sep31-receiver":{"description":"U.S. citizens receiving USD"},"sep31-foreign-receiver":{"description":"non-U.S. citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["SEPA","SWIFT"],"optional":false}}}}
+  """.trimIndent()
+
   @Test
   fun test_info_response() {
     val info = sep31Service.info
-    val jpyc = info.receive.get("JPYC")!!
-    val usdc = info.receive.get("USDC")!!
+    val gotJpyc = info.receive.get("JPYC")!!
+    val gotUsdc = info.receive.get("USDC")!!
 
-    // Test correctness of reading test_assets.json
-    assertTrue(jpyc.enabled)
-    assertTrue(jpyc.quotesSupported)
-    assertTrue(jpyc.quotesRequired)
-    assertEquals(0, jpyc.feeFixed)
-    assertEquals(0, jpyc.feePercent)
-    assertEquals(1, jpyc.minAmount)
-    assertEquals(1000000, jpyc.maxAmount)
-    assertNotNull(jpyc.sep12)
-    assertNotNull(jpyc.sep12.sender)
-    assertNotNull(jpyc.sep12.sender.types)
-    assertEquals(1, jpyc.sep12.sender.types.size)
-    assertNotNull(jpyc.sep12.receiver)
-    assertNotNull(jpyc.sep12.receiver.types)
-    assertEquals(1, jpyc.sep12.receiver.types.size)
-    assertNotNull(jpyc.fields.transaction)
-    assertEquals(3, jpyc.fields.transaction.size)
+    val wantJpyc = gson.fromJson(jpycJson, Sep31InfoResponse.AssetResponse::class.java)
+    val wantUsdc = gson.fromJson(usdcJson, Sep31InfoResponse.AssetResponse::class.java)
 
-    assertTrue(usdc.enabled)
-    assertTrue(usdc.quotesSupported)
-    assertTrue(usdc.quotesRequired)
-    assertEquals(0, usdc.feeFixed)
-    assertEquals(0, usdc.feePercent)
-    assertEquals(1, usdc.minAmount)
-    assertEquals(1000000, usdc.maxAmount)
-    assertNotNull(usdc.sep12)
-    assertNotNull(usdc.sep12.sender)
-    assertNotNull(usdc.sep12.sender.types)
-    assertEquals(3, usdc.sep12.sender.types.size)
-    assertNotNull(usdc.sep12.receiver)
-    assertNotNull(usdc.sep12.receiver.types)
-    assertEquals(2, usdc.sep12.receiver.types.size)
-    assertNotNull(usdc.fields.transaction)
-    assertEquals(3, usdc.fields.transaction.size)
-
-    print(info)
+    assertEquals(wantJpyc, gotJpyc)
+    assertEquals(wantUsdc, gotUsdc)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -46,13 +46,13 @@ class Sep31ServiceTest {
     val gson: Gson = GsonUtils.getInstance()
 
     private const val stellarUSDC =
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 
     private const val stellarJPYC =
-        "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
 
     private const val requestJson =
-        """
+      """
         {
           "amount": "500",
           "asset_code": "USDC",
@@ -69,7 +69,7 @@ class Sep31ServiceTest {
     """
 
     private const val feeJson =
-        """
+      """
         {
           "amount": "2",
           "asset": "USDC"
@@ -77,7 +77,7 @@ class Sep31ServiceTest {
     """
 
     private const val assetJson =
-        """
+      """
             {
               "code": "USDC",
               "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
@@ -166,7 +166,7 @@ class Sep31ServiceTest {
         """
 
     private const val txnJson =
-        """
+      """
     {
       "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
       "status": "pending_sender",
@@ -196,7 +196,7 @@ class Sep31ServiceTest {
     """
 
     private const val quoteJson =
-        """
+      """
       {
         "id": "de762cda-a193-4961-861e-57b31fed6eb3",
         "expires_at": "2021-04-30T07:42:23",
@@ -213,7 +213,7 @@ class Sep31ServiceTest {
       }
   """
     private const val patchTxnRequestJson =
-        """
+      """
       {
         "id": "a2392add-87c9-42f0-a5c1-5f1728030b68",
         "fields": {
@@ -259,17 +259,17 @@ class Sep31ServiceTest {
     jwtService = spyk(JwtService(appConfig))
 
     sep31Service =
-        Sep31Service(
-            appConfig,
-            sep31Config,
-            txnStore,
-            sep31DepositInfoGenerator,
-            quoteStore,
-            assetService,
-            feeIntegration,
-            customerIntegration,
-            eventPublishService,
-        )
+      Sep31Service(
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetService,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
+      )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
     txn = gson.fromJson(txnJson, PojoSep31Transaction::class.java)
@@ -308,26 +308,26 @@ class Sep31ServiceTest {
   @Test
   fun test_quotesSupportedAndRequiredValidation() {
     val assetServiceQuotesNotSupported: AssetService =
-        ResourceJsonAssetService(
-            "test_assets.json.quotes_required_but_not_supported",
-        )
+      ResourceJsonAssetService(
+        "test_assets.json.quotes_required_but_not_supported",
+      )
     val ex: AnchorException = assertThrows {
       Sep31Service(
-          appConfig,
-          sep31Config,
-          txnStore,
-          sep31DepositInfoGenerator,
-          quoteStore,
-          assetServiceQuotesNotSupported,
-          feeIntegration,
-          customerIntegration,
-          eventPublishService,
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetServiceQuotesNotSupported,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
       )
     }
     assertInstanceOf(SepValidationException::class.java, ex)
     assertEquals(
-        "if quotes_required is true, quotes_supported must also be true",
-        ex.message,
+      "if quotes_required is true, quotes_supported must also be true",
+      ex.message,
     )
   }
 
@@ -348,15 +348,16 @@ class Sep31ServiceTest {
     // TODO: Add fee validation.
     assertEquals("100", txn.amountIn)
     assertEquals(
-        "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-        txn.amountInAsset,
+      "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      txn.amountInAsset,
     )
     assertEquals("12500", txn.amountOut)
     assertEquals(stellarJPYC, txn.amountOutAsset)
 
     // Test null quote failure
     Context.get().setQuote(null)
-    assertThrows<ServerErrorException> { sep31Service.updateTxAmountsBasedOnQuote() }
+    val ex = assertThrows<ServerErrorException> { sep31Service.updateTxAmountsBasedOnQuote() }
+    assertEquals("Quote not found.", ex.message)
   }
   @Test
   fun test_getTransaction() {
@@ -402,9 +403,9 @@ class Sep31ServiceTest {
     assertEquals("request cannot be null", ex1.message)
 
     val ex2 =
-        assertThrows<BadRequestException> {
-          sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
-        }
+      assertThrows<BadRequestException> {
+        sep31Service.patchTransaction(Sep31PatchTransactionRequest.builder().build())
+      }
     assertEquals("id cannot be null or empty", ex2.message)
 
     every { txnStore.findByTransactionId(any()) } returns null
@@ -494,24 +495,24 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31MissingFieldException::class.java, ex)
     val wantMissingFieldsNames =
-        listOf("receiver_account_number", "type", "receiver_routing_number")
+      listOf("receiver_account_number", "type", "receiver_routing_number")
     val gotMissingFieldsNames = (ex as Sep31MissingFieldException).missingFields.transaction.keys
     assertTrue(
-        wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
-        "missing field names don't match",
+      wantMissingFieldsNames.containsAll(gotMissingFieldsNames),
+      "missing field names don't match",
     )
     assertTrue(
-        gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
-        "missing field names don't match",
+      gotMissingFieldsNames.containsAll(wantMissingFieldsNames),
+      "missing field names don't match",
     )
 
     // missing receiver_id
     val fields =
-        hashMapOf(
-            "receiver_account_number" to "1",
-            "type" to "1",
-            "receiver_routing_number" to "SWIFT",
-        )
+      hashMapOf(
+        "receiver_account_number" to "1",
+        "type" to "1",
+        "receiver_routing_number" to "SWIFT",
+      )
     postTxRequest.fields = Sep31TxnFields(fields)
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -563,8 +564,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
-        ex.message,
+      "Quote sell amount [100.1] is different from the SEP-31 transaction amount [100]",
+      ex.message,
     )
 
     // quote and tx assets don't match (quote.sell_asset is null)
@@ -573,8 +574,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-        ex.message,
+      "Quote sell asset [null] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+      ex.message,
     )
 
     // quote and tx assets don't match
@@ -583,8 +584,8 @@ class Sep31ServiceTest {
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals(
-        "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
-        ex.message,
+      "Quote sell asset [stellar:USDC:zzz] is different from the SEP-31 transaction asset [stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP]",
+      ex.message,
     )
 
     // quote is missing the `fee` field
@@ -620,13 +621,13 @@ class Sep31ServiceTest {
     postTxRequest.receiverId = receiverId
     postTxRequest.quoteId = "my_quote_id"
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -636,13 +637,13 @@ class Sep31ServiceTest {
     every {
       sep31DepositInfoGenerator.getSep31DepositInfo(capture(txForDepositInfoGenerator))
     } answers
-        {
-          val tx: Sep31Transaction = txForDepositInfoGenerator.captured
-          var memo = StringUtils.truncate(tx.id, 32)
-          memo = StringUtils.leftPad(memo, 32, '0')
-          memo = String(Base64.getEncoder().encode(memo.toByteArray()))
-          Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
-        }
+      {
+        val tx: Sep31Transaction = txForDepositInfoGenerator.captured
+        var memo = StringUtils.truncate(tx.id, 32)
+        memo = StringUtils.leftPad(memo, 32, '0')
+        memo = String(Base64.getEncoder().encode(memo.toByteArray()))
+        Sep31DepositInfo(tx.stellarAccountId, memo, "hash")
+      }
 
     // mock eventService
     val txEventSlot = slot<TransactionEvent>()
@@ -674,7 +675,7 @@ class Sep31ServiceTest {
     memo = String(Base64.getEncoder().encode(memo.toByteArray()))
     val txStartedAt = slotTxn.captured.startedAt
     val wantTx =
-        """{
+      """{
       "id": "$txId",
       "status": "pending_sender",
       "amountFee": "10",
@@ -702,49 +703,48 @@ class Sep31ServiceTest {
 
     // validate event response
     val wantEvent: TransactionEvent =
-        TransactionEvent.builder()
-            .eventId(txEventSlot.captured.eventId)
-            .type(TransactionEvent.Type.TRANSACTION_CREATED)
-            .id(txId)
-            .sep(TransactionEvent.Sep.SEP_31)
-            .kind(TransactionEvent.Kind.RECEIVE)
-            .status(TransactionEvent.Status.PENDING_SENDER)
-            .statusChange(
-                TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
-            .amountExpected(Amount("100", stellarUSDC))
-            .amountIn(Amount("100", stellarUSDC))
-            .amountOut(Amount("12500", stellarJPYC))
-            .amountFee(Amount("10", stellarUSDC))
-            .quoteId("my_quote_id")
-            .startedAt(txStartedAt)
-            .updatedAt(txStartedAt)
-            .completedAt(null)
-            .transferReceivedAt(null)
-            .message(null)
-            .refunds(null)
-            .stellarTransactions(null)
-            .externalTransactionId(null)
-            .custodialTransactionId(null)
-            .sourceAccount(senderId)
-            .destinationAccount(receiverId)
-            .creator(
-                StellarId.builder()
-                    .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-                    .memo(memo)
-                    .memoType("hash")
-                    .build(),
-            )
-            .build()
+      TransactionEvent.builder()
+        .eventId(txEventSlot.captured.eventId)
+        .type(TransactionEvent.Type.TRANSACTION_CREATED)
+        .id(txId)
+        .sep(TransactionEvent.Sep.SEP_31)
+        .kind(TransactionEvent.Kind.RECEIVE)
+        .status(TransactionEvent.Status.PENDING_SENDER)
+        .statusChange(TransactionEvent.StatusChange(null, TransactionEvent.Status.PENDING_SENDER))
+        .amountExpected(Amount("100", stellarUSDC))
+        .amountIn(Amount("100", stellarUSDC))
+        .amountOut(Amount("12500", stellarJPYC))
+        .amountFee(Amount("10", stellarUSDC))
+        .quoteId("my_quote_id")
+        .startedAt(txStartedAt)
+        .updatedAt(txStartedAt)
+        .completedAt(null)
+        .transferReceivedAt(null)
+        .message(null)
+        .refunds(null)
+        .stellarTransactions(null)
+        .externalTransactionId(null)
+        .custodialTransactionId(null)
+        .sourceAccount(senderId)
+        .destinationAccount(receiverId)
+        .creator(
+          StellarId.builder()
+            .account("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+            .memo(memo)
+            .memoType("hash")
+            .build(),
+        )
+        .build()
     assertEquals(wantEvent, txEventSlot.captured)
 
     // validate the final response
     val wantResponse =
-        Sep31PostTransactionResponse.builder()
-            .id(txId)
-            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-            .stellarMemo(memo)
-            .stellarMemoType("hash")
-            .build()
+      Sep31PostTransactionResponse.builder()
+        .id(txId)
+        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+        .stellarMemo(memo)
+        .stellarMemoType("hash")
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -760,13 +760,13 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Make sure we can get the sender and receiver customers
     every { customerIntegration.getCustomer(any()) } returns Sep12GetCustomerResponse()
@@ -787,21 +787,21 @@ class Sep31ServiceTest {
   @Test
   fun test_postTransaction_quoteNotSupported() {
     val assetServiceQuotesNotSupported: AssetService =
-        ResourceJsonAssetService(
-            "test_assets.json.quotes_not_supported",
-        )
+      ResourceJsonAssetService(
+        "test_assets.json.quotes_not_supported",
+      )
     sep31Service =
-        Sep31Service(
-            appConfig,
-            sep31Config,
-            txnStore,
-            sep31DepositInfoGenerator,
-            quoteStore,
-            assetServiceQuotesNotSupported,
-            feeIntegration,
-            customerIntegration,
-            eventPublishService,
-        )
+      Sep31Service(
+        appConfig,
+        sep31Config,
+        txnStore,
+        sep31DepositInfoGenerator,
+        quoteStore,
+        assetServiceQuotesNotSupported,
+        feeIntegration,
+        customerIntegration,
+        eventPublishService,
+      )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
     val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
@@ -812,22 +812,22 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.fields =
-        Sep31TxnFields(
-            hashMapOf(
-                "receiver_account_number" to "1",
-                "type" to "1",
-                "receiver_routing_number" to "SWIFT",
-            ),
-        )
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
 
     // Provide fee response.
     every { feeIntegration.getFee(any()) } returns
-        GetFeeResponse(
-            Amount(
-                "2",
-                "stellar:USDC",
-            ),
-        )
+      GetFeeResponse(
+        Amount(
+          "2",
+          "stellar:USDC",
+        ),
+      )
 
     // POST transaction
     val jwtToken = TestHelper.createJwtToken()
@@ -835,22 +835,22 @@ class Sep31ServiceTest {
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
     val wantResponse =
-        Sep31PostTransactionResponse.builder()
-            .id(gotResponse!!.id)
-            .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
-            .stellarMemo("")
-            .stellarMemoType("")
-            .build()
+      Sep31PostTransactionResponse.builder()
+        .id(gotResponse!!.id)
+        .stellarAccountId("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I")
+        .stellarMemo("")
+        .stellarMemoType("")
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
   val jpycJson =
-      """
+    """
     {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"Japanese citizens"}}},"receiver":{"types":{"sep31-receiver":{"description":"Japanese citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["ACH","SWIFT","WIRE"],"optional":false}}}}
   """.trimIndent()
 
   val usdcJson =
-      """
+    """
     {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"},"sep31-large-sender":{"description":"U.S. citizens that do not have sending limits"},"sep31-foreign-sender":{"description":"non-U.S. citizens sending payments of less than ${'$'}10,000 in value"}}},"receiver":{"types":{"sep31-receiver":{"description":"U.S. citizens receiving USD"},"sep31-foreign-receiver":{"description":"non-U.S. citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["SEPA","SWIFT"],"optional":false}}}}
   """.trimIndent()
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -926,6 +926,7 @@ class Sep31ServiceTest {
     // With quote
     Context.get().setQuote(quote)
     quote.fee = null
-    assertThrows<SepValidationException> { sep31Service.updateFee() }
+    val ex = assertThrows<SepValidationException> { sep31Service.updateFee() }
+    assertEquals("Quote is missing the 'fee' field", ex.message)
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionBuilderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionBuilderTest.kt
@@ -1,0 +1,47 @@
+package org.stellar.anchor.sep31
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class Sep31TransactionBuilderTest {
+  @MockK(relaxed = true) private lateinit var txnStore: Sep31TransactionStore
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+  }
+
+  @Test
+  fun test_RefundBuilder() {
+    every { txnStore.newRefunds() } returns PojoSep31Refunds()
+    every { txnStore.newRefundPayment() } returns PojoSep31RefundPayment()
+
+    val refundPayments =
+        listOf(
+            RefundPaymentBuilder(txnStore)
+                .id("de762cda-a193-4961-861e-57b31fed6eb3")
+                .amount("10")
+                .fee("1")
+                .build(),
+            (RefundPaymentBuilder(txnStore)
+                .id("aa762cda-a193-4961-861e-57b31fed6eb3")
+                .amount("20")
+                .fee("1")
+                .build()))
+
+    val refunds =
+        RefundsBuilder(txnStore)
+            .amountRefunded("32")
+            .amountFee("3")
+            .payments(refundPayments)
+            .build()
+
+    assertEquals("32", refunds.amountRefunded)
+    assertEquals("3", refunds.amountFee)
+    assertEquals(2, refunds.refundPayments.size)
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionBuilderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionBuilderTest.kt
@@ -21,24 +21,21 @@ class Sep31TransactionBuilderTest {
     every { txnStore.newRefundPayment() } returns PojoSep31RefundPayment()
 
     val refundPayments =
-        listOf(
-            RefundPaymentBuilder(txnStore)
-                .id("de762cda-a193-4961-861e-57b31fed6eb3")
-                .amount("10")
-                .fee("1")
-                .build(),
-            (RefundPaymentBuilder(txnStore)
-                .id("aa762cda-a193-4961-861e-57b31fed6eb3")
-                .amount("20")
-                .fee("1")
-                .build()))
+      listOf(
+        RefundPaymentBuilder(txnStore)
+          .id("de762cda-a193-4961-861e-57b31fed6eb3")
+          .amount("10")
+          .fee("1")
+          .build(),
+        (RefundPaymentBuilder(txnStore)
+          .id("aa762cda-a193-4961-861e-57b31fed6eb3")
+          .amount("20")
+          .fee("1")
+          .build())
+      )
 
     val refunds =
-        RefundsBuilder(txnStore)
-            .amountRefunded("32")
-            .amountFee("3")
-            .payments(refundPayments)
-            .build()
+      RefundsBuilder(txnStore).amountRefunded("32").amountFee("3").payments(refundPayments).build()
 
     assertEquals("32", refunds.amountRefunded)
     assertEquals("3", refunds.amountFee)

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Refunds.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Refunds.java
@@ -13,5 +13,6 @@ public class JdbcSep31Refunds implements Sep31Transaction.Refunds {
   @SerializedName("amount_fee")
   String amountFee;
 
+  @SerializedName("payments")
   List<Sep31Transaction.RefundPayment> refundPayments;
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

Improve the core's `org.stellar.anchor.sep31` package test coverage to 100%.

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This PR is to improve SEP-31 core package test coverage to 100%. 

### Why

N/A

### Known limitations

This PR focuses on test coverage with some validations. More validation can be added to cover the corner cases.