### PR TITLE
simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,13 @@
 FROM openjdk:11-jdk AS build
-# build jar
-ADD . /code
 WORKDIR /code
+COPY . .
 RUN ./gradlew clean bootJar --stacktrace
 
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-apt-get install -y --no-install-recommends \
-        openjdk-11-jre
+    apt-get install -y --no-install-recommends openjdk-11-jre
 
-#temporary for testing reece
-RUN apt-get install -y net-tools
-RUN apt-get install -y wget
-
-RUN mkdir /app
 COPY --from=build /code/service-runner/build/libs/anchor-platform-runner*.jar /app/anchor-platform-runner.jar
 
-RUN mkdir /config
-ENV STELLAR_ANCHOR_CONFIG=file:/config/anchor-config.yaml
-
-ENV REFERENCE_SERVER_CONFIG_ENV=file:/config/reference-config.yaml
-
-EXPOSE 8080 8081
-
-#ENTRYPOINT ["java", "-jar", "/app/anchor-platform-runner.jar"]
+ENTRYPOINT ["java", "-jar", "/app/anchor-platform-runner.jar"]


### PR DESCRIPTION
Makes some minor changes to the Dockerfile to make it a bit simpler:

- Uses `WORKDIR` to create the `/code` directory, allowing the `COPY` command to use `. .`
- Removed unnecessary installs (these can always be installed when `docker exec`'ed in the container)
- Removes `ENV` commands.
    - I'm not sure if this would break anything, but we should be able to specify these environment variables at runtime instead of having defaults built into the image
- Removes the `EXPOSE` command, since it actually has no affect