### PR TITLE
platform: Set the integration-auth as NONE and disable the metrics in default

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
@@ -12,5 +12,5 @@ public class IntegrationAuthSettings {
   AuthType authType = AuthType.NONE;
   String platformToAnchorSecret;
   String anchorToPlatformSecret;
-  long expirationMilliseconds = 30000;
+  Long expirationMilliseconds;
 }

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
@@ -1,11 +1,13 @@
 package org.stellar.anchor.reference.config;
 
 import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.config.IntegrationAuthConfig.AuthType;
 
 @Data
 @Configuration
+@ConfigurationProperties(prefix = "integration-auth")
 public class IntegrationAuthSettings {
   AuthType authType = AuthType.NONE;
   String platformToAnchorSecret;

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/IntegrationAuthSettings.java
@@ -1,13 +1,11 @@
 package org.stellar.anchor.reference.config;
 
 import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.config.IntegrationAuthConfig.AuthType;
 
 @Data
 @Configuration
-@ConfigurationProperties(prefix = "integration-auth")
 public class IntegrationAuthSettings {
   AuthType authType = AuthType.NONE;
   String platformToAnchorSecret;

--- a/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
@@ -23,16 +23,16 @@ integration-auth:
   #     NONE: no authentication is used
   #     API_KEY: the authentication is done using an API key added to the `X-Api-Key` header.
   #     JWT_TOKEN: the authentication is done using a JWT token added to the `Authorization` header. this token is generated from the secret key.
-  authType: JWT_TOKEN
+  authType: NONE
   # CallbackAPI requests (`Platform->Anchor`) will contain an authentication header whose token was built using this
   # secret. The Anchor Backend will also store this same secret and use it to decode the incoming token to verify it
   # came from the Platform.
-  platformToAnchorSecret: myPlatformToAnchorSecret
+  platformToAnchorSecret:
   # PlatformAPI requests (`Anchor->Platform`) will contain an authentication header whose token was built using this
   # secret. The Platform Server will use this secret to decode the incoming token to verify it came from the Anchor.
-  anchorToPlatformSecret: myAnchorToPlatformSecret
+  anchorToPlatformSecret:
   # Expiration time, in milliseconds, that will be used to build and validate the JWT tokens
-  expirationMilliseconds: 30000
+  expirationMilliseconds:
 
 event:
   # The listener type. values: [kafka, sqs, amqp]

--- a/core/src/main/java/org/stellar/anchor/config/IntegrationAuthConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/IntegrationAuthConfig.java
@@ -9,7 +9,7 @@ public interface IntegrationAuthConfig {
   @Secret
   String getAnchorToPlatformSecret();
 
-  long getExpirationMilliseconds();
+  Long getExpirationMilliseconds();
 
   enum AuthType {
     NONE,

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyIntegrationAuthConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyIntegrationAuthConfig.java
@@ -15,7 +15,7 @@ public class PropertyIntegrationAuthConfig implements IntegrationAuthConfig, Val
   AuthType authType = NONE;
   String platformToAnchorSecret;
   String anchorToPlatformSecret;
-  long expirationMilliseconds = 10000;
+  Long expirationMilliseconds;
 
   @Override
   public boolean supports(Class<?> clazz) {

--- a/platform/src/main/resources/anchor-config-defaults.yaml
+++ b/platform/src/main/resources/anchor-config-defaults.yaml
@@ -86,16 +86,16 @@ app-config:
     #     NONE: no authentication is used
     #     API_KEY: the authentication is done using an API key added to the `X-Api-Key` header.
     #     JWT_TOKEN: the authentication is done using a JWT token added to the `Authorization` header. this token is generated from the secret key.
-    authType: JWT_TOKEN
+    authType: NONE
     # CallbackAPI requests (`Platform->Anchor`) will contain an authentication header whose token was built using this
     # secret. The Anchor Backend will also store this same secret and use it to decode the incoming token to verify it
     # came from the Platform.
-    platformToAnchorSecret: ${PLATFORM_TO_ANCHOR_SECRET}
+    platformToAnchorSecret:
     # PlatformAPI requests (`Anchor->Platform`) will contain an authentication header whose token was built using this
     # secret. The Platform Server will use this secret to decode the incoming token to verify it came from the Anchor.
-    anchorToPlatformSecret: ${ANCHOR_TO_PLATFORM_SECRET}
+    anchorToPlatformSecret:
     # Expiration time, in milliseconds, that will be used to build and validate the JWT tokens
-    expirationMilliseconds: 30000
+    expirationMilliseconds:
 
   # sep-1
   sep1:

--- a/platform/src/main/resources/anchor-config-defaults.yaml
+++ b/platform/src/main/resources/anchor-config-defaults.yaml
@@ -234,7 +234,7 @@ app-config:
     publisherType: kafka
 
   metrics-service:
-    optionalMetricsEnabled: true    # optional metrics that periodically query the database
+    optionalMetricsEnabled: false    # optional metrics that periodically query the database
     runInterval: 30                 # interval to query the database to generate the optional metrics
 
   kafka.publisher:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The default value of integration-auth configuration is JWT_TOKEN. We should set it to none.

### Why

N/A

### Known limitations

N/A