### PR TITLE
hotfix: solve issue where `uniqueAddressService` was crashing

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/UniqueAddressController.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/controller/UniqueAddressController.java
@@ -1,15 +1,14 @@
 package org.stellar.anchor.reference.controller;
 
-import com.google.gson.Gson;
 import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.api.callback.GetUniqueAddressResponse;
 import org.stellar.anchor.reference.service.UniqueAddressService;
-import org.stellar.anchor.util.GsonUtils;
+import org.stellar.anchor.util.ConditionalOnPropertyNotEmpty;
 
 @RestController
+@ConditionalOnPropertyNotEmpty("anchor.settings.distributionWallet")
 public class UniqueAddressController {
   final UniqueAddressService uniqueAddressService;
-  static final Gson gson = GsonUtils.builder().create();
 
   public UniqueAddressController(UniqueAddressService uniqueAddressService) {
     this.uniqueAddressService = uniqueAddressService;

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/UniqueAddressService.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/UniqueAddressService.java
@@ -5,10 +5,12 @@ import org.springframework.stereotype.Service;
 import org.stellar.anchor.api.callback.GetUniqueAddressResponse;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.reference.config.AppSettings;
+import org.stellar.anchor.util.ConditionalOnPropertyNotEmpty;
 import org.stellar.anchor.util.MemoHelper;
 import org.stellar.sdk.KeyPair;
 
 @Service
+@ConditionalOnPropertyNotEmpty("anchor.settings.distributionWallet")
 public class UniqueAddressService {
   String distributionWallet;
   String distributionWalletMemo;

--- a/core/src/main/java/org/stellar/anchor/util/ConditionalOnPropertyNotEmpty.java
+++ b/core/src/main/java/org/stellar/anchor/util/ConditionalOnPropertyNotEmpty.java
@@ -1,0 +1,34 @@
+package org.stellar.anchor.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(ConditionalOnPropertyNotEmpty.OnPropertyNotEmptyCondition.class)
+public @interface ConditionalOnPropertyNotEmpty {
+  String value();
+
+  class OnPropertyNotEmptyCondition implements Condition {
+
+    @Override
+    public boolean matches(@NotNull ConditionContext context, AnnotatedTypeMetadata metadata) {
+      Map<String, Object> attrs =
+          metadata.getAnnotationAttributes(ConditionalOnPropertyNotEmpty.class.getName());
+      if (attrs == null) {
+        return false;
+      }
+      String propertyName = (String) attrs.get("value");
+      String val = context.getEnvironment().getProperty(propertyName);
+      return val != null && !val.trim().isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Create annotation `ConditionalOnPropertyNotEmpty` and add it to the `UniqueAddressController` and `UniqueAddressService`, so they are only instantiated when the `anchor.settings.distributionWallet` property is not empty.

### Why

Close #443
