### PR TITLE
helm: Fix typo in helm chart for kafkaPublisher.eventTypeToQueue

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.84 
+version: 0.3.85

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -187,7 +187,7 @@ data:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}
         useIAM: {{ .Values.stellar.app_config.kafka_publisher.useIAM | default "false" }}
         useSingleQueue: {{ .Values.stellar.app_config.kafka_publisher.useSingleQueue | default "false" }}
-        {{- if (((.Values.stellar.app_config).event).kafka_publisher).eventTypeQueue }}
+        {{- if ((.Values.stellar.app_config).kafka_publisher).eventTypeToQueue }}
         eventTypeToQueue:
           all: {{ .Values.stellar.app_config.kafka_publisher.eventTypeToQueue.all | default "dev_ap_event_single_queue" }}
           quoteCreated: {{ .Values.stellar.app_config.kafka_publisher.eventTypeToQueue.quoteCreated | default "dev_ap_event_quote_created" }}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix typo in helm chart to check for kafkaPublisher

### Why

The typo causes the template to always use the default clause for `kafkaPublisher.eventTypeToQueue`
