### PR TITLE
platform: Fix error when not running LogAppenderTest from console

### DIFF
--- a/platform/src/test/kotlin/org/stellar/anchor/platform/LogAppenderTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/LogAppenderTest.kt
@@ -6,25 +6,62 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.Appender
 import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.LoggerContext
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.stellar.anchor.util.*
 
 class LogAppenderTest {
-  @Test
-  fun test_loggerInfo_accurateLoggerName() {
-    val appender = mockk<Appender>()
-    val capturedLogEvent = slot<LogEvent>()
-
+  private val appender = mockk<Appender>()
+  private val capturedLogEvent = slot<LogEvent>()
+  private val loggerContext: LoggerContext = LogManager.getContext(false) as LoggerContext
+  private val rootLoggerConfig = loggerContext.configuration.getLoggerConfig("org.stellar")
+  private val lastLevel = rootLoggerConfig.level
+  @BeforeEach
+  fun setup() {
     every { appender.name } returns "mock appender"
     every { appender.isStarted } returns true
     every { appender.append(capture(capturedLogEvent)) }
 
-    val loggerContext: LoggerContext = LogManager.getContext(false) as LoggerContext
-    val loggerConfig = loggerContext.configuration.getLoggerConfig("root")
-    loggerConfig.addAppender(appender, Level.ALL, null)
+    rootLoggerConfig.addAppender(appender, Level.ALL, null)
+    rootLoggerConfig.level = Level.TRACE
+  }
 
-    Log.info("hello world")
+  @AfterEach
+  fun tearDown() {
+    clearAllMocks()
+    unmockkAll()
+    rootLoggerConfig.removeAppender("mock appender")
+    rootLoggerConfig.level = lastLevel
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value =
+          [
+              "error,error_message,ERROR",
+              "warn,warn_message,WARN",
+              "info,info_message,INFO",
+              "debug,debug_message,DEBUG",
+              "trace,trace_message,TRACE",
+          ])
+  fun test_logger_outputAccurateLoggerName(
+      methodName: String,
+      wantMessage: String,
+      wantLevelName: String
+  ) {
+    when (methodName) {
+      "error" -> Log.error(wantMessage)
+      "warn" -> Log.warn(wantMessage)
+      "info" -> Log.info(wantMessage)
+      "debug" -> Log.debug(wantMessage)
+      "trace" -> Log.trace(wantMessage)
+    }
     assertEquals(LogAppenderTest::class.qualifiedName, capturedLogEvent.captured.loggerName)
+    assertEquals(wantLevelName, capturedLogEvent.captured.level.toString())
+    assertEquals(wantMessage, capturedLogEvent.captured.message.toString())
+    capturedLogEvent.clear()
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/LogAppenderTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/LogAppenderTest.kt
@@ -1,22 +1,30 @@
 package org.stellar.anchor.platform
 
-import java.io.*
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import io.mockk.*
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.LoggerContext
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.stellar.anchor.util.*
 
 class LogAppenderTest {
   @Test
-  fun test_logJsonAppenderFormat() {
-    val outputStreamCaptor = ByteArrayOutputStream()
-    System.setOut(PrintStream(outputStreamCaptor))
-    Log.info("hello world")
-    val outputStream = outputStreamCaptor.toString().trim()
+  fun test_loggerInfo_accurateLoggerName() {
+    val appender = mockk<Appender>()
+    val capturedLogEvent = slot<LogEvent>()
 
-    MatcherAssert.assertThat(
-      outputStream,
-      CoreMatchers.endsWith("INFO  - o.s.a.p.LogAppenderTest - hello world")
-    )
+    every { appender.name } returns "mock appender"
+    every { appender.isStarted } returns true
+    every { appender.append(capture(capturedLogEvent)) }
+
+    val loggerContext: LoggerContext = LogManager.getContext(false) as LoggerContext
+    val loggerConfig = loggerContext.configuration.getLoggerConfig("root")
+    loggerConfig.addAppender(appender, Level.ALL, null)
+
+    Log.info("hello world")
+    assertEquals(LogAppenderTest::class.qualifiedName, capturedLogEvent.captured.loggerName)
   }
 }


### PR DESCRIPTION
Closes #452 

While running LogAppenderTest in IntelliJ, the test fails because the log4j console appender does not write to system output. The system capture would fail. 

This PR fixes 

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What
Make sure the logger output correct logger name. 

### Why
While running LogAppenderTest in IntelliJ, the test fails because the log4j console appender does not write to system output. The system capture would fail. 

### Known limitations

N/A