### PR TITLE
bump helm chart version for  uniqueAddressIntegrationEndPoint 

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.85
+version: 0.3.86


### PR DESCRIPTION
bumps helm chart for [add uniqueAddressIntegrationEndPoint to helm chart pr](https://github.com/stellar/java-stellar-anchor-sdk/commit/1acb2a014dbb6f6dd3ca12d1e5606d791b2de6da)
