### PR TITLE
codebuild_source_version

### DIFF
--- a/docs/resources/deployment-examples/example-fargate/terraform/codebuild_config.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/codebuild_config.tf
@@ -238,7 +238,7 @@ resource "aws_codebuild_project" "codebuild_config" {
     }
   }
 
-  source_version = "refs/heads/fargate"
+  source_version = var.codebuild_source_version
 
   vpc_config {
     vpc_id = module.vpc.vpc_id

--- a/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
@@ -47,6 +47,12 @@ variable "anchor_config_build_spec" {
   default = "docs/resources/deployment-examples/aws-fargate-ecs/buildspec-dev.yml"
 }
 
+variable "codebuild_source_version" {
+  description = "deployment environment"
+  type = string
+  default = "main"
+}  
+
 variable "anchor_config_repository" {
   type = string
   default = "https://github.com/reecexlm/java-stellar-anchor-sdk"


### PR DESCRIPTION
This PR removes hardcoded branch for AWS CodeBuild source version and replaces it with a terraform variable with default to "main".   our design partner was deploying the fargate example and buildspec error was given:

```
YAML_FILE_ERROR: stat /codebuild/output/src961726718/src/github.com/jlaguilarm/java-stellar-anchor-sdk/docs/resources/deployment-examples/aws-fargate-ecs/buildspec-dev.yml: no such file or directory
```


