### PR TITLE
Bump Helm Chart to 0.3.87

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.86
+version: 0.3.87


### PR DESCRIPTION
This bumps helm chart version number to 0.3.87 prior to publishing.   This chart update includes fixes for CI integration testing of unique endpoint feature for sep31 post transaction.
https://github.com/stellar/java-stellar-anchor-sdk/pull/466
https://github.com/stellar/java-stellar-anchor-sdk/pull/458
