### PR TITLE
fixing paths for buildspec after documentation refactor

### DIFF
--- a/docs/resources/deployment-examples/example-fargate/Dockerfile
+++ b/docs/resources/deployment-examples/example-fargate/Dockerfile
@@ -12,5 +12,5 @@ ADD ./reference_config.yaml /config_files/reference_config.yaml
 ADD ./stellar_wks.toml /config_files/stellar_wks.toml 
 RUN echo $(ls -1 /config_files)
 RUN echo $(ls -1 /)
-WORKDIR "/docs/deployment-examples/aws-fargate-ecs"
+WORKDIR "/docs/resources/deployment-examples/example-fargate"
 ENTRYPOINT ["/copy_config.sh"]

--- a/docs/resources/deployment-examples/example-fargate/buildspec-dev.yml
+++ b/docs/resources/deployment-examples/example-fargate/buildspec-dev.yml
@@ -9,7 +9,7 @@ env:
 phases:
   build:
     commands:
-      - cd docs/resources/deployment-examples/aws-fargate-ecs
+      - cd docs/resources/deployment-examples/example-fargate
       - aws s3 ls s3://$ANCHOR_CONFIG_S3_BUCKET
       - aws s3 cp s3://$ANCHOR_CONFIG_S3_BUCKET/anchor_config.yaml .
       - aws s3 cp s3://$ANCHOR_CONFIG_S3_BUCKET/stellar.toml ./stellar_wks.toml

--- a/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
@@ -44,7 +44,7 @@ variable  "anchor_to_platform_secret" {
 
 variable "anchor_config_build_spec" {
   type = string
-  default = "docs/resources/deployment-examples/aws-fargate-ecs/buildspec-dev.yml"
+  default = "docs/resources/deployment-examples/example-fargate/buildspec-dev.yml"
 }
 
 variable "codebuild_source_version" {


### PR DESCRIPTION
after deploying to partner, some paths which existed prior to documentation refactor remained.  
specifically,  docs/resources/deployment-examples/example-fargate