### PR TITLE
all: fix complete ci job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -90,8 +90,9 @@ jobs:
           stellar-anchor-tests --home-domain $HOME_DOMAIN --seps 1 10 12 31 38 --sep-config platform/src/test/resources/stellar-anchor-tests-sep-config.json
 
   complete:
+    if: always()
     needs: [build_and_test, sep_validation_suite]
     runs-on: ubuntu-latest
     steps:
-      - if: contains(needs.*.result, 'failure')
-        run: exit 1
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Change the `complete` ci job so that it always runs, regardless of whether other jobs succeed or not, and it errors if a needed job is cancelled.

### Why

GitHub jobs are by default skipped if a needed job fails. Skipped jobs are, surprise, interpreted as successful/passes by the GitHub Actions required checks. Here's an example of one where this happened:

<img width="585" alt="Screen Shot 2022-08-16 at 7 57 28 PM" src="https://user-images.githubusercontent.com/351529/185024762-df3aab1f-b471-42a2-b329-1af5b23ba331.png">
Ref: https://github.com/stellar/java-stellar-anchor-sdk/pull/468

Therefore the `complete` job needs to always run, regardless of whether its needed jobs complete successfully or not.

Also, GitHub jobs can be cancelled. When a job is cancelled its `needs.*.result` value will be `"cancelled"` rather than `"failed"`, and so it is important we check for both. They are the only two values that are not successful indicators. It would be ideal if there was a succinct way to write an `if` statement on the positive result rather than negative, but unfortunately there's no way to write an `all` condition that requires all `needs.*.result` to match a specific value.

This change matches the pattern we're using in other repos and has so far worked well: https://github.com/stellar/rs-soroban-sdk/blob/afe4a152070849234ff14a8db56da7af86165233/.github/workflows/rust.yml#L13-L19

### Known limitations

N/A