### PR TITLE
hotfix: fix build.gradle.kts from the integration-tests package, so the integration tests can be executed

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   `java-library`
   alias(libs.plugins.spring.boot)
   alias(libs.plugins.spring.dependency.management)
+  alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix `build.gradle.kts` from the integration-tests package.

### Why

So the integration tests can be executed.
