### PR TITLE
Add SEP-9 field types country_code, language_code, and phone_number to SEP-12 fields

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Field.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Field.java
@@ -35,7 +35,16 @@ public class Field {
     NUMBER("number"),
 
     @SerializedName("date")
-    DATE("date");
+    DATE("date"),
+
+    @SerializedName("country_code")
+    COUNTRY_CODE("country_code"),
+
+    @SerializedName("phone_number")
+    PHONE_NUMBER("phone_number"),
+
+    @SerializedName("language_code")
+    LANGUAGE_CODE("language_code");
 
     private final String name;
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add SEP-9 field types country_code, language_code, and phone_number to SEP-12 fields.

### Why
SEP-12 does not currently support these field types.