### PR TITLE
hotfix: stop inferring the sep12 account on `GET sep12/customer` when no account is explicitly passed

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -24,10 +24,6 @@ public class Sep12Service {
   public Sep12GetCustomerResponse getCustomer(JwtToken token, Sep12GetCustomerRequest request)
       throws AnchorException {
     validateGetOrPutRequest(request, token);
-    if (request.getId() == null && request.getAccount() == null && token.getAccount() != null) {
-      request.setAccount(token.getAccount());
-    }
-
     return customerIntegration.getCustomer(request);
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -239,6 +239,7 @@ class Sep12ServiceTest {
     // Execute the request
     val mockGetRequest =
       Sep12GetCustomerRequest.builder()
+        .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
         .memoType("text")
         .type("sep31_sender")

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep12Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/Sep12Tests.kt
@@ -60,7 +60,7 @@ fun sep12TestHappyPath() {
   printResponse(pr)
 
   // make sure the customer was uploaded correctly.
-  printRequest("Calling GET /customer", customer)
+  printRequest("Calling GET /customer", customer.id)
   var gr = sep12Client.getCustomer(pr!!.id)
   printResponse(gr)
 
@@ -69,6 +69,18 @@ fun sep12TestHappyPath() {
 
   customer.emailAddress = "john.doe@stellar.org"
   customer.type = "sep31-receiver"
+
+  // make sure a request without parameters will return a NEEDS_INFO response without the user id
+  printRequest("Calling GET /customer without id")
+  val noCustomer = sep12Client.getCustomer()
+  assertNotNull(noCustomer)
+  assertEquals(Sep12Status.NEEDS_INFO, noCustomer?.status)
+  assertNull(noCustomer?.id)
+  assertNull(noCustomer?.providedFields)
+  assertNull(noCustomer?.message)
+  assertNotNull(noCustomer?.fields)
+  assertEquals(3, noCustomer?.fields?.size)
+  printResponse(noCustomer)
 
   // Modify the customer
   printRequest("Calling PUT /customer", customer)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Stop inferring the sep12 account on `GET sep12/customer` when no account is explicitly passed.

### Why

Close #504 