### PR TITLE
hotfix: SEP-12's deletion should not require the memo to be in the JWT_TOKEN when it is sent on the request body

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -49,17 +49,17 @@ public class Sep12Service {
             .filter(Objects::nonNull)
             .anyMatch(tokenAccount -> Objects.equals(tokenAccount, account));
 
-    boolean isMemoAuthenticated = memo == null;
+    boolean isMemoMissingAuthentication = false;
     String muxedAccountId = Objects.toString(jwtToken.getMuxedAccountId(), null);
     if (muxedAccountId != null) {
       if (!Objects.equals(jwtToken.getMuxedAccount(), account)) {
-        isMemoAuthenticated = Objects.equals(muxedAccountId, memo);
+        isMemoMissingAuthentication = !Objects.equals(muxedAccountId, memo);
       }
     } else if (jwtToken.getAccountMemo() != null) {
-      isMemoAuthenticated = Objects.equals(jwtToken.getAccountMemo(), memo);
+      isMemoMissingAuthentication = !Objects.equals(jwtToken.getAccountMemo(), memo);
     }
 
-    if (!isAccountAuthenticated || !isMemoAuthenticated) {
+    if (!isAccountAuthenticated || isMemoMissingAuthentication) {
       infoF("Requester ({}) not authorized to delete account ({})", jwtToken.getAccount(), account);
       throw new SepNotAuthorizedException(
           String.format("Not authorized to delete account [%s] with memo [%s]", account, memo));

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -303,6 +303,11 @@ class Sep12ServiceTest {
     // succeeds if request account and memo are equal the token's
     assertDoesNotThrow { sep12Service.deleteCustomer(jwtToken, TEST_ACCOUNT, TEST_MEMO, null) }
 
+    // succeeds if the request account is equals the token's, and the token memo is empty while the
+    // request's is not
+    jwtToken = createJwtToken(TEST_ACCOUNT)
+    assertDoesNotThrow { sep12Service.deleteCustomer(jwtToken, TEST_ACCOUNT, "foo_bar", null) }
+
     // PART 3 - muxed account
     // throws exception if request is missing the memo
     jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
@@ -332,7 +337,7 @@ class Sep12ServiceTest {
     val mockNoCustomerFound = Sep12GetCustomerResponse()
     every { customerIntegration.getCustomer(any()) } returns mockNoCustomerFound
 
-    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
     val ex: AnchorException = assertThrows {
       sep12Service.deleteCustomer(jwtToken, TEST_ACCOUNT, TEST_MEMO, null)
     }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The SEP-12's deletion should not require the memo to be in the JWT_TOKEN when it is sent on the request body

### Why

Close #509 