### PR TITLE
platform: Fix the contention problem that causes locked database.

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.stellar.anchor.config.MetricConfig;
 import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
@@ -13,6 +14,7 @@ import org.stellar.anchor.util.Log;
 
 public class MetricEmitterService {
   private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+  private MetricConfig metricConfig;
   private final JdbcSep31TransactionRepo sep31TransactionStore;
   AtomicInteger pendingStellarTxns = new AtomicInteger(0);
   AtomicInteger pendingCustomerInfoUpdateTxns = new AtomicInteger(0);
@@ -24,6 +26,7 @@ public class MetricEmitterService {
 
   public MetricEmitterService(
       MetricConfig metricConfig, JdbcSep31TransactionRepo sep31TransactionRepo) {
+    this.metricConfig = metricConfig;
     this.sep31TransactionStore = sep31TransactionRepo;
     // Create counters
     Metrics.counter(
@@ -89,11 +92,6 @@ public class MetricEmitterService {
         errorTxns);
 
     // TODO add gauges for SEP-24 Transactions
-
-    if (metricConfig.isOptionalMetricsEnabled()) {
-      this.executor.scheduleAtFixedRate(
-          new MetricEmitter(), 10, metricConfig.getRunInterval(), TimeUnit.SECONDS);
-    }
   }
 
   class MetricEmitter implements Runnable {
@@ -113,12 +111,18 @@ public class MetricEmitterService {
     }
   }
 
+  @PreDestroy
   public void stop() {
     executor.shutdownNow();
   }
 
-  @PreDestroy
-  public void destroy() {
-    stop();
+  @PostConstruct
+  public void start() {
+    if (metricConfig != null) {
+      if (metricConfig.isOptionalMetricsEnabled()) {
+        this.executor.scheduleAtFixedRate(
+            new MetricEmitter(), 10, metricConfig.getRunInterval(), TimeUnit.SECONDS);
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Start the metrics emitter in @PostConstruct. 

### Why

If MetricsEmitter calls Hibernate before it is fully initialized, it causes database locking error in SQLite. We should delay the scheduling of the thread to avoid the contention.

### Known limitations

This issue can be further avoided when we implement the start-up sequence dependency. 