### PR TITLE
Move @Bean declarations from AnchorPlatformServer to HelperConfig and…

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/AnchorPlatformServer.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.platform;
 
 import static org.springframework.boot.Banner.Mode.OFF;
 
-import com.google.gson.Gson;
 import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,17 +9,12 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.stellar.anchor.config.MetricConfig;
 import org.stellar.anchor.platform.configurator.DataAccessConfigurator;
 import org.stellar.anchor.platform.configurator.PlatformAppConfigurator;
 import org.stellar.anchor.platform.configurator.PropertiesReader;
 import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator;
-import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
-import org.stellar.anchor.platform.service.MetricEmitterService;
-import org.stellar.anchor.util.GsonUtils;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"org.stellar.anchor.platform.data"})
@@ -66,18 +60,7 @@ public class AnchorPlatformServer implements WebMvcConfigurer {
     return springApplication.run();
   }
 
-  @Bean
-  public Gson gson() {
-    return GsonUtils.builder().create();
-  }
-
   public static void start(int port, String contextPath) {
     start(port, contextPath, null, false);
-  }
-
-  @Bean
-  public MetricEmitterService metricService(
-      MetricConfig metricConfig, JdbcSep31TransactionRepo sep31TransactionRepo) {
-    return new MetricEmitterService(metricConfig, sep31TransactionRepo);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/HelperConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/HelperConfig.java
@@ -1,0 +1,14 @@
+package org.stellar.anchor.platform;
+
+import com.google.gson.Gson;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.util.GsonUtils;
+
+@Configuration
+public class HelperConfig {
+  @Bean
+  public Gson gson() {
+    return GsonUtils.builder().create();
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/MetricsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/MetricsConfig.java
@@ -1,0 +1,16 @@
+package org.stellar.anchor.platform;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.config.MetricConfig;
+import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
+import org.stellar.anchor.platform.service.MetricEmitterService;
+
+@Configuration
+public class MetricsConfig {
+  @Bean
+  public MetricEmitterService metricService(
+      MetricConfig metricConfig, JdbcSep31TransactionRepo sep31TransactionRepo) {
+    return new MetricEmitterService(metricConfig, sep31TransactionRepo);
+  }
+}


### PR DESCRIPTION
… MetricsConfig for preparation of configuration management refactoring.

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

 Move @Bean declarations from AnchorPlatformServer to HelperConfig and MetricsConfig. 

### Why

The configuration management can take more time to finish. This PR is to strip down the AnchorPlatformServer so that we can have two versions of AnchorPlatformServer without Spring bean initialization conflicts.

### Known limitations

N/A