### PR TITLE
Feature: when no cursor can be found in the database, the Stellar streamer will start from the most recent cursor in the Network

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -66,6 +66,13 @@ public class StellarPaymentObserver implements HealthCheckable {
     this.stream.close();
   }
 
+  /**
+   * fetchStreamingCursor will gather a starting cursor for the streamer. If there is a cursor
+   * already stored in the database, that value will be returned. Otherwise, this method will fetch
+   * the most recent cursor from the Network and use that as a starting point.
+   *
+   * @return the starting point to start streaming from.
+   */
   String fetchStreamingCursor() {
     // Use database value, if any.
     String lastToken = paymentStreamerCursorStore.load();

--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -5,6 +5,7 @@ import static org.stellar.anchor.api.platform.HealthCheckStatus.RED;
 import static org.stellar.anchor.util.ReflectionUtil.getField;
 
 import com.google.gson.annotations.SerializedName;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,12 +26,18 @@ import org.stellar.sdk.requests.EventListener;
 import org.stellar.sdk.requests.PaymentsRequestBuilder;
 import org.stellar.sdk.requests.RequestBuilder;
 import org.stellar.sdk.requests.SSEStream;
+import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
 import shadow.com.google.common.base.Optional;
 
 public class StellarPaymentObserver implements HealthCheckable {
+  /** The maximum number of results the Stellar Blockchain can return. */
+  private static final int MAX_RESULTS = 200;
+  /** The minimum number of results the Stellar Blockchain can return. */
+  private static final int MIN_RESULTS = 1;
+
   final Server server;
   final Set<PaymentListener> observers;
   final StellarPaymentStreamerCursorStore paymentStreamerCursorStore;
@@ -59,13 +66,40 @@ public class StellarPaymentObserver implements HealthCheckable {
     this.stream.close();
   }
 
-  public SSEStream<OperationResponse> watch() {
-    PaymentsRequestBuilder paymentsRequest =
-        server.payments().includeTransactions(true).order(RequestBuilder.Order.ASC);
+  String fetchStreamingCursor() {
+    // Use database value, if any.
     String lastToken = paymentStreamerCursorStore.load();
     if (lastToken != null) {
-      paymentsRequest.cursor(lastToken);
+      return lastToken;
     }
+
+    // Otherwise, fetch the latest value from the network.
+    Page<OperationResponse> pageOpResponse;
+    try {
+      pageOpResponse =
+          server.payments().order(RequestBuilder.Order.DESC).limit(MIN_RESULTS).execute();
+    } catch (IOException e) {
+      Log.errorEx("Error fetching the latest /payments result.", e);
+      return null;
+    }
+
+    if (pageOpResponse == null
+        || pageOpResponse.getRecords() == null
+        || pageOpResponse.getRecords().size() == 0) {
+      return null;
+    }
+    return pageOpResponse.getRecords().get(0).getPagingToken();
+  }
+
+  public SSEStream<OperationResponse> watch() {
+    String latestCursor = fetchStreamingCursor();
+    PaymentsRequestBuilder paymentsRequest =
+        server
+            .payments()
+            .includeTransactions(true)
+            .cursor(latestCursor)
+            .order(RequestBuilder.Order.ASC)
+            .limit(MAX_RESULTS);
 
     return paymentsRequest.stream(
         new EventListener<>() {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserverTest.kt
@@ -1,0 +1,128 @@
+package org.stellar.anchor.platform.payment.observer.stellar
+
+import com.google.gson.reflect.TypeToken
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import java.io.IOException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.sdk.Server
+import org.stellar.sdk.requests.RequestBuilder
+import org.stellar.sdk.responses.GsonSingleton
+import org.stellar.sdk.responses.Page
+import org.stellar.sdk.responses.operations.OperationResponse
+
+class StellarPaymentObserverTest {
+  companion object {
+    const val TEST_HORIZON_URI = "https://horizon-testnet.stellar.org/"
+  }
+
+  @MockK private lateinit var paymentStreamerCursorStore: StellarPaymentStreamerCursorStore
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxed = true)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clearAllMocks()
+    unmockkAll()
+  }
+
+  @Test
+  fun `test if StellarPaymentObserver will fetch the cursor from the DB, then fallback to the Network`() {
+    // 1 - If there is a stored cursor, we'll use that.
+    every { paymentStreamerCursorStore.load() } returns "123"
+    var stellarObserver =
+      StellarPaymentObserver(TEST_HORIZON_URI, null, null, paymentStreamerCursorStore)
+
+    var gotCursor = stellarObserver.fetchStreamingCursor()
+    assertEquals("123", gotCursor)
+    verify(exactly = 1) { paymentStreamerCursorStore.load() }
+
+    // 2 - If there is no stored constructor, we will fall back to fetching a result from the
+    // network.
+    every { paymentStreamerCursorStore.load() } returns null
+    mockkConstructor(Server::class)
+    stellarObserver =
+      StellarPaymentObserver(TEST_HORIZON_URI, null, null, paymentStreamerCursorStore)
+
+    // 2.1 If fetching from the network throws an error, we return `null`
+    every {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    } throws IOException("Some IO Problem happened!")
+
+    gotCursor = stellarObserver.fetchStreamingCursor()
+    verify(exactly = 2) { paymentStreamerCursorStore.load() }
+    verify(exactly = 1) {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    }
+    assertNull(gotCursor)
+
+    // 2.2 If fetching from the network does not return any result, we return `null`
+    every {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    } returns null
+
+    gotCursor = stellarObserver.fetchStreamingCursor()
+    verify(exactly = 3) { paymentStreamerCursorStore.load() }
+    verify(exactly = 2) {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    }
+    assertNull(gotCursor)
+
+    // 2.3 If fetching from the network returns a value, use that.
+    val opPageJson =
+      """{
+      "_embedded": {
+        "records": [
+          {
+            "paging_token": "4322708489777153",
+            "type_i": 0
+          }
+        ]
+      }
+    }"""
+    val operationPageType = object : TypeToken<Page<OperationResponse?>?>() {}.type
+    val operationPage: Page<OperationResponse> =
+      GsonSingleton.getInstance().fromJson(opPageJson, operationPageType)
+
+    every {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    } returns operationPage
+
+    gotCursor = stellarObserver.fetchStreamingCursor()
+    verify(exactly = 4) { paymentStreamerCursorStore.load() }
+    verify(exactly = 3) {
+      constructedWith<Server>(EqMatcher(TEST_HORIZON_URI))
+        .payments()
+        .order(RequestBuilder.Order.DESC)
+        .limit(1)
+        .execute()
+    }
+    assertEquals("4322708489777153", gotCursor)
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

- When no cursor can be found in the database, the Stellar streamer will start from the most recent cursor in the Network.
- Also, the streaming request was updated to use `?limit=200` for improved efficiency. The default limit is 10, which is 20 times less efficient.

### Why

To improve the efficiency of the streamer on average and mostly on the first run.

Close #500.