### PR TITLE
core: Make testing connection of UrlValidateionUtil.validateUrl() optional

### DIFF
--- a/core/src/main/java/org/stellar/anchor/util/UrlValidationUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/UrlValidationUtil.java
@@ -8,10 +8,16 @@ import org.springframework.validation.Errors;
 
 public class UrlValidationUtil {
   static UrlConnectionStatus validateUrl(String urlString) {
+    return validateUrl(urlString, false);
+  }
+
+  static UrlConnectionStatus validateUrl(String urlString, boolean testConnection) {
     try {
       URL url = new URL(urlString);
-      URLConnection conn = url.openConnection();
-      conn.connect();
+      if (testConnection) {
+        URLConnection conn = url.openConnection();
+        conn.connect();
+      }
     } catch (MalformedURLException e) {
       return UrlConnectionStatus.MALFORMED;
     } catch (IOException e) {

--- a/core/src/main/java/org/stellar/anchor/util/UrlValidationUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/UrlValidationUtil.java
@@ -34,7 +34,7 @@ public class UrlValidationUtil {
           String.format("invalidUrl-%s", fieldName),
           String.format("%s is not in valid format", fieldName));
     } else if (urlStatus == UrlConnectionStatus.UNREACHABLE) {
-      Log.error(String.format("%s field invalid: cannot connect to %s", fieldName, fieldName));
+      Log.error(String.format("%s field invalid: cannot connect to %s", fieldName, url));
     }
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The `UrlValidateionUtil.validateUrl()` tries to connect to a URL defined in a config file. However, the URL may not be reachable at the time of construction. 

Added `testConnection` argument to make the connection test optional.

### Why

N/A

### Known limitations

N/A