### PR TITLE
Feature: update docker hub description when publishing an image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,6 @@ jobs:
         cat /home/runner/work/java-stellar-anchor-sdk/java-stellar-anchor-sdk/anchor-reference-server/build/reports/tests/test/index.html
 
   build_and_push_anchor_platform:
-    if: github.event.pull_request == null
     needs: [build_and_test]
     runs-on: ubuntu-latest
     name: Push stellar/anchor-platform:sha to DockerHub
@@ -53,7 +52,7 @@ jobs:
       uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
       with:
         push: true
-        tags: stellar/anchor-platform:${{ steps.get_tag.outputs.TAG }},stellar/anchor-platform:latest
+        tags: stellar/anchor-platform:${{ steps.get_tag.outputs.TAG }}-debug
         file: Dockerfile
 
     - name: Update repo description in DockerHub

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,6 +56,14 @@ jobs:
         tags: stellar/anchor-platform:${{ steps.get_tag.outputs.TAG }},stellar/anchor-platform:latest
         file: Dockerfile
 
+    - name: Update repo description in DockerHub
+      uses: peter-evans/dockerhub-description@da890086d39c735e41d8823c8a95bde4302c3d64
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: stellar/java-stellar-anchor-sdk
+        short-description: ${{ github.event.repository.description }}
+
   sep_validation_suite:
     needs: [build_and_test]
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,8 +60,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-        repository: stellar/java-stellar-anchor-sdk
-        short-description: ${{ github.event.repository.description }}
+        repository: stellar/anchor-platform
+        # readme-filepath: "./docs/00 - Stellar Anchor Platform.md"
+        # short-description: ${{ github.event.repository.description }} For more information, go to https://github.com/stellar/java-stellar-anchor-sdk.
 
   sep_validation_suite:
     needs: [build_and_test]


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update docker hub description when publishing an image.

### Why

So the Docker Hub contains information about the root repository from where those images were generated.
