### PR TITLE
Hotfix: update docs to say SEP-24 is not supported

### DIFF
--- a/docs/00 - Stellar Anchor Platform.md
+++ b/docs/00 - Stellar Anchor Platform.md
@@ -59,7 +59,7 @@ Here are the important terminology used in this project:
   | :------: | :----------------------------------------------------------------------------: | :----------: | :--------------------------: | :---------------------------: | :------------------: |
   | [SEP-10] |                            Handles authentication.                             |     YES      |              NO              |              YES              |         YES          |
   | [SEP-12] |                                  Handles KYC.                                  |     YES      |             YES              |              YES              |         YES          |
-  | [SEP-24] |       Handles deposit & withdrawal of assets in/out the Stellar network.       |     YES      |              NO              |              NO               |         YES          |
+  | [SEP-24] |       Handles deposit & withdrawal of assets in/out the Stellar network.       |     NO       |              NO              |              NO               |         NO           |
   | [SEP-31] | Used for international remittances. **Only the receiver side is implemented.** |     YES      |             YES              |              YES              |         YES          |
   | [SEP-38] |                Used for [rfq] **in conjunction with [SEP-31]**.                |     YES      |             YES              |              YES              |         YES          |
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update docs to say SEP-24 is not supported

### Why

Despite we having some SEP-24 code in the project, it's not released yet and we need to add a ton more tests to state it's ready for implementation.