### PR TITLE
hotfix: fix how the GH Action gets the tag name

### DIFF
--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -5,9 +5,6 @@ name: Basic Tests
 
 on:
   pull_request:
-    branches-ignore:  # ignoring these patterns because this workflow is already being manually called from `release_release.yml`.
-      - 'release/**'
-      - 'releases/**'
   workflow_call: # Allows this workflow to be called from another workflow
 
 jobs:

--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -32,7 +32,7 @@ jobs:
       uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
       with:
         push: true
-        tags: stellar/anchor-platform:${{ GITHUB_REF_NAME }},stellar/anchor-platform:latest
+        tags: stellar/anchor-platform:${{ github.event.release.tag_name }},stellar/anchor-platform:latest
         file: Dockerfile
 
   complete:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix the way the Action tries to grab the Release tag name.

### Why

the previous way was not working: https://github.com/stellar/java-stellar-anchor-sdk/actions/runs/3063883688
