### PR TITLE
Feature: add health check to stellar observer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,7 @@ subprojects {
       testLogging {
         events("SKIPPED", "FAILED")
         showExceptions = true
-        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL // test with type SHORT
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,31 +102,7 @@ subprojects {
       testLogging {
         events("SKIPPED", "FAILED")
         showExceptions = true
-        showCauses = true
-        showStackTraces = true
-        showStandardStreams = true
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL // test with type SHORT
-
-        afterSuite(
-          KotlinClosure2({ desc: TestDescriptor, result: TestResult ->
-            if (desc.parent == null) {
-              val output = result.run {
-                "Results: $resultType (" +
-                    "$testCount tests, " +
-                    "$successfulTestCount successes, " +
-                    "$failedTestCount failures, " +
-                    "$skippedTestCount skipped" +
-                    ")"
-              }
-              val testResultLine = "|  $output  |"
-              val repeatLength = testResultLine.length
-              val separationLine = "-".repeat(repeatLength)
-              println(separationLine)
-              println(testResultLine)
-              println(separationLine)
-            }
-          })
-        )
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,39 @@ subprojects {
 
     javadoc { options.encoding = "UTF-8" }
 
-    test { useJUnitPlatform() }
+    test {
+      useJUnitPlatform()
+
+      testLogging {
+        events("SKIPPED", "FAILED")
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        showStandardStreams = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL // test with type SHORT
+
+        afterSuite(
+          KotlinClosure2({ desc: TestDescriptor, result: TestResult ->
+            if (desc.parent == null) {
+              val output = result.run {
+                "Results: $resultType (" +
+                    "$testCount tests, " +
+                    "$successfulTestCount successes, " +
+                    "$failedTestCount failures, " +
+                    "$skippedTestCount skipped" +
+                    ")"
+              }
+              val testResultLine = "|  $output  |"
+              val repeatLength = testResultLine.length
+              val separationLine = "-".repeat(repeatLength)
+              println(separationLine)
+              println(testResultLine)
+              println(separationLine)
+            }
+          })
+        )
+      }
+    }
   }
 
   configurations {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.skyscreamer.jsonassert.JSONAssert
@@ -37,6 +38,7 @@ class AnchorPlatformIntegrationTest {
   companion object {
     private const val SEP_SERVER_PORT = 8080
     private const val REFERENCE_SERVER_PORT = 8081
+    private const val OBSERVER_HEALTH_SERVER_PORT = 8083
 
     private const val PLATFORM_TO_ANCHOR_SECRET = "myPlatformToAnchorSecret"
     private const val JWT_EXPIRATION_MILLISECONDS: Long = 10000
@@ -364,5 +366,42 @@ class AnchorPlatformIntegrationTest {
 
     assertEquals(true, sep38Config.isEnabled)
     assertEquals("http://localhost:8081", sep38Config.quoteIntegrationEndPoint)
+  }
+
+  @Test
+  fun testStellarObserverHealth() {
+    val httpRequest =
+      Request.Builder()
+        .url("http://localhost:$OBSERVER_HEALTH_SERVER_PORT/health")
+        .header("Content-Type", "application/json")
+        .get()
+        .build()
+    val response = httpClient.newCall(httpRequest).execute()
+    assertEquals(200, response.code)
+
+    val responseBody = gson.fromJson(response.body!!.string(), HashMap::class.java)
+    assertEquals(5, responseBody.size)
+    assertNotNull(responseBody["started_at"])
+    assertNotNull(responseBody["elapsed_time_ms"])
+    assertNotNull(responseBody["number_of_checks"])
+    assertEquals(1.0, responseBody["number_of_checks"])
+    assertNotNull(responseBody["version"])
+    assertNotNull(responseBody["checks"])
+
+    val checks = responseBody["checks"] as Map<*, *>
+    assertEquals(1, checks.size)
+
+    val stellarPaymentObserverCheck = checks["stellar_payment_observer"] as Map<*, *>
+    assertEquals(2, stellarPaymentObserverCheck.size)
+    assertEquals("green", stellarPaymentObserverCheck["status"])
+
+    val observerStreams = stellarPaymentObserverCheck["streams"] as List<*>
+    assertEquals(1, observerStreams.size)
+
+    val stream1 = observerStreams[0] as Map<*, *>
+    assertEquals(
+      mapOf("thread_shutdown" to false, "thread_terminated" to false, "stopped" to false),
+      stream1
+    )
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -399,9 +399,10 @@ class AnchorPlatformIntegrationTest {
     assertEquals(1, observerStreams.size)
 
     val stream1 = observerStreams[0] as Map<*, *>
-    assertEquals(
-      mapOf("thread_shutdown" to false, "thread_terminated" to false, "stopped" to false),
-      stream1
-    )
+    assertEquals(4, stream1.size)
+    assertEquals(false, stream1["thread_shutdown"])
+    assertEquals(false, stream1["thread_terminated"])
+    assertEquals(false, stream1["stopped"])
+    assertNotNull(stream1["lastEventId"])
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/StellarObservingService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/StellarObservingService.java
@@ -4,7 +4,6 @@ import static org.springframework.boot.Banner.Mode.OFF;
 
 import java.util.Map;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -25,18 +24,20 @@ import org.stellar.anchor.platform.configurator.SpringFrameworkConfigurator;
 @EnableConfigurationProperties
 public class StellarObservingService implements WebMvcConfigurer {
 
-  public static ConfigurableApplicationContext start(Map<String, Object> environment) {
+  public static ConfigurableApplicationContext start(
+      int port, String contextPath, Map<String, Object> environment) {
     SpringApplicationBuilder builder =
         new SpringApplicationBuilder(StellarObservingService.class)
             .bannerMode(OFF)
-            .web(WebApplicationType.NONE)
             .properties(
                 // TODO: update when the ticket
                 // https://github.com/stellar/java-stellar-anchor-sdk/issues/297 is completed.
                 "spring.mvc.converters.preferred-json-mapper=gson",
                 // this allows a developer to use a .env file for local development
                 "spring.config.import=optional:classpath:example.env[.properties]",
-                "spring.profiles.active=stellar-observer");
+                "spring.profiles.active=stellar-observer",
+                String.format("server.port=%d", port),
+                String.format("server.contextPath=%s", contextPath));
 
     if (environment != null) {
       builder.properties(environment);
@@ -56,7 +57,7 @@ public class StellarObservingService implements WebMvcConfigurer {
     return springApplication.run();
   }
 
-  public static ConfigurableApplicationContext start() {
-    return start(null);
+  public static ConfigurableApplicationContext start(int port, String contextPath) {
+    return start(port, contextPath, null);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/CirclePaymentObserverController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/CirclePaymentObserverController.java
@@ -5,6 +5,7 @@ import static org.stellar.anchor.util.Log.warnEx;
 
 import com.google.gson.Gson;
 import java.util.Map;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +19,7 @@ import org.stellar.anchor.platform.payment.observer.circle.model.CircleNotificat
 
 @RestController
 @RequestMapping("/circle-observer")
+@Profile("default")
 public class CirclePaymentObserverController {
   private final Gson gson = new Gson();
   private final CirclePaymentObserverService circlePaymentObserverService;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/PlatformController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/PlatformController.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.api.exception.AnchorException;
@@ -10,6 +11,7 @@ import org.stellar.anchor.api.platform.PatchTransactionsResponse;
 import org.stellar.anchor.platform.service.TransactionService;
 
 @RestController
+@Profile("default")
 public class PlatformController {
 
   private final TransactionService transactionService;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep10Controller.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.*;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,7 @@ import org.stellar.sdk.InvalidSep10ChallengeException;
 @RestController
 @CrossOrigin(origins = "*")
 @ConditionalOnAllSepsEnabled(seps = {"sep10"})
+@Profile("default")
 public class Sep10Controller {
 
   private final Sep10Service sep10Service;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep12Controller.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +22,7 @@ import org.stellar.anchor.util.GsonUtils;
 @CrossOrigin(origins = "*")
 @RequestMapping("/sep12")
 @ConditionalOnAllSepsEnabled(seps = {"sep12"})
+@Profile("default")
 public class Sep12Controller {
   private final Sep12Service sep12Service;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep1Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep1Controller.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.controller;
 
 import java.io.IOException;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.stellar.anchor.sep1.Sep1Service;
 @RestController
 @CrossOrigin(origins = "*")
 @ConditionalOnAllSepsEnabled(seps = {"sep1"})
+@Profile("default")
 public class Sep1Controller {
   private final Sep1Config sep1Config;
   private final Sep1Service sep1Service;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep24Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep24Controller.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -26,6 +27,7 @@ import org.stellar.anchor.sep24.Sep24Service;
 @CrossOrigin(origins = "*")
 @RequestMapping("/sep24")
 @ConditionalOnAllSepsEnabled(seps = {"sep24"})
+@Profile("default")
 public class Sep24Controller {
   private final Sep24Service sep24Service;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep31Controller.java
@@ -5,6 +5,7 @@ import static org.stellar.anchor.util.Log.debugF;
 import static org.stellar.anchor.util.Log.errorEx;
 
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +22,7 @@ import org.stellar.anchor.sep31.Sep31Service;
 @CrossOrigin(origins = "*")
 @RequestMapping("sep31")
 @ConditionalOnAllSepsEnabled(seps = {"sep31"})
+@Profile("default")
 public class Sep31Controller {
   private final Sep31Service sep31Service;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,7 @@ import org.stellar.anchor.util.GsonUtils;
 @CrossOrigin(origins = "*")
 @RequestMapping("/sep38")
 @ConditionalOnAllSepsEnabled(seps = {"sep38"})
+@Profile("default")
 public class Sep38Controller {
   private final Sep38Service sep38Service;
   private static final Gson gson = GsonUtils.builder().create();

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -7,6 +7,7 @@ import org.stellar.anchor.reference.AnchorReferenceServer;
 public class ServiceRunner {
   public static final int DEFAULT_SEP_SERVER_PORT = 8080;
   public static final int DEFAULT_ANCHOR_REFERENCE_SERVER_PORT = 8081;
+  public static final int DEFAULT_OBSERVER_HEALTH_SERVER_PORT = 8083;
   public static final String DEFAULT_CONTEXTPATH = "/";
 
   public static void main(String[] args) {
@@ -60,7 +61,17 @@ public class ServiceRunner {
   }
 
   static void startStellarObserver() {
-    StellarObservingService.start();
+    String strPort = System.getProperty("OBSERVER_HEALTH_SERVER_PORT");
+    int port = DEFAULT_OBSERVER_HEALTH_SERVER_PORT;
+    if (strPort != null) {
+      port = Integer.parseInt(strPort);
+    }
+    String contextPath = System.getProperty("SEP_CONTEXTPATH");
+    if (contextPath == null) {
+      contextPath = DEFAULT_CONTEXTPATH;
+    }
+
+    StellarObservingService.start(port, contextPath);
   }
 
   static void startAnchorReferenceServer() {

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -8,7 +8,7 @@ public class ServiceRunner {
   public static final int DEFAULT_SEP_SERVER_PORT = 8080;
   public static final int DEFAULT_ANCHOR_REFERENCE_SERVER_PORT = 8081;
   public static final int DEFAULT_OBSERVER_HEALTH_SERVER_PORT = 8083;
-  public static final String DEFAULT_CONTEXTPATH = "/";
+  public static final String DEFAULT_CONTEXT_PATH = "/";
 
   public static void main(String[] args) {
     Options options = new Options();
@@ -53,9 +53,9 @@ public class ServiceRunner {
     if (strPort != null) {
       port = Integer.parseInt(strPort);
     }
-    String contextPath = System.getProperty("SEP_CONTEXTPATH");
+    String contextPath = System.getProperty("SEP_CONTEXT_PATH");
     if (contextPath == null) {
-      contextPath = DEFAULT_CONTEXTPATH;
+      contextPath = DEFAULT_CONTEXT_PATH;
     }
     return AnchorPlatformServer.start(port, contextPath);
   }
@@ -68,7 +68,7 @@ public class ServiceRunner {
     }
     String contextPath = System.getProperty("SEP_CONTEXTPATH");
     if (contextPath == null) {
-      contextPath = DEFAULT_CONTEXTPATH;
+      contextPath = DEFAULT_CONTEXT_PATH;
     }
 
     StellarObservingService.start(port, contextPath);
@@ -80,9 +80,9 @@ public class ServiceRunner {
     if (strPort != null) {
       port = Integer.parseInt(strPort);
     }
-    String contextPath = System.getProperty("ANCHOR_REFERENCE_CONTEXTPATH");
+    String contextPath = System.getProperty("ANCHOR_REFERENCE_CONTEXT_PATH");
     if (contextPath == null) {
-      contextPath = DEFAULT_CONTEXTPATH;
+      contextPath = DEFAULT_CONTEXT_PATH;
     }
     AnchorReferenceServer.start(port, contextPath);
   }

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -7,7 +7,7 @@ import org.stellar.anchor.reference.AnchorReferenceServer;
 public class ServiceRunner {
   public static final int DEFAULT_SEP_SERVER_PORT = 8080;
   public static final int DEFAULT_ANCHOR_REFERENCE_SERVER_PORT = 8081;
-  public static final int DEFAULT_OBSERVER_HEALTH_SERVER_PORT = 8083;
+  public static final int DEFAULT_STELLAR_OBSERVER_SERVER_PORT = 8083;
   public static final String DEFAULT_CONTEXT_PATH = "/";
 
   public static void main(String[] args) {
@@ -61,12 +61,12 @@ public class ServiceRunner {
   }
 
   static void startStellarObserver() {
-    String strPort = System.getProperty("OBSERVER_HEALTH_SERVER_PORT");
-    int port = DEFAULT_OBSERVER_HEALTH_SERVER_PORT;
+    String strPort = System.getProperty("STELLAR_OBSERVER_SERVER_PORT");
+    int port = DEFAULT_STELLAR_OBSERVER_SERVER_PORT;
     if (strPort != null) {
       port = Integer.parseInt(strPort);
     }
-    String contextPath = System.getProperty("SEP_CONTEXTPATH");
+    String contextPath = System.getProperty("STELLAR_OBSERVER_CONTEXT_PATH");
     if (contextPath == null) {
       contextPath = DEFAULT_CONTEXT_PATH;
     }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add a `/health` endpoint to the Stellar Observer deployment.

### Why

To enable people to check the status of the Stellar Observer.
