### PR TITLE
Fix: workflow secrets were not being passed from parent (caller) to child (callee) workflows

### DIFF
--- a/.github/workflows/branch_develop.yml
+++ b/.github/workflows/branch_develop.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/basic_tests.yml  # use the callable tests job to run tests
+    secrets: inherit # pass all secrets
   
   build_and_push_docker_image:
     name: Push to DockerHub # stellar/anchor-platform:{sha} and stellar/anchor-platform:edge

--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/basic_tests.yml  # use the callable tests job to run tests
+    secrets: inherit # pass all secrets
   
   build_and_push_docker_image:
     name: Push to DockerHub # stellar/anchor-platform:sha

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -9,9 +9,11 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/basic_tests.yml  # execute the callable basic_tests.yml
+    secrets: inherit # pass all secrets
 
   end_to_end_tests:
     uses: ./.github/workflows/end_to_end_tests.yml  # execute the callable end_to_end_tests.yml
+    secrets: inherit # pass all secrets
   
   build_and_push_docker_image:
     name: Push to DockerHub # stellar/anchor-platform:{VERSION}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

When calling another workflow, make sure it will inherit the secrets from its parent.

### Why

Jobs like [this](https://github.com/stellar/java-stellar-anchor-sdk/actions/runs/3137863047/jobs/5100787037) were failing because the secrets were not being passed from caller to callee.

GH covers this in https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows.