### PR TITLE
Feature: update helm chart by exposing the metrics port to the internal network

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.88
+version: 0.3.89

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -28,6 +28,10 @@ deployment:
        backend:
          servicePort: "{{ .Values.service.containerPort }}"
          serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
+   annotations:
+        prometheus.io/path: /actuator/prometheus
+        prometheus.io/port: "8082"
+        prometheus.io/scrape: "true"
    env:
    - name: STELLAR_ANCHOR_CONFIG
      value: file:/config/anchor-config.yaml

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -66,7 +66,6 @@ stellar:
          ORG_NAME: "Stellar Development Foundation"
          ORG_URL: "https://www.stellar.org"
          ORG_DESCRIPTION: "Stellar Network"
-         ORG_URL: "https://your_org_url.png"
          ORG_SUPPORT_EMAIL: "reece@stellar.org"
    anchor:
       data_access:

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
           - name: http
             containerPort: {{ .Values.service.containerPort }}
             protocol: TCP
+          - name: metrics
+            containerPort: 8082
+            protocol: TCP
           {{- if (.Values.deployment).env }}
           env:
 {{ toYaml .Values.deployment.env | indent 12 }}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

* Expose the `8082` metrics port to the internal network.
* Add `deployment.annotations` to the example values.
* Delete duplicate appearance of `ORG_URL` in the example values.

### Why

To improve the helm chart to be closer to a real-world scenario.
