### PR TITLE
Fix: stop crashing when parsing response content into ErrorResponse

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -54,6 +54,7 @@ public class PlatformIntegrationHelper {
     try {
       errorResponse = gson.fromJson(responseContent, ErrorResponse.class);
     } catch (Exception e) { // cannot read body from response
+      Log.errorF("Failed to parse responseContent {} to an ErrorResponse object.", responseContent);
       return new ServerErrorException("internal server error", e);
     }
 
@@ -76,7 +77,7 @@ public class PlatformIntegrationHelper {
     } else if (responseCode == HttpStatus.NOT_FOUND.value()) {
       return new NotFoundException(errorMessage);
     }
-    Log.error(errorMessage);
+    Log.errorF("Unsupported status code {} with body {}", responseCode, errorResponse);
     return new ServerErrorException("internal server error");
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -65,11 +65,11 @@ public class PlatformIntegrationHelper {
                 ? HttpStatus.BAD_REQUEST.getReasonPhrase()
                 : HttpStatus.valueOf(responseCode).getReasonPhrase();
 
-    switch (responseCode) {
-      case 422:
-      case 400:
+    switch (HttpStatus.valueOf(responseCode)) {
+      case UNPROCESSABLE_ENTITY: // 422
+      case BAD_REQUEST: // 400
         return new BadRequestException(errorMessage);
-      case 404:
+      case NOT_FOUND: // 404
         return new NotFoundException(errorMessage);
       default:
         Log.errorF("Unsupported status code {}.", responseCode);


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Stop crashing when parsing response content into ErrorResponse.

### Why

So we can better debug what's causing an issue.
