### PR TITLE
Feature: separate observer deployment

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.89
+version: 0.3.90

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.90
+version: 0.3.91

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -55,6 +55,7 @@ ingress:
           backend:
             servicePort: "{{ .Values.service.containerPort }}"
             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
+#
 # If you want to have a dedicated stellar-observer service, you need to
 # uncomment the `stellarObserver` section below.
 #
@@ -62,26 +63,27 @@ ingress:
 # `stellarObserver.enabled` flag to `true` – you must use a shared database that
 # will be accessible by both deployments (sep-server and stellar-observer).
 # In-memory databases won't work.
-stellarObserver:
-   # This will enable the stellar-observer service as a separate deployment:
-   enabled: true
-   # The stellarObserver.deployment section is optional, the templates have
-   # default values.
-   deployment:
-      port: 8083
-      probePath: "/health"
-      probePeriodSeconds: 15
-      initialDelaySeconds: 60
-      startupProbeFailureThreshold: 10
-      livenessProbeFailureThreshold: 2
-   ingress:
-      tls:
-         host: "observer.your_anchor_domain.com"    # Replace this with a valid host name
-      rules:
-         hosts:
-         - host: "observer.your_anchor_domain.com"  # Replace this with a valid host name
-           path: /
-           pathType: Prefix
+# stellarObserver:
+#    # This will enable the stellar-observer service as a separate deployment:
+#    enabled: true
+#    # The stellarObserver.deployment section is optional, the templates have
+#    # default values.
+#    deployment:
+#       port: 8083
+#       probePath: "/health"
+#       probePeriodSeconds: 15
+#       initialDelaySeconds: 60
+#       startupProbeFailureThreshold: 10
+#       livenessProbeFailureThreshold: 2
+#    ingress:
+#       tls:
+#          host: "observer.your_anchor_domain.com"    # Replace this with a valid host name
+#       rules:
+#          hosts:
+#          - host: "observer.your_anchor_domain.com"  # Replace this with a valid host name
+#            path: /
+#            pathType: Prefix
+#
 stellar:
    toml:
       #accounts: ['"GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"'] 

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -55,8 +55,18 @@ ingress:
           backend:
             servicePort: "{{ .Values.service.containerPort }}"
             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
+# If you want to have a dedicated stellar-observer service, you need to
+# uncomment the `stellarObserver` section below.
+#
+# Attention! If you use the stellar observer as a separate service – by setting
+# `stellarObserver.enabled` flag to `true` – you must use a shared database that
+# will be accessible by both deployments (sep-server and stellar-observer).
+# In-memory databases won't work.
 stellarObserver:
+   # This will enable the stellar-observer service as a separate deployment:
    enabled: true
+   # The stellarObserver.deployment section is optional, the templates have
+   # default values.
    deployment:
       port: 8083
       probePath: "/health"
@@ -66,10 +76,10 @@ stellarObserver:
       livenessProbeFailureThreshold: 2
    ingress:
       tls:
-         host: "observer.your_anchor_domain.com"
+         host: "observer.your_anchor_domain.com"    # Replace this with a valid host name
       rules:
          hosts:
-         - host: "observer.your_anchor_domain.com"
+         - host: "observer.your_anchor_domain.com"  # Replace this with a valid host name
            path: /
            pathType: Prefix
            backend:

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -11,6 +11,15 @@ image:
    tag: latest
    pullPolicy: Always
 deployment:
+   dedicatedStellarObserver:
+      port: 8083
+      probePath: "/health"
+      probePort: 8083
+      probePeriodSeconds: 15
+      initialDelaySeconds: 60
+      # probe type specifics:
+      startupProbeFailureThreshold: 10
+      livenessProbeFailureThreshold: 2
    startupProbePeriodSeconds: 10
    startupProbeFailureThreshold: 30
    serviceAccountName: default
@@ -21,13 +30,6 @@ deployment:
       configMaps:
          - name: assets
            mountPath: assets
-   hosts:
-     - host: "your_anchor_domain.com"
-       path: /
-       pathType: Prefix
-       backend:
-         servicePort: "{{ .Values.service.containerPort }}"
-         serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
    annotations:
         prometheus.io/path: /actuator/prometheus
         prometheus.io/port: "8082"
@@ -53,6 +55,7 @@ ingress:
      ingress.kubernetes.io/hsts-include-subdomains: "true"
    tls:
      host: "your_anchor_domain.com"
+     observerHost: "observer.your_anchor_domain.com"
      secretName: anchor-platform-sep-server-cert 
    rules:
       hosts:
@@ -62,6 +65,12 @@ ingress:
           backend:
             servicePort: "{{ .Values.service.containerPort }}"
             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
+   observerHosts:
+        - host: "observer.your_anchor_domain.com"
+          path: /
+          pathType: Prefix
+          backend:
+            serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer"
 stellar:
    toml:
       #accounts: ['"GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"'] 

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -82,8 +82,6 @@ stellarObserver:
          - host: "observer.your_anchor_domain.com"  # Replace this with a valid host name
            path: /
            pathType: Prefix
-           backend:
-             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer"
 stellar:
    toml:
       #accounts: ['"GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"'] 

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -11,15 +11,6 @@ image:
    tag: latest
    pullPolicy: Always
 deployment:
-   dedicatedStellarObserver:
-      port: 8083
-      probePath: "/health"
-      probePort: 8083
-      probePeriodSeconds: 15
-      initialDelaySeconds: 60
-      # probe type specifics:
-      startupProbeFailureThreshold: 10
-      livenessProbeFailureThreshold: 2
    startupProbePeriodSeconds: 10
    startupProbeFailureThreshold: 30
    serviceAccountName: default
@@ -55,7 +46,6 @@ ingress:
      ingress.kubernetes.io/hsts-include-subdomains: "true"
    tls:
      host: "your_anchor_domain.com"
-     observerHost: "observer.your_anchor_domain.com"
      secretName: anchor-platform-sep-server-cert 
    rules:
       hosts:
@@ -65,12 +55,25 @@ ingress:
           backend:
             servicePort: "{{ .Values.service.containerPort }}"
             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}"
-   observerHosts:
-        - host: "observer.your_anchor_domain.com"
-          path: /
-          pathType: Prefix
-          backend:
-            serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer"
+stellarObserver:
+   enabled: true
+   deployment:
+      port: 8083
+      probePath: "/health"
+      probePeriodSeconds: 15
+      initialDelaySeconds: 60
+      startupProbeFailureThreshold: 10
+      livenessProbeFailureThreshold: 2
+   ingress:
+      tls:
+         host: "observer.your_anchor_domain.com"
+      rules:
+         hosts:
+         - host: "observer.your_anchor_domain.com"
+           path: /
+           pathType: Prefix
+           backend:
+             serviceName: "{{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer"
 stellar:
    toml:
       #accounts: ['"GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"'] 

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -113,9 +113,8 @@ spec:
 
 ---
 # Stellar Observer
+{{- $stellarObserverDeployment := ((.Values.stellarObserver).deployment) }}
 {{- if (.Values.stellarObserver).enabled }}
-{{- $stellarObserverDeployment := ((.Values.stellarObserver).deployment) -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repo }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-          {{- if .Values.deployment.dedicatedStellarObserver }}
+          {{- if (.Values.stellarObserver).enabled }}
           args: ["--sep-server"]
           {{- else }}
           args: ["--sep-server", "--stellar-observer"]
@@ -112,7 +112,8 @@ spec:
       {{- end }}
 
 # Stellar Observer
-{{- if .Values.deployment.dedicatedStellarObserver }}
+{{- if (.Values.stellarObserver).enabled }}
+{{- $stellarObserverDeployment := ((.Values.stellarObserver).deployment) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -150,23 +151,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           startupProbe:
             httpGet:
-              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
-              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
-            failureThreshold: {{ .Values.deployment.dedicatedStellarObserver.startupProbeFailureThreshold | default 10 }}
-            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            failureThreshold: {{ $stellarObserverDeployment.startupProbeFailureThreshold | default 10 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
-              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
-            initialDelaySeconds: {{ .Values.deployment.dedicatedStellarObserver.initialDelaySeconds | default 30 }}
-            failureThreshold: {{ .Values.deployment.dedicatedStellarObserver.livenessProbeFailureThreshold | default 2 }}
-            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            initialDelaySeconds: {{ $stellarObserverDeployment.initialDelaySeconds | default 30 }}
+            failureThreshold: {{ $stellarObserverDeployment.livenessProbeFailureThreshold | default 2 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
-              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
-            initialDelaySeconds: {{ .Values.deployment.dedicatedStellarObserver.initialDelaySeconds | default 30 }}
-            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+              path: {{ $stellarObserverDeployment.probePath | default "/health" }}
+              port: {{ $stellarObserverDeployment.port | default 8083 }}
+            initialDelaySeconds: {{ $stellarObserverDeployment.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ $stellarObserverDeployment.probePeriodSeconds | default 15 }}
           volumeMounts:
             - name: sep-config-volume
               mountPath: /config
@@ -185,7 +186,7 @@ spec:
           {{- end }}
           ports:
           - name: http
-            containerPort: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083 }}
+            containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
           {{- if (.Values.deployment).env }}
           env:

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -111,10 +111,11 @@ spec:
       {{- end }}
       {{- end }}
 
+---
 # Stellar Observer
 {{- if (.Values.stellarObserver).enabled }}
 {{- $stellarObserverDeployment := ((.Values.stellarObserver).deployment) -}}
----
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -1,3 +1,5 @@
+---
+# SEP Server
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,9 +32,11 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repo }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-          args:
-            - --sep-server
-            - --stellar-observer
+          {{- if .Values.deployment.dedicatedStellarObserver }}
+          args: ["--sep-server"]
+          {{- else }}
+          args: ["--sep-server", "--stellar-observer"]
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           startupProbe:
             httpGet:
@@ -106,3 +110,112 @@ spec:
             secretName: {{ $secret.name }}
       {{- end }}
       {{- end }}
+
+# Stellar Observer
+{{- if .Values.deployment.dedicatedStellarObserver }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.fullName }}-observer
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+    helm.sh/chart: {{ include "common.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.fullName }}-observer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.fullName }}-observer
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if (.Values.deployment).annotations }}
+      annotations:
+        {{- range $key, $value := .Values.deployment.annotations }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      {{- end }}
+    spec:
+      {{- if (.Values.deployment).serviceAccountName }}
+      serviceAccountName: {{ .Values.deployment.serviceAccountName | default "default" }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-observer
+          image: "{{ .Values.image.repo }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          args: ["--stellar-observer"]
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
+              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
+            failureThreshold: {{ .Values.deployment.dedicatedStellarObserver.startupProbeFailureThreshold | default 10 }}
+            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
+              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
+            initialDelaySeconds: {{ .Values.deployment.dedicatedStellarObserver.initialDelaySeconds | default 30 }}
+            failureThreshold: {{ .Values.deployment.dedicatedStellarObserver.livenessProbeFailureThreshold | default 2 }}
+            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.deployment.dedicatedStellarObserver.probePath | default "/health" }}
+              port: {{ .Values.deployment.dedicatedStellarObserver.probePort | default 8083 }}
+            initialDelaySeconds: {{ .Values.deployment.dedicatedStellarObserver.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.deployment.dedicatedStellarObserver.probePeriodSeconds | default 15 }}
+          volumeMounts:
+            - name: sep-config-volume
+              mountPath: /config
+              readOnly: true
+          {{- if ((.Values.deployment).volumeMounts).configMaps }}
+          {{- range $conf := .Values.deployment.volumeMounts.configMaps }}
+            - mountPath: {{ $conf.mountPath }}
+              name: {{ $conf.name }}-volume
+          {{- end }}
+          {{- end }}
+          {{- if ((.Values.deployment).volumeMounts).secrets }}
+          {{- range $secret := .Values.deployment.volumeMounts.secrets }}
+            - mountPath: {{ $secret.mountPath | default $secret.name }}
+              name: {{ $secret.name }}-volume
+          {{- end }}
+          {{- end }}
+          ports:
+          - name: http
+            containerPort: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083 }}
+            protocol: TCP
+          {{- if (.Values.deployment).env }}
+          env:
+{{ toYaml .Values.deployment.env | indent 12 }}
+          {{- end }}
+          {{- if (.Values.deployment).envFrom }}
+          envFrom:
+{{ toYaml .Values.deployment.envFrom | indent 12 }}
+          {{- end }}
+          {{- if (.Values.deployment).resources }}
+          resources:
+{{- toYaml .Values.deployment.resources | indent 12 }}
+          {{- end }}     
+      volumes:
+        - name: sep-config-volume
+          configMap:
+            name: {{ .Values.fullName }}
+      {{- if ((.Values.deployment).volumeMounts).configMaps }}
+      {{- range $conf := .Values.deployment.volumeMounts.configMaps }}
+        - name: {{ $conf.name }}-volume
+          configMap:
+            name: {{ $conf.name }}
+      {{- end }}
+      {{- end }}
+      {{- if ((.Values.deployment).volumeMounts).secrets }}
+      {{- range $secret := .Values.deployment.volumeMounts.secrets }}
+        - name: {{ $secret.name }}-volume
+          secret:
+            secretName: {{ $secret.name }}
+      {{- end }}
+      {{- end }}
+
+{{- end }}

--- a/helm-charts/sep-service/templates/ingress.yaml
+++ b/helm-charts/sep-service/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- $root := . -}}
 # SEP Server
 ---
 apiVersion: networking.k8s.io/v1
@@ -49,7 +48,8 @@ spec:
   {{- end }}
 
 # Stellar Observer
-{{- if $root.Values.deployment.dedicatedStellarObserver }}
+{{- $stellarObserver := (.Values.stellarObserver) -}}
+{{- if $stellarObserver.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -77,14 +77,14 @@ spec:
   {{- if .Values.ingress.tls }}
   tls:
   - hosts:
-    - {{ .Values.ingress.tls.observerHost }}
+    - {{ $stellarObserver.ingress.tls.host }}
     {{- if .Values.ingress.tls.secretName }}
     secretName: {{ .Values.ingress.tls.secretName }}
     {{- end }}      
   {{- end }}
   {{- if .Values.ingress.rules }}
   rules:
-  {{- range .Values.ingress.rules.observerHosts }}
+  {{- range $stellarObserver.ingress.rules.hosts }}
   - host: {{ tpl .host $ }}
     http:
       paths:
@@ -94,7 +94,7 @@ spec:
             service:
               name: {{ tpl .backend.serviceName $ }}
               port:
-                number: {{ $root.Values.deployment.dedicatedStellarObserver.port | default 8083 }}
+                number: {{ $stellarObserver.deployment.port | default 8083 }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/helm-charts/sep-service/templates/ingress.yaml
+++ b/helm-charts/sep-service/templates/ingress.yaml
@@ -48,6 +48,7 @@ spec:
   {{- end }}
 
 # Stellar Observer
+{{- $root := . }}
 {{- $stellarObserver := (.Values.stellarObserver) }}
 {{- if $stellarObserver.enabled }}
 ---
@@ -92,7 +93,7 @@ spec:
           pathType: {{ .pathType | quote }}
           backend:
             service:
-              name: {{ tpl .backend.serviceName $ }}
+              name: {{ $root.Values.fullName }}-svc-{{ $root.Values.service.name }}-observer
               port:
                 number: {{ $stellarObserver.deployment.port | default 8083 }}
   {{- end }}

--- a/helm-charts/sep-service/templates/ingress.yaml
+++ b/helm-charts/sep-service/templates/ingress.yaml
@@ -1,3 +1,6 @@
+{{- $root := . -}}
+# SEP Server
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,7 +38,7 @@ spec:
   - host: {{ tpl .host $ }}
     http:
       paths:
-        - path: {{ .path | quote }}
+        - path: {{ .path }}
           pathType: {{ .pathType| quote }}
           backend:
             service:
@@ -44,3 +47,54 @@ spec:
                 number: {{ tpl .backend.servicePort $ }}
   {{- end }}
   {{- end }}
+
+# Stellar Observer
+{{- if $root.Values.deployment.dedicatedStellarObserver }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.fullName }}-ing-{{ .Values.service.name }}-observer
+  {{- if .Values.ingress.metadata }}
+  {{- range $key, $value := .Values.ingress.metadata }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-ing-{{ .Values.service.name }}-observer
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}  
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.tls.observerHost }}
+    {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+    {{- end }}      
+  {{- end }}
+  {{- if .Values.ingress.rules }}
+  rules:
+  {{- range .Values.ingress.rules.observerHosts }}
+  - host: {{ tpl .host $ }}
+    http:
+      paths:
+        - path: {{ .path }}
+          pathType: {{ .pathType | quote }}
+          backend:
+            service:
+              name: {{ tpl .backend.serviceName $ }}
+              port:
+                number: {{ $root.Values.deployment.dedicatedStellarObserver.port | default 8083 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/sep-service/templates/ingress.yaml
+++ b/helm-charts/sep-service/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
   {{- end }}
 
 # Stellar Observer
-{{- $stellarObserver := (.Values.stellarObserver) -}}
+{{- $stellarObserver := (.Values.stellarObserver) }}
 {{- if $stellarObserver.enabled }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/helm-charts/sep-service/templates/service.yaml
+++ b/helm-charts/sep-service/templates/service.yaml
@@ -1,3 +1,5 @@
+---
+# SEP Server
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +27,36 @@ spec:
     targetPort: {{ .Values.service.targetPort | default 8080 }}  # port number pods listen on
   selector:
     app.kubernetes.io/name: {{ .Values.fullName }}
+
+
+# Stellar Observer
+{{- if .Values.deployment.dedicatedStellarObserver }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.fullName }}-svc-{{ .Values.service.name }}-observer
+{{- if .Values.service.annotations }}
+  annotations:
+{{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
+  labels:
+    {{- if .Values.service.labels }}
+    {{- range $key, $value := .Values.service.labels }}
+    {{- end }}
+    {{- end }}
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083}}       # port number the service will listen on
+    targetPort: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083 }}  # port number pods listen on
+  selector:
+    app.kubernetes.io/name: {{ .Values.fullName }}-observer
+{{- end }}

--- a/helm-charts/sep-service/templates/service.yaml
+++ b/helm-charts/sep-service/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
 
 
 # Stellar Observer
-{{- if .Values.deployment.dedicatedStellarObserver }}
+{{- if (.Values.stellarObserver).enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -55,8 +55,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - protocol: TCP
-    port: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083}}       # port number the service will listen on
-    targetPort: {{ .Values.deployment.dedicatedStellarObserver.port | default 8083 }}  # port number pods listen on
+    port: {{ ((.Values.stellarObserver).deployment).port | default 8083}}         # port number the service will listen on
+    targetPort: {{ ((.Values.stellarObserver).deployment).port | default 8083 }}  # port number pods listen on
   selector:
     app.kubernetes.io/name: {{ .Values.fullName }}-observer
 {{- end }}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add an option to make the Stellar observer into a separate deployment service.

### Why

Because it's recommended to use it as a separate service.
