### PR TITLE
Fix Sep31Transaction.refunds Gson serialization exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1
+* Fix gson serialization error of the Refunds object. [#626](https://github.com/stellar/java-stellar-anchor-sdk/issues/626)
+
 ## 1.2.0
 * Add Stellar observer retries with exponential back-off timer [#607](https://github.com/stellar/java-stellar-anchor-sdk/pull/607)
 * Add health check endpoint to the Stellar observer [#602](https://github.com/stellar/java-stellar-anchor-sdk/pull/602)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.0"
+  version = "1.2.1"
 
   tasks.jar {
     manifest {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -136,7 +136,7 @@ class Sep31TransactionTest {
   }
 
   @Test
-  fun test_toPlatformApiGetTransactionResponse() {
+  fun `test PlatformApiGetTransactionResponse correctness`() {
     val wantRefunds: Refund =
       Refund.builder()
         .amountRefunded(Amount("90.0000", fiatUSD))
@@ -196,7 +196,7 @@ class Sep31TransactionTest {
   }
 
   @Test
-  fun test_toSep31GetTransactionResponse() {
+  fun `test Sep31GetTransactionResponse correctness`() {
     val refunds =
       Sep31GetTransactionResponse.Refunds.builder()
         .amountRefunded("90.0000")

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31RefundPayment.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31RefundPayment.java
@@ -3,11 +3,9 @@ package org.stellar.anchor.platform.data;
 import lombok.Data;
 import org.stellar.anchor.sep31.RefundPayment;
 
-public class JdbcSep31RefundPayment {
-  @Data
-  public static class JdbcRefundPayment implements RefundPayment {
-    String Id;
-    String amount;
-    String fee;
-  }
+@Data
+public class JdbcSep31RefundPayment implements RefundPayment {
+  String id;
+  String amount;
+  String fee;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Refunds.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Refunds.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.data;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.sep31.RefundPayment;
@@ -15,5 +16,28 @@ public class JdbcSep31Refunds implements Refunds {
   String amountFee;
 
   @SerializedName("payments")
-  List<RefundPayment> refundPayments;
+  List<JdbcSep31RefundPayment> refundPayments;
+
+  @Override
+  public List<RefundPayment> getRefundPayments() {
+    if (refundPayments == null) return null;
+    // getPayments() is made for Gson serialization.
+    List<RefundPayment> payments = new ArrayList<>(refundPayments.size());
+    for (JdbcSep31RefundPayment refundPayment : refundPayments) {
+      payments.add(refundPayment);
+    }
+    return payments;
+  }
+
+  @Override
+  public void setRefundPayments(List<RefundPayment> refundPayments) {
+    this.refundPayments = new ArrayList<>(refundPayments.size());
+    for (RefundPayment rp : refundPayments) {
+      if (rp instanceof JdbcSep31RefundPayment)
+        this.refundPayments.add((JdbcSep31RefundPayment) rp);
+      else
+        throw new ClassCastException(
+            String.format("Error casting %s to JdbcSep31RefundPayment", rp.getClass()));
+    }
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
@@ -143,7 +143,7 @@ public class JdbcSep31Transaction implements Sep31Transaction, SepTransaction {
 
   public void setRefundsJson(String refundsJson) {
     if (refundsJson != null) {
-      this.refunds = gson.fromJson(refundsJson, Refunds.class);
+      this.refunds = gson.fromJson(refundsJson, JdbcSep31Refunds.class);
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -31,7 +31,7 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
 
   @Override
   public RefundPayment newRefundPayment() {
-    return new JdbcSep31RefundPayment.JdbcRefundPayment();
+    return new JdbcSep31RefundPayment();
   }
 
   @Override

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31TransactionTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31TransactionTest.kt
@@ -1,0 +1,61 @@
+package org.stellar.anchor.platform.data
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+
+class JdbcSep31TransactionTest {
+  private val refundsJsonNoRefundPayment =
+    """
+            {
+              "amount_refunded": "10",
+              "amount_fee": "5",
+              "refundPayments": null
+            }
+        """.trimIndent()
+
+  private val refundsJsonWithRefundPayment =
+    """
+            {
+              "amount_refunded": "10",
+              "amount_fee": "5",
+              "payments": [
+                {
+                  "id": "1",
+                  "amount": "5",
+                  "fee": "1"
+                },
+                {
+                  "id": "2",
+                  "amount": "5",
+                  "fee": "4"
+                }
+              ]
+            }
+        """.trimIndent()
+
+  @Test
+  fun `test JdbcSep31Transaction refunds Json conversion`() {
+    val txn = JdbcSep31Transaction()
+    txn.refundsJson = refundsJsonNoRefundPayment
+    // strict is set to false because refundPayments is omitted in txn.refundsJson when it is set to
+    // null.
+    JSONAssert.assertEquals(txn.refundsJson, refundsJsonNoRefundPayment, false)
+    assertEquals("10", txn.refunds.amountRefunded)
+    assertEquals("5", txn.refunds.amountFee)
+    assertNull(txn.refunds.refundPayments)
+
+    txn.refundsJson = refundsJsonWithRefundPayment
+    JSONAssert.assertEquals(txn.refundsJson, refundsJsonWithRefundPayment, true)
+    assertEquals("10", txn.refunds.amountRefunded)
+    assertEquals("5", txn.refunds.amountFee)
+    assertEquals(2, txn.refunds.refundPayments.size)
+    assertEquals("1", txn.refunds.refundPayments[0].id)
+    assertEquals("5", txn.refunds.refundPayments[0].amount)
+    assertEquals("1", txn.refunds.refundPayments[0].fee)
+    assertEquals("2", txn.refunds.refundPayments[1].id)
+    assertEquals("5", txn.refunds.refundPayments[1].amount)
+    assertEquals("4", txn.refunds.refundPayments[1].fee)
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
@@ -3,8 +3,11 @@ package org.stellar.anchor.platform.service
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import java.time.Instant
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.stellar.anchor.api.exception.AnchorException
@@ -19,7 +22,7 @@ import org.stellar.anchor.api.shared.RefundPayment
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.ResourceJsonAssetService
 import org.stellar.anchor.event.models.TransactionEvent
-import org.stellar.anchor.platform.data.JdbcSep31RefundPayment.JdbcRefundPayment
+import org.stellar.anchor.platform.data.JdbcSep31RefundPayment
 import org.stellar.anchor.platform.data.JdbcSep31Refunds
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
 import org.stellar.anchor.sep31.*
@@ -78,7 +81,7 @@ class TransactionServiceTest {
     // Mock the store
     every { sep31TransactionStore.newTransaction() } returns JdbcSep31Transaction()
     every { sep31TransactionStore.newRefunds() } returns JdbcSep31Refunds()
-    every { sep31TransactionStore.newRefundPayment() } answers { JdbcRefundPayment() }
+    every { sep31TransactionStore.newRefundPayment() } answers { JdbcSep31RefundPayment() }
 
     // mock time
     val mockStartedAt = Instant.now().minusSeconds(180)


### PR DESCRIPTION
closes #626 

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix gson serialization error of the Refunds object.

Gson tries to serialize JdbcSep31Transaction.refunds, which is an interface. It is changed to JdbcSep31Refunds. 

### Why

Bug fixes.

### Known limitations

Add `PATCH /transactions` to integration tests.