### PR TITLE
observer: Merge 1.2.2 to `develop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2
+* Detects and handle silent and errored SSEStream. [#632](https://github.com/stellar/java-stellar-anchor-sdk/issues/632)
+* When the health status is RED, set the status code to 500.
+
 ## 1.2.1
 * Fix gson serialization error of the Refunds object. [#626](https://github.com/stellar/java-stellar-anchor-sdk/issues/626) 
 

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
@@ -143,7 +143,7 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
 
     return KafkaHealthCheckResult.builder()
         .name(getName())
-        .status(status.getName())
+        .status(status)
         .kafkaAvailable(kafkaAvailable)
         .running(!executor.isTerminated())
         .build();
@@ -164,9 +164,9 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
 class KafkaHealthCheckResult implements HealthCheckResult {
   transient String name;
 
-  List<String> statuses;
+  List<HealthCheckStatus> statuses = List.of(GREEN, RED);
 
-  String status;
+  HealthCheckStatus status;
 
   boolean running;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/HealthCheckResult.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/HealthCheckResult.java
@@ -10,12 +10,12 @@ public interface HealthCheckResult {
    *
    * @return the list of health check status.
    */
-  List<String> getStatuses();
+  List<HealthCheckStatus> getStatuses();
 
   /**
    * the current status of the health check result.
    *
    * @return the status.
    */
-  String getStatus();
+  HealthCheckStatus getStatus();
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.1"
+  version = "1.2.2"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/healthcheck/HealthCheckProcessor.java
+++ b/core/src/main/java/org/stellar/anchor/healthcheck/HealthCheckProcessor.java
@@ -21,7 +21,7 @@ public class HealthCheckProcessor {
     HealthCheckResponse healthCheckResponse = new HealthCheckResponse();
     SortedSet<HealthCheckable> checkSet = new TreeSet<>();
     for (String checkTag : checkTags) {
-      List<HealthCheckable> checkables = mapCheckable.get(checkTag);
+      List<HealthCheckable> checkables = mapCheckable.get(checkTag.toLowerCase());
       if (checkables != null) checkSet.addAll(checkables);
     }
 

--- a/core/src/main/java/org/stellar/anchor/util/ExponentialBackoffTimer.java
+++ b/core/src/main/java/org/stellar/anchor/util/ExponentialBackoffTimer.java
@@ -42,4 +42,12 @@ public class ExponentialBackoffTimer {
   public void sleep() throws InterruptedException {
     Thread.sleep(sleepSeconds * 1000);
   }
+
+  public long currentTimer() {
+    return sleepSeconds;
+  }
+
+  public boolean isTimerMaxed() {
+    return sleepSeconds >= maxSleepSeconds;
+  }
 }

--- a/docs/resources/docker-examples/kafka/docker-compose.yaml
+++ b/docs/resources/docker-examples/kafka/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.4'
 services:
   zookeeper:
     platform: linux/x86_64

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -178,7 +178,8 @@ class AnchorPlatformIntegrationTest {
         "sell_amount": "100",
         "buy_amount": "98.0392"
       }
-    }""".trimMargin()
+    }"""
+        .trimMargin()
     JSONAssert.assertEquals(wantBody, gson.toJson(result), true)
   }
 
@@ -214,14 +215,16 @@ class AnchorPlatformIntegrationTest {
           ]
         }
       }
-    }""".trimMargin()
+    }"""
+        .trimMargin()
     JSONAssert.assertEquals(wantBody, gson.toJson(result), true)
   }
 
   @Test
   fun testRate_firm() {
     val rate =
-      rriClient.getRate(
+      rriClient
+        .getRate(
           GetRateRequest.builder()
             .type(FIRM)
             .context(SEP31)
@@ -277,7 +280,8 @@ class AnchorPlatformIntegrationTest {
           ]
         }
       }
-    }""".trimMargin()
+    }"""
+        .trimMargin()
     JSONAssert.assertEquals(wantBody, gson.toJson(gotQuote), true)
   }
 
@@ -372,11 +376,9 @@ class AnchorPlatformIntegrationTest {
 
     val checks = responseBody["checks"] as Map<*, *>
 
-    //    assertEquals(2, checks.size)
-    //    assertNotNull(checks["config"])
-    //    assertNotNull(checks["stellar_payment_observer"])
-
-    assertEquals(1, checks.size)
+    assertEquals(2, checks.size)
+    assertNotNull(checks["config"])
+    assertNotNull(checks["stellar_payment_observer"])
 
     val stellarPaymentObserverCheck = checks["stellar_payment_observer"] as Map<*, *>
     assertEquals(2, stellarPaymentObserverCheck.size)

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -319,6 +319,7 @@ class AnchorPlatformIntegrationTest {
   }
 
   @Test
+
   fun testAppConfig() {
     val appConfig = platformServerContext.getBean(AppConfig::class.java)
     assertEquals("Test SDF Network ; September 2015", appConfig.stellarNetworkPassphrase)
@@ -371,8 +372,25 @@ class AnchorPlatformIntegrationTest {
     assertNotNull(responseBody["checks"])
 
     val checks = responseBody["checks"] as Map<*, *>
-    assertEquals(2, checks.size)
-    assertNotNull(checks["config"])
-    assertNotNull(checks["stellar_payment_observer"])
+
+//    assertEquals(2, checks.size)
+//    assertNotNull(checks["config"])
+//    assertNotNull(checks["stellar_payment_observer"])
+
+    assertEquals(1, checks.size)
+
+    val stellarPaymentObserverCheck = checks["stellar_payment_observer"] as Map<*, *>
+    assertEquals(2, stellarPaymentObserverCheck.size)
+    assertEquals("GREEN", stellarPaymentObserverCheck["status"])
+
+    val observerStreams = stellarPaymentObserverCheck["streams"] as List<*>
+    assertEquals(1, observerStreams.size)
+
+    val stream1 = observerStreams[0] as Map<*, *>
+    assertEquals(5, stream1.size)
+    assertEquals(false, stream1["thread_shutdown"])
+    assertEquals(false, stream1["thread_terminated"])
+    assertEquals(false, stream1["stopped"])
+    assertNotNull(stream1["last_event_id"])
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -319,7 +319,6 @@ class AnchorPlatformIntegrationTest {
   }
 
   @Test
-
   fun testAppConfig() {
     val appConfig = platformServerContext.getBean(AppConfig::class.java)
     assertEquals("Test SDF Network ; September 2015", appConfig.stellarNetworkPassphrase)
@@ -373,9 +372,9 @@ class AnchorPlatformIntegrationTest {
 
     val checks = responseBody["checks"] as Map<*, *>
 
-//    assertEquals(2, checks.size)
-//    assertNotNull(checks["config"])
-//    assertNotNull(checks["stellar_payment_observer"])
+    //    assertEquals(2, checks.size)
+    //    assertNotNull(checks["config"])
+    //    assertNotNull(checks["stellar_payment_observer"])
 
     assertEquals(1, checks.size)
 

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
@@ -19,6 +19,7 @@ import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.io.Resource;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.api.platform.HealthCheckResult;
+import org.stellar.anchor.api.platform.HealthCheckStatus;
 import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.util.Log;
 
@@ -184,12 +185,12 @@ class ConfigManagerHealthCheckResult implements HealthCheckResult {
   }
 
   @Override
-  public List<String> getStatuses() {
+  public List<HealthCheckStatus> getStatuses() {
     return List.of();
   }
 
   @Override
-  public String getStatus() {
-    return GREEN.toString();
+  public HealthCheckStatus getStatus() {
+    return GREEN;
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -1,15 +1,22 @@
 package org.stellar.anchor.platform.payment.observer.stellar;
 
-import static org.stellar.anchor.api.platform.HealthCheckStatus.GREEN;
-import static org.stellar.anchor.api.platform.HealthCheckStatus.RED;
+import static org.stellar.anchor.api.platform.HealthCheckStatus.*;
 import static org.stellar.anchor.healthcheck.HealthCheckable.Tags.ALL;
 import static org.stellar.anchor.healthcheck.HealthCheckable.Tags.EVENT;
+import static org.stellar.anchor.platform.payment.observer.stellar.ObserverStatus.*;
+import static org.stellar.anchor.util.Log.debugF;
+import static org.stellar.anchor.util.Log.infoF;
 import static org.stellar.anchor.util.ReflectionUtil.getField;
 
 import com.google.gson.annotations.SerializedName;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Builder;
@@ -42,49 +49,198 @@ public class StellarPaymentObserver implements HealthCheckable {
   /** The minimum number of results the Stellar Blockchain can return. */
   private static final int MIN_RESULTS = 1;
 
+  // If the observer had been silent for longer than SILENC_TIMEOUT, a SilenceTimeoutException will
+  // be thrown to trigger reconnections.
+  private static final long SILENCE_TIMEOUT = 90;
+  // If the observer has more than 2 SILENCE_TIMEOUT_RETRIES, it will be marked unhealthy
+  private static final long SILENCE_TIMEOUT_RETRIES = 2;
+
+  // The time interval between silence checks
+  private static final long SILENCE_CHECK_INTERVAL = 5;
+
   final Server server;
-  final Set<PaymentListener> observers;
+  final Set<PaymentListener> paymentListeners;
   final StellarPaymentStreamerCursorStore paymentStreamerCursorStore;
   final Map<SSEStream<OperationResponse>, String> mapStreamToAccount = new HashMap<>();
   final PaymentObservingAccountsManager paymentObservingAccountsManager;
   SSEStream<OperationResponse> stream;
 
-  private final ExponentialBackoffTimer exponentialBackoffTimer = new ExponentialBackoffTimer();
+  final ExponentialBackoffTimer publishingBackoffTimer = new ExponentialBackoffTimer();
+  final ExponentialBackoffTimer streamBackoffTimer = new ExponentialBackoffTimer();
+  int silenceTimeoutCount = 0;
+
+  ObserverStatus status = RUNNING;
+
+  Instant lastActivityTime;
+
+  ScheduledExecutorService silenceWatcher = Executors.newSingleThreadScheduledExecutor();
+  ScheduledExecutorService statusWatcher = Executors.newSingleThreadScheduledExecutor();
 
   StellarPaymentObserver(
       String horizonServer,
-      Set<PaymentListener> observers,
+      Set<PaymentListener> paymentListeners,
       PaymentObservingAccountsManager paymentObservingAccountsManager,
       StellarPaymentStreamerCursorStore paymentStreamerCursorStore) {
     this.server = new Server(horizonServer);
-    this.observers = observers;
+    this.paymentListeners = paymentListeners;
     this.paymentObservingAccountsManager = paymentObservingAccountsManager;
     this.paymentStreamerCursorStore = paymentStreamerCursorStore;
   }
 
-  /** Start watching the accounts. */
+  /** Start the observer. */
   public void start() {
-    this.stream = watch();
+    infoF("Starting the SSEStream");
+    startStream();
+
+    infoF("Starting the observer silence watcher");
+    silenceWatcher.scheduleAtFixedRate(
+        this::checkSilence,
+        1,
+        SILENCE_CHECK_INTERVAL,
+        TimeUnit.SECONDS); // TODO: The period should be made configurable in version 2.x
+
+    infoF("Starting the status watcher");
+    statusWatcher.scheduleWithFixedDelay(this::checkStatus, 1, 1, TimeUnit.SECONDS);
+
+    setStatus(RUNNING);
   }
 
-  /** Graceful shutdown. */
+  /** Graceful shut down the observer */
   public void shutdown() {
-    this.stream.close();
-    this.stream = null;
+    infoF("Shutting down the SSEStream");
+    stopStream();
+
+    infoF("Stopping the silence watcher");
+    silenceWatcher.shutdown();
+
+    infoF("Stopping the status watcher");
+    statusWatcher.shutdown();
+    setStatus(SHUTDOWN);
   }
 
-  private void restart() {
-    Log.info("Restarting the Stellar observer.");
-    if (this.stream != null) {
-      this.shutdown();
-    }
+  void startStream() {
+    this.stream = startSSEStream();
+  }
 
-    try {
-      exponentialBackoffTimer.sleep();
-      exponentialBackoffTimer.increase();
-      this.start();
-    } catch (InterruptedException ex) {
-      Log.errorEx(ex);
+  SSEStream<OperationResponse> startSSEStream() {
+    String latestCursor = fetchStreamingCursor();
+    debugF("SSEStream last cursor={}", latestCursor);
+
+    PaymentsRequestBuilder paymentsRequest =
+        server
+            .payments()
+            .includeTransactions(true)
+            .cursor(latestCursor)
+            .order(RequestBuilder.Order.ASC)
+            .limit(MAX_RESULTS);
+    return paymentsRequest.stream(
+        new EventListener<>() {
+          @Override
+          public void onEvent(OperationResponse operationResponse) {
+            debugF("received event {}", operationResponse.getId());
+            // clear stream timeout/reconnect status
+            lastActivityTime = Instant.now();
+            silenceTimeoutCount = 0;
+            streamBackoffTimer.reset();
+            handleEvent(operationResponse);
+          }
+
+          @Override
+          public void onFailure(Optional<Throwable> exception, Optional<Integer> statusCode) {
+            handleFailure(exception);
+          }
+        });
+  }
+
+  void stopStream() {
+    if (this.stream != null) {
+      this.stream.close();
+      this.stream = null;
+    }
+  }
+
+  void checkSilence() {
+    if (status != NEEDS_SHUTDOWN && status != SHUTDOWN) {
+      Instant now = Instant.now();
+      if (lastActivityTime != null) {
+        Duration silenceDuration = Duration.between(lastActivityTime, now);
+        if (silenceDuration.getSeconds() > SILENCE_TIMEOUT) {
+          infoF("The observer had been silent for {} seconds.", silenceDuration.getSeconds());
+          setStatus(SILENCE_ERROR);
+        } else {
+          debugF("The observer had been silent for {} seconds.", silenceDuration.getSeconds());
+        }
+      }
+    }
+  }
+
+  void restartStream() {
+    infoF("Restarting the stream");
+    stopStream();
+    startStream();
+    setStatus(RUNNING);
+  }
+
+  void checkStatus() {
+    switch (status) {
+      case NEEDS_SHUTDOWN:
+        infoF("shut down the observer");
+        shutdown();
+        break;
+      case STREAM_ERROR:
+        // We got stream connection error. We will use the backoff timer to reconnect.
+        // If the backoff timer reaches max, we will shut down the observer
+        if (streamBackoffTimer.isTimerMaxed()) {
+          infoF("The streamer backoff timer is maxed. Shutdown the observer");
+          setStatus(NEEDS_SHUTDOWN);
+        } else {
+          try {
+            infoF(
+                "The streamer needs restart. Start backoff timer: {} seconds",
+                streamBackoffTimer.currentTimer());
+            streamBackoffTimer.sleep();
+            streamBackoffTimer.increase();
+            restartStream();
+          } catch (InterruptedException e) {
+            // if this thread is interrupted, we are shutting down the status watcher.
+            infoF("The status watcher is interrupted. Shutdown the observer");
+            setStatus(NEEDS_SHUTDOWN);
+          }
+        }
+        break;
+      case SILENCE_ERROR:
+        infoF("The silence reconnection count: {}", silenceTimeoutCount);
+        // We got the silence error. If silence reconnect too many times, we will shut down the
+        // observer.
+        if (silenceTimeoutCount >= SILENCE_TIMEOUT_RETRIES) {
+          infoF(
+              "The silence error has happened for too many times:{}. Shutdown the observer",
+              silenceTimeoutCount);
+          setStatus(NEEDS_SHUTDOWN);
+        } else {
+          restartStream();
+          lastActivityTime = Instant.now();
+          silenceTimeoutCount++;
+        }
+        break;
+      case PUBLISHER_ERROR:
+        try {
+          infoF(
+              "Start the publishing backoff timer: {} seconds",
+              publishingBackoffTimer.currentTimer());
+          publishingBackoffTimer.sleep();
+          publishingBackoffTimer.increase();
+          restartStream();
+        } catch (InterruptedException e) {
+          // if this thread is interrupted, we are shutting down the status watcher.
+          setStatus(NEEDS_SHUTDOWN);
+        }
+        break;
+      case RUNNING:
+      case SHUTDOWN:
+      default:
+        // NOOP
+        break;
     }
   }
 
@@ -120,85 +276,74 @@ public class StellarPaymentObserver implements HealthCheckable {
     return pageOpResponse.getRecords().get(0).getPagingToken();
   }
 
-  SSEStream<OperationResponse> watch() {
-    String latestCursor = fetchStreamingCursor();
-    PaymentsRequestBuilder paymentsRequest =
-        server
-            .payments()
-            .includeTransactions(true)
-            .cursor(latestCursor)
-            .order(RequestBuilder.Order.ASC)
-            .limit(MAX_RESULTS);
+  void handleEvent(OperationResponse operationResponse) {
+    if (!operationResponse.isTransactionSuccessful()) {
+      paymentStreamerCursorStore.save(operationResponse.getPagingToken());
+      return;
+    }
 
-    return paymentsRequest.stream(
-        new EventListener<>() {
-          @Override
-          public void onEvent(OperationResponse operationResponse) {
-            if (!operationResponse.isTransactionSuccessful()) {
-              paymentStreamerCursorStore.save(operationResponse.getPagingToken());
-              return;
-            }
+    ObservedPayment observedPayment = null;
+    try {
+      if (operationResponse instanceof PaymentOperationResponse) {
+        PaymentOperationResponse payment = (PaymentOperationResponse) operationResponse;
+        observedPayment = ObservedPayment.fromPaymentOperationResponse(payment);
+      } else if (operationResponse instanceof PathPaymentBaseOperationResponse) {
+        PathPaymentBaseOperationResponse pathPayment =
+            (PathPaymentBaseOperationResponse) operationResponse;
+        observedPayment = ObservedPayment.fromPathPaymentOperationResponse(pathPayment);
+      }
+    } catch (SepException ex) {
+      Log.warn(
+          String.format(
+              "Payment of id %s contains unsupported memo %s.",
+              operationResponse.getId(),
+              operationResponse.getTransaction().get().getMemo().toString()));
+      Log.warnEx(ex);
+    }
 
-            ObservedPayment observedPayment = null;
-            try {
-              if (operationResponse instanceof PaymentOperationResponse) {
-                PaymentOperationResponse payment = (PaymentOperationResponse) operationResponse;
-                observedPayment = ObservedPayment.fromPaymentOperationResponse(payment);
-              } else if (operationResponse instanceof PathPaymentBaseOperationResponse) {
-                PathPaymentBaseOperationResponse pathPayment =
-                    (PathPaymentBaseOperationResponse) operationResponse;
-                observedPayment = ObservedPayment.fromPathPaymentOperationResponse(pathPayment);
-              }
-            } catch (SepException ex) {
-              Log.warn(
-                  String.format(
-                      "Payment of id %s contains unsupported memo %s.",
-                      operationResponse.getId(),
-                      operationResponse.getTransaction().get().getMemo().toString()));
-              Log.warnEx(ex);
-            }
-
-            if (observedPayment != null) {
-              try {
-                if (paymentObservingAccountsManager.lookupAndUpdate(observedPayment.getTo())) {
-                  for (PaymentListener listener : observers) {
-                    listener.onReceived(observedPayment);
-                  }
-                }
-
-                if (paymentObservingAccountsManager.lookupAndUpdate(observedPayment.getFrom())
-                    && !observedPayment.getTo().equals(observedPayment.getFrom())) {
-                  final ObservedPayment finalObservedPayment = observedPayment;
-                  observers.forEach(observer -> observer.onSent(finalObservedPayment));
-                }
-
-              } catch (EventPublishException ex) {
-                // restart the observer from where it stopped, in case the queue fails to
-                // publish the message.
-                Log.errorEx("Failed to send event to observer.", ex);
-                restart();
-                return;
-              } catch (Throwable t) {
-                Log.errorEx("Something went wrong in the streamer", t);
-                if (!Thread.interrupted()) {
-                  restart();
-                }
-                return;
-              }
-
-              exponentialBackoffTimer.reset();
-            }
-
-            paymentStreamerCursorStore.save(operationResponse.getPagingToken());
+    if (observedPayment == null) {
+      paymentStreamerCursorStore.save(operationResponse.getPagingToken());
+    } else {
+      try {
+        if (paymentObservingAccountsManager.lookupAndUpdate(observedPayment.getTo())) {
+          for (PaymentListener listener : paymentListeners) {
+            listener.onReceived(observedPayment);
           }
+        }
 
-          @Override
-          public void onFailure(Optional<Throwable> exception, Optional<Integer> statusCode) {
-            Log.errorEx("stellar payment observer error: ", exception.get());
-            // TODO: The stream seems closed when failure happens. Improve the reliability of the
-            // stream.
-          }
-        });
+        if (paymentObservingAccountsManager.lookupAndUpdate(observedPayment.getFrom())
+            && !observedPayment.getTo().equals(observedPayment.getFrom())) {
+          final ObservedPayment finalObservedPayment = observedPayment;
+          paymentListeners.forEach(observer -> observer.onSent(finalObservedPayment));
+        }
+
+        publishingBackoffTimer.reset();
+        paymentStreamerCursorStore.save(operationResponse.getPagingToken());
+      } catch (EventPublishException ex) {
+        // restart the observer from where it stopped, in case the queue fails to
+        // publish the message.
+        Log.errorEx("Failed to send event to payment listeners.", ex);
+        setStatus(PUBLISHER_ERROR);
+      } catch (Throwable t) {
+        Log.errorEx("Something went wrong in the observer while sending the event", t);
+        setStatus(PUBLISHER_ERROR);
+      }
+    }
+  }
+
+  void handleFailure(Optional<Throwable> exception) {
+    // The SSEStreamer has internal errors. We will give up and let the container
+    // manager to
+    // restart.
+    Log.errorEx("stellar payment observer stream error: ", exception.get());
+
+    // Mark the observer unhealthy
+    setStatus(STREAM_ERROR);
+  }
+
+  void setStatus(ObserverStatus status) {
+    debugF("Setting status to {}", status);
+    this.status = status;
   }
 
   public static Builder builder() {
@@ -260,40 +405,65 @@ public class StellarPaymentObserver implements HealthCheckable {
   @Override
   public HealthCheckResult check() {
     List<StreamHealth> results = new ArrayList<>();
-    HealthCheckStatus status = GREEN;
+
+    HealthCheckStatus status;
+    switch (this.status) {
+      case STREAM_ERROR:
+      case SILENCE_ERROR:
+      case PUBLISHER_ERROR:
+        status = YELLOW;
+        break;
+      case NEEDS_SHUTDOWN:
+      case SHUTDOWN:
+        status = RED;
+        break;
+      case RUNNING:
+      default:
+        status = GREEN;
+        break;
+    }
 
     StreamHealth.StreamHealthBuilder healthBuilder = StreamHealth.builder();
     healthBuilder.account(mapStreamToAccount.get(stream));
     // populate executorService information
-    ExecutorService executorService = getField(stream, "executorService", null);
-    if (executorService != null) {
-      healthBuilder.threadShutdown(executorService.isShutdown());
-      healthBuilder.threadTerminated(executorService.isTerminated());
-      if (executorService.isShutdown() || executorService.isTerminated()) {
+    if (stream != null) {
+      ExecutorService executorService = getField(stream, "executorService", null);
+      if (executorService != null) {
+        healthBuilder.threadShutdown(executorService.isShutdown());
+        healthBuilder.threadTerminated(executorService.isTerminated());
+        if (executorService.isShutdown() || executorService.isTerminated()) {
+          status = RED;
+        }
+      } else {
         status = RED;
       }
+
+      AtomicBoolean isStopped = getField(stream, "isStopped", new AtomicBoolean(false));
+      if (isStopped != null) {
+        healthBuilder.stopped(isStopped.get());
+        if (isStopped.get()) {
+          status = RED;
+        }
+      }
+
+      AtomicReference<String> lastEventId = getField(stream, "lastEventId", null);
+      if (lastEventId != null && lastEventId.get() != null) {
+        healthBuilder.lastEventId(lastEventId.get());
+      } else {
+        healthBuilder.lastEventId("-1");
+      }
+    }
+
+    if (lastActivityTime == null) {
+      healthBuilder.silenceSinceLastEvent("0");
     } else {
-      status = RED;
-    }
-
-    boolean isStopped = getField(stream, "isStopped", new AtomicBoolean(false)).get();
-    healthBuilder.stopped(isStopped);
-    if (isStopped) {
-      status = RED;
-    }
-
-    AtomicReference<String> lastEventId = getField(stream, "lastEventId", null);
-    if (lastEventId != null) {
-      healthBuilder.lastEventId(lastEventId.get());
+      healthBuilder.silenceSinceLastEvent(
+          String.valueOf(Duration.between(lastActivityTime, Instant.now()).getSeconds()));
     }
 
     results.add(healthBuilder.build());
 
-    return SPOHealthCheckResult.builder()
-        .name(getName())
-        .streams(results)
-        .status(status.getName())
-        .build();
+    return SPOHealthCheckResult.builder().name(getName()).streams(results).status(status).build();
   }
 }
 
@@ -303,9 +473,9 @@ public class StellarPaymentObserver implements HealthCheckable {
 class SPOHealthCheckResult implements HealthCheckResult {
   transient String name;
 
-  List<String> statuses;
+  List<HealthCheckStatus> statuses;
 
-  String status;
+  HealthCheckStatus status;
 
   List<StreamHealth> streams;
 
@@ -326,5 +496,19 @@ class StreamHealth {
   boolean threadTerminated;
 
   boolean stopped;
+
+  @SerializedName("last_event_id")
   String lastEventId;
+
+  @SerializedName("seconds_since_last_event")
+  String silenceSinceLastEvent;
+}
+
+enum ObserverStatus {
+  RUNNING,
+  STREAM_ERROR,
+  SILENCE_ERROR,
+  PUBLISHER_ERROR,
+  NEEDS_SHUTDOWN,
+  SHUTDOWN,
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/HealthCheckService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/HealthCheckService.java
@@ -1,24 +1,28 @@
 package org.stellar.anchor.platform.service;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 import org.stellar.anchor.api.platform.HealthCheckResponse;
 import org.stellar.anchor.healthcheck.HealthCheckProcessor;
-import org.stellar.anchor.platform.payment.observer.stellar.StellarPaymentObserver;
+import org.stellar.anchor.healthcheck.HealthCheckable;
+
+import java.util.List;
+
+import static org.stellar.anchor.util.Log.debugF;
+import static org.stellar.anchor.util.Log.warnF;
 
 @Service
 @DependsOn("configManager")
 public class HealthCheckService {
   HealthCheckProcessor processor;
 
-  public HealthCheckService(Optional<StellarPaymentObserver> stellarPaymentObserver) {
-    if (!stellarPaymentObserver.isEmpty()) {
-      processor = new HealthCheckProcessor(List.of(stellarPaymentObserver.get()));
-    } else {
-      processor = new HealthCheckProcessor(List.of());
+  public HealthCheckService(List<HealthCheckable> checkables) {
+    checkables.forEach(
+        checkable -> debugF("{} is added to the health check list.", checkable.getName()));
+    if (checkables.size() == 0) {
+      warnF("No health-checkable services are found");
     }
+    processor = new HealthCheckProcessor(checkables);
   }
 
   public HealthCheckResponse check(List<String> checks) {

--- a/platform/src/main/java/org/stellar/anchor/platform/service/HealthCheckService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/HealthCheckService.java
@@ -1,27 +1,24 @@
 package org.stellar.anchor.platform.service;
 
-import static org.stellar.anchor.util.Log.debugF;
-import static org.stellar.anchor.util.Log.warnF;
-
 import java.util.List;
+import java.util.Optional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 import org.stellar.anchor.api.platform.HealthCheckResponse;
 import org.stellar.anchor.healthcheck.HealthCheckProcessor;
-import org.stellar.anchor.healthcheck.HealthCheckable;
+import org.stellar.anchor.platform.payment.observer.stellar.StellarPaymentObserver;
 
 @Service
 @DependsOn("configManager")
 public class HealthCheckService {
   HealthCheckProcessor processor;
 
-  public HealthCheckService(List<HealthCheckable> checkables) {
-    checkables.forEach(
-        checkable -> debugF("{} is added to the health check list.", checkable.getName()));
-    if (checkables.size() == 0) {
-      warnF("No health-checkable services are found");
+  public HealthCheckService(Optional<StellarPaymentObserver> stellarPaymentObserver) {
+    if (!stellarPaymentObserver.isEmpty()) {
+      processor = new HealthCheckProcessor(List.of(stellarPaymentObserver.get()));
+    } else {
+      processor = new HealthCheckProcessor(List.of());
     }
-    processor = new HealthCheckProcessor(checkables);
   }
 
   public HealthCheckResponse check(List<String> checks) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/controller/HealthControllerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/controller/HealthControllerTest.kt
@@ -5,7 +5,6 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.unmockkAll
-import java.util.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -37,7 +36,7 @@ class HealthControllerTest {
     every { stellarPaymentObserver.tags } returns
       listOf(HealthCheckable.Tags.ALL, HealthCheckable.Tags.EVENT)
 
-    val healthCheckService = HealthCheckService(Optional.of(stellarPaymentObserver))
+    val healthCheckService = HealthCheckService(listOf(stellarPaymentObserver))
     val healthController = HealthController(healthCheckService)
 
     // RED should result 500

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/controller/HealthControllerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/controller/HealthControllerTest.kt
@@ -1,0 +1,74 @@
+package org.stellar.anchor.platform.controller
+
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.unmockkAll
+import java.util.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.stellar.anchor.api.platform.HealthCheckResult
+import org.stellar.anchor.api.platform.HealthCheckStatus
+import org.stellar.anchor.api.platform.HealthCheckStatus.*
+import org.stellar.anchor.healthcheck.HealthCheckable
+import org.stellar.anchor.platform.payment.observer.stellar.StellarPaymentObserver
+import org.stellar.anchor.platform.service.HealthCheckService
+
+class HealthControllerTest {
+  @MockK private lateinit var stellarPaymentObserver: StellarPaymentObserver
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxed = true)
+  }
+
+  @AfterEach
+  fun teardown() {
+    clearAllMocks()
+    unmockkAll()
+  }
+
+  @Test
+  fun `health controller and stellar payment observer status code checks`() {
+    every { stellarPaymentObserver.tags } returns
+      listOf(HealthCheckable.Tags.ALL, HealthCheckable.Tags.EVENT)
+
+    val healthCheckService = HealthCheckService(Optional.of(stellarPaymentObserver))
+    val healthController = HealthController(healthCheckService)
+
+    // RED should result 500
+    every { stellarPaymentObserver.check() } returns PojoHealthCheckResult("observer", RED)
+    var response = healthController.health(listOf("all"))
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+
+    // GREEN should result 200
+    every { stellarPaymentObserver.check() } returns PojoHealthCheckResult("observer", GREEN)
+    response = healthController.health(listOf("all"))
+    assertEquals(HttpStatus.OK, response.statusCode)
+
+    // YELLOW should result 200
+    every { stellarPaymentObserver.check() } returns PojoHealthCheckResult("observer", YELLOW)
+    response = healthController.health(listOf("all"))
+    assertEquals(HttpStatus.OK, response.statusCode)
+  }
+}
+
+class PojoHealthCheckResult(private val name: String, private val status: HealthCheckStatus) :
+  HealthCheckResult {
+
+  override fun name(): String {
+    return name
+  }
+
+  override fun getStatuses(): MutableList<HealthCheckStatus>? {
+    return mutableListOf(GREEN, RED)
+  }
+
+  override fun getStatus(): HealthCheckStatus {
+    return status
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What
From Release 1.2.2.
1. Add silence watcher that sets the observer to SILENCE_ERROR when the SSEStream is silent for too long.
2. Add SSEStream failure handler that sets the observer to STREAM_ERROR when failed.
3. Add status watcher that decides to reconnect or to set the health status to RED depends on the reconnection/backoff timer status.
4. Add proper HTTP status code to the /health endpoint.

### Why

Merge from release 1.2.2

### Known limitations

N/A