### PR TITLE
Add type and value checks to PropertyAssetsConfig

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAssetsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAssetsConfig.java
@@ -1,10 +1,16 @@
 package org.stellar.anchor.platform.config;
 
+import com.google.gson.JsonSyntaxException;
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
+import org.stellar.anchor.asset.Assets;
 import org.stellar.anchor.config.AssetsConfig;
+import org.stellar.anchor.util.GsonUtils;
+import org.stellar.anchor.util.StringHelper;
+
+import static org.stellar.anchor.util.Log.error;
 
 @Data
 public class PropertyAssetsConfig implements AssetsConfig, Validator {
@@ -17,5 +23,46 @@ public class PropertyAssetsConfig implements AssetsConfig, Validator {
   }
 
   @Override
-  public void validate(@NotNull Object target, @NotNull Errors errors) {}
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    PropertyAssetsConfig config = (PropertyAssetsConfig) target;
+    checkType(config, errors);
+    checkValue(config, errors);
+  }
+
+  void checkValue(PropertyAssetsConfig config, Errors errors) {
+    if (StringHelper.isEmpty(config.getValue())) {
+      errors.reject("invalid-no-value-defined", "assets.value is empty. Please define.");
+    } else {
+      switch (config.getType()) {
+        case JSON:
+          try {
+            GsonUtils.getInstance().fromJson(config.getValue(), Assets.class);
+          } catch (JsonSyntaxException jsex) {
+            error("JSON parsing exception:", jsex);
+            errors.reject(
+                "invalid-asset-json-format",
+                "assets.value does not contain a valid JSON string for assets");
+          }
+          break;
+        case YAML:
+        default:
+          break;
+      }
+    }
+  }
+
+  void checkType(PropertyAssetsConfig config, Errors errors) {
+    if (config.getType() == null) {
+      errors.reject("invalid-no-type-defined", "assets.type is empty. Please define.");
+    }
+    switch (config.getType()) {
+      case JSON:
+        break;
+      case YAML:
+      default:
+        errors.reject(
+            "invalid-type-defined",
+            String.format("assets.type:%s is invalid. Only JSON is supported.", config.getType()));
+    }
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PropertyAssetsService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PropertyAssetsService.java
@@ -11,6 +11,9 @@ import org.stellar.anchor.config.AssetsConfig;
 import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.Log;
 
+import static org.stellar.anchor.util.Log.error;
+import static org.stellar.anchor.util.Log.infoF;
+
 public class PropertyAssetsService implements AssetService {
   static final Gson gson = GsonUtils.getInstance();
   Assets assets;
@@ -20,10 +23,14 @@ public class PropertyAssetsService implements AssetService {
       case JSON:
         String assetsJson = assetsConfig.getValue();
         assets = gson.fromJson(assetsJson, Assets.class);
+        if (assets == null || assets.getAssets() == null || assets.getAssets().size() == 0) {
+          error("Invalid asset defined. assets JSON=", assetsJson);
+          throw new InvalidConfigException(String.format("Invalid assets defined in configuration. Please check the logs for details."));
+        }
         break;
       case YAML:
       default:
-        Log.infoF("assets type {} is not supported", assetsConfig.getType());
+        infoF("assets type {} is not supported", assetsConfig.getType());
         throw new InvalidConfigException(
             String.format("assets type %s is not supported", assetsConfig.getType()));
     }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Added type and value checks to PropertyAssetsConfig.

### Why

When running sep server with empty configuration, it throws NPE because assets are not defined. Although this is expected, but not friendly. 

Validator checks will make catching errors earlier and easier to fix the issues without reading the stack trace.

### Known limitations

N/A