### PR TITLE
Reece fixobserver

### DIFF
--- a/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
@@ -143,7 +143,7 @@ resource "aws_alb_target_group" "stellar_observer" {
  
   health_check {
    healthy_threshold   = "2"
-   interval            = "15"
+   interval            = "30"
    protocol            = "HTTP"
    matcher             = "200-299"
    timeout             = "20"

--- a/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
@@ -139,11 +139,11 @@ resource "aws_alb_target_group" "stellar_observer" {
   protocol    = "HTTP"
   vpc_id      = module.vpc.vpc_id
   target_type = "ip"
-  slow_start = 120
+  slow_start = 60
  
   health_check {
    healthy_threshold   = "2"
-   interval            = "45"
+   interval            = "15"
    protocol            = "HTTP"
    matcher             = "200-299"
    timeout             = "20"

--- a/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/ecs.tf
@@ -84,9 +84,9 @@ resource "aws_ecs_service" "ref" {
    container_port   = 8081
  }
  
- #lifecycle {
- #  ignore_changes = [task_definition, desired_count]
- #}
+ lifecycle {
+   ignore_changes = [task_definition, desired_count]
+ }
   depends_on = [aws_alb_listener.sep_http]
 }
 
@@ -131,6 +131,26 @@ resource "aws_alb_target_group" "sep" {
    unhealthy_threshold = "5"
   }
   depends_on = [aws_lb.sep]
+}
+
+resource "aws_alb_target_group" "stellar_observer" {
+  name        = "${var.environment}-stellar-observer-tg"
+  port        = 8083
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+  slow_start = 120
+ 
+  health_check {
+   healthy_threshold   = "2"
+   interval            = "45"
+   protocol            = "HTTP"
+   matcher             = "200-299"
+   timeout             = "20"
+   path                = "/health"
+   unhealthy_threshold = "5"
+  }
+  depends_on = [aws_lb.ref]
 }
 
 
@@ -194,6 +214,18 @@ resource "aws_alb_listener" "ref_http" {
  
   default_action {
    target_group_arn = aws_alb_target_group.ref.arn
+   type             = "forward" 
+  }
+  depends_on = [aws_lb.ref]
+}
+
+resource "aws_alb_listener" "stellar_observer" {
+  load_balancer_arn = aws_lb.ref.arn
+  port              = 8083
+  protocol          = "HTTP"
+ 
+  default_action {
+   target_group_arn = aws_alb_target_group.stellar_observer.arn
    type             = "forward" 
   }
   depends_on = [aws_lb.ref]

--- a/docs/resources/deployment-examples/example-fargate/terraform/security-groups.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/security-groups.tf
@@ -55,7 +55,7 @@ resource "aws_security_group" "ref_alb" {
   ingress {
    protocol         = "tcp"
    from_port        = 8081
-   to_port          = 8081
+   to_port          = 8083
    cidr_blocks      = ["0.0.0.0/0"]
    ipv6_cidr_blocks = ["::/0"]
   }

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "sep" {
 
 resource "aws_ecs_service" "stellar_observer" {
  name                               = "${var.environment}-stellar-observer-service"
- cluster                            = aws_ecs_cluster.sep.id
+ cluster                            = aws_ecs_cluster.ref.id
  task_definition                    = aws_ecs_task_definition.stellar_observer.arn
  desired_count                      = 1
  deployment_minimum_healthy_percent = 100

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "stellar_observer" {
  scheduling_strategy                = "REPLICA"
  
  network_configuration {
-   security_groups  = [aws_security_group.sep.id]
+   security_groups  = [aws_security_group.ref.id]
    subnets          = module.vpc.private_subnets
    assign_public_ip = false
  }

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -44,7 +44,7 @@ resource "aws_ecs_service" "stellar_observer" {
  
  load_balancer {
    target_group_arn = aws_alb_target_group.stellar_observer.arn
-   container_name   = "${var.environment}-sep"
+   container_name   = "${var.environment}-stellar-observer"
    container_port   = 8083
  }
  

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -48,8 +48,8 @@ resource "aws_ecs_service" "stellar_observer" {
    container_port   = 8083
  }
  
- #lifecycle {
- #  ignore_changes = [task_definition, desired_count]
- #}
+ lifecycle {
+   ignore_changes = [task_definition, desired_count]
+ }
  
 }

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -25,3 +25,31 @@ resource "aws_ecs_service" "sep" {
  #}
  
 }
+
+esource "aws_ecs_service" "stellar_observer" {
+ name                               = "${var.environment}-stellar-observer-service"
+ cluster                            = aws_ecs_cluster.sep.id
+ task_definition                    = aws_ecs_task_definition.stellar_observer.arn
+ desired_count                      = 1
+ deployment_minimum_healthy_percent = 100
+ deployment_maximum_percent         = 200
+ launch_type                        = "FARGATE"
+ scheduling_strategy                = "REPLICA"
+ 
+ network_configuration {
+   security_groups  = [aws_security_group.sep.id]
+   subnets          = module.vpc.private_subnets
+   assign_public_ip = false
+ }
+ 
+ load_balancer {
+   target_group_arn = aws_alb_target_group.stellar_observer.arn
+   container_name   = "${var.environment}-sep"
+   container_port   = 8083
+ }
+ 
+ #lifecycle {
+ #  ignore_changes = [task_definition, desired_count]
+ #}
+ 
+}

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "sep" {
  
 }
 
-esource "aws_ecs_service" "stellar_observer" {
+resource "aws_ecs_service" "stellar_observer" {
  name                               = "${var.environment}-stellar-observer-service"
  cluster                            = aws_ecs_cluster.sep.id
  task_definition                    = aws_ecs_task_definition.stellar_observer.arn

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "sep" {
 
 resource "aws_ecs_service" "stellar_observer" {
  name                               = "${var.environment}-stellar-observer-service"
- cluster                            = aws_ecs_cluster.ref_alb.id
+ cluster                            = aws_ecs_cluster.ref.id
  task_definition                    = aws_ecs_task_definition.stellar_observer.arn
  desired_count                      = 1
  deployment_minimum_healthy_percent = 100
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "stellar_observer" {
  scheduling_strategy                = "REPLICA"
  
  network_configuration {
-   security_groups  = [aws_security_group.sep.id]
+   security_groups  = [aws_security_group.ref_alb.id]
    subnets          = module.vpc.private_subnets
    assign_public_ip = false
  }
@@ -48,8 +48,8 @@ resource "aws_ecs_service" "stellar_observer" {
    container_port   = 8083
  }
  
- #lifecycle {
- #  ignore_changes = [task_definition, desired_count]
- #}
+ lifecycle {
+   ignore_changes = [task_definition, desired_count]
+ }
  
 }

--- a/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/sep_service.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "sep" {
 
 resource "aws_ecs_service" "stellar_observer" {
  name                               = "${var.environment}-stellar-observer-service"
- cluster                            = aws_ecs_cluster.ref.id
+ cluster                            = aws_ecs_cluster.ref_alb.id
  task_definition                    = aws_ecs_task_definition.stellar_observer.arn
  desired_count                      = 1
  deployment_minimum_healthy_percent = 100
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "stellar_observer" {
  scheduling_strategy                = "REPLICA"
  
  network_configuration {
-   security_groups  = [aws_security_group.ref.id]
+   security_groups  = [aws_security_group.sep.id]
    subnets          = module.vpc.private_subnets
    assign_public_ip = false
  }
@@ -48,8 +48,8 @@ resource "aws_ecs_service" "stellar_observer" {
    container_port   = 8083
  }
  
- lifecycle {
-   ignore_changes = [task_definition, desired_count]
- }
+ #lifecycle {
+ #  ignore_changes = [task_definition, desired_count]
+ #}
  
 }

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "stellar-observer" {
    name        = "${var.environment}-stellar-observer-service" 
    image       = "stellar/anchor-platform:${var.image_tag}"
    dependsOn =  [ {
-     containerName = "${var.environment}-stellar-observe-config"
+     containerName = "${var.environment}-stellar-observer-config"
      condition = "START"
    }]
    #entryPoint = ["/anchor_config/sep.sh"]

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -104,8 +104,8 @@ resource "aws_ecs_task_definition" "stellar_observer" {
             }
    portMappings = [{
      protocol      = "tcp"
-     containerPort = 8080
-     hostPort      = 8080
+     containerPort = 8083
+     hostPort      = 8083
    }]
   }
   ])

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "stellar_observer" {
                 }
             }
   },{
-   name        = "${var.environment}-stellar-observer-service" 
+   name        = "${var.environment}-stellar-observer" 
    image       = "stellar/anchor-platform:${var.image_tag}"
    dependsOn =  [ {
      containerName = "${var.environment}-stellar-observer-config"

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -1,4 +1,4 @@
-resource "aws_ecs_task_definition" "stellar-observer" {
+resource "aws_ecs_task_definition" "stellar_observer" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = 256

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -1,4 +1,4 @@
-resource "aws_ecs_task_definition" "sep" {
+resource "aws_ecs_task_definition" "stellar-observer" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = 256
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "sep" {
                 }
             }
   },{
-   name        = "${var.environment}-sep" //?
+   name        = "${var.environment}-stellar-observer" 
    image       = "stellar/anchor-platform:${var.image_tag}"
    dependsOn =  [ {
      containerName = "${var.environment}-stellar-observer"

--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_stellar_observer.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_task_definition" "stellar-observer" {
   }
   
   container_definitions = jsonencode([{
-   name        = "${var.environment}-stellar-observer"
+   name        = "${var.environment}-stellar-observer-config"
    image       = "${var.aws_account}.dkr.ecr.${var.aws_region}.amazonaws.com/${aws_ecr_repository.anchor_config.name}:latest"
    entryPoint  = ["/copy_config.sh"]
    
@@ -34,10 +34,10 @@ resource "aws_ecs_task_definition" "stellar-observer" {
                 }
             }
   },{
-   name        = "${var.environment}-stellar-observer" 
+   name        = "${var.environment}-stellar-observer-service" 
    image       = "stellar/anchor-platform:${var.image_tag}"
    dependsOn =  [ {
-     containerName = "${var.environment}-stellar-observer"
+     containerName = "${var.environment}-stellar-observe-config"
      condition = "START"
    }]
    #entryPoint = ["/anchor_config/sep.sh"]


### PR DESCRIPTION
This pull request fixes payment observer terraform.  It ensures resource naming is unique and adds the required service resources to enable payment observer as a separate service.

note, this was tested by deploying to fresh AWS account using terraform cloud and using stellar tests validation

### Why

introduction of payment observer task definition broke terraform for anchor playform for fargate.

## JIRA
https://stellarorg.atlassian.net/browse/ANCHOR-62