### PR TITLE
fix sep10 signing seed env variable name

### DIFF
--- a/docs/resources/deployment-examples/example-fargate/terraform/task_def_sep.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/task_def_sep.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_task_definition" "sep" {
         "valueFrom": data.aws_ssm_parameter.sqlite_password.arn
       },
       {
-        "name": "SEP_10_SIGNING_SEED",
+        "name": "SEP10_SIGNING_SEED",
         "valueFrom": data.aws_ssm_parameter.sep10_signing_seed.arn
       },
       {


### PR DESCRIPTION
This PR is a hotfix to align the Fargate SEP10_SIGNING_SEED task definition container environment variable with the configuration file placeholder.]
_
Currently the configuration that gets deployed expects a variable named SEP10_SIGNING_SEED
```
      sep10:
        enabled: true
        homeDomain: anchor-sep-preview-id.previews.kube001.services.stellar-ops.com
        signingSeed: ${SEP10_SIGNING_SEED}
```
the Fargate Task Definition environment variable name is incorrectly named SEP_10_SIGNING_SEED
in this case, sep10 defaults (in code) are used.
