### PR TITLE
platform: [ANCHOR-105] Disable Kafka client if events.publisher.type is not KAFKA or event service is not enabled

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/EventBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/EventBeans.java
@@ -31,23 +31,26 @@ public class EventBeans {
     EventService eventService = new EventService(eventConfig);
     if (!eventConfig.isEnabled()) {
       eventService.setEventPublisher(new NoopEventPublisher());
-    }
-    String publisherType = eventConfig.getPublisher().getType();
-    switch (publisherType) {
-      case "kafka":
-        eventService.setEventPublisher(
-            KafkaEventPublisher.getInstance(eventConfig.getPublisher().getKafka()));
-        break;
-      case "sqs":
-        eventService.setEventPublisher(new SqsEventPublisher(eventConfig.getPublisher().getSqs()));
-        break;
-      case "msk":
-        eventService.setEventPublisher(new MskEventPublisher(eventConfig.getPublisher().getMsk()));
-        break;
-      default:
-        errorF("Invalid event publisher: {}", publisherType);
-        throw new InvalidConfigException(
-            String.format("Invalid event publisher: %s", publisherType));
+    } else {
+      String publisherType = eventConfig.getPublisher().getType();
+      switch (publisherType) {
+        case "kafka":
+          eventService.setEventPublisher(
+              KafkaEventPublisher.getInstance(eventConfig.getPublisher().getKafka()));
+          break;
+        case "sqs":
+          eventService.setEventPublisher(
+              new SqsEventPublisher(eventConfig.getPublisher().getSqs()));
+          break;
+        case "msk":
+          eventService.setEventPublisher(
+              new MskEventPublisher(eventConfig.getPublisher().getMsk()));
+          break;
+        default:
+          errorF("Invalid event publisher: {}", publisherType);
+          throw new InvalidConfigException(
+              String.format("Invalid event publisher: %s", publisherType));
+      }
     }
 
     return eventService;

--- a/platform/src/main/java/org/stellar/anchor/platform/event/KafkaEventPublisher.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/KafkaEventPublisher.java
@@ -32,6 +32,10 @@ public class KafkaEventPublisher implements EventPublisher {
     props.put(RETRIES_CONFIG, kafkaConfig.getRetries());
     props.put(LINGER_MS_CONFIG, kafkaConfig.getLingerMs());
     props.put(BATCH_SIZE_CONFIG, kafkaConfig.getBatchSize());
+    // reconnect back-off is 1 second
+    props.put(RECONNECT_BACKOFF_MS_CONFIG, "1000");
+    // maximum reconnect back-off is 10 seconds
+    props.put(RECONNECT_BACKOFF_MAX_MS_CONFIG, "10000");
 
     createPublisher(props);
   }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What
Fix ANCHOR-105.

- Set Kafka producer backoff timer starting from 1 second and max at 20 seconds.
- Disable Kafka producer if event service is not enabled.

### Why

Bug fixes.

### Known limitations

N/A