### PR TITLE
core: [ANCHOR-49] Make PropertySep1Config.type as an enum

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
@@ -1,10 +1,31 @@
 package org.stellar.anchor.config;
 
+import org.stellar.anchor.api.exception.InvalidConfigException;
+
 @SuppressWarnings("unused")
 public interface Sep1Config {
   boolean isEnabled();
 
-  String getType();
+  TomlType getType();
 
   String getValue();
+
+  enum TomlType {
+    STRING,
+    FILE,
+    URL;
+
+    public static TomlType fromString(String name) throws InvalidConfigException {
+      if (name == null) return null;
+      switch (name.toLowerCase()) {
+        case "string":
+          return STRING;
+        case "file":
+          return FILE;
+        case "url":
+          return URL;
+      }
+      throw new InvalidConfigException(String.format("Invalid sep1.type:[%s]", name));
+    }
+  }
 }

--- a/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.config;
 
 import org.stellar.anchor.api.exception.InvalidConfigException;
+import org.stellar.anchor.util.StringHelper;
 
 @SuppressWarnings("unused")
 public interface Sep1Config {
@@ -16,7 +17,7 @@ public interface Sep1Config {
     URL;
 
     public static TomlType fromString(String name) throws InvalidConfigException {
-      if (name == null) return null;
+      if (StringHelper.isEmpty(name)) name = "";
       switch (name.toLowerCase()) {
         case "string":
           return STRING;

--- a/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
@@ -24,16 +24,16 @@ public class Sep1Service {
   public Sep1Service(Sep1Config sep1Config) throws IOException, InvalidConfigException {
     if (sep1Config.isEnabled()) {
       debug("sep1Config:", sep1Config);
-      switch (sep1Config.getType().toLowerCase()) {
-        case "string":
+      switch (sep1Config.getType()) {
+        case STRING:
           debug("reading stellar.toml from config[sep1.toml.value]");
           tomlValue = sep1Config.getValue();
           break;
-        case "file":
+        case FILE:
           debugF("reading stellar.toml from {}", sep1Config.getValue());
           tomlValue = Files.readString(Path.of(sep1Config.getValue()));
           break;
-        case "url":
+        case URL:
           debugF("reading stellar.toml from {}", sep1Config.getValue());
           tomlValue = NetUtil.fetch(sep1Config.getValue());
           break;

--- a/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
@@ -11,9 +11,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertThrows
-import org.stellar.anchor.api.exception.InvalidConfigException
 import org.stellar.anchor.config.Sep1Config
+import org.stellar.anchor.config.Sep1Config.TomlType.*
 import org.stellar.anchor.util.NetUtil
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -36,7 +35,7 @@ internal class Sep1ServiceTest {
   @Test
   fun `test string type`() {
     every { sep1Config.isEnabled } returns true
-    every { sep1Config.type } returns "string"
+    every { sep1Config.type } returns STRING
     every { sep1Config.value } returns "toml content"
     val sep1Service = Sep1Service(sep1Config)
     assertEquals("toml content", sep1Service.stellarToml)
@@ -47,7 +46,7 @@ internal class Sep1ServiceTest {
     mockkStatic(Files::class)
     every { Files.readString(any()) } returns "toml content"
     every { sep1Config.isEnabled } returns true
-    every { sep1Config.type } returns "file"
+    every { sep1Config.type } returns FILE
     every { sep1Config.value } returns "toml_file_path"
 
     val sep1Service = Sep1Service(sep1Config)
@@ -59,19 +58,10 @@ internal class Sep1ServiceTest {
     mockkStatic(NetUtil::class)
     every { NetUtil.fetch(any()) } returns "toml content"
     every { sep1Config.isEnabled } returns true
-    every { sep1Config.type } returns "url"
+    every { sep1Config.type } returns URL
     every { sep1Config.value } returns "toml_file_path"
 
     val sep1Service = Sep1Service(sep1Config)
     assertEquals("toml content", sep1Service.stellarToml)
-  }
-
-  @Test
-  fun `test bad type`() {
-    every { sep1Config.isEnabled } returns true
-    every { sep1Config.type } returns "bad"
-    every { sep1Config.value } returns "toml_file_path"
-
-    assertThrows<InvalidConfigException> { Sep1Service(sep1Config) }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep1Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep1Config.java
@@ -1,7 +1,5 @@
 package org.stellar.anchor.platform.config;
 
-import static org.stellar.anchor.util.StringHelper.isEmpty;
-
 import java.io.File;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -22,7 +20,7 @@ public class PropertySep1Config implements Sep1Config, Validator {
   boolean enabled;
 
   @Value("${sep1.toml.type:#{null}}")
-  String type;
+  TomlType type;
 
   @Value("${sep1.toml.value:#{null}}")
   String value;
@@ -43,11 +41,11 @@ public class PropertySep1Config implements Sep1Config, Validator {
   }
 
   void validateTomlTypeAndValue(Sep1Config config, Errors errors) {
-    if (isEmpty(config.getType())) {
+    if (config.getType() == null) {
       errors.rejectValue("type", "sep1-toml-type-empty", "sep1.toml.type must not be empty");
     } else {
-      switch (config.getType().toLowerCase()) {
-        case "string":
+      switch (config.getType()) {
+        case STRING:
           try {
             Sep1Helper.parse(config.getValue());
           } catch (IllegalStateException isex) {
@@ -58,7 +56,7 @@ public class PropertySep1Config implements Sep1Config, Validator {
                     "sep1.toml.value does not contain a valid TOML. %s", isex.getMessage()));
           }
           break;
-        case "url":
+        case URL:
           if (!NetUtil.isUrlValid(config.getValue())) {
             errors.rejectValue(
                 "value",
@@ -66,7 +64,7 @@ public class PropertySep1Config implements Sep1Config, Validator {
                 String.format("sep1.toml.value=%s is not a valid URL", config.getValue()));
           }
           break;
-        case "file":
+        case FILE:
           File file = new File(config.getValue());
           if (!file.exists()) {
             errors.rejectValue(

--- a/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
@@ -6,6 +6,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.stellar.anchor.config.Sep1Config.TomlType.*
 import org.stellar.anchor.platform.config.PropertySep1Config
 import org.stellar.anchor.platform.config.Sep1ConfigTest
 import org.stellar.anchor.sep1.Sep1Service
@@ -46,14 +47,14 @@ class Sep1ServiceTest {
   @Test
   fun `test Sep1Service reading toml from inline string`() {
 
-    val config = PropertySep1Config(true, "string", stellarToml)
+    val config = PropertySep1Config(true, STRING, stellarToml)
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, stellarToml)
   }
 
   @Test
   fun `test Sep1Service reading toml from file`() {
-    val config = PropertySep1Config(true, "file", Sep1ConfigTest.getTestTomlAsFile())
+    val config = PropertySep1Config(true, FILE, Sep1ConfigTest.getTestTomlAsFile())
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, Files.readString(Path.of(Sep1ConfigTest.getTestTomlAsFile())))
   }
@@ -65,7 +66,7 @@ class Sep1ServiceTest {
     val mockAnchorUrl = mockServer.url("").toString()
     mockServer.enqueue(MockResponse().setBody(stellarToml))
 
-    val config = PropertySep1Config(true, "url", mockAnchorUrl)
+    val config = PropertySep1Config(true, URL, mockAnchorUrl)
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, stellarToml)
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep1ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep1ConfigTest.kt
@@ -63,9 +63,9 @@ class Sep1ConfigTest {
   @ParameterizedTest
   @ValueSource(strings = ["bad", "strin g"])
   fun `test bad Sep1Config values`(type: String?) {
-    val errors = validate(PropertySep1Config(true, fromString(type), getTestTomlAsUrl()))
-    assertEquals(1, errors.errorCount)
-    assertEquals("sep1-toml-type-invalid", errors.allErrors[0].code)
+    assertThrows<InvalidConfigException> {
+      validate(PropertySep1Config(true, fromString(type), getTestTomlAsUrl()))
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Make PropertySep1Config.type as an enum

### Why

N/A

### Known limitations

N/A