### PR TITLE
all: [ANCHOR-95] Removed MetricsConfig interface

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/MetricConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/MetricConfig.java
@@ -1,7 +1,0 @@
-package org.stellar.anchor.config;
-
-public interface MetricConfig {
-  boolean isExtrasEnabled();
-
-  Integer getRunInterval();
-}

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/MetricsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/MetricsBeans.java
@@ -3,8 +3,7 @@ package org.stellar.anchor.platform.component.share;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.stellar.anchor.config.MetricConfig;
-import org.stellar.anchor.platform.config.PropertyMetricConfig;
+import org.stellar.anchor.platform.config.MetricConfig;
 import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
 import org.stellar.anchor.platform.service.MetricEmitterService;
 
@@ -17,7 +16,7 @@ public class MetricsBeans {
   @Bean
   @ConfigurationProperties(prefix = "metrics")
   MetricConfig metricConfig() {
-    return new PropertyMetricConfig();
+    return new MetricConfig();
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/config/MetricConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/MetricConfig.java
@@ -5,10 +5,9 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.stellar.anchor.config.AppConfig;
-import org.stellar.anchor.config.MetricConfig;
 
 @Data
-public class PropertyMetricConfig implements MetricConfig, Validator {
+public class MetricConfig implements Validator {
   private boolean enabled = false;
   private boolean extrasEnabled = false;
   private Integer runInterval = 30;
@@ -21,10 +20,5 @@ public class PropertyMetricConfig implements MetricConfig, Validator {
   @Override
   public void validate(@NotNull Object target, @NotNull Errors errors) {
     System.out.println("here");
-  }
-
-  @Override
-  public boolean isExtrasEnabled() {
-    return this.extrasEnabled;
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import org.stellar.anchor.config.MetricConfig;
+import org.stellar.anchor.platform.config.MetricConfig;
 import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
 import org.stellar.anchor.util.Log;
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

1. Removed `MetricsConfig` interface.
2. Renamed `PropertyMetricsConfig` to `MetricsConfig`.

### Why

`MetricsConfig` interface is not necessary

### Known limitations
N/A