### PR TITLE
[Anchor-149] Fix customer type not being properly resolved (when multiple types are configured)

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/service/CustomerService.java
@@ -33,6 +33,14 @@ public class CustomerService {
       if (maybeCustomer.isEmpty()) {
         throw new NotFoundException(
             String.format("customer for 'id' '%s' not found", request.getId()));
+      } else if (request.getType() != null) {
+        if (!request.getType().equals("sep31-sender")
+            && !request.getType().equals("sep31-receiver")) {
+          throw new NotFoundException(
+              String.format(
+                  "customer for 'id' '%s' and 'type' '%s' not found",
+                  request.getId(), request.getType()));
+        }
       }
     } else {
       maybeCustomer =

--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/Sep31AmbiguousCustomerInfoException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/Sep31AmbiguousCustomerInfoException.java
@@ -1,0 +1,13 @@
+package org.stellar.anchor.api.exception;
+
+public class Sep31AmbiguousCustomerInfoException extends AnchorException {
+  private final String type;
+
+  public Sep31AmbiguousCustomerInfoException(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -539,21 +539,49 @@ public class Sep31Service {
       throw new BadRequestException("receiver_id cannot be empty.");
     }
 
-    // TODO: Populate customer type with the first receiver type; this is a temporary fix for cases
-    // where customerType is required
     Sep12Operation sep12Operation = Context.get().getAsset().getSep31().getSep12();
-    String receiverType = null;
+    Sep12GetCustomerResponse receiver;
+
+    // Fix for https://github.com/stellar/java-stellar-anchor-sdk/issues/717 (ANCHOR-149)
+    // TODO: check if there is a better way to do it, i.e. request a type first for a customer OR
+    // stop iteration after first hit.
     if (sep12Operation != null) {
-      Optional<String> receiverTypeOptional =
-          sep12Operation.getReceiver().getTypes().keySet().stream().findFirst();
-      receiverType = receiverTypeOptional.orElse(null);
-    }
-    Sep12GetCustomerRequest request =
-        Sep12GetCustomerRequest.builder().id(receiverId).type(receiverType).build();
-    Sep12GetCustomerResponse receiver = this.customerIntegration.getCustomer(request);
-    if (receiver == null || receiver.getStatus() != Sep12Status.ACCEPTED) {
-      infoF("Customer (receiver) info needed for request ({})", Context.get().getRequest());
-      throw new Sep31CustomerInfoNeededException("sep31-receiver");
+      Set<String> types = sep12Operation.getReceiver().getTypes().keySet();
+      List<Sep12GetCustomerRequest> requests =
+          types.stream()
+              .map(type -> Sep12GetCustomerRequest.builder().id(receiverId).type(type).build())
+              .collect(Collectors.toList());
+      List<Sep12GetCustomerResponse> responses = new ArrayList<>();
+
+      for (Sep12GetCustomerRequest request : requests) {
+        responses.add(this.customerIntegration.getCustomer(request));
+      }
+
+      List<Sep12GetCustomerResponse> accepted =
+          responses.stream()
+              .filter(Objects::nonNull)
+              .filter(x -> x.getStatus() == Sep12Status.ACCEPTED)
+              .collect(Collectors.toList());
+
+      if (accepted.isEmpty()) {
+        infoF("Customer (receiver) info needed for request ({})", Context.get().getRequest());
+        throw new Sep31CustomerInfoNeededException(types.toString());
+      }
+      if (accepted.size() != 1) {
+        infoF(
+            "Ambiguous customer info for request ({}) having multiple accepted responses ({})",
+            Context.get().getRequest(),
+            accepted);
+        throw new Sep31AmbiguousCustomerInfoException(accepted.toString());
+      }
+    } else {
+      Sep12GetCustomerRequest request = Sep12GetCustomerRequest.builder().id(receiverId).build();
+
+      receiver = this.customerIntegration.getCustomer(request);
+      if (receiver == null || receiver.getStatus() != Sep12Status.ACCEPTED) {
+        infoF("Customer (receiver) info needed for request ({})", Context.get().getRequest());
+        throw new Sep31CustomerInfoNeededException("sep31-receiver");
+      }
     }
 
     String senderId = Context.get().getRequest().getSenderId();
@@ -562,20 +590,43 @@ public class Sep31Service {
       throw new BadRequestException("sender_id cannot be empty.");
     }
 
-    // TODO: Populate customer type with the first sender type; this is a temporary fix for cases
-    // where customerType is required
-    String senderType = null;
     if (sep12Operation != null) {
-      Optional<String> senderTypeOptional =
-          Context.get().getAsset().getSep31().getSep12().getSender().getTypes().keySet().stream()
-              .findFirst();
-      senderType = senderTypeOptional.orElse(null);
-    }
-    request = Sep12GetCustomerRequest.builder().id(senderId).type(senderType).build();
-    Sep12GetCustomerResponse sender = this.customerIntegration.getCustomer(request);
-    if (sender == null || sender.getStatus() != Sep12Status.ACCEPTED) {
-      infoF("Customer (sender) info needed for request ({})", Context.get().getRequest());
-      throw new Sep31CustomerInfoNeededException("sep31-sender");
+      Set<String> types = sep12Operation.getSender().getTypes().keySet();
+      List<Sep12GetCustomerRequest> requests =
+          types.stream()
+              .map(type -> Sep12GetCustomerRequest.builder().id(senderId).type(type).build())
+              .collect(Collectors.toList());
+      List<Sep12GetCustomerResponse> responses = new ArrayList<>();
+
+      for (Sep12GetCustomerRequest request : requests) {
+        responses.add(this.customerIntegration.getCustomer(request));
+      }
+
+      List<Sep12GetCustomerResponse> accepted =
+          responses.stream()
+              .filter(Objects::nonNull)
+              .filter(x -> x.getStatus() == Sep12Status.ACCEPTED)
+              .collect(Collectors.toList());
+
+      if (accepted.isEmpty()) {
+        infoF("Customer (sender) info needed for request ({})", Context.get().getRequest());
+        throw new Sep31CustomerInfoNeededException(types.toString());
+      }
+      if (accepted.size() != 1) {
+        infoF(
+            "Ambiguous customer (sender) info for request ({}) having multiple accepted responses ({})",
+            Context.get().getRequest(),
+            accepted);
+        throw new Sep31AmbiguousCustomerInfoException(accepted.toString());
+      }
+    } else {
+      Sep12GetCustomerRequest request = Sep12GetCustomerRequest.builder().id(senderId).build();
+
+      Sep12GetCustomerResponse sender = this.customerIntegration.getCustomer(request);
+      if (sender == null || sender.getStatus() != Sep12Status.ACCEPTED) {
+        infoF("Customer (sender) info needed for request ({})", Context.get().getRequest());
+        throw new Sep31CustomerInfoNeededException("sep31-sender");
+      }
     }
   }
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -554,7 +554,11 @@ public class Sep31Service {
       List<Sep12GetCustomerResponse> responses = new ArrayList<>();
 
       for (Sep12GetCustomerRequest request : requests) {
-        responses.add(this.customerIntegration.getCustomer(request));
+        try {
+          responses.add(this.customerIntegration.getCustomer(request));
+        } catch (AnchorException e) {
+          infoF("Failed to get customer (receiver) info with an error ({})", e);
+        }
       }
 
       List<Sep12GetCustomerResponse> accepted =
@@ -599,7 +603,11 @@ public class Sep31Service {
       List<Sep12GetCustomerResponse> responses = new ArrayList<>();
 
       for (Sep12GetCustomerRequest request : requests) {
-        responses.add(this.customerIntegration.getCustomer(request));
+        try {
+          responses.add(this.customerIntegration.getCustomer(request));
+        } catch (AnchorException e) {
+          infoF("Failed to get customer (sender) info with an error ({})", e);
+        }
       }
 
       List<Sep12GetCustomerResponse> accepted =

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -607,7 +607,10 @@ class Sep31ServiceTest {
     postTxRequest.receiverId = "receiver_foo"
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31CustomerInfoNeededException::class.java, ex)
-    assertEquals("sep31-receiver", (ex as Sep31CustomerInfoNeededException).type)
+    assertEquals(
+      "[sep31-receiver, sep31-foreign-receiver]",
+      (ex as Sep31CustomerInfoNeededException).type
+    )
 
     // receiver status is not ACCEPTED
     val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
@@ -618,7 +621,10 @@ class Sep31ServiceTest {
     every { customerIntegration.getCustomer(request) } returns mockReceiver
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31CustomerInfoNeededException::class.java, ex)
-    assertEquals("sep31-receiver", (ex as Sep31CustomerInfoNeededException).type)
+    assertEquals(
+      "[sep31-receiver, sep31-foreign-receiver]",
+      (ex as Sep31CustomerInfoNeededException).type
+    )
 
     // missing sender_id
     mockReceiver.status = Sep12Status.ACCEPTED
@@ -631,7 +637,10 @@ class Sep31ServiceTest {
     postTxRequest.senderId = "sender_bar"
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31CustomerInfoNeededException::class.java, ex)
-    assertEquals("sep31-sender", (ex as Sep31CustomerInfoNeededException).type)
+    assertEquals(
+      "[sep31-sender, sep31-large-sender, sep31-foreign-sender]",
+      (ex as Sep31CustomerInfoNeededException).type
+    )
 
     // sender status is not ACCEPTED
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
@@ -642,7 +651,10 @@ class Sep31ServiceTest {
     every { customerIntegration.getCustomer(request) } returns mockSender
     ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(Sep31CustomerInfoNeededException::class.java, ex)
-    assertEquals("sep31-sender", (ex as Sep31CustomerInfoNeededException).type)
+    assertEquals(
+      "[sep31-sender, sep31-large-sender, sep31-foreign-sender]",
+      (ex as Sep31CustomerInfoNeededException).type
+    )
 
     // ----- QUOTE_ID IS USED ⬇️ -----
     // not found quote_id
@@ -734,7 +746,11 @@ class Sep31ServiceTest {
     // Make sure we can get the sender and receiver customers
     val mockCustomer = Sep12GetCustomerResponse()
     mockCustomer.status = Sep12Status.ACCEPTED
-    every { customerIntegration.getCustomer(any()) } returns mockCustomer
+    val sep31Receiver =
+      Sep12GetCustomerRequest.builder().id(receiverId).type("sep31-receiver").build()
+    val sep31Sender = Sep12GetCustomerRequest.builder().id(senderId).type("sep31-sender").build()
+    every { customerIntegration.getCustomer(sep31Receiver) } returns mockCustomer
+    every { customerIntegration.getCustomer(sep31Sender) } returns mockCustomer
 
     // mock sep31 deposit info generation
     val txForDepositInfoGenerator = slot<Sep31Transaction>()
@@ -885,7 +901,11 @@ class Sep31ServiceTest {
     // Make sure we can get the sender and receiver customers
     val mockCustomer = Sep12GetCustomerResponse()
     mockCustomer.status = Sep12Status.ACCEPTED
-    every { customerIntegration.getCustomer(any()) } returns mockCustomer
+    val sep31Receiver =
+      Sep12GetCustomerRequest.builder().id(receiverId).type("sep31-receiver").build()
+    val sep31Sender = Sep12GetCustomerRequest.builder().id(senderId).type("sep31-sender").build()
+    every { customerIntegration.getCustomer(sep31Receiver) } returns mockCustomer
+    every { customerIntegration.getCustomer(sep31Sender) } returns mockCustomer
 
     // POST transaction
     val jwtToken = TestHelper.createJwtToken()

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -901,6 +901,63 @@ class Sep31ServiceTest {
   }
 
   @Test
+  fun `test post transaction multiple types`() {
+    quote.sellAsset = stellarUSDC
+    every { quoteStore.findByQuoteId("my_quote_id") } returns quote
+
+    Context.get().setAsset(asset)
+    val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
+    val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
+    val postTxRequest = Sep31PostTransactionRequest()
+    postTxRequest.amount = "100"
+    postTxRequest.assetCode = "USDC"
+    postTxRequest.assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    postTxRequest.senderId = senderId
+    postTxRequest.receiverId = receiverId
+    postTxRequest.quoteId = "my_quote_id"
+    postTxRequest.fields =
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "1",
+          "receiver_routing_number" to "SWIFT",
+        ),
+      )
+
+    // Make sure we can get the sender and receiver customers
+    val mockCustomer = Sep12GetCustomerResponse()
+    mockCustomer.status = Sep12Status.ACCEPTED
+
+    val sep31Receiver =
+      Sep12GetCustomerRequest.builder().id(receiverId).type("sep31-receiver").build()
+    val sep31ForeignReceiver =
+      Sep12GetCustomerRequest.builder().id(receiverId).type("sep31-foreign-receiver").build()
+    val sep31Sender = Sep12GetCustomerRequest.builder().id(senderId).type("sep31-sender").build()
+
+    every { customerIntegration.getCustomer(sep31Receiver) } returns null
+    every { customerIntegration.getCustomer(sep31ForeignReceiver) } returns mockCustomer
+    every { customerIntegration.getCustomer(sep31Sender) } returns mockCustomer
+
+    // mock eventService
+    val txEventSlot = slot<TransactionEvent>()
+    every { eventPublishService.publish(capture(txEventSlot)) } just Runs
+
+    // mock transaction save
+    val slotTxn = slot<Sep31Transaction>()
+    every { txnStore.save(capture(slotTxn)) } answers
+      {
+        firstArg<Sep31Transaction>().id = "ABC-123"
+        firstArg()
+      }
+
+    // POST transactionzZZ
+    val jwtToken = TestHelper.createJwtToken()
+    val t = sep31Service.postTransaction(jwtToken, postTxRequest)
+
+    println(t)
+  }
+
+  @Test
   fun `test post transaction when quote is not supported`() {
     every { sep31DepositInfoGenerator.generate(any()) } returns
       Sep31DepositInfo("GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I", "123456", "id")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Adding iteration over customer types in validateSenderAndReceiver.

### Why

Should fix #717. Previously, this method was searching for the customer with a first type in the map. Now, it searches for all types. 

### Known limitations

Customer types must be mutually exclusive (i.e. same customer can NOT have multiple types at the same time)