### PR TITLE
SEP-24: add `refund_memo` and `refund_memo_type` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ target/
 */bin/*
 */generated/*
 *.tgz
-
+.vscode

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -130,19 +130,21 @@ public class Sep24Service {
     }
 
     Memo memo = makeMemo(withdrawRequest.get("memo"), withdrawRequest.get("memo_type"));
-    Memo refundMemo = makeMemo(withdrawRequest.get("refund_memo"), withdrawRequest.get("refund_memo_type"));
+    Memo refundMemo =
+        makeMemo(withdrawRequest.get("refund_memo"), withdrawRequest.get("refund_memo_type"));
     String txnId = UUID.randomUUID().toString();
-    Sep24TransactionBuilder builder = new Sep24TransactionBuilder(txnStore)
-        .transactionId(txnId)
-        .status(INCOMPLETE.toString())
-        .kind(WITHDRAWAL.toString())
-        .amountExpected(strAmount)
-        .assetCode(assetCode)
-        .assetIssuer(withdrawRequest.get("asset_issuer"))
-        .startedAt(Instant.now())
-        .sep10Account(token.getAccount())
-        .fromAccount(sourceAccount)
-        .clientDomain(token.getClientDomain());
+    Sep24TransactionBuilder builder =
+        new Sep24TransactionBuilder(txnStore)
+            .transactionId(txnId)
+            .status(INCOMPLETE.toString())
+            .kind(WITHDRAWAL.toString())
+            .amountExpected(strAmount)
+            .assetCode(assetCode)
+            .assetIssuer(withdrawRequest.get("asset_issuer"))
+            .startedAt(Instant.now())
+            .sep10Account(token.getAccount())
+            .fromAccount(sourceAccount)
+            .clientDomain(token.getClientDomain());
 
     if (memo != null) {
       debug("transaction memo detected.", memo);
@@ -248,18 +250,19 @@ public class Sep24Service {
 
     Memo memo = makeMemo(depositRequest.get("memo"), depositRequest.get("memo_type"));
     String txnId = generateSepTransactionId();
-    Sep24TransactionBuilder builder = new Sep24TransactionBuilder(txnStore)
-        .transactionId(txnId)
-        .status(INCOMPLETE.toString())
-        .kind(Sep24Transaction.Kind.DEPOSIT.toString())
-        .amountExpected(strAmount)
-        .assetCode(assetCode)
-        .assetIssuer(depositRequest.get("asset_issuer"))
-        .startedAt(Instant.now())
-        .sep10Account(token.getAccount())
-        .toAccount(destinationAccount)
-        .clientDomain(token.getClientDomain())
-        .claimableBalanceSupported(claimableSupported);
+    Sep24TransactionBuilder builder =
+        new Sep24TransactionBuilder(txnStore)
+            .transactionId(txnId)
+            .status(INCOMPLETE.toString())
+            .kind(Sep24Transaction.Kind.DEPOSIT.toString())
+            .amountExpected(strAmount)
+            .assetCode(assetCode)
+            .assetIssuer(depositRequest.get("asset_issuer"))
+            .startedAt(Instant.now())
+            .sep10Account(token.getAccount())
+            .toAccount(destinationAccount)
+            .clientDomain(token.getClientDomain())
+            .claimableBalanceSupported(claimableSupported);
 
     if (memo != null) {
       debug("transaction memo detected.", memo);
@@ -298,7 +301,8 @@ public class Sep24Service {
           (txReq.getAssetCode() == null) ? "null" : txReq.getAssetCode());
       throw new SepValidationException("asset code not supported");
     }
-    List<Sep24Transaction> txns = txnStore.findTransactions(token.getAccount(), token.getAccountMemo(), txReq);
+    List<Sep24Transaction> txns =
+        txnStore.findTransactions(token.getAccount(), token.getAccountMemo(), txReq);
     GetTransactionsResponse result = new GetTransactionsResponse();
     List<TransactionResponse> list = new ArrayList<>();
     debugF("found {} transactions", txns.size());
@@ -392,14 +396,16 @@ public class Sep24Service {
     }
 
     // Calculate refund information.
-    AssetInfo assetInfo = assetService.getAsset(txn.getRequestAssetCode(), txn.getRequestAssetIssuer());
+    AssetInfo assetInfo =
+        assetService.getAsset(txn.getRequestAssetCode(), txn.getRequestAssetIssuer());
     return Sep24Helper.updateRefundInfo(response, txn, assetInfo);
   }
 
   public TransactionResponse fromDepositTxn(Sep24Transaction txn)
       throws MalformedURLException, URISyntaxException {
 
-    DepositTransactionResponse txnR = gson.fromJson(gson.toJson(txn), DepositTransactionResponse.class);
+    DepositTransactionResponse txnR =
+        gson.fromJson(gson.toJson(txn), DepositTransactionResponse.class);
 
     setSharedTransactionResponseFields(txnR, txn);
 
@@ -416,7 +422,8 @@ public class Sep24Service {
   public WithdrawTransactionResponse fromWithdrawTxn(Sep24Transaction txn)
       throws MalformedURLException, URISyntaxException {
 
-    WithdrawTransactionResponse txnR = gson.fromJson(gson.toJson(txn), WithdrawTransactionResponse.class);
+    WithdrawTransactionResponse txnR =
+        gson.fromJson(gson.toJson(txn), WithdrawTransactionResponse.class);
 
     setSharedTransactionResponseFields(txnR, txn);
 

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
@@ -24,24 +24,20 @@ public interface Sep24Transaction {
   void setTransactionId(String transactionId);
 
   /**
-   * <code>transaction_id</code> on Stellar network of the transfer that either
-   * completed the
+   * <code>transaction_id</code> on Stellar network of the transfer that either completed the
    * deposit or started the withdrawal.
    *
-   * @return The <code>stellar_transction_id</code> field of the SEP-24
-   *         transaction history.
+   * @return The <code>stellar_transction_id</code> field of the SEP-24 transaction history.
    */
   String getStellarTransactionId();
 
   void setStellarTransactionId(String stellarTransactionId);
 
   /**
-   * ID of transaction on external network that either started the deposit or
-   * completed the
+   * ID of transaction on external network that either started the deposit or completed the
    * withdrawal.
    *
-   * @return The <code>external_transction_id</code> field of the SEP-24
-   *         transaction history.
+   * @return The <code>external_transction_id</code> field of the SEP-24 transaction history.
    */
   String getExternalTransactionId();
 
@@ -75,8 +71,7 @@ public interface Sep24Transaction {
   void setStartedAt(Instant startedAt);
 
   /**
-   * The date and time of transaction reaching <code>completed</code> or
-   * <code>refunded</code>
+   * The date and time of transaction reaching <code>completed</code> or <code>refunded</code>
    * status.
    *
    * @return <code>completed</code> field of the SEP-24 transaction history.
@@ -95,10 +90,8 @@ public interface Sep24Transaction {
   void setRequestAssetCode(String assetCode);
 
   /**
-   * The issuer of the stellar asset the user wants to receive for their deposit
-   * with the anchor. If
-   * asset_issuer is not provided, the anchor should use the asset issued by
-   * themselves as described
+   * The issuer of the stellar asset the user wants to receive for their deposit with the anchor. If
+   * asset_issuer is not provided, the anchor should use the asset issued by themselves as described
    * in their TOML file.
    *
    * @return the asset issuer of the transaction's <code>asset_code</code> .
@@ -122,12 +115,10 @@ public interface Sep24Transaction {
   void setSep10Account(String sep10Account);
 
   /**
-   * If this is a withdrawal, this is the anchor's Stellar account that the user
-   * transferred (or
+   * If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or
    * will transfer) their issued asset to.
    *
-   * @return <code>withdraw_anchor_account</code> field of the SEP-24 transaction
-   *         history.
+   * @return <code>withdraw_anchor_account</code> field of the SEP-24 transaction history.
    */
   String getWithdrawAnchorAccount();
 
@@ -136,8 +127,7 @@ public interface Sep24Transaction {
   /**
    * If withdrawal, the Stellar account the assets were withdrawn from.
    *
-   * <p>
-   * If deposit, sent from address, perhaps BTC, IBAN, or bank account.
+   * <p>If deposit, sent from address, perhaps BTC, IBAN, or bank account.
    *
    * @return <code>from</code> field of the SEP-24 transaction history.
    */
@@ -146,12 +136,10 @@ public interface Sep24Transaction {
   void setFromAccount(String fromAccount);
 
   /**
-   * If withdrawal, sent to address (perhaps BTC, IBAN, or bank account in the
-   * case of a withdrawal,
+   * If withdrawal, sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal,
    * Stellar account in the case of a deposit).
    *
-   * <p>
-   * If deposit, the Stellar account the deposited assets were sent to.
+   * <p>If deposit, the Stellar account the deposited assets were sent to.
    *
    * @return <code>to</code> field of the SEP-24 transaction history.
    */
@@ -160,19 +148,14 @@ public interface Sep24Transaction {
   void setToAccount(String toAccount);
 
   /**
-   * If withdrawal, this is the memo used when the user transferred to
-   * withdraw_anchor_account.
-   * Assigned null if the withdraw is not ready to receive payment, for example if
-   * KYC is not
+   * If withdrawal, this is the memo used when the user transferred to withdraw_anchor_account.
+   * Assigned null if the withdraw is not ready to receive payment, for example if KYC is not
    * completed.
    *
-   * <p>
-   * If deposit, this is the memo (if any) used to transfer the asset to the to
-   * Stellar address
+   * <p>If deposit, this is the memo (if any) used to transfer the asset to the to Stellar address
    *
-   * @return <code>withdraw_memo</code> or <code>deposit_memo</code> of the SEP-24
-   *         transaction
-   *         history.
+   * @return <code>withdraw_memo</code> or <code>deposit_memo</code> of the SEP-24 transaction
+   *     history.
    */
   String getMemo();
 
@@ -181,9 +164,8 @@ public interface Sep24Transaction {
   /**
    * Type for the <code>memo</code> field.
    *
-   * @return <code>withdraw_memo_type</code> or <code>deposit_memo_type</code> of
-   *         the SEP-24
-   *         transaction history.
+   * @return <code>withdraw_memo_type</code> or <code>deposit_memo_type</code> of the SEP-24
+   *     transaction history.
    */
   String getMemoType();
 
@@ -199,8 +181,7 @@ public interface Sep24Transaction {
   void setClientDomain(String domainClient);
 
   /**
-   * True if the client supports receiving deposit transactions as a claimable
-   * balance, false
+   * True if the client supports receiving deposit transactions as a claimable balance, false
    * otherwise.
    *
    * @return <code>true</code> or <code>false</code>
@@ -210,8 +191,7 @@ public interface Sep24Transaction {
   void setClaimableBalanceSupported(Boolean claimableBalanceSupported);
 
   /**
-   * Amount received by anchor at start of transaction as a string with up to 7
-   * decimals. Excludes
+   * Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes
    * any fees charged before the anchor received the funds.
    *
    * @return <code>amount_in</code> field of the SEP-24 transaction history.
@@ -221,10 +201,8 @@ public interface Sep24Transaction {
   void setAmountIn(String amountIn);
 
   /**
-   * The asset received or to be received by the Anchor. Must be present if the
-   * deposit/withdraw was
-   * made using non-equivalent assets. The value must be in SEP-38 Asset
-   * Identification Format. See
+   * The asset received or to be received by the Anchor. Must be present if the deposit/withdraw was
+   * made using non-equivalent assets. The value must be in SEP-38 Asset Identification Format. See
    * the Asset Exchanges section for more information.
    *
    * @return <code>amount_in_asset</code> field of the SEP-24 transaction history.
@@ -234,8 +212,7 @@ public interface Sep24Transaction {
   void setAmountInAsset(String amountInAsset);
 
   /**
-   * Amount sent by anchor to user at end of transaction as a string with up to 7
-   * decimals. Excludes
+   * Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes
    * amount converted to XLM to fund account and any external fees.
    *
    * @return <code>amount_out</code> field of the SEP-24 transaction history.
@@ -247,8 +224,7 @@ public interface Sep24Transaction {
   /**
    * The asset of the <code>amount_out</code> field.
    *
-   * @return <code>amount_out_asset</code> field of the SEP-24 transaction
-   *         history.
+   * @return <code>amount_out_asset</code> field of the SEP-24 transaction history.
    */
   String getAmountOutAsset();
 
@@ -264,14 +240,11 @@ public interface Sep24Transaction {
   void setAmountFee(String amountFee);
 
   /**
-   * The asset in which fees are calculated in. Must be present if the
-   * deposit/withdraw was made
-   * using non-equivalent assets. The value must be in SEP-38 Asset Identification
-   * Format. See the
+   * The asset in which fees are calculated in. Must be present if the deposit/withdraw was made
+   * using non-equivalent assets. The value must be in SEP-38 Asset Identification Format. See the
    * Asset Exchanges section for more information.
    *
-   * @return <code>amount_fee_asset</code> field of the SEP-24 transaction
-   *         history.
+   * @return <code>amount_fee_asset</code> field of the SEP-24 transaction history.
    */
   String getAmountFeeAsset();
 
@@ -286,12 +259,10 @@ public interface Sep24Transaction {
   void setRefunds(Sep24Refunds refunds);
 
   /**
-   * The memo the anchor must use when sending refund payments back to the user.
-   * If not specified,
-   * the anchor should use the same memo used by the user to send the original
-   * payment.
-   * If specified, <code>refund_memo_type</code> must also be specified.
-   * 
+   * The memo the anchor must use when sending refund payments back to the user. If not specified,
+   * the anchor should use the same memo used by the user to send the original payment. If
+   * specified, <code>refund_memo_type</code> must also be specified.
+   *
    * @return <code>refund_memo</code> provided in the SEP-24 withdrawal request.
    */
   String getRefundMemo();

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
@@ -24,20 +24,24 @@ public interface Sep24Transaction {
   void setTransactionId(String transactionId);
 
   /**
-   * <code>transaction_id</code> on Stellar network of the transfer that either completed the
+   * <code>transaction_id</code> on Stellar network of the transfer that either
+   * completed the
    * deposit or started the withdrawal.
    *
-   * @return The <code>stellar_transction_id</code> field of the SEP-24 transaction history.
+   * @return The <code>stellar_transction_id</code> field of the SEP-24
+   *         transaction history.
    */
   String getStellarTransactionId();
 
   void setStellarTransactionId(String stellarTransactionId);
 
   /**
-   * ID of transaction on external network that either started the deposit or completed the
+   * ID of transaction on external network that either started the deposit or
+   * completed the
    * withdrawal.
    *
-   * @return The <code>external_transction_id</code> field of the SEP-24 transaction history.
+   * @return The <code>external_transction_id</code> field of the SEP-24
+   *         transaction history.
    */
   String getExternalTransactionId();
 
@@ -71,7 +75,8 @@ public interface Sep24Transaction {
   void setStartedAt(Instant startedAt);
 
   /**
-   * The date and time of transaction reaching <code>completed</code> or <code>refunded</code>
+   * The date and time of transaction reaching <code>completed</code> or
+   * <code>refunded</code>
    * status.
    *
    * @return <code>completed</code> field of the SEP-24 transaction history.
@@ -90,8 +95,10 @@ public interface Sep24Transaction {
   void setRequestAssetCode(String assetCode);
 
   /**
-   * The issuer of the stellar asset the user wants to receive for their deposit with the anchor. If
-   * asset_issuer is not provided, the anchor should use the asset issued by themselves as described
+   * The issuer of the stellar asset the user wants to receive for their deposit
+   * with the anchor. If
+   * asset_issuer is not provided, the anchor should use the asset issued by
+   * themselves as described
    * in their TOML file.
    *
    * @return the asset issuer of the transaction's <code>asset_code</code> .
@@ -115,10 +122,12 @@ public interface Sep24Transaction {
   void setSep10Account(String sep10Account);
 
   /**
-   * If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or
+   * If this is a withdrawal, this is the anchor's Stellar account that the user
+   * transferred (or
    * will transfer) their issued asset to.
    *
-   * @return <code>withdraw_anchor_account</code> field of the SEP-24 transaction history.
+   * @return <code>withdraw_anchor_account</code> field of the SEP-24 transaction
+   *         history.
    */
   String getWithdrawAnchorAccount();
 
@@ -127,7 +136,8 @@ public interface Sep24Transaction {
   /**
    * If withdrawal, the Stellar account the assets were withdrawn from.
    *
-   * <p>If deposit, sent from address, perhaps BTC, IBAN, or bank account.
+   * <p>
+   * If deposit, sent from address, perhaps BTC, IBAN, or bank account.
    *
    * @return <code>from</code> field of the SEP-24 transaction history.
    */
@@ -136,10 +146,12 @@ public interface Sep24Transaction {
   void setFromAccount(String fromAccount);
 
   /**
-   * If withdrawal, sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal,
+   * If withdrawal, sent to address (perhaps BTC, IBAN, or bank account in the
+   * case of a withdrawal,
    * Stellar account in the case of a deposit).
    *
-   * <p>If deposit, the Stellar account the deposited assets were sent to.
+   * <p>
+   * If deposit, the Stellar account the deposited assets were sent to.
    *
    * @return <code>to</code> field of the SEP-24 transaction history.
    */
@@ -148,14 +160,19 @@ public interface Sep24Transaction {
   void setToAccount(String toAccount);
 
   /**
-   * If withdrawal, this is the memo used when the user transferred to withdraw_anchor_account.
-   * Assigned null if the withdraw is not ready to receive payment, for example if KYC is not
+   * If withdrawal, this is the memo used when the user transferred to
+   * withdraw_anchor_account.
+   * Assigned null if the withdraw is not ready to receive payment, for example if
+   * KYC is not
    * completed.
    *
-   * <p>If deposit, this is the memo (if any) used to transfer the asset to the to Stellar address
+   * <p>
+   * If deposit, this is the memo (if any) used to transfer the asset to the to
+   * Stellar address
    *
-   * @return <code>withdraw_memo</code> or <code>deposit_memo</code> of the SEP-24 transaction
-   *     history.
+   * @return <code>withdraw_memo</code> or <code>deposit_memo</code> of the SEP-24
+   *         transaction
+   *         history.
    */
   String getMemo();
 
@@ -164,8 +181,9 @@ public interface Sep24Transaction {
   /**
    * Type for the <code>memo</code> field.
    *
-   * @return <code>withdraw_memo_type</code> or <code>deposit_memo_type</code> of the SEP-24
-   *     transaction history.
+   * @return <code>withdraw_memo_type</code> or <code>deposit_memo_type</code> of
+   *         the SEP-24
+   *         transaction history.
    */
   String getMemoType();
 
@@ -181,7 +199,8 @@ public interface Sep24Transaction {
   void setClientDomain(String domainClient);
 
   /**
-   * True if the client supports receiving deposit transactions as a claimable balance, false
+   * True if the client supports receiving deposit transactions as a claimable
+   * balance, false
    * otherwise.
    *
    * @return <code>true</code> or <code>false</code>
@@ -191,7 +210,8 @@ public interface Sep24Transaction {
   void setClaimableBalanceSupported(Boolean claimableBalanceSupported);
 
   /**
-   * Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes
+   * Amount received by anchor at start of transaction as a string with up to 7
+   * decimals. Excludes
    * any fees charged before the anchor received the funds.
    *
    * @return <code>amount_in</code> field of the SEP-24 transaction history.
@@ -201,8 +221,10 @@ public interface Sep24Transaction {
   void setAmountIn(String amountIn);
 
   /**
-   * The asset received or to be received by the Anchor. Must be present if the deposit/withdraw was
-   * made using non-equivalent assets. The value must be in SEP-38 Asset Identification Format. See
+   * The asset received or to be received by the Anchor. Must be present if the
+   * deposit/withdraw was
+   * made using non-equivalent assets. The value must be in SEP-38 Asset
+   * Identification Format. See
    * the Asset Exchanges section for more information.
    *
    * @return <code>amount_in_asset</code> field of the SEP-24 transaction history.
@@ -212,7 +234,8 @@ public interface Sep24Transaction {
   void setAmountInAsset(String amountInAsset);
 
   /**
-   * Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes
+   * Amount sent by anchor to user at end of transaction as a string with up to 7
+   * decimals. Excludes
    * amount converted to XLM to fund account and any external fees.
    *
    * @return <code>amount_out</code> field of the SEP-24 transaction history.
@@ -224,11 +247,13 @@ public interface Sep24Transaction {
   /**
    * The asset of the <code>amount_out</code> field.
    *
-   * @return <code>amount_out_asset</code> field of the SEP-24 transaction history.
+   * @return <code>amount_out_asset</code> field of the SEP-24 transaction
+   *         history.
    */
   String getAmountOutAsset();
 
   void setAmountOutAsset(String amountOutAsset);
+
   /**
    * Amount of fee charged by anchor.
    *
@@ -239,11 +264,14 @@ public interface Sep24Transaction {
   void setAmountFee(String amountFee);
 
   /**
-   * The asset in which fees are calculated in. Must be present if the deposit/withdraw was made
-   * using non-equivalent assets. The value must be in SEP-38 Asset Identification Format. See the
+   * The asset in which fees are calculated in. Must be present if the
+   * deposit/withdraw was made
+   * using non-equivalent assets. The value must be in SEP-38 Asset Identification
+   * Format. See the
    * Asset Exchanges section for more information.
    *
-   * @return <code>amount_fee_asset</code> field of the SEP-24 transaction history.
+   * @return <code>amount_fee_asset</code> field of the SEP-24 transaction
+   *         history.
    */
   String getAmountFeeAsset();
 
@@ -257,10 +285,28 @@ public interface Sep24Transaction {
 
   void setRefunds(Sep24Refunds refunds);
 
+  /**
+   * The memo the anchor must use when sending refund payments back to the user.
+   * If not specified,
+   * the anchor should use the same memo used by the user to send the original
+   * payment.
+   * If specified, <code>refund_memo_type</code> must also be specified.
+   * 
+   * @return <code>refund_memo</code> provided in the SEP-24 withdrawal request.
+   */
+  String getRefundMemo();
+
+  void setRefundMemo(String refundMemo);
+
+  String getRefundMemoType();
+
+  void setRefundMemoType(String refundMemoType);
+
   enum Kind {
     DEPOSIT("deposit"),
     WITHDRAWAL("withdrawal"),
     SEND("send");
+
     private final String name;
 
     Kind(String name) {

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24TransactionBuilder.java
@@ -120,6 +120,16 @@ public class Sep24TransactionBuilder {
     return this;
   }
 
+  public Sep24TransactionBuilder refundMemo(String refundMemo) {
+    txn.setRefundMemo(refundMemo);
+    return this;
+  }
+
+  public Sep24TransactionBuilder refundMemoType(String refundMemoType) {
+    txn.setRefundMemoType(refundMemoType);
+    return this;
+  }
+
   public Sep24Transaction build() {
     return txn;
   }

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -48,12 +48,12 @@ public class MemoHelper {
   }
 
   public static Memo makeMemo(String memo, String memoType) throws SepException {
-    if (isEmpty(memoType)) {
-      memoType = "none";
-    }
-
     if (isEmpty(memo)) {
       return null;
+    }
+
+    if (isEmpty(memoType)) {
+      throw new SepValidationException("memo_type is required if memo is specified");
     }
 
     switch (memoType) {

--- a/core/src/test/java/org/stellar/anchor/sep24/PojoSep24Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep24/PojoSep24Transaction.java
@@ -31,8 +31,9 @@ public class PojoSep24Transaction implements Sep24Transaction {
   String amountInAsset;
   String amountOutAsset;
   String amountFeeAsset;
-
   Boolean refunded;
   Sep24Refunds refunds;
   String amountExpected;
+  String refundMemo;
+  String refundMemoType;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
@@ -25,8 +25,7 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
     return "24";
   }
 
-  @Id
-  String id;
+  @Id String id;
 
   String kind;
 
@@ -64,8 +63,7 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   }
 
   /**
-   * If this is a withdrawal, this is the anchor's Stellar account that the user
-   * transferred (or
+   * If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or
    * will transfer) their issued asset to.
    */
   @SerializedName("withdraw_anchor_account")
@@ -81,14 +79,10 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * Sent from address.
    *
-   * <p>
-   * In a deposit transaction, this would be a non-stellar account such as, BTC,
-   * IBAN, or bank
+   * <p>In a deposit transaction, this would be a non-stellar account such as, BTC, IBAN, or bank
    * account.
    *
-   * <p>
-   * In a withdrawal transaction, this would be the stellar account the assets
-   * were withdrawn
+   * <p>In a withdrawal transaction, this would be the stellar account the assets were withdrawn
    * from.
    */
   @SerializedName("from_account")
@@ -97,13 +91,9 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * Sent to address.
    *
-   * <p>
-   * In a deposit transaction, this would be a stellar account the assets were
-   * deposited to.
+   * <p>In a deposit transaction, this would be a stellar account the assets were deposited to.
    *
-   * <p>
-   * In a withdrawal transaction, this would be the non-stellar account such as
-   * BTC, IBAN, or
+   * <p>In a withdrawal transaction, this would be the non-stellar account such as BTC, IBAN, or
    * bank account.
    */
   @SerializedName("to_account")
@@ -118,9 +108,7 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * The SEP10 account used for authentication.
    *
-   * <p>
-   * The account can be in the format of 1) stellar_account (G...) 2)
-   * stellar_account:memo
+   * <p>The account can be in the format of 1) stellar_account (G...) 2) stellar_account:memo
    * (G...:2810101841641761712) 3) muxed account (M...)
    */
   @SerializedName("sep10_account")

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
@@ -25,7 +25,8 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
     return "24";
   }
 
-  @Id String id;
+  @Id
+  String id;
 
   String kind;
 
@@ -63,7 +64,8 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   }
 
   /**
-   * If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or
+   * If this is a withdrawal, this is the anchor's Stellar account that the user
+   * transferred (or
    * will transfer) their issued asset to.
    */
   @SerializedName("withdraw_anchor_account")
@@ -79,10 +81,14 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * Sent from address.
    *
-   * <p>In a deposit transaction, this would be a non-stellar account such as, BTC, IBAN, or bank
+   * <p>
+   * In a deposit transaction, this would be a non-stellar account such as, BTC,
+   * IBAN, or bank
    * account.
    *
-   * <p>In a withdrawal transaction, this would be the stellar account the assets were withdrawn
+   * <p>
+   * In a withdrawal transaction, this would be the stellar account the assets
+   * were withdrawn
    * from.
    */
   @SerializedName("from_account")
@@ -91,9 +97,13 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * Sent to address.
    *
-   * <p>In a deposit transaction, this would be a stellar account the assets were deposited to.
+   * <p>
+   * In a deposit transaction, this would be a stellar account the assets were
+   * deposited to.
    *
-   * <p>In a withdrawal transaction, this would be the non-stellar account such as BTC, IBAN, or
+   * <p>
+   * In a withdrawal transaction, this would be the non-stellar account such as
+   * BTC, IBAN, or
    * bank account.
    */
   @SerializedName("to_account")
@@ -108,7 +118,9 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   /**
    * The SEP10 account used for authentication.
    *
-   * <p>The account can be in the format of 1) stellar_account (G...) 2) stellar_account:memo
+   * <p>
+   * The account can be in the format of 1) stellar_account (G...) 2)
+   * stellar_account:memo
    * (G...:2810101841641761712) 3) muxed account (M...)
    */
   @SerializedName("sep10_account")
@@ -122,4 +134,10 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
 
   @SerializedName("amount_expected")
   String amountExpected;
+
+  @SerializedName("refund_memo")
+  String refundMemo;
+
+  @SerializedName("refund_memo_type")
+  String refundMemoType;
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Adds `refund_memo` and `refund_memo_type` support to SEP-24 `POST /transactions/withdraw/interactive` request.

### Why

This was added to SEP-24. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))