### PR TITLE
Change the gradle build image to gradle:jdk11-alpine

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -6,10 +6,10 @@ on:
   push:
     branches:
       - main
-      - develop
+#      - develop
       - 'release/**'
       - 'releases/**'
-      - 'hotfix/**'
+#      - 'hotfix/**'
 
 jobs:
   end_to_end_tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM openjdk:11-jdk AS build
+#FROM openjdk:11-jdk AS build
+FROM gradle:jdk11-alpine AS build
 WORKDIR /code
-COPY . .
-RUN ./gradlew clean bootJar --stacktrace
+COPY --chown=gradle:gradle . .
+RUN gradle clean bootJar --stacktrace
 
 FROM ubuntu:20.04
 

--- a/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
@@ -12,7 +12,7 @@ anchor.settings:
   hostUrl: http://localhost:8081
 
 integration-auth:
-  authType: JWT_TOKEN
+  authType: none
   platformToAnchorSecret: myPlatformToAnchorSecret
   anchorToPlatformSecret: myAnchorToPlatformSecret
   expirationMilliseconds: 30000

--- a/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/reference-server-config-map.yaml
+++ b/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/reference-server-config-map.yaml
@@ -22,7 +22,7 @@ data:
       distributionWalletMemoType:    
 
     integration-auth:
-      authType: JWT_TOKEN
+      authType: none
       platformToAnchorSecret: myPlatformToAnchorSecret
       anchorToPlatformSecret: myAnchorToPlatformSecret
       expirationMilliseconds: 30000

--- a/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-platform-config.yaml
+++ b/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-platform-config.yaml
@@ -7,13 +7,11 @@ logging:
 callback_api:
   base_url: http://host.docker.internal:8081
   auth:
-    type: JWT_TOKEN
-    expiration_milliseconds: 30000
+    type: none
 
 platform_api:
   auth:
-    type: JWT_TOKEN
-    expiration_milliseconds: 30000
+    type: none
   base_url: http://host.docker.internal:8080
 
 events:
@@ -64,7 +62,6 @@ sep12:
 
 sep24:
   enabled: true
-#  interactive_url: http://host.docker.internal:8091/sep24/interactive
 
 sep31:
   enabled: true

--- a/integration-tests/docker-compose-configs/anchor-platform-unique-address/anchor-reference-server-config.yaml
+++ b/integration-tests/docker-compose-configs/anchor-platform-unique-address/anchor-reference-server-config.yaml
@@ -17,7 +17,7 @@ anchor.settings:
   distributionWalletMemoType:
 
 integration-auth:
-  authType: JWT_TOKEN
+  authType: none
   platformToAnchorSecret: myPlatformToAnchorSecret
   anchorToPlatformSecret: myAnchorToPlatformSecret
   expirationMilliseconds: 30000

--- a/integration-tests/src/test/resources/integration-test.anchor-config.yaml
+++ b/integration-tests/src/test/resources/integration-test.anchor-config.yaml
@@ -52,12 +52,6 @@ sep12:
 
 sep24:
   enabled: true
-  interactive_url:
-    base_url: http://localhost:8081/sep24/interactive
-    txn_fields: transaction_id
-  more_info_url:
-    base_url: http://localhost:8081/sep24/transaction/more_info
-    txn_fields: transaction_id
 
 sep31:
   enabled: true

--- a/platform/src/main/resources/anchor-docker-compose-config.yaml
+++ b/platform/src/main/resources/anchor-docker-compose-config.yaml
@@ -7,13 +7,11 @@ logging:
 callback_api:
   base_url: http://localhost:8081
   auth:
-    type: JWT_TOKEN
-    expiration_milliseconds: 30000
+    type: none
 
 platform_api:
   auth:
-    type: JWT_TOKEN
-    expiration_milliseconds: 30000
+    type: none
 
 events:
   enabled: true


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Replace the Gradle build image to `gradle:jdk11-alpine`.

### Why

The `open-jdk:11-jdk` is not working fine in some environment. 

### Known limitations