### PR TITLE
Small fix for payment observer

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -241,17 +241,17 @@ public class PaymentOperationToEventListener implements PaymentListener {
     SepTransactionStatus newStatus = SepTransactionStatus.PENDING_ANCHOR;
 
     // Check if the payment contains the expected amount (or greater)
-    BigDecimal expectedAmount = decimal(txn.getAmountIn());
+    BigDecimal amountIn = decimal(txn.getAmountIn());
     BigDecimal gotAmount = decimal(payment.getAmount());
     String message = "Incoming payment for SEP-24 transaction";
-    if (gotAmount.compareTo(expectedAmount) == 0) {
+    if (gotAmount.compareTo(amountIn) == 0) {
       Log.info(message);
       txn.setTransferReceivedAt(paymentTime);
     } else {
       message =
           String.format(
               "The incoming payment amount was insufficient! Expected: \"%s\", Received: \"%s\"",
-              formatAmount(expectedAmount), formatAmount(gotAmount));
+              formatAmount(amountIn), formatAmount(gotAmount));
       Log.warn(message);
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -241,7 +241,7 @@ public class PaymentOperationToEventListener implements PaymentListener {
     SepTransactionStatus newStatus = SepTransactionStatus.PENDING_ANCHOR;
 
     // Check if the payment contains the expected amount (or greater)
-    BigDecimal expectedAmount = decimal(txn.getAmountExpected());
+    BigDecimal expectedAmount = decimal(txn.getAmountIn());
     BigDecimal gotAmount = decimal(payment.getAmount());
     String message = "Incoming payment for SEP-24 transaction";
     if (gotAmount.compareTo(expectedAmount) == 0) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Change `amountExpected` to `amountIn`

### Why

`amountExpected` is amount passed from wallet as part of request. This field is optional and can be null. `amountIn` is either `amountExpected` (if not null) or amount set by the user in the web view. It's always non-null.

### Known limitations

N/A/