### PR TITLE
Disable Kafka requirements for integration tests

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/KafkaListenerSettings.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/config/KafkaListenerSettings.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "kafka.listener")
 public class KafkaListenerSettings {
+  Boolean enabled = true;
   String bootStrapServer;
   Boolean useSingleQueue;
   Boolean useIAM = false;

--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
@@ -38,7 +38,9 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
       KafkaListenerSettings kafkaListenerSettings, AnchorEventProcessor processor) {
     this.kafkaListenerSettings = kafkaListenerSettings;
     this.processor = processor;
-    this.executor.submit(this::listen);
+    if (kafkaListenerSettings.getEnabled()) {
+      this.executor.submit(this::listen);
+    }
   }
 
   Consumer<String, AnchorEvent> createKafkaConsumer() {
@@ -127,9 +129,12 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
       status = RED;
     }
 
-    boolean kafkaAvailable = validateKafka();
-    if (!kafkaAvailable) {
-      status = RED;
+    boolean kafkaAvailable = false;
+    if (kafkaListenerSettings.getEnabled()) {
+      kafkaAvailable = validateKafka();
+      if (!kafkaAvailable) {
+        status = RED;
+      }
     }
 
     return KafkaHealthCheckResult.builder()

--- a/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
@@ -38,6 +38,7 @@ event:
 
 # NOTE: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables need to be set if using AWS MSK
 kafka.listener:
+  enabled: true
   bootstrapServer: kafka:29092
   #bootstrapServer: b-1-public.democluster1.w7j4hi.c25.kafka.us-east-1.amazonaws.com:9198   # AWS MSK broker example
   useSingleQueue: false

--- a/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
@@ -48,6 +48,7 @@ event:
 
 # NOTE: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables need to be set if using AWS MSK
 kafka.listener:
+  enabled: false
   bootstrapServer: localhost:29092
   #bootstrapServer: b-1-public.democluster1.w7j4hi.c25.kafka.us-east-1.amazonaws.com:9198   # AWS MSK broker example
   useSingleQueue: false

--- a/docker-compose/anchor-get-started/common-services/reference-config.yaml
+++ b/docker-compose/anchor-get-started/common-services/reference-config.yaml
@@ -38,6 +38,7 @@ event:
 
 # NOTE: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables need to be set if using AWS MSK
 kafka.listener:
+  enabled: true
   bootstrapServer: kafka:29092
   #bootstrapServer: b-1-public.democluster1.w7j4hi.c25.kafka.us-east-1.amazonaws.com:9198   # AWS MSK broker example
   useSingleQueue: false

--- a/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/reference-server-config-map.yaml
+++ b/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/reference-server-config-map.yaml
@@ -35,6 +35,7 @@ data:
       listenerType: kafka
 
     kafka.listener:
+      enabled: true
       bootstrapServer: anchor-platform-kafka:9092
       eventTypeToQueue:
         all: dev_ap_event_single_queue

--- a/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-reference-server-config.yaml
+++ b/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-reference-server-config.yaml
@@ -21,6 +21,7 @@ event:
   listenerType: kafka
 
 kafka.listener:
+  enabled: true
   bootstrapServer: host.docker.internal:29092
   useSingleQueue: false
   eventTypeToQueue:

--- a/integration-tests/docker-compose-configs/anchor-platform-unique-address/anchor-reference-server-config.yaml
+++ b/integration-tests/docker-compose-configs/anchor-platform-unique-address/anchor-reference-server-config.yaml
@@ -26,6 +26,7 @@ event:
   listenerType: kafka
 
 kafka.listener:
+  enabled: true
   bootstrapServer: host.docker.internal:29092
   useSingleQueue: false
   eventTypeToQueue:

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -39,12 +39,13 @@ class AnchorPlatformIntegrationTest {
           "secret.data.username" to "user1",
           "secret.data.password" to "password",
           "secret.callback_api.auth_secret" to "callback_jwt_secret",
-          "secret.platform_api.auth_secret" to "platform_jwt_secret"
+          "secret.platform_api.auth_secret" to "platform_jwt_secret",
+          "events.enabled" to false
         )
 
-      ServiceRunner.startSepServer(envMap)
-      ServiceRunner.startStellarObserver(envMap)
       ServiceRunner.startAnchorReferenceServer()
+      ServiceRunner.startStellarObserver(envMap)
+      ServiceRunner.startSepServer(envMap)
 
       toml =
         Sep1Helper.parse(

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/StellarObserverTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/StellarObserverTests.kt
@@ -63,7 +63,6 @@ class StellarObserverTests {
 
 fun stellarObserverTestAll() {
   StellarObserverTests.setup()
-
   println("Performing Stellar observer tests...")
-  StellarObserverTests.setup()
+  StellarObserverTests.testStellarObserverHealth()
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

We are taking Kafka out from the integration tests. 

### Why

To accelerate the integration tests. The events/kafka are tested in e2e tests.

### Known limitations

N/A