### PR TITLE
Fixes for stellarTransactionId and Customers

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -57,8 +57,11 @@ public class PlatformTransactionData {
   @SerializedName("stellar_transactions")
   List<StellarTransaction> stellarTransactions;
 
-  @SerializedName("stellar_transaction_id")
-  String stellarTransactionId;
+  @SerializedName("source_account")
+  String sourceAccount;
+
+  @SerializedName("destination_account")
+  String destinationAccount;
 
   @SerializedName("external_transaction_id")
   String externalTransactionId;

--- a/api-schema/src/main/java/org/stellar/anchor/api/shared/Customers.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/shared/Customers.java
@@ -1,9 +1,11 @@
 package org.stellar.anchor.api.shared;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 @AllArgsConstructor
 public class Customers {
   StellarId sender;

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -118,7 +118,6 @@ public class PaymentOperationToEventListener implements PaymentListener {
                                 .stellarTransactions(
                                     StellarTransaction.addOrUpdateTransactions(
                                         txn.getStellarTransactions(), stellarTransaction))
-                                .stellarTransactionId(payment.getTransactionHash())
                                 .id(txn.getId())
                                 .build())
                         .build()))
@@ -268,7 +267,6 @@ public class PaymentOperationToEventListener implements PaymentListener {
                                 .stellarTransactions(
                                     StellarTransaction.addOrUpdateTransactions(
                                         txn.getStellarTransactions(), stellarTransaction))
-                                .stellarTransactionId(payment.getTransactionHash())
                                 .id(txn.getId())
                                 .build())
                         .build()))

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -196,6 +196,7 @@ public class TransactionService {
     txnUpdated = updateField(patch, txn, "externalTransactionId", txnUpdated);
     // update stellar_transactions
     txnUpdated = updateField(patch, txn, "stellarTransactions", txnUpdated);
+    txnUpdated = updateField(patch, txn, "stellarTransactionId", txnUpdated);
 
     switch (txn.getProtocol()) {
       case "24":

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -196,7 +196,6 @@ public class TransactionService {
     txnUpdated = updateField(patch, txn, "externalTransactionId", txnUpdated);
     // update stellar_transactions
     txnUpdated = updateField(patch, txn, "stellarTransactions", txnUpdated);
-    txnUpdated = updateField(patch, txn, "stellarTransactionId", txnUpdated);
 
     switch (txn.getProtocol()) {
       case "24":

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionHelper.java
@@ -70,8 +70,7 @@ public class TransactionHelper {
     String amountOutAsset = makeAsset(txn.getAmountOutAsset(), assetService, txn);
     String amountFeeAsset = makeAsset(txn.getAmountFeeAsset(), assetService, txn);
     String amountExpectedAsset = makeAsset(null, assetService, txn);
-    String sourceAccount =
-        DEPOSIT.kind.equals(txn.getKind()) ? txn.getToAccount() : txn.getFromAccount();
+    String sourceAccount = txn.getFromAccount();
 
     return GetTransactionResponse.builder()
         .id(txn.getId())
@@ -84,7 +83,7 @@ public class TransactionHelper {
         // constructor is used because AMOUNT can be null, when ASSET is always non-null
         .amountExpected(new Amount(txn.getAmountExpected(), amountExpectedAsset))
         .sourceAccount(sourceAccount)
-        .destinationAccount(txn.getWithdrawAnchorAccount())
+        .destinationAccount(txn.getToAccount())
         .startedAt(txn.getStartedAt())
         .updatedAt(txn.getUpdatedAt())
         .completedAt(txn.getCompletedAt())

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionHelper.java
@@ -66,18 +66,12 @@ public class TransactionHelper {
       refunds = toRefunds(txn.getRefunds(), txn.getAmountInAsset());
     }
 
-    String sender = DEPOSIT.kind.equals(txn.getKind()) ? txn.getToAccount() : txn.getFromAccount();
-
     String amountInAsset = makeAsset(txn.getAmountInAsset(), assetService, txn);
     String amountOutAsset = makeAsset(txn.getAmountOutAsset(), assetService, txn);
     String amountFeeAsset = makeAsset(txn.getAmountFeeAsset(), assetService, txn);
     String amountExpectedAsset = makeAsset(null, assetService, txn);
-    Customers.CustomersBuilder builder =
-        Customers.builder().sender(StellarId.builder().account(sender).build());
-
-    if (WITHDRAWAL.kind.equals(txn.getKind()) && txn.getWithdrawAnchorAccount() != null) {
-      builder.receiver(StellarId.builder().account(txn.getWithdrawAnchorAccount()).build());
-    }
+    String sourceAccount =
+        DEPOSIT.kind.equals(txn.getKind()) ? txn.getToAccount() : txn.getFromAccount();
 
     return GetTransactionResponse.builder()
         .id(txn.getId())
@@ -89,13 +83,13 @@ public class TransactionHelper {
         .amountFee(Amount.create(txn.getAmountFee(), amountFeeAsset))
         // constructor is used because AMOUNT can be null, when ASSET is always non-null
         .amountExpected(new Amount(txn.getAmountExpected(), amountExpectedAsset))
-        .customers(builder.build())
+        .sourceAccount(sourceAccount)
+        .destinationAccount(txn.getWithdrawAnchorAccount())
         .startedAt(txn.getStartedAt())
         .updatedAt(txn.getUpdatedAt())
         .completedAt(txn.getCompletedAt())
         .refunds(refunds)
         .stellarTransactions(txn.getStellarTransactions())
-        .stellarTransactionId(txn.getStellarTransactionId())
         .externalTransactionId(txn.getExternalTransactionId())
         .build();
   }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Small fixes.
1. Make it possible to update `stellarTransactionId` in patch (previously missed updates from payment observer). Also add it to `getTransaction`
2. Fix `amountExpected` in `getTransaction` (see comment)
3. Update customers logic. Now sender is always user account address (regardless of type). Receiver is set to null for deposit, and to `withdraw_anchor_account` for withdraw.

### Why

To make reference server work

### Known limitations

N/A