### PR TITLE
[ANCHOR-172] When database credential is not provided, print error messages instead of exceptions

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/SecretConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/SecretConfig.java
@@ -12,4 +12,8 @@ public interface SecretConfig {
   String getCallbackApiSecret();
 
   String getPlatformApiSecret();
+
+  String getDataSourceUsername();
+
+  String getDataSourcePassword();
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -78,6 +78,12 @@ public class SepBeans {
     return new PropertySep38Config();
   }
 
+  @Bean
+  @ConfigurationProperties(prefix = "data")
+  PropertyDataConfig dataConfig(SecretConfig secretConfig) {
+    return new PropertyDataConfig(secretConfig);
+  }
+
   /**
    * Used by SEP-10 authentication service.
    *

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyDataConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyDataConfig.java
@@ -1,0 +1,59 @@
+package org.stellar.anchor.platform.config;
+
+import static org.stellar.anchor.platform.config.PropertySecretConfig.SECRET_DATA_PASSWORD;
+import static org.stellar.anchor.platform.config.PropertySecretConfig.SECRET_DATA_USERNAME;
+import static org.stellar.anchor.platform.configurator.DataConfigAdapter.*;
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
+import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.stellar.anchor.config.SecretConfig;
+
+@Data
+public class PropertyDataConfig implements Validator {
+  public static final String ERROR_SECRET_DATA_USERNAME_EMPTY = "secret-data-username-empty";
+  public static final String ERROR_SECRET_DATA_PASSWORD_EMPTY = "secret-data-password-empty";
+  String type;
+  String url;
+  int initialConnectionPoolSize;
+  int max_active_connections;
+  boolean flywayEnabled;
+  boolean dllAuto;
+  String flywayLocation;
+  private SecretConfig secretConfig;
+
+  public PropertyDataConfig(SecretConfig secretConfig) {
+    this.secretConfig = secretConfig;
+  }
+
+  @Override
+  public boolean supports(@NotNull Class<?> clazz) {
+    return PropertyEventConfig.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    validateSecrets(errors);
+  }
+
+  private void validateSecrets(Errors errors) {
+    switch (type) {
+      case DATABASE_H2:
+        break;
+      case DATABASE_POSTGRES:
+      case DATABASE_SQLITE:
+      case DATABASE_AURORA:
+        if (isEmpty(secretConfig.getDataSourceUsername())) {
+          errors.reject(
+              ERROR_SECRET_DATA_USERNAME_EMPTY, SECRET_DATA_USERNAME + " must not be empty.");
+        }
+        if (isEmpty(secretConfig.getDataSourcePassword())) {
+          errors.reject(
+              ERROR_SECRET_DATA_PASSWORD_EMPTY, SECRET_DATA_PASSWORD + " must not be empty.");
+        }
+        break;
+    }
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
@@ -13,6 +13,8 @@ public class PropertySecretConfig implements SecretConfig {
       "secret.sep24.more_info_url.jwt_secret";
   public static final String SECRET_CALLBACK_API_AUTH_SECRET = "secret.callback_api.auth_secret";
   public static final String SECRET_PLATFORM_API_AUTH_SECRET = "secret.platform_api.auth_secret";
+  public static final String SECRET_DATA_USERNAME = "secret.data.username";
+  public static final String SECRET_DATA_PASSWORD = "secret.data.password";
 
   public String getSep10JwtSecretKey() {
     return SecretManager.getInstance().get(SECRET_SEP_10_JWT_SECRET);
@@ -32,11 +34,23 @@ public class PropertySecretConfig implements SecretConfig {
     return SecretManager.getInstance().get(SECRET_SEP_24_MORE_INFO_URL_JWT_SECRET);
   }
 
+  @Override
   public String getCallbackApiSecret() {
     return SecretManager.getInstance().get(SECRET_CALLBACK_API_AUTH_SECRET);
   }
 
+  @Override
   public String getPlatformApiSecret() {
     return SecretManager.getInstance().get(SECRET_PLATFORM_API_AUTH_SECRET);
+  }
+
+  @Override
+  public String getDataSourceUsername() {
+    return SecretManager.getInstance().get(SECRET_DATA_USERNAME);
+  }
+
+  @Override
+  public String getDataSourcePassword() {
+    return SecretManager.getInstance().get(SECRET_DATA_PASSWORD);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
@@ -3,8 +3,7 @@ package org.stellar.anchor.platform.configurator;
 import static org.stellar.anchor.api.platform.HealthCheckStatus.GREEN;
 import static org.stellar.anchor.platform.configurator.ConfigHelper.*;
 import static org.stellar.anchor.platform.configurator.ConfigMap.ConfigSource.FILE;
-import static org.stellar.anchor.util.Log.info;
-import static org.stellar.anchor.util.Log.infoF;
+import static org.stellar.anchor.util.Log.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -72,6 +71,17 @@ public abstract class ConfigManager
     applicationContext.getEnvironment().getPropertySources().addFirst(pps);
 
     for (SpringConfigAdapter adapter : adapters) {
+      try {
+        adapter.validate(config);
+      } catch (InvalidConfigException icex) {
+        errorF(
+            "Invalid configuration. {}{} Reason={}",
+            System.lineSeparator(),
+            System.lineSeparator(),
+            icex.getMessage());
+        // We should not continue.
+        System.exit(1);
+      }
       adapter.updateSpringEnv(applicationContext, config);
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/EventProcessorConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/EventProcessorConfigManager.java
@@ -44,4 +44,7 @@ class EventProcessorConfigAdapter extends SpringConfigAdapter {
     copy(config, "event_processor.port", "server.port");
     set("spring.mvc.converters.preferred-json-mapper", "gson");
   }
+
+  @Override
+  void validate(ConfigMap config) throws InvalidConfigException {}
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/LogConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/LogConfigAdapter.java
@@ -31,6 +31,9 @@ public class LogConfigAdapter extends SpringConfigAdapter {
     }
   }
 
+  @Override
+  void validate(ConfigMap config) throws InvalidConfigException {}
+
   private Level getLog4j2Level(String level) throws InvalidConfigException {
     switch (level.toUpperCase()) {
       case "TRACE":

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ObserverConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ObserverConfigManager.java
@@ -42,4 +42,7 @@ class ObserverConfigAdapter extends SpringConfigAdapter {
     copy(config, "payment_observer.port", "server.port");
     set("spring.mvc.converters.preferred-json-mapper", "gson");
   }
+
+  @Override
+  void validate(ConfigMap config) throws InvalidConfigException {}
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/SecretManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/SecretManager.java
@@ -22,8 +22,8 @@ public class SecretManager
           SECRET_SEP_24_MORE_INFO_URL_JWT_SECRET,
           SECRET_CALLBACK_API_AUTH_SECRET,
           SECRET_PLATFORM_API_AUTH_SECRET,
-          "secret.data.username",
-          "secret.data.password");
+          SECRET_DATA_USERNAME,
+          SECRET_DATA_PASSWORD);
 
   final Properties props = new Properties();
 

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/SepConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/SepConfigManager.java
@@ -49,4 +49,9 @@ class SepServerConfigAdapter extends SpringConfigAdapter {
       set("management.endpoints.enabled-by-default", false);
     }
   }
+
+  @Override
+  void validate(ConfigMap config) throws InvalidConfigException {
+    // noop
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/SpringConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/SpringConfigAdapter.java
@@ -1,5 +1,8 @@
 package org.stellar.anchor.platform.configurator;
 
+import static org.stellar.anchor.util.Log.warn;
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
 import java.util.Properties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.PropertiesPropertySource;
@@ -26,7 +29,9 @@ public abstract class SpringConfigAdapter {
   }
 
   protected void set(String name, String value) {
-    props.setProperty(name, value);
+    if (isEmpty(name) || isEmpty(value))
+      warn(String.format("Ignored [%s]=[%s] spring configuration.", name, value));
+    else props.setProperty(name, value);
   }
 
   protected void copy(ConfigMap config, String from, String to) throws InvalidConfigException {
@@ -54,4 +59,15 @@ public abstract class SpringConfigAdapter {
   }
 
   abstract void updateSpringEnv(ConfigMap config) throws InvalidConfigException;
+
+  /**
+   * This method is called to validate the configuration before Spring loads.
+   *
+   * <p>We should avoid the validations in this method if they can be done by the Spring
+   * validations.
+   *
+   * @param config The configuration map
+   * @throws InvalidConfigException Invalid configuration value exception
+   */
+  abstract void validate(ConfigMap config) throws InvalidConfigException;
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

When database credential is not provided, print error messages instead of exceptions. 

**Note**: The database initialization happens before the Spring validation framework. We need to do pre-Spring validation.

**Example output:**
username not set:
```
12:12:09.276 INFO  - o.s.a.p.c.SecretManager - Secret manager started.
12:12:09.291 INFO  - o.s.a.p.c.SepConfigManager - Read and process configurations
12:12:09.291 INFO  - o.s.a.p.c.ConfigManager - reading default configuration values
12:12:09.338 INFO  - o.s.a.p.c.ConfigManager - default configuration version=1
12:12:09.354 INFO  - o.s.a.p.c.ConfigManager - validating default configuration values
12:12:09.354 INFO  - o.s.a.p.c.ConfigManager - reading configuration file from file:/C:/projects/wip/java-stellar-anchor-sdk/integration-tests/src/test/resources/integration-test.anchor-config.yaml
12:12:09.354 INFO  - o.s.a.p.c.ConfigHelper - System env['version'] is not defined. version:1 is assumed}
12:12:09.354 INFO  - o.s.a.p.c.ConfigManager - Processing system environment variables
12:12:09.369 ERROR - o.s.a.p.c.DataConfigAdapter - secret.data.username is not set. Please provide the datasource username.
12:12:09.401 ERROR - o.s.a.p.c.ConfigManager - Invalid configuration. 

 Reason=secret.data.username is not set. Please provide the datasource username.

Process finished with exit code 1
```

password not set
```
12:16:21.452 INFO  - o.s.a.p.c.SecretManager - Secret manager started.
12:16:21.452 INFO  - o.s.a.p.c.SepConfigManager - Read and process configurations
12:16:21.452 INFO  - o.s.a.p.c.ConfigManager - reading default configuration values
12:16:21.515 INFO  - o.s.a.p.c.ConfigManager - default configuration version=1
12:16:21.515 INFO  - o.s.a.p.c.ConfigManager - validating default configuration values
12:16:21.515 INFO  - o.s.a.p.c.ConfigManager - reading configuration file from file:/C:/projects/wip/java-stellar-anchor-sdk/integration-tests/src/test/resources/integration-test.anchor-config.yaml
12:16:21.530 INFO  - o.s.a.p.c.ConfigHelper - System env['version'] is not defined. version:1 is assumed}
12:16:21.530 INFO  - o.s.a.p.c.ConfigManager - Processing system environment variables
12:16:21.530 WARN  - o.s.a.p.c.ConfigManager - Possible secret leak of config[secret.data.username]. Please remove the secret from configuration.
12:16:21.577 ERROR - o.s.a.p.c.DataConfigAdapter - secret.data.password is not set. Please provide the datasource username.
12:16:21.577 ERROR - o.s.a.p.c.ConfigManager - Invalid configuration. 

 Reason=secret.data.password is not set. Please provide the datasource username.

Process finished with exit code 1
```

### Why

Improve user experience.

### Known limitations

N/A