### PR TITLE
[ANCHOR-173] Removed data.url and add data.server and data.database fields

### DIFF
--- a/.run/v2.0 - Platform Server - ServiceRunner [Integration Test Config].run.xml
+++ b/.run/v2.0 - Platform Server - ServiceRunner [Integration Test Config].run.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="v2.0 - Platform Server - ServiceRunner [Integration Test Config]" type="Application" factoryName="Application">
     <envs>
+      <env name="data.database" value="anchor-proxy" />
       <env name="data.ddl_auto" value="update" />
       <env name="data.type" value="sqlite" />
-      <env name="data.url" value="jdbc:sqlite:anchor-proxy.db" />
       <env name="SECRET.DATA.PASSWORD" value="password" />
       <env name="SECRET.DATA.USERNAME" value="admin" />
       <env name="secret.sep10.jwt_secret" value="secret" />

--- a/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
@@ -91,7 +91,6 @@ spring.mvc.converters.preferred-json-mapper: gson
 #spring.jpa.database: POSTGRESQL
 #spring.jpa.show-sql: false
 #spring.datasource.driver-class-name: org.postgresql.Driver
-#spring.datasource.url: jdbc:postgresql://localhost:5432/anchorplatform
 #spring.datasource.username: anchorplatform
 #spring.datasource.password: <PASSWORD>
 #spring.mvc.converters.preferred-json-mapper: gson

--- a/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
@@ -101,7 +101,6 @@ spring.mvc.converters.preferred-json-mapper: gson
 #spring.jpa.database: POSTGRESQL
 #spring.jpa.show-sql: false
 #spring.datasource.driver-class-name: org.postgresql.Driver
-#spring.datasource.url: jdbc:postgresql://localhost:5432/anchorplatform
 #spring.datasource.username: anchorplatform
 #spring.datasource.password: <PASSWORD>
 #spring.mvc.converters.preferred-json-mapper: gson

--- a/docker-compose/anchor-get-started/common-services/common-services.yaml
+++ b/docker-compose/anchor-get-started/common-services/common-services.yaml
@@ -19,7 +19,7 @@ services:
     depends_on:
       - zookeeper
     ports:
-      - 29092:29092
+      - "29092:29092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -35,12 +35,12 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     ports:
-      - 2181:2181
+      - "2181:2181"
 
   db_a:
     image: postgres:latest
     ports:
-      - "5431:5432"  # use 5431 so this doesn't conflict if you have a local postgres instance running
+      - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/docker-compose/anchor-get-started/sep24/docker-compose.yaml
+++ b/docker-compose/anchor-get-started/sep24/docker-compose.yaml
@@ -22,7 +22,8 @@ services:
       - events.publisher.kafka.bootstrap_server=kafka:29092
       # data
       - data.type=postgres
-      - data.url=jdbc:postgresql://db:5432/postgres
+      - data.server=db:5432
+      - data.database=postgres
       - data.flyway_enabled=false
       # seps
       - sep1.enabled=true

--- a/docker-compose/anchor-get-started/sep24/docker-compose.yaml
+++ b/docker-compose/anchor-get-started/sep24/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - events.publisher.kafka.bootstrap_server=kafka:29092
       # data
       - data.type=postgres
-      - data.url=jdbc:postgresql://db:5432/
+      - data.url=jdbc:postgresql://db:5432/postgres
       - data.flyway_enabled=false
       # seps
       - sep1.enabled=true

--- a/docker-compose/anchor-get-started/sep31/docker-compose.yaml
+++ b/docker-compose/anchor-get-started/sep31/docker-compose.yaml
@@ -20,7 +20,8 @@ services:
       - events.publisher.kafka.bootstrap_server=kafka:29092
       # data
       - data.type=postgres
-      - data.url=jdbc:postgresql://db:5432/
+      - data.server=db:5432
+      - data.database=postgres
       - data.flyway_enabled=false
       # seps
       - sep1.enabled=true

--- a/docs/resources/deployment-examples/example-fargate/example_config/anchor_config.yaml
+++ b/docs/resources/deployment-examples/example-fargate/example_config/anchor_config.yaml
@@ -284,7 +284,6 @@ data-spring-jdbc-aws-aurora-postgres:
   spring.jpa.show-sql: false
   spring.datasource.driver-class-name: org.postgresql.Driver
   spring.datasource.type: org.stellar.anchor.platform.databaseintegration.IAMAuthDataSource
-  spring.datasource.url: jdbc:postgresql://database-aurora-iam-instance-1.chizvyczscs2.us-east-1.rds.amazonaws.com:5432/anchorplatform
   spring.datasource.username: anchorplatform1
   spring.datasource.hikari.max-lifetime: 840000    # 14 minutes because IAM tokens are valid for 15min
   spring.mvc.converters.preferred-json-mapper: gson
@@ -295,7 +294,6 @@ data-spring-jdbc-local-postgres:
   spring.jpa.database: POSTGRESQL
   spring.jpa.show-sql: false
   spring.datasource.driver-class-name: org.postgresql.Driver
-  spring.datasource.url: jdbc:postgresql://localhost:5432/anchorplatform
   spring.datasource.username: ${POSTGRES_USERNAME}
   spring.datasource.password: ${POSTGRES_PASSWORD}
   spring.mvc.converters.preferred-json-mapper: gson

--- a/helm-charts/sep-service/example_values.yaml
+++ b/helm-charts/sep-service/example_values.yaml
@@ -105,7 +105,7 @@ app_config:
   #
   # Database (PostgreSQL):
   # data.type: postgres
-  # data.url: jdbc:postgresql://<host>:<port>/<database_name>
+  # data.server: <host>:<port>
   # data.username: POSTGRES_USERNAME  # TODO: use secrets
   # data.password: POSTGRES_PASSWORD  # TODO: use secrets
   # data.initial_connection_pool_size: 3

--- a/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-platform-config.yaml
+++ b/integration-tests/docker-compose-configs/anchor-platform-default-configs/anchor-platform-config.yaml
@@ -302,11 +302,10 @@ data:
   #
   type: postgres
 
-  ## @param: url
-  ## @type: string
-  ## Location of the database
-  #
-  url: jdbc:postgresql://host.docker.internal:5440/
+  server: host.docker.internal:5440
+
+  database: postgres
+
 
   ## @param: initial_connection_pool_size
   ## @type: integer

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyDataConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyDataConfig.java
@@ -16,7 +16,8 @@ public class PropertyDataConfig implements Validator {
   public static final String ERROR_SECRET_DATA_USERNAME_EMPTY = "secret-data-username-empty";
   public static final String ERROR_SECRET_DATA_PASSWORD_EMPTY = "secret-data-password-empty";
   String type;
-  String url;
+  String server;
+  String database;
   int initialConnectionPoolSize;
   int max_active_connections;
   boolean flywayEnabled;

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigHelper.java
@@ -96,13 +96,6 @@ public class ConfigHelper {
       config.put(name, "", VERSION_SCHEMA);
     }
 
-    config.put("secret.sep10_signing_seed", "", VERSION_SCHEMA);
-    config.put("secret.jwt_secret", "", VERSION_SCHEMA);
-    config.put("secret.platform_api.secret", "", VERSION_SCHEMA);
-    config.put("secret.callback_api.secret", "", VERSION_SCHEMA);
-    config.put("secret.data.username", "", VERSION_SCHEMA);
-    config.put("secret.data.password", "", VERSION_SCHEMA);
-
     return config.printToString();
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
@@ -75,10 +75,11 @@ public abstract class ConfigManager
         adapter.validate(config);
       } catch (InvalidConfigException icex) {
         errorF(
-            "Invalid configuration. {}{} Reason={}",
+            "Invalid configuration. {}{} Reason={}{}",
             System.lineSeparator(),
             System.lineSeparator(),
-            icex.getMessage());
+            icex.getMessage(),
+            System.lineSeparator());
         // We should not continue.
         System.exit(1);
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
@@ -98,7 +98,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
         set("spring.datasource.driver-class-name", "org.h2.Driver");
         set("spring.datasource.embedded-database-connection", "H2");
         set("spring.datasource.name", "anchor-platform");
-        set("spring.datasource.url", "jdbc:h2:mem:test");
+        set("spring.datasource.url", constructH2Url(config));
         set("spring.jpa.database-platform", "org.hibernate.dialect.H2Dialect");
         set("spring.jpa.properties.hibernate.dialect", "org.hibernate.dialect.H2Dialect");
         break;
@@ -108,7 +108,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
         set("spring.jpa.database-platform", "org.stellar.anchor.platform.sqlite.SQLiteDialect");
         set("spring.jpa.generate-ddl", true);
         set("spring.jpa.hibernate.ddl-auto", "update");
-        copy(config, "data.url", "spring.datasource.url");
+        set("spring.datasource.url", constructSQLiteUrl(config));
         set("spring.datasource.username", SecretManager.getInstance().get(SECRET_DATA_USERNAME));
         set("spring.datasource.password", SecretManager.getInstance().get(SECRET_DATA_PASSWORD));
         break;
@@ -119,7 +119,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
         set(
             "spring.datasource.hikari.max-lifetime",
             840000); // 14 minutes because IAM tokens are valid for 15 min
-        copy(config, "data.url", "spring.datasource.url");
+        set("spring.datasource.url", constructPostgressUrl(config));
         set("spring.datasource.username", SecretManager.getInstance().get(SECRET_DATA_USERNAME));
         set("spring.datasource.password", SecretManager.getInstance().get(SECRET_DATA_PASSWORD));
         if (config.getString("data.flyway_enabled", "").equalsIgnoreCase("true")) {
@@ -127,7 +127,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
           set("spring.flyway.locations", "classpath:/db/migration");
           set("spring.flyway.user", SecretManager.getInstance().get(SECRET_DATA_USERNAME));
           set("spring.flyway.password", SecretManager.getInstance().get(SECRET_DATA_PASSWORD));
-          copy(config, "data.url", "spring.flyway.url");
+          set("spring.flyway.url", constructPostgressUrl(config));
         } else {
           set("spring.jpa.generate-ddl", true);
           set("spring.jpa.hibernate.ddl-auto", "update");
@@ -137,7 +137,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
         set("spring.datasource.driver-class-name", "org.postgresql.Driver");
         set("spring.datasource.name", "anchor-platform");
         set("spring.jpa.database-platform", "org.hibernate.dialect.PostgreSQL9Dialect");
-        copy(config, "data.url", "spring.datasource.url");
+        set("spring.datasource.url", constructPostgressUrl(config));
         set("spring.datasource.username", SecretManager.getInstance().get(SECRET_DATA_USERNAME));
         set("spring.datasource.password", SecretManager.getInstance().get(SECRET_DATA_PASSWORD));
         if (config.getString("data.flyway_enabled", "").equalsIgnoreCase("true")) {
@@ -145,7 +145,7 @@ public class DataConfigAdapter extends SpringConfigAdapter {
           set("spring.flyway.locations", "classpath:/db/migration");
           set("spring.flyway.user", SecretManager.getInstance().get(SECRET_DATA_USERNAME));
           set("spring.flyway.password", SecretManager.getInstance().get(SECRET_DATA_PASSWORD));
-          copy(config, "data.url", "spring.flyway.url");
+          set("spring.flyway.url", constructPostgressUrl(config));
         } else {
           set("spring.jpa.generate-ddl", true);
           set("spring.jpa.hibernate.ddl-auto", "update");
@@ -157,6 +157,20 @@ public class DataConfigAdapter extends SpringConfigAdapter {
     }
 
     checkIfAllFieldsAreSet();
+  }
+
+  private String constructPostgressUrl(ConfigMap config) {
+    return String.format(
+        "jdbc:postgresql://%s/%s",
+        config.getString("data.server"), config.getString("data.database"));
+  }
+
+  private String constructSQLiteUrl(ConfigMap config) {
+    return String.format("jdbc:sqlite:%s.db", config.getString("data.database"));
+  }
+
+  private String constructH2Url(ConfigMap config) {
+    return "jdbc:h2:mem:anchor-platform";
   }
 
   @Override

--- a/platform/src/main/resources/anchor-docker-compose-config.yaml
+++ b/platform/src/main/resources/anchor-docker-compose-config.yaml
@@ -300,11 +300,9 @@ data:
   #
   type: postgres
 
-  ## @param: url
-  ## @type: string
-  ## Location of the database
-  #
-  url: jdbc:postgresql://db:5432/
+  server: db:5432
+
+  database: postgres
 
   ## @param: initial_connection_pool_size
   ## @type: integer

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -492,10 +492,10 @@ data:
   #
 #  url: jdbc:h2:mem:anchor-platform
 
-  ## The hostname of the database server.
+  ## The hostname and port of the database server.
   server:
 
-  ## Name of the database. Optional. Default to anchor-platform or the default name of the type of database.
+  ## Name of the database.
   database:
 
   ## @param: initial_connection_pool_size

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -485,11 +485,19 @@ data:
   #
   #
   type: h2
+
   ## @param: url
   ## @type: string
   ## Location of the database
   #
-  url: jdbc:h2:mem:anchor-platform
+#  url: jdbc:h2:mem:anchor-platform
+
+  ## The hostname of the database server.
+  server:
+
+  ## Name of the database. Optional. Default to anchor-platform or the default name of the type of database.
+  database:
+
   ## @param: initial_connection_pool_size
   ## @type: integer
   ## Initial number of connections

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -486,12 +486,6 @@ data:
   #
   type: h2
 
-  ## @param: url
-  ## @type: string
-  ## Location of the database
-  #
-#  url: jdbc:h2:mem:anchor-platform
-
   ## The hostname and port of the database server.
   server:
 

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -6,13 +6,14 @@ callback_api.auth.jwt.http_header:
 callback_api.auth.type:
 callback_api.base_url:
 callback_api.check_certificate:
+data.database:
 data.ddl_auto:
 data.flyway_enabled:
 data.flyway_location:
 data.initial_connection_pool_size:
 data.max_active_connections:
+data.server:
 data.type:
-data.url:
 event_processor.context_path:
 event_processor.port:
 event_processor.queue.kafka.bootstrap_server:

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -64,12 +64,6 @@ platform_api.auth.jwt.expiration_milliseconds:
 platform_api.auth.jwt.http_header:
 platform_api.auth.type:
 platform_api.base_url:
-secret.callback_api.secret:
-secret.data.password:
-secret.data.username:
-secret.jwt_secret:
-secret.platform_api.secret:
-secret.sep10_signing_seed:
 sep1.enabled:
 sep1.toml.type:
 sep1.toml.value:

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -32,7 +32,8 @@ data:
 
 #data:
 #  type: postgres
-#  url: jdbc:postgresql://localhost:5432/anchorplatform
+#  server: localhost:5432
+#  database: postgres
 #  username: anchorplatform
 #  password:
 #  initial_connection_pool_size: 3

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -24,7 +24,7 @@ logging:
 
 data:
   type: sqlite
-  url: jdbc:sqlite:anchor-platform.db
+  database: anchor-platform
   initial_connection_pool_size: 2
   max_active_connections: 10
   flyway_enabled: true


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This is to replace `data.url` with `data.server` and `data.database` fields.

Here is the original data configuration:
```
  data: 
    url: jdbc:postgresql://127.0.0.1:5432/postgres
```

Here is the data configuration after the refactoring.

```
data:
  type: postgres
  server: 127.0.0.1:5432
  database: postgres
```

### Why

This is to avoid mistakes while constructing database url string to reduce the user friction. 

### Known limitations

N/A