### PR TITLE
[ANCHOR-174] Stop creating SEP service beans when disabled in configuration. (fix Sep10 npe)

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -17,6 +17,7 @@ import org.stellar.anchor.config.*;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.filter.JwtTokenFilter;
 import org.stellar.anchor.horizon.Horizon;
+import org.stellar.anchor.platform.condition.ConditionalOnAllSepsEnabled;
 import org.stellar.anchor.platform.config.*;
 import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountsManager;
 import org.stellar.anchor.platform.service.Sep31DepositInfoGeneratorApi;
@@ -120,11 +121,13 @@ public class SepBeans {
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep1"})
   Sep1Service sep1Service(Sep1Config sep1Config) throws IOException, InvalidConfigException {
     return new Sep1Service(sep1Config);
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep10"})
   Sep10Service sep10Service(
       AppConfig appConfig,
       SecretConfig secretConfig,
@@ -135,11 +138,13 @@ public class SepBeans {
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep12"})
   Sep12Service sep12Service(CustomerIntegration customerIntegration, AssetService assetService) {
     return new Sep12Service(customerIntegration, assetService);
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep24"})
   Sep24Service sep24Service(
       AppConfig appConfig,
       Sep24Config sep24Config,
@@ -189,6 +194,7 @@ public class SepBeans {
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep31"})
   Sep31Service sep31Service(
       AppConfig appConfig,
       Sep31Config sep31Config,
@@ -212,6 +218,7 @@ public class SepBeans {
   }
 
   @Bean
+  @ConditionalOnAllSepsEnabled(seps = {"sep38"})
   Sep38Service sep38Service(
       Sep38Config sep38Config,
       AssetService assetService,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This is to fix:
```
When sep10.enabled is false or omitted, and secret.sep10.signing_seed / SECRET_SEP10_SIGNING_SEED is omitted, a null pointer exception is raised. I noticed that if I enable SEP-10, but omit the signing seed, this results in a user-friendly error message as expected.

The signing seed should not be required if SEP-10 is not enabled.
```
The bug is caused by creating Sep10Service bean when `sep10.enabled` is set to false. 

This fix avoids creating SEP service beans when the configuration is disabled. 

### Why

Bug fixes.

### Known limitations

N/A