### PR TITLE
[ANCHOR-176] Add sub field to SEP24 interactive URL JWT

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -75,7 +75,11 @@ public class JwtService {
     }
     Calendar calExp = Calendar.getInstance();
     calExp.setTimeInMillis(1000L * token.getExp());
-    JwtBuilder builder = Jwts.builder().setId(token.getJti()).setExpiration(calExp.getTime());
+    JwtBuilder builder =
+        Jwts.builder()
+            .setId(token.getJti())
+            .setExpiration(calExp.getTime())
+            .setSubject(token.getSub());
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
     }

--- a/core/src/main/java/org/stellar/anchor/auth/Sep24InteractiveUrlJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/Sep24InteractiveUrlJwt.java
@@ -6,7 +6,9 @@ import io.jsonwebtoken.Jwt;
 import org.stellar.anchor.api.exception.SepException;
 
 public class Sep24InteractiveUrlJwt extends AbstractJwt {
-  public Sep24InteractiveUrlJwt(String jti, long exp, String clientDomain) throws SepException {
+  public Sep24InteractiveUrlJwt(String sub, String jti, long exp, String clientDomain)
+      throws SepException {
+    super.sub = sub;
     super.jti = jti;
     super.exp = exp;
     super.claim(CLIENT_DOMAIN, clientDomain);

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -23,6 +23,7 @@ internal class JwtServiceTest {
     val TEST_EXP = System.currentTimeMillis() / 1000 + 900
     const val TEST_JTI = "test_jti"
     const val TEST_CLIENT_DOMAIN = "test_client_domain"
+    const val TEST_ACCOUNT = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
   }
 
   lateinit var secretConfig: SecretConfig
@@ -76,7 +77,7 @@ internal class JwtServiceTest {
   @Test
   fun `test apply Sep24InteractiveUrlJwt encoding and decoding and make sure the original values are not changed`() {
     val jwtService = JwtService(secretConfig)
-    val token = Sep24InteractiveUrlJwt(TEST_ISS, TEST_EXP, TEST_CLIENT_DOMAIN)
+    val token = Sep24InteractiveUrlJwt(TEST_ACCOUNT, TEST_ISS, TEST_EXP, TEST_CLIENT_DOMAIN)
     val cipher = jwtService.encode(token)
     val sep24InteractiveUrlJwt = jwtService.decode(cipher, Sep24InteractiveUrlJwt::class.java)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add sub field to SEP24 interactive URL JWT. The `sub` field contains:

- Just account: `GASBFIRJMPVQGT66PLVGBLT37I3QDQSWYUIKZ3W7JJIJXB7SVB6KA7WM`
- Just account + memo:  `GASBFIRJMPVQGT66PLVGBLT37I3QDQSWYUIKZ3W7JJIJXB7SVB6KA7WM:123456`
- Mux account:  `GASBFIRJMPVQGT66PLVGBLT37I3QDQSWYUIKZ3W7JJIJXB7SVB6KA7WM:123456`

The mux account will be decoded and represented as just account + memo

### Why

The first step for building a business server will be to authenticate the user by verifying the JWT added to the interactive url by the Anchor Platform.

It is straightforward to verify the JWT’s signature using the shared secret, but it is less straightforward to identify the user who initiated the transaction. Currently, the developer has to use the token’s jti field to fetch the transaction from the platform’s GET /transactions/:id endpoint and fetch the fields that identify the user (transaction.sender.account and transaction.sender.memo).

It would be easier for the developer if we added a sub field to the interactive url’s JWT so that the business server didn’t have to fetch the transaction in order to authenticate the user. The sub field format should be the same as SEP-10’s.

- just account: `GASBFIRJMPVQGT66PLVGBLT37I3QDQSWYUIKZ3W7JJIJXB7SVB6KA7WM`
- mux account & account + memo: `GASBFIRJMPVQGT66PLVGBLT37I3QDQSWYUIKZ3W7JJIJXB7SVB6KA7WM:123456`

The developer will need to maintain a mapping of each of their users to a list of sub values for that user (since users can have multiple stellar accounts or use multiple custodial wallets).

### Known limitations

N/A