### PR TITLE
root: Fix the Gradle build docker image to gradle:7.6.0-jdk11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM openjdk:11-jdk AS build
-FROM gradle:jdk11-alpine AS build
+FROM gradle:7.6.0-jdk11-alpine AS build
 WORKDIR /code
 COPY --chown=gradle:gradle . .
 RUN gradle clean bootJar --stacktrace


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix the Gradle build docker image to 7.6.0

### Why

We were using `gradle:jdk11` which gets upgraded to 8.x and breaks the Jenkins build. That is not desired. We are fixing it to `gradle:7.6.0-jdk11-alpine` to avoid unexpected issues.

### Known limitations

N/A