### PR TITLE
[ANCHOR-175] Fix missing more_info URL JWT secret validation.

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep24Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep24Config.java
@@ -138,7 +138,7 @@ public class PropertySep24Config implements Sep24Config, Validator {
           }
         }
       }
-      if (isEmpty(secretConfig.getSep24InteractiveUrlJwtSecret())) {
+      if (isEmpty(secretConfig.getSep24MoreInfoUrlJwtSecret())) {
         errors.reject(
             "sep24-more-info-url-jwt-secret-not-defined",
             "Please set the secret.sep24.more_info_url.jwt_secret or SECRET_SEP24_MORE_INFO_URL_JWT_SECRET environment variable");

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep24ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep24ConfigTest.kt
@@ -39,6 +39,20 @@ class Sep24ConfigTest {
     assertFalse(errors.hasErrors())
   }
 
+  @Test
+  fun `test validation rejecting missing more_info url jwt secret`() {
+    every { secretConfig.sep24MoreInfoUrlJwtSecret } returns null
+    config.validate(config, errors)
+    assertEquals("sep24-more-info-url-jwt-secret-not-defined", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test validation rejecting missing interactive url jwt secret`() {
+    every { secretConfig.sep24InteractiveUrlJwtSecret } returns null
+    config.validate(config, errors)
+    assertEquals("sep24-interactive-url-jwt-secret-not-defined", errors.allErrors[0].code)
+  }
+
   @ParameterizedTest
   @ValueSource(strings = ["httpss://www.stellar.org"])
   fun `test interactive url with bad url configuration`(url: String) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix missing more_info URL JWT secret validation.

### Why

Here is the original bug report: 
================
If the developer does not configure `secret.sep24.more_info_url.jwt_secret` / `SECRET_SEP24_MORE_INFO_URL_JWT_SECRET`, requests to SEP-24’s `GET /transaction(s`) endpoints return 500 because the anchor platform cannot create the url tokens without the secret.

This makes the more info URL jwt secret a required environment variable. However, I suggest we make both the interactive url and more info url use the same jwt secret.


### Known limitations
N/A