### PR TITLE
[ANCHOR-181] Remove stellar_transaction_id from database and Java data classes

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -34,7 +34,7 @@ public class PlatformTransactionData {
   Amount amountFee;
 
   @SerializedName("kyc_verified")
-  Boolean kycVerified = false;
+  Boolean kycVerified;
 
   @SerializedName("quote_id")
   String quoteId;

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Transaction.java
@@ -31,8 +31,6 @@ public interface Sep24Transaction {
    */
   String getStellarTransactionId();
 
-  void setStellarTransactionId(String stellarTransactionId);
-
   /**
    * ID of transaction on external network that either started the deposit or completed the
    * withdrawal.

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -143,21 +143,13 @@ public class Sep31Service {
         new Sep31TransactionBuilder(sep31TransactionStore)
             .id(generateSepTransactionId())
             .status(SepTransactionStatus.PENDING_SENDER.getStatus())
-            .statusEta(null)
             .amountFee(fee.getAmount())
             .amountFeeAsset(fee.getAsset())
             .startedAt(now)
             .updatedAt(now) // this will be overwritten by the sep31TransactionStore#save method.
-            .completedAt(null)
-            .stellarTransactionId(null)
-            .externalTransactionId(null)
-            .requiredInfoMessage(null)
             .quoteId(request.getQuoteId())
             .clientDomain(sep10Jwt.getClientDomain())
-            .requiredInfoUpdates(null)
             .fields(request.getFields().getTransaction())
-            .refunded(null)
-            .refunds(null)
             .senderId(Context.get().getRequest().getSenderId())
             .receiverId(Context.get().getRequest().getReceiverId())
             .creator(creatorStellarId)
@@ -165,12 +157,8 @@ public class Sep31Service {
             .amountExpected(request.getAmount())
             .amountIn(request.getAmount())
             .amountInAsset(assetInfo.getAssetName())
-            .amountOut(null)
-            .amountOutAsset(null)
             // updateDepositInfo will update these ⬇️
             .stellarAccountId(assetInfo.getDistributionAccount())
-            .stellarMemo(null)
-            .stellarMemoType(null)
             .build();
 
     Context.get().setTransaction(txn);
@@ -481,7 +469,6 @@ public class Sep31Service {
                         (request.getDestinationAsset() == null)
                             ? assetName
                             : request.getDestinationAsset())
-                    .receiveAmount(null)
                     .senderId(request.getSenderId())
                     .receiverId(request.getReceiverId())
                     .clientId(token.getAccount())

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
@@ -79,8 +79,6 @@ public interface Sep31Transaction {
 
   String getStellarTransactionId();
 
-  void setStellarTransactionId(String stellarTransactionId);
-
   List<StellarTransaction> getStellarTransactions();
 
   void setStellarTransactions(List<StellarTransaction> stellarTransactions);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
@@ -99,11 +99,6 @@ public class Sep31TransactionBuilder {
     return this;
   }
 
-  public Sep31TransactionBuilder stellarTransactionId(String stellarTransactionId) {
-    txn.setStellarTransactionId(stellarTransactionId);
-    return this;
-  }
-
   public Sep31TransactionBuilder stellarTransactions(List<StellarTransaction> stellarTransactions) {
     txn.setStellarTransactions(stellarTransactions);
     return this;

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
@@ -3,12 +3,14 @@ package org.stellar.anchor.sep31;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.api.shared.StellarTransaction;
 
-@Data
+@Getter
+@Setter
 public class PojoSep31Transaction implements Sep31Transaction {
   String id;
   String status;
@@ -40,6 +42,14 @@ public class PojoSep31Transaction implements Sep31Transaction {
   String receiverId;
   String senderId;
   StellarId creator;
+
+  @Override
+  public String getStellarTransactionId() {
+    if (stellarTransactions != null && stellarTransactions.size() > 0) {
+      return stellarTransactions.get(0).getId();
+    }
+    return null;
+  }
 
   @Override
   public void setRefunds(Sep31Refunds sep31Refunds) {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -187,7 +187,6 @@ class Sep31ServiceTest {
       "transferReceivedAt": "2022-04-18T14:30:00.000Z",
       "updatedAt": "2022-04-18T15:00:00.000Z",
       "completedAt": "2022-04-18T15:00:00.000Z",
-      "stellarTransactionId": "18db1b8dffa78a0567faadeab7b08b7be8b3f65c40018d609cc530b757e67bc2",
       "externalTransactionId": "external-id",
       "requiredInfoMessage": "Don't forget to foo bar",
       "quoteId": "quote_id",
@@ -462,7 +461,6 @@ class Sep31ServiceTest {
           .stellarMemoType("text")
           .startedAt(wantStartedAt)
           .completedAt(wantCompletedAt)
-          .stellarTransactionId("18db1b8dffa78a0567faadeab7b08b7be8b3f65c40018d609cc530b757e67bc2")
           .externalTransactionId("external-id")
           .refunded(true)
           .refunds(wantRefunds)

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -116,7 +116,6 @@ class Sep31TransactionTest {
         .updatedAt(mockUpdatedAt)
         .transferReceivedAt(mockTransferReceivedAt)
         .completedAt(mockCompletedAt)
-        .stellarTransactionId("2b862ac297c93e2db43fc58d407cc477396212bce5e6d5f61789f963d5a11300")
         .stellarTransactions(listOf(stellarTransaction))
         .externalTransactionId("external-tx-id")
         .refunded(true)

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSepTransaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSepTransaction.java
@@ -51,15 +51,19 @@ public abstract class JdbcSepTransaction {
   @SerializedName("transfer_received_at")
   Instant transferReceivedAt;
 
-  @SerializedName("stellar_transaction_id")
-  String stellarTransactionId;
-
   @SerializedName("external_transaction_id")
   String externalTransactionId;
 
   @Column(columnDefinition = "json")
   @Type(type = "json")
   List<StellarTransaction> stellarTransactions;
+
+  public String getStellarTransactionId() {
+    if (stellarTransactions != null && stellarTransactions.size() > 0) {
+      return stellarTransactions.get(0).getId();
+    }
+    return null;
+  }
 
   public abstract String getProtocol();
 }

--- a/platform/src/main/resources/db/migration/V6__sep24_field_updates.sql
+++ b/platform/src/main/resources/db/migration/V6__sep24_field_updates.sql
@@ -46,6 +46,8 @@ ALTER TABLE sep24_transaction DROP COLUMN completed_at;
 
 ALTER TABLE sep24_transaction DROP COLUMN started_at;
 
+ALTER TABLE sep24_transaction DROP COLUMN stellar_transaction_id;
+
 ALTER TABLE sep24_transaction ADD completed_at TIMESTAMP WITHOUT TIME ZONE;
 
 ALTER TABLE sep24_transaction ALTER COLUMN  id SET NOT NULL;
@@ -57,3 +59,5 @@ ALTER TABLE sep24_transaction ADD CONSTRAINT pk_sep24_transaction PRIMARY KEY (i
 ALTER TABLE sep31_transaction ALTER COLUMN refunds type JSONB using refunds::jsonb;
 
 ALTER TABLE sep31_transaction ADD bank_account_type VARCHAR(255);
+
+ALTER TABLE sep31_transaction DROP COLUMN stellar_transaction_id;


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

- Remove stellarTransactionId from JdbcSepTransaction class.
- Add getStellarTransactionId to JdbcSep24Transaction and JdbcSep31Transaction that queries the list of stellar transactions and calculates the proper stellarTransactionId
- Remove setStellarTransactionId from Sep24Transaction and Sep31Transaction interfaces.
- Remove stellarTransactionId from DB migration file.

### Why

To avoid multiple sources of `stellar_transaction_id`.

### Known limitations

This PR CANNOT be merged because we need to support [query transactions ](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#single-historical-transaction)based on `stellarTransactionId` .