### PR TITLE
core: use `token.getSub()` instead of `token.getAccount()` for interactive JWT

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -369,7 +369,7 @@ public class Sep24Service {
   JwtToken buildRedirectJwtToken(String fullRequestUrl, JwtToken token, Sep24Transaction txn) {
     return JwtToken.of(
         fullRequestUrl,
-        token.getAccount(),
+        token.getSub(),
         Instant.now().getEpochSecond(),
         Instant.now().getEpochSecond() + sep24Config.getInteractiveJwtExpiration(),
         txn.getTransactionId(),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Replaces the use of `token.getAccount()` with `token.getSub()` when generating the interactive URL JWT.

### Why

This fix ensures the interactive JWT includes the user's memo when the wallet is custodial. This bug is not present in the develop branch so no port is needed.

### Known limitations

[TODO or N/A]