### PR TITLE
Release 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.2.9
+* Commit the dirty SEP-31 transaction before calling the `/unique_address` endpoint. [#797](https://github.com/stellar/java-stellar-anchor-sdk/pull/797)
+
 ## 1.2.8
 * Fix the SEP-31 transaction not saved to database when deposit info is updated. [#791](https://github.com/stellar/java-stellar-anchor-sdk/pull/791)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.8"
+  version = "1.2.9"
 
   tasks.jar {
     manifest {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Commit Sep31 transaction to database before calling the unique_address endpoint

### Why

This is to fix the bug where the Sep31 transaction object is dirty after calling `txnStore.save()`. At that moment, the `unieuq_address` is called which in turn calls the `GET /transaction` endpoint to retrieve the saved transaction. 

### Known limitations

N/A