### PR TITLE
Update CHANGELOG.md to inform Sep-24 Protocol Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ## 1.0.12
 
 ### Updates
-
+* The java-stellar-anchor-sdk currently supports SEP-24 Protocol Release [V3.0.0](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#changelog)
+* Please note, optional features may not be implemented by your service provider using this SDK. Please consult with your service provider to review any optional features that you may require. 
+* Please subscribe to this reposistory on the `core-release-1.0` branch to be notified of any updates.  Consult with your service provider to determine which version of the SDK the currently support.
 * Support for accepting `refund_memo` and `refund_memo_type` parameters in SEP-24 `POST /transactions/withdraw/interactive` requests
     * Add the following methods to `org.stellar.anchor.model.Sep24Transaction` interface:
         * `String getRefundMemo()`


### PR DESCRIPTION

### What

I am proposing this change to the java-stellar-anchor-sdk in order to make it possible for partners and service providers to inform their clients about which sep-24 protocol version they currently support.  The change supports the following questions from our partner:

1.  Each time there is a change, v. 1.0.13, 1.1.0, 2.6.0, etc.  can we see what versions have been release and the dates?  
2.  Stellar would provide documentation of the change.  Someone at (partner) would need to determine if we need to build to the latest version?  

with this change, we will provide a statement about protocol support in the change log of the SDK. 

this is only a change to the changelog. will update the changelog with statement of protocol support each release.

### Why

to inform service providers and sep-24 clients about what protocol support the SDK they or their service provider is using supports.

### Known limitations

still requires manual communication.  we are planning to look into if this is something that can be facilitated via information within the sep24 /info endpoint itself.