### PR TITLE
ANCHOR-227: Fix incorrect asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.2.10
+* Fix asset being set incorrectly when quote is null. [#805](https://github.com/stellar/java-stellar-anchor-sdk/pull/805)
+
 ## 1.2.9
 * Commit the dirty SEP-31 transaction before calling the `/unique_address` endpoint. [#797](https://github.com/stellar/java-stellar-anchor-sdk/pull/797)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.9"
+  version = "1.2.10"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -341,7 +341,7 @@ public class Sep31Service {
     txn.setAmountExpected(formatAmount(amountIn, scale));
     txn.setAmountInAsset(reqAsset.getAssetName());
     txn.setAmountOut(formatAmount(amountOut, scale));
-    txn.setAmountOutAsset(reqAsset.getAssetName());
+    txn.setAmountOutAsset(request.getDestinationAsset());
 
     // Update fee
     String feeStr = formatAmount(fee, scale);


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix asset being set incorrectly when quote is null

### Why

Bug fix

### Known limitations

N/A