### PR TITLE
fix: getenv so it can handle line breaks `/n` and quotes `/"` when reading System envs

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigEnvironment.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigEnvironment.java
@@ -46,7 +46,11 @@ public class ConfigEnvironment {
    * @return the value of the environment variable.
    */
   public static String getenv(String name) {
-    return env.get(toPosixForm(name));
+    String envValue = env.get(toPosixForm(name));
+    if (envValue != null) {
+      envValue = envValue.replace("\\n", "\n").replace("\\\"", "\"");
+    }
+    return envValue;
   }
 
   public static Collection<String> names() {

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigEnvironment.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigEnvironment.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class ConfigEnvironment {
   static Map<String, String> env;
@@ -43,14 +44,10 @@ public class ConfigEnvironment {
    * environment variables.
    *
    * @param name the name of the environment variable
-   * @return the value of the environment variable.
+   * @return the value of the environment variable. If the variable is not set, null is returned.
    */
   public static String getenv(String name) {
-    String envValue = env.get(toPosixForm(name));
-    if (envValue != null) {
-      envValue = envValue.replace("\\n", "\n").replace("\\\"", "\"");
-    }
-    return envValue;
+    return StringEscapeUtils.unescapeJava(env.get(toPosixForm(name)));
   }
 
   public static Collection<String> names() {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
@@ -112,4 +112,20 @@ class ConfigManagerTest {
     ConfigEnvironment.rebuild()
     assertNull(ConfigEnvironment.getenv(multilineEnvName))
   }
+
+  @Test
+  fun `test ConfigEnvironment getenv without line breaks or quotes`() {
+    val simpleEnvName = "SIMPLE_ENV"
+    val simpleEnvValue = "FOOBAR"
+    val wantValue = "FOOBAR"
+
+    System.setProperty(simpleEnvName, simpleEnvValue)
+    ConfigEnvironment.rebuild()
+
+    assertEquals(wantValue, ConfigEnvironment.getenv(simpleEnvName))
+
+    System.clearProperty(simpleEnvName)
+    ConfigEnvironment.rebuild()
+    assertNull(ConfigEnvironment.getenv(simpleEnvName))
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.configurator
 
 import io.mockk.*
+import kotlin.test.assertNull
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -94,5 +95,21 @@ class ConfigManagerTest {
     val gotConfig = configManager.processConfigurations(null)
 
     assertTrue(gotConfig.equals(wantedConfig))
+  }
+
+  @Test
+  fun `test ConfigEnvironment getenv with line breaks and quotes`() {
+    val multilineEnvName = "MULTILINE_ENV"
+    val multilineEnvValue = """FOO=\"FOO\"\nBAR=\"BAR\""""
+    val wantValue = "FOO=\"FOO\"\nBAR=\"BAR\""
+
+    System.setProperty(multilineEnvName, multilineEnvValue)
+    ConfigEnvironment.rebuild()
+
+    assertEquals(wantValue, ConfigEnvironment.getenv(multilineEnvName))
+
+    System.clearProperty(multilineEnvName)
+    ConfigEnvironment.rebuild()
+    assertNull(ConfigEnvironment.getenv(multilineEnvName))
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix the getenv method so it can handle line breaks /n and quotes /" when reading System envs

### Why

When providing a multiline env var with `\n`, it was being ingested as `\\n`. The same for quotes.
