### PR TITLE
[ANCHOR-233] When sep10.web_auth_domain is not set, it is default to the domain of host_url

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -1,10 +1,10 @@
 package org.stellar.anchor.sep10;
 
 import static org.stellar.anchor.util.Log.*;
+import static org.stellar.anchor.util.NetUtil.getDomainFromURL;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.stellar.anchor.api.exception.SepException;
@@ -343,13 +343,5 @@ public class Sep10Service {
             clientDomain);
     debug("jwtToken:", sep10Jwt);
     return jwtService.encode(sep10Jwt);
-  }
-
-  String getDomainFromURL(String strUri) throws MalformedURLException {
-    URL uri = new URL(strUri);
-    if (uri.getPort() < 0) {
-      return uri.getHost();
-    }
-    return uri.getHost() + ":" + uri.getPort();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/util/NetUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/NetUtil.java
@@ -5,6 +5,7 @@ import static org.stellar.anchor.util.StringHelper.isEmpty;
 import io.jsonwebtoken.lang.Strings;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
 import okhttp3.Call;
@@ -57,6 +58,14 @@ public class NetUtil {
       default:
         return false;
     }
+  }
+
+  public static String getDomainFromURL(String strUri) throws MalformedURLException {
+    URL uri = new URL(strUri);
+    if (uri.getPort() < 0) {
+      return uri.getHost();
+    }
+    return uri.getHost() + ":" + uri.getPort();
   }
 
   static boolean isHostnameValid(String hostname) {

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -6,7 +6,6 @@ import com.google.common.io.BaseEncoding
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import java.io.IOException
-import java.net.MalformedURLException
 import java.security.SecureRandom
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
@@ -660,26 +659,5 @@ internal class Sep10ServiceTest {
     verify(exactly = 2) { sep10Config.omnibusAccountList }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
     assertEquals("unable to process", ex.message)
-  }
-
-  @ParameterizedTest
-  @CsvSource(
-    value =
-      [
-        "https://test.stellar.org,test.stellar.org",
-        "http://test.stellar.org,test.stellar.org",
-        "https://test.stellar.org:9800,test.stellar.org:9800",
-        "http://test.stellar.org:9800,test.stellar.org:9800",
-      ]
-  )
-  fun `test goodURLs for getDomainFromURL`(testUri: String, compareDomain: String) {
-    val domain = sep10Service.getDomainFromURL(testUri)
-    assertEquals(domain, compareDomain)
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = ["bad url", "http :///test.stellar.org:9800/"])
-  fun `test bad URLs for getDomainFromURL`(testUrl: String) {
-    assertThrows<MalformedURLException> { sep10Service.getDomainFromURL(testUrl) }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
@@ -4,6 +4,7 @@ package org.stellar.anchor.util
 
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import java.net.MalformedURLException
 import okhttp3.Response
 import okhttp3.ResponseBody
 import org.junit.jupiter.api.AfterEach
@@ -11,10 +12,10 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.stellar.anchor.util.NetUtil.isServerPortValid
-import org.stellar.anchor.util.NetUtil.isUrlValid
+import org.stellar.anchor.util.NetUtil.*
 
 internal class NetUtilTest {
   @MockK private lateinit var mockCall: okhttp3.Call
@@ -147,5 +148,26 @@ internal class NetUtilTest {
   )
   fun `test bad server port with isServerPortValid`(testValue: String?) {
     assertFalse(isServerPortValid(testValue))
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value =
+      [
+        "https://test.stellar.org,test.stellar.org",
+        "http://test.stellar.org,test.stellar.org",
+        "https://test.stellar.org:9800,test.stellar.org:9800",
+        "http://test.stellar.org:9800,test.stellar.org:9800",
+      ]
+  )
+  fun `test good URLs for getDomainFromURL`(testUri: String, compareDomain: String) {
+    val domain = getDomainFromURL(testUri)
+    assertEquals(domain, compareDomain)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["bad url", "http :///test.stellar.org:9800/"])
+  fun `test bad URLs for getDomainFromURL`(testUrl: String) {
+    org.junit.jupiter.api.assertThrows<MalformedURLException> { getDomainFromURL(testUrl) }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -51,8 +51,8 @@ public class SepBeans {
 
   @Bean
   @ConfigurationProperties(prefix = "sep10")
-  Sep10Config sep10Config(SecretConfig secretConfig) {
-    return new PropertySep10Config(secretConfig);
+  Sep10Config sep10Config(AppConfig appConfig, SecretConfig secretConfig) {
+    return new PropertySep10Config(appConfig, secretConfig);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -1,14 +1,18 @@
 package org.stellar.anchor.platform.config;
 
 import static java.lang.String.format;
+import static org.stellar.anchor.util.NetUtil.getDomainFromURL;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 import static org.stellar.anchor.util.StringHelper.isNotEmpty;
 
+import java.net.MalformedURLException;
 import java.util.List;
+import javax.annotation.PostConstruct;
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
+import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.util.ListHelper;
@@ -26,10 +30,19 @@ public class PropertySep10Config implements Sep10Config, Validator {
   private List<String> clientAttributionAllowList;
   private List<String> omnibusAccountList;
   private boolean requireKnownOmnibusAccount;
+  private AppConfig appConfig;
   private SecretConfig secretConfig;
 
-  public PropertySep10Config(SecretConfig secretConfig) {
+  public PropertySep10Config(AppConfig appConfig, SecretConfig secretConfig) {
+    this.appConfig = appConfig;
     this.secretConfig = secretConfig;
+  }
+
+  @PostConstruct
+  public void postConstruct() throws MalformedURLException {
+    if (isEmpty(webAuthDomain)) {
+      webAuthDomain = getDomainFromURL(appConfig.getHostUrl());
+    }
   }
 
   @Override

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -219,8 +219,9 @@ sep10:
   ## @param: web_auth_domain
   ## @type: string
   ## The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
+  ## If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of the value of the `host_url`.
   #
-  web_auth_domain: localhost:8080
+  web_auth_domain:
   ## @param: client_attribution_required
   ## @type: bool
   ## Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -30,7 +30,6 @@ sep1.enabled=true
 sep1.toml.type=file
 sep1.toml.value=/config/stellar.toml
 sep10.enabled=true
-sep10.web_auth_domain=localhost:8080
 sep12.enabled=true
 sep31.enabled=true
 sep38.enabled=true

--- a/service-runner/src/main/resources/profiles/sep24/config.env
+++ b/service-runner/src/main/resources/profiles/sep24/config.env
@@ -30,7 +30,6 @@ sep1.enabled=true
 sep1.toml.type=file
 sep1.toml.value=/config/stellar.toml
 sep10.enabled=true
-sep10.web_auth_domain=localhost:8080
 sep12.enabled=true
 sep31.enabled=true
 sep38.enabled=true


### PR DESCRIPTION
… host_url

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

When sep10.web_auth_domain is not set, it is default to the domain of host_ur. 

### Why

This is to simplify the `sep10.web_auth_domain` configuration and avoid configuration mistakes.