### PR TITLE
Fix stellar transaction id is not set properly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ subprojects {
     implementation(rootProject.libs.bundles.kafka)
     implementation(rootProject.libs.spring.kafka)
     implementation(rootProject.libs.log4j.template.json)
-    implementation(rootProject.libs.stellar.wallet.sdk)
 
     // Although the following libraries are transitive dependencies, we are including them here to
     // override the version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ apache-commons-lang3 = "3.12.0"
 aws-iam-auth = "1.1.4"
 aws-rds = "1.12.248"
 aws-sqs = "1.12.200"
+coroutines = "1.6.4"
 commons-beanutils = "1.9.4"
 commons-cli = "1.5.0"
 commons-codec = "1.15"
@@ -52,7 +53,7 @@ aws-java-sdk-s3 = "1.12.342"
 sqlite-jdbc = "3.34.0"
 slf4j = "1.7.35"
 slf4j2 = "2.0.5"
-stellar-wallet-sdk = "0.6.0"
+stellar-wallet-sdk = "0.7.0-SNAPSHOT"
 toml4j = "0.7.2"
 
 # Plugin versions
@@ -72,6 +73,7 @@ commons-cli = { module = "commons-cli:commons-cli", version.ref = "commons-cli" 
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 commons-validator = { module = "commons-validator:commons-validator", version.ref = "commons-validator" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 docker-compose-rule = {module = "com.palantir.docker.compose:docker-compose-junit-jupiter", version.ref = "docker-compose-rule" }
 dotenv = { module = "io.github.cdimascio:dotenv-java", version.ref = "dotenv" }
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
 }
 
+repositories {
+  maven {
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+  }
+}
+
 dependencies {
   implementation("org.springframework.boot:spring-boot")
   implementation("org.springframework.boot:spring-boot-autoconfigure")

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -13,10 +13,7 @@ import static org.stellar.sdk.xdr.MemoType.MEMO_HASH;
 
 import io.micrometer.core.instrument.Metrics;
 import java.time.Instant;
-import java.util.Base64;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -144,6 +141,13 @@ public class TransactionService {
           memo = new String(Base64.getEncoder().encode(memo.getBytes()));
           sep24Transaction.setMemo(memo);
           sep24Transaction.setMemoType(memoTypeAsString(MEMO_HASH));
+        }
+        if (patch.getTransaction().getStellarTransactions() != null) {
+          patch.getTransaction().getStellarTransactions().stream()
+              .max(Comparator.comparingLong(x -> x.getCreatedAt().toEpochMilli()))
+              .ifPresent(
+                  stellarTransaction ->
+                      sep24Transaction.setStellarTransactionId(stellarTransaction.getId()));
         }
         txn24Store.save(sep24Transaction);
         eventService.publish(sep24Transaction, TRANSACTION_STATUS_CHANGED);

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -142,13 +142,6 @@ public class TransactionService {
           sep24Transaction.setMemo(memo);
           sep24Transaction.setMemoType(memoTypeAsString(MEMO_HASH));
         }
-        if (patch.getTransaction().getStellarTransactions() != null) {
-          patch.getTransaction().getStellarTransactions().stream()
-              .max(Comparator.comparingLong(x -> x.getCreatedAt().toEpochMilli()))
-              .ifPresent(
-                  stellarTransaction ->
-                      sep24Transaction.setStellarTransactionId(stellarTransaction.getId()));
-        }
         txn24Store.save(sep24Transaction);
         eventService.publish(sep24Transaction, TRANSACTION_STATUS_CHANGED);
         break;
@@ -202,6 +195,12 @@ public class TransactionService {
     txnUpdated = updateField(patch, txn, "externalTransactionId", txnUpdated);
     // update stellar_transactions
     txnUpdated = updateField(patch, txn, "stellarTransactions", txnUpdated);
+
+    if (patch.getStellarTransactions() != null) {
+      patch.getStellarTransactions().stream()
+          .max(Comparator.comparingLong(x -> x.getCreatedAt().toEpochMilli()))
+          .ifPresent(stellarTransaction -> txn.setStellarTransactionId(stellarTransaction.getId()));
+    }
 
     switch (txn.getProtocol()) {
       case "24":

--- a/service-runner/build.gradle.kts
+++ b/service-runner/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   implementation(libs.dotenv)
   implementation(libs.google.gson)
   implementation(libs.okhttp3)
+  implementation(libs.coroutines.core)
 
   // From projects
   implementation(project(":core"))

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -5,6 +5,7 @@ package org.stellar.anchor.platform
 import com.palantir.docker.compose.DockerComposeExtension
 import com.palantir.docker.compose.connection.waiting.HealthChecks
 import java.io.File
+import java.lang.Thread.sleep
 import java.lang.reflect.Field
 import java.util.*
 import kotlinx.coroutines.*
@@ -56,6 +57,7 @@ class TestProfileExecutor(val config: TestConfig) {
     shouldStartKotlinReferenceServer = config.env["run_kotlin_reference_server"].toBoolean()
 
     startDocker()
+    sleep(5000)
     startServers(wait)
   }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix stellar_transaction_id is not set in DB 

### Why

Due to this bug stellar_transaction_id is not set in the result GET transaction response. Also, it's not possible to query by stellar_transaction_id.

### Known limitations

Only works with the latest transaction's id. If multiple Stellar transactions are associated with the SEP transaction, only latest Stellar transaction will be visible.