### PR TITLE
kotlin-reference-server: Remove stellar prefix for deposit and withdrawal

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/Sep24Route.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/Sep24Route.kt
@@ -100,13 +100,15 @@ fun Route.sep24(
 
             call.respond(Success(sessionId))
 
+            val stellarAsset = asset.replace("stellar:", "")
+
             // Run deposit processing asynchronously
             CoroutineScope(Job()).launch {
               depositService.processDeposit(
                 transaction.id,
                 deposit.amount.toBigDecimal(),
                 account,
-                asset,
+                stellarAsset,
                 memo,
                 memoType
               )
@@ -121,12 +123,14 @@ fun Route.sep24(
               transaction.amountExpected?.asset
                 ?: throw ClientException("Missing amountExpected.asset field")
 
+            val stellarAsset = asset.replace("stellar:", "")
+
             // Run deposit processing asynchronously
             CoroutineScope(Job()).launch {
               withdrawalService.processWithdrawal(
                 transaction.id,
                 withdrawal.amount.toBigDecimal(),
-                asset
+                stellarAsset
               )
             }
           }

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform;
 
 import static org.stellar.anchor.util.Log.info;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.cli.*;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -55,7 +56,7 @@ public class ServiceRunner {
       }
 
       if (cmd.hasOption("kotlin-reference-server") || cmd.hasOption("all")) {
-        startKotlinReferenceServer(null, true);
+        startKotlinReferenceServer(new HashMap<>(), true);
         anyServerStarted = true;
       }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Remove stellar prefix for deposit and withdrawal

### Why

Stellar asset validation fails. Need this fix for development

### Known limitations

[TODO or N/A]