### PR TITLE
Make more_info_url to be mandatory

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/TransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/TransactionResponse.java
@@ -16,7 +16,7 @@ public class TransactionResponse {
   Integer status_eta;
 
   @SerializedName("more_info_url")
-  String moreInfoUrl = "http://www.stellar.org";
+  String moreInfoUrl;
 
   @SerializedName("amount_in")
   String amountIn;

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
@@ -7,7 +7,6 @@ import static org.stellar.anchor.util.MathHelper.decimal;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.BeanUtils;
 import org.stellar.anchor.api.sep.AssetInfo;
@@ -18,27 +17,6 @@ import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.config.Sep24Config;
 
 public class Sep24Helper {
-  static final List<String> needsMoreInfoUrlDeposit =
-      Arrays.asList(
-          INCOMPLETE.toString(),
-          PENDING_USR_TRANSFER_START.toString(),
-          PENDING_USR_TRANSFER_COMPLETE.toString(),
-          COMPLETED.toString(),
-          REFUNDED.toString(),
-          PENDING_EXTERNAL.toString(),
-          PENDING_ANCHOR.toString(),
-          PENDING_USER.toString());
-  static final List<String> needsMoreInfoUrlWithdraw =
-      Arrays.asList(
-          INCOMPLETE.toString(),
-          PENDING_USR_TRANSFER_START.toString(),
-          PENDING_USR_TRANSFER_COMPLETE.toString(),
-          COMPLETED.toString(),
-          REFUNDED.toString(),
-          PENDING_EXTERNAL.toString(),
-          PENDING_ANCHOR.toString(),
-          PENDING_USER.toString());
-
   static void setSharedTransactionResponseFields(TransactionResponse txnR, Sep24Transaction txn) {
     txnR.setId(txn.getTransactionId());
     if (txn.getFromAccount() != null) txnR.setFrom(txn.getFromAccount());

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -441,9 +441,7 @@ public class Sep24Service {
     txnR.setDepositMemo(txn.getMemo());
     txnR.setDepositMemoType(txn.getMemoType());
 
-    if (needsMoreInfoUrlDeposit.contains(txn.getStatus())) {
-      txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
-    }
+    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
 
     return txnR;
   }
@@ -460,9 +458,7 @@ public class Sep24Service {
     txnR.setWithdrawMemoType(txn.getMemoType());
     txnR.setWithdrawAnchorAccount(txn.getWithdrawAnchorAccount());
 
-    if (needsMoreInfoUrlWithdraw.contains(txn.getStatus())) {
-      txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
-    }
+    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
 
     return txnR;
   }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Make more_info_url to be mandatory

### Why

Previously, it was not being set in some statuses. This fixes it and removes default url (stellar.org)

### Known limitations

N/A