### PR TITLE
[ANCHOR-205] Validate PATCH transactions request body.

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -131,16 +131,25 @@ public class TransactionService {
   public PatchTransactionsResponse patchTransactions(PatchTransactionsRequest request)
       throws AnchorException {
     List<PatchTransactionRequest> patchRequests = request.getRecords();
+    if (patchRequests == null) {
+      throw new BadRequestException("Records are missing.");
+    }
 
     List<GetTransactionResponse> txnResponses = new LinkedList<>();
+
     for (PatchTransactionRequest patchRequest : patchRequests) {
       txnResponses.add(patchTransaction(patchRequest));
     }
+
     return new PatchTransactionsResponse(txnResponses);
   }
 
   private GetTransactionResponse patchTransaction(PatchTransactionRequest patch)
       throws AnchorException {
+    if (patch.getTransaction() == null) {
+      throw new BadRequestException("Transaction is missing.");
+    }
+
     validateIfStatusIsSupported(patch.getTransaction().getStatus().toString());
     validateAsset("amount_in", patch.getTransaction().getAmountIn());
     validateAsset("amount_out", patch.getTransaction().getAmountOut());

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
@@ -20,6 +20,7 @@ import org.stellar.anchor.api.exception.AnchorException
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.platform.PatchTransactionRequest
+import org.stellar.anchor.api.platform.PatchTransactionsRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus
 import org.stellar.anchor.api.sep.sep38.RateFee
 import org.stellar.anchor.api.shared.Amount
@@ -708,4 +709,27 @@ class TransactionServiceTest {
       }   
   """
       .trimIndent()
+
+  @Test
+  fun `patch transaction with bad body`() {
+    var patchTransactionsRequest = PatchTransactionsRequest.builder().records(null).build()
+
+    var ex =
+      assertThrows<BadRequestException> {
+        transactionService.patchTransactions(patchTransactionsRequest)
+      }
+    assertInstanceOf(BadRequestException::class.java, ex)
+    assertEquals("Records are missing.", ex.message)
+
+    val patchTransactionRequest = PatchTransactionRequest.builder().transaction(null).build()
+    val records: List<PatchTransactionRequest> = listOf(patchTransactionRequest)
+    patchTransactionsRequest = PatchTransactionsRequest.builder().records(records).build()
+
+    ex =
+      assertThrows<BadRequestException> {
+        transactionService.patchTransactions(patchTransactionsRequest)
+      }
+    assertInstanceOf(BadRequestException::class.java, ex)
+    assertEquals("Transaction is missing.", ex.message)
+  }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add NPE catchs on sending PATCH transactions request

### Why

Return a understandable error response to the user instead of only Null exception error stack trace

### Known limitations

The PATCH transactions endpoint will need more attention to handle failures of one or more transactions inside a list of transactions. Today the TransactionService returns a BadRequestException as soon as the first failure occurs, even if other transactions were already committed.