### PR TITLE
SDFSOF-24 - Added mapping of stellar asset codes to fireblocks asset codes

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/custody/fireblocks/CreateTransactionRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/custody/fireblocks/CreateTransactionRequest.java
@@ -40,16 +40,25 @@ public class CreateTransactionRequest {
   }
 
   @Data
-  @AllArgsConstructor
   public static class DestinationTransferPeerPath {
+
+    public DestinationTransferPeerPath(
+        DestinationTransferPeerPathType type, OneTimeAddress oneTimeAddress) {
+      this.type = type;
+      this.oneTimeAddress = oneTimeAddress;
+    }
+
     private DestinationTransferPeerPathType type;
     private String id;
     private OneTimeAddress oneTimeAddress;
   }
 
   @Data
-  @AllArgsConstructor
   public static class OneTimeAddress {
+    public OneTimeAddress(String address) {
+      this.address = address;
+    }
+
     private String address;
     private String tag;
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/FireblocksConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/FireblocksConfig.java
@@ -9,16 +9,22 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.platform.utils.RSAUtil;
+import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.NetUtil;
 
 @Data
@@ -30,6 +36,7 @@ public class FireblocksConfig implements Validator {
   private String transactionsReconciliationCron;
   private String publicKey;
   private RetryConfig retryConfig;
+  private Map<String, String> assetMappings;
 
   public FireblocksConfig(CustodySecretConfig secretConfig) {
     this.secretConfig = secretConfig;
@@ -37,6 +44,36 @@ public class FireblocksConfig implements Validator {
 
   public void setRetryConfig(RetryConfig retryConfig) {
     this.retryConfig = retryConfig;
+  }
+
+  public void setAssetMappings(String assetMappings) {
+    if (StringUtils.isEmpty(assetMappings)) {
+      this.assetMappings = Collections.emptyMap();
+    } else {
+      this.assetMappings =
+          Arrays.stream(assetMappings.split(StringUtils.LF))
+              .collect(
+                  Collectors.toMap(
+                      mapping -> mapping.substring(mapping.indexOf(' ') + 1),
+                      mapping -> mapping.substring(0, mapping.indexOf(' '))));
+    }
+  }
+
+  /**
+   * Get Fireblocks asset code by Stellar asset code
+   *
+   * @return Fireblocks asset code or null if no mapping found
+   */
+  public String getFireblocksAssetCode(String stellarAssetCode) {
+    if (assetMappings.containsKey(stellarAssetCode)) {
+      return assetMappings.get(stellarAssetCode);
+    }
+
+    Log.warnF(
+        "Unable to find Fireblocks asset code by Stellar asset code [%s]."
+            + " Please add corresponding asset mapping in custody.fireblocks.asset_mapping",
+        stellarAssetCode);
+    return null;
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/config/FireblocksConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/FireblocksConfig.java
@@ -54,8 +54,8 @@ public class FireblocksConfig implements Validator {
           Arrays.stream(assetMappings.split(StringUtils.LF))
               .collect(
                   Collectors.toMap(
-                      mapping -> mapping.substring(mapping.indexOf(' ') + 1),
-                      mapping -> mapping.substring(0, mapping.indexOf(' '))));
+                      mapping -> mapping.substring(mapping.indexOf(StringUtils.SPACE) + 1),
+                      mapping -> mapping.substring(0, mapping.indexOf(StringUtils.SPACE))));
     }
   }
 
@@ -64,16 +64,17 @@ public class FireblocksConfig implements Validator {
    *
    * @return Fireblocks asset code or null if no mapping found
    */
-  public String getFireblocksAssetCode(String stellarAssetCode) {
+  public String getFireblocksAssetCode(String stellarAssetCode) throws InvalidConfigException {
     if (assetMappings.containsKey(stellarAssetCode)) {
       return assetMappings.get(stellarAssetCode);
     }
 
+    String message =
+        String.format(
+            "Unable to find Fireblocks asset code by Stellar asset code [%s]", stellarAssetCode);
     Log.warnF(
-        "Unable to find Fireblocks asset code by Stellar asset code [%s]."
-            + " Please add corresponding asset mapping in custody.fireblocks.asset_mapping",
-        stellarAssetCode);
-    return null;
+        message + " Please add corresponding asset mapping in custody.fireblocks.asset_mapping");
+    throw new InvalidConfigException(message);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/PaymentController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/PaymentController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.stellar.anchor.api.custody.GenerateDepositAddressResponse;
 import org.stellar.anchor.api.exception.FireblocksException;
+import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.platform.custody.PaymentService;
 
 @RestController
@@ -26,7 +27,7 @@ public class PaymentController {
       value = "/transactions/payments/assets/{assetId}/address",
       method = {RequestMethod.POST})
   public GenerateDepositAddressResponse generateDepositAddress(@PathVariable String assetId)
-      throws FireblocksException {
+      throws FireblocksException, InvalidConfigException {
     return paymentService.generateDepositAddress(assetId);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/PaymentService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/PaymentService.java
@@ -3,12 +3,15 @@ package org.stellar.anchor.platform.custody;
 import org.stellar.anchor.api.custody.CreateTransactionPaymentResponse;
 import org.stellar.anchor.api.custody.GenerateDepositAddressResponse;
 import org.stellar.anchor.api.exception.FireblocksException;
+import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.platform.data.JdbcCustodyTransaction;
 
 public interface PaymentService {
 
-  GenerateDepositAddressResponse generateDepositAddress(String assetId) throws FireblocksException;
+  GenerateDepositAddressResponse generateDepositAddress(String assetId)
+      throws FireblocksException, InvalidConfigException;
 
   CreateTransactionPaymentResponse createTransactionPayment(
-      JdbcCustodyTransaction custodyTxn, String requestBody) throws FireblocksException;
+      JdbcCustodyTransaction custodyTxn, String requestBody)
+      throws FireblocksException, InvalidConfigException;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
@@ -14,6 +14,7 @@ import org.stellar.anchor.api.custody.fireblocks.CreateAddressResponse;
 import org.stellar.anchor.api.custody.fireblocks.CreateTransactionRequest;
 import org.stellar.anchor.api.custody.fireblocks.CreateTransactionResponse;
 import org.stellar.anchor.api.exception.FireblocksException;
+import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.platform.config.FireblocksConfig;
 import org.stellar.anchor.platform.custody.PaymentService;
 import org.stellar.anchor.platform.data.JdbcCustodyTransaction;
@@ -39,7 +40,7 @@ public class FireblocksPaymentService implements PaymentService {
 
   @Override
   public GenerateDepositAddressResponse generateDepositAddress(String assetId)
-      throws FireblocksException {
+      throws FireblocksException, InvalidConfigException {
     CreateAddressRequest request = new CreateAddressRequest();
     CreateAddressResponse depositAddress =
         gson.fromJson(
@@ -62,7 +63,8 @@ public class FireblocksPaymentService implements PaymentService {
           "#root instanceof T(org.stellar.anchor.api.exception.FireblocksException) AND"
               + "(#root.statusCode == 429 OR #root.statusCode == 503)")
   public CreateTransactionPaymentResponse createTransactionPayment(
-      JdbcCustodyTransaction txn, String requestBody) throws FireblocksException {
+      JdbcCustodyTransaction txn, String requestBody)
+      throws FireblocksException, InvalidConfigException {
     CreateTransactionRequest request = getCreateTransactionRequest(txn);
 
     CreateTransactionResponse response =
@@ -73,7 +75,8 @@ public class FireblocksPaymentService implements PaymentService {
     return new CreateTransactionPaymentResponse(response.getId());
   }
 
-  public CreateTransactionRequest getCreateTransactionRequest(JdbcCustodyTransaction txn) {
+  public CreateTransactionRequest getCreateTransactionRequest(JdbcCustodyTransaction txn)
+      throws InvalidConfigException {
     return CreateTransactionRequest.builder()
         .assetId(fireblocksConfig.getFireblocksAssetCode(txn.getAmountOutAsset()))
         .amount(txn.getAmountOut())

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
@@ -1,6 +1,6 @@
 package org.stellar.anchor.platform.custody.fireblocks;
 
-import static org.stellar.anchor.api.custody.fireblocks.CreateTransactionRequest.DestinationTransferPeerPathType.EXTERNAL_WALLET;
+import static org.stellar.anchor.api.custody.fireblocks.CreateTransactionRequest.DestinationTransferPeerPathType.ONE_TIME_ADDRESS;
 import static org.stellar.anchor.api.custody.fireblocks.CreateTransactionRequest.TransferPeerPathType.VAULT_ACCOUNT;
 import static org.stellar.anchor.util.MemoHelper.memoTypeAsString;
 
@@ -47,7 +47,7 @@ public class FireblocksPaymentService implements PaymentService {
                 String.format(
                     CREATE_NEW_DEPOSIT_ADDRESS_URL_FORMAT,
                     fireblocksConfig.getVaultAccountId(),
-                    assetId),
+                    fireblocksConfig.getFireblocksAssetCode(assetId)),
                 gson.toJson(request)),
             CreateAddressResponse.class);
     return new GenerateDepositAddressResponse(
@@ -75,14 +75,14 @@ public class FireblocksPaymentService implements PaymentService {
 
   public CreateTransactionRequest getCreateTransactionRequest(JdbcCustodyTransaction txn) {
     return CreateTransactionRequest.builder()
-        .assetId(txn.getAmountOutAsset())
+        .assetId(fireblocksConfig.getFireblocksAssetCode(txn.getAmountOutAsset()))
         .amount(txn.getAmountOut())
         .source(
             new CreateTransactionRequest.TransferPeerPath(
                 VAULT_ACCOUNT, fireblocksConfig.getVaultAccountId()))
         .destination(
             new CreateTransactionRequest.DestinationTransferPeerPath(
-                EXTERNAL_WALLET, txn.getToAccount(), null))
+                ONE_TIME_ADDRESS, new CreateTransactionRequest.OneTimeAddress(txn.getToAccount())))
         .build();
   }
 }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -440,6 +440,17 @@ custody:
       #
       delay: 1000
 
+    ## @param: assetMappings
+    ## @type:  string
+    ## Defines mappings of fireblocks asset codes to stellar asset codes
+    ## Each mapping should be in a new line
+    ## Mappings should be in a format FIREBLOCKS_ASSET_CODE STELLAR_ASSET_CODE separated with space character
+    ## Example:
+    ##  XLM_USDC_1 stellar:USDC:6HW07AE2MZU3JWWARR9CUSDV5S68K4SLY6FGDJ6KIU6ZJETC3HJP00I2V
+    ##  XLM_USDC_2 stellar:USDC:CKG0R9OEL0RJKFONEP3KHZA1Y1PC1R5TMVIM3T88CG1R239TSWJ5OKKST
+    #
+    asset_mappings: |
+
 ##########################
 ## Metrics Configuration
 ##########################

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -111,3 +111,4 @@ custody.fireblocks.transactions_reconciliation_cron:
 custody.fireblocks.public_key:
 custody.fireblocks.retry_config.max_attempts:
 custody.fireblocks.retry_config.delay:
+custody.fireblocks.asset_mappings:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/FireblocksConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/FireblocksConfigTest.kt
@@ -2,7 +2,10 @@ package org.stellar.anchor.platform.config
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -188,5 +191,21 @@ class FireblocksConfigTest {
     config.retryConfig.delay = delay
     config.validate(config, errors)
     assertErrorCode(errors, "custody-fireblocks-retry_config-delay-invalid")
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = [""])
+  fun `test empty asset mappings`(mappings: String) {
+    config.setAssetMappings(mappings)
+    assertTrue(config.assetMappings.isEmpty())
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["FIREBLOCKS_ASSET_CODE STELLAR_ASSET_CODE"])
+  fun `test getFireblocksAssetCode`(mappings: String) {
+    config.setAssetMappings(mappings)
+    val stellarAssetCode = config.getFireblocksAssetCode("STELLAR_ASSET_CODE")
+    assertEquals("FIREBLOCKS_ASSET_CODE", stellarAssetCode)
+    assertNull(config.getFireblocksAssetCode("INVALID_ASSET_CODE"))
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/FireblocksConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/FireblocksConfigTest.kt
@@ -2,17 +2,18 @@ package org.stellar.anchor.platform.config
 
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.validation.BindException
 import org.springframework.validation.Errors
+import org.stellar.anchor.api.exception.InvalidConfigException
 import org.stellar.anchor.platform.config.FireblocksConfig.RetryConfig
 import org.stellar.anchor.util.FileUtil
 
@@ -206,6 +207,7 @@ class FireblocksConfigTest {
     config.setAssetMappings(mappings)
     val stellarAssetCode = config.getFireblocksAssetCode("STELLAR_ASSET_CODE")
     assertEquals("FIREBLOCKS_ASSET_CODE", stellarAssetCode)
-    assertNull(config.getFireblocksAssetCode("INVALID_ASSET_CODE"))
+
+    assertThrows<InvalidConfigException> { config.getFireblocksAssetCode("INVALID_ASSET_CODE") }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentServiceTest.kt
@@ -62,6 +62,7 @@ class FireblocksPaymentServiceTest {
 
     every { fireblocksClient.post(capture(urlCapture), capture(requestCapture)) } returns
       responseJson
+    every { fireblocksConfig.getFireblocksAssetCode(ASSET_ID) } returns ASSET_ID
 
     val response = fireblocksPaymentService.generateDepositAddress(ASSET_ID)
 
@@ -89,6 +90,7 @@ class FireblocksPaymentServiceTest {
 
     every { fireblocksClient.post(capture(urlCapture), capture(requestCapture)) } returns
       responseJson
+    every { fireblocksConfig.getFireblocksAssetCode(ASSET_ID) } returns ASSET_ID
 
     val transaction =
       JdbcCustodyTransaction.builder()

--- a/platform/src/test/resources/custody/api/payment/fireblocks/create_new_transaction_payment_request.json
+++ b/platform/src/test/resources/custody/api/payment/fireblocks/create_new_transaction_payment_request.json
@@ -5,8 +5,10 @@
     "id": "testVaultAccountId"
   },
   "destination": {
-    "type": "EXTERNAL_WALLET",
-    "id": "toVaultAccountId"
+    "type": "ONE_TIME_ADDRESS",
+    "oneTimeAddress": {
+      "address": "toVaultAccountId"
+    }
   },
   "amount": "10"
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Added configuration for mapping stellar asset codes to fireblocks asset codes.

### Why

Platform can match Fireblocks asset codes to Stellat asset codes.

### Known limitations

[TODO or N/A]