### PR TITLE
Fix the bug that allows SEP1_VALUE and SEP1_TYPE mapped to sep1.toml.value and sep1.toml.type

### DIFF
--- a/.run/Run - Java Reference Server - no Docker.run.xml
+++ b/.run/Run - Java Reference Server - no Docker.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="RunSEP24NoFrontend" type="JetRunConfigurationType" nameIsGenerated="true">
+  <configuration default="false" name="Run - Java Reference Server - no Docker" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunSEP24NoFrontend" />
     <module name="java-stellar-anchor-sdk.service-runner.main" />
     <shortenClasspath name="NONE" />

--- a/.run/Run - Kotlin Reference Server - no Docker.run.xml
+++ b/.run/Run - Kotlin Reference Server - no Docker.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run - Kotlin Reference Server" type="JetRunConfigurationType">
+  <configuration default="false" name="Run - Kotlin Reference Server - no Docker" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunKotlinReferenceServer" />
     <module name="java-stellar-anchor-sdk.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />

--- a/.run/Run - SepServer - no Docker.run.xml
+++ b/.run/Run - SepServer - no Docker.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run - SepServer - no Docker" type="JetRunConfigurationType">
+    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunSepServer" />
+    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <shortenClasspath name="ARGS_FILE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.config.Sep1Config.TomlType.*
 import org.stellar.anchor.platform.config.PropertySep1Config
+import org.stellar.anchor.platform.config.PropertySep1Config.TomlConfig
 import org.stellar.anchor.platform.config.Sep1ConfigTest
 import org.stellar.anchor.sep1.Sep1Service
 
@@ -47,14 +48,14 @@ class Sep1ServiceTest {
   @Test
   fun `test Sep1Service reading toml from inline string`() {
 
-    val config = PropertySep1Config(true, STRING, stellarToml)
+    val config = PropertySep1Config(true, TomlConfig(STRING, stellarToml))
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, stellarToml)
   }
 
   @Test
   fun `test Sep1Service reading toml from file`() {
-    val config = PropertySep1Config(true, FILE, Sep1ConfigTest.getTestTomlAsFile())
+    val config = PropertySep1Config(true, TomlConfig(FILE, Sep1ConfigTest.getTestTomlAsFile()))
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, Files.readString(Path.of(Sep1ConfigTest.getTestTomlAsFile())))
   }
@@ -66,7 +67,7 @@ class Sep1ServiceTest {
     val mockAnchorUrl = mockServer.url("").toString()
     mockServer.enqueue(MockResponse().setBody(stellarToml))
 
-    val config = PropertySep1Config(true, URL, mockAnchorUrl)
+    val config = PropertySep1Config(true, TomlConfig(URL, mockAnchorUrl))
     sep1 = Sep1Service(config)
     assertEquals(sep1.stellarToml, stellarToml)
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep1ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep1ConfigTest.kt
@@ -13,6 +13,7 @@ import org.springframework.validation.ValidationUtils
 import org.stellar.anchor.api.exception.InvalidConfigException
 import org.stellar.anchor.config.Sep1Config.TomlType.FILE
 import org.stellar.anchor.config.Sep1Config.TomlType.fromString
+import org.stellar.anchor.platform.config.PropertySep1Config.TomlConfig
 
 class Sep1ConfigTest {
   companion object {
@@ -42,21 +43,24 @@ class Sep1ConfigTest {
   @ParameterizedTest
   @ValueSource(strings = ["file", "FILE", "File"])
   fun `test reading from sep1-stellar-test toml file`(type: String) {
-    val errors = validate(PropertySep1Config(true, fromString(type), getTestTomlAsFile()))
+    val errors =
+      validate(PropertySep1Config(true, TomlConfig(fromString(type), getTestTomlAsFile())))
     assertEquals(0, errors.errorCount)
   }
 
   @ParameterizedTest
   @ValueSource(strings = ["string", "STRING", "String"])
   fun `test inline toml`(type: String) {
-    val errors = validate(PropertySep1Config(true, fromString(type), "VERSION = \"0.1.0\""))
+    val errors =
+      validate(PropertySep1Config(true, TomlConfig(fromString(type), "VERSION = \"0.1.0\"")))
     assertEquals(0, errors.errorCount)
   }
 
   @ParameterizedTest
   @ValueSource(strings = ["url", "URL", "Url", "urL"])
   fun `test toml with sep1-stellar-test specified as a URL`(type: String) {
-    val errors = validate(PropertySep1Config(true, fromString(type), getTestTomlAsUrl()))
+    val errors =
+      validate(PropertySep1Config(true, TomlConfig(fromString(type), getTestTomlAsUrl())))
     assertEquals(0, errors.errorCount)
   }
 
@@ -64,7 +68,7 @@ class Sep1ConfigTest {
   @ValueSource(strings = ["bad", "strin g"])
   fun `test bad Sep1Config values`(type: String?) {
     assertThrows<InvalidConfigException> {
-      validate(PropertySep1Config(true, fromString(type), getTestTomlAsUrl()))
+      validate(PropertySep1Config(true, TomlConfig(fromString(type), getTestTomlAsUrl())))
     }
   }
 
@@ -73,29 +77,29 @@ class Sep1ConfigTest {
   @ValueSource(strings = [""])
   fun `test empty Sep1Config types`(type: String?) {
     assertThrows<InvalidConfigException> {
-      validate(PropertySep1Config(true, fromString(type), getTestTomlAsUrl()))
+      validate(PropertySep1Config(true, TomlConfig(fromString(type), getTestTomlAsUrl())))
     }
   }
 
   @ParameterizedTest
   @ValueSource(strings = ["bad file", "c:/hello"])
   fun `test file of Sep1Config does not exist`(file: String) {
-    var errors = validate(PropertySep1Config(true, FILE, file))
+    var errors = validate(PropertySep1Config(true, TomlConfig(FILE, file)))
     assertEquals(1, errors.errorCount)
     assertEquals("sep1-toml-value-file-does-not-exist", errors.allErrors[0].code)
 
-    errors = validate(PropertySep1Config(false, FILE, file))
+    errors = validate(PropertySep1Config(false, TomlConfig(FILE, file)))
     assertEquals(0, errors.errorCount)
   }
 
   @ParameterizedTest
   @ValueSource(strings = ["string", "file", "url"])
   fun `test Sep1Config empty values`(type: String) {
-    var errors = validate(PropertySep1Config(true, fromString(type), null))
+    var errors = validate(PropertySep1Config(true, TomlConfig(fromString(type), null)))
     assertEquals(1, errors.errorCount)
     assertEquals("sep1-toml-value-empty", errors.allErrors[0].code)
 
-    errors = validate(PropertySep1Config(true, fromString(type), ""))
+    errors = validate(PropertySep1Config(true, TomlConfig(fromString(type), "")))
     assertEquals(1, errors.errorCount)
     assertEquals("sep1-toml-value-empty", errors.allErrors[0].code)
   }

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -3,6 +3,7 @@
 package org.stellar.anchor.platform
 
 import com.palantir.docker.compose.DockerComposeExtension
+import com.palantir.docker.compose.configuration.ProjectName
 import com.palantir.docker.compose.connection.waiting.HealthChecks
 import java.io.File
 import java.lang.Thread.sleep
@@ -124,6 +125,7 @@ class TestProfileExecutor(val config: TestConfig) {
           .waitingForService("kafka", HealthChecks.toHaveAllPortsOpen())
           .waitingForService("db", HealthChecks.toHaveAllPortsOpen())
           .pullOnStartup(true)
+          .projectName(ProjectName.fromString("anchorplatform${UUID.randomUUID().toString().takeLast(6)}"))
           .build()
 
       docker.beforeAll(null)

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -108,8 +108,8 @@ class TestProfileExecutor(val config: TestConfig) {
   }
 
   private fun startDocker() {
-    info("Starting docker compose...")
     if (shouldStartDockerCompose) {
+      info("Starting docker compose...")
       if (isWindows()) {
         setupWindowsEnv()
       }

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunSEP24NoFrontend.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunSEP24NoFrontend.kt
@@ -12,8 +12,8 @@ fun main() = runBlocking {
   testProfileExecutor = TestProfileExecutor(TestConfig(profileName = "sep24"))
   launch { registerShutdownHook(testProfileExecutor) }
   testProfileExecutor.start(true) {
-    it.env["run_docker"] = "true"
-    it.env["run_all_servers"] = "true"
+    it.env["run_docker"] = "false"
+    it.env["run_all_servers"] = "false"
     it.env["run_reference_server"] = "true"
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fix ANCHOR-259: https://stellarorg.atlassian.net/browse/ANCHOR-259

### Why

Bug fixes.
