### PR TITLE
[ANCHOR-290] Default STELLAR_ANCHOR_CONFIG to "file:" prefix if not specified.

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
@@ -6,6 +6,7 @@ import static org.stellar.anchor.platform.configurator.ConfigMap.ConfigSource.FI
 import static org.stellar.anchor.util.Log.*;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import lombok.Builder;
@@ -141,7 +142,18 @@ public abstract class ConfigManager
     String yamlConfigFile = ConfigEnvironment.getenv(STELLAR_ANCHOR_CONFIG);
 
     if (yamlConfigFile != null) {
-      Resource resource = applicationContext.getResource(yamlConfigFile);
+      List<String> yamlConfigFiles =
+          Arrays.asList(
+              yamlConfigFile,
+              String.format("file://%s", yamlConfigFile), // For Linux file systems
+              String.format("file:%s", yamlConfigFile)); // For Windows file systems
+      Resource resource = null;
+      for (String file : yamlConfigFiles) {
+        resource = applicationContext.getResource(file);
+        if (resource.exists()) {
+          return resource;
+        }
+      }
       if (!resource.exists()) {
         throw new IOException(
             String.format("Failed to read configuration from %s", yamlConfigFile));


### PR DESCRIPTION
…prefix

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Default STELLAR_ANCHOR_CONFIG to "file:" prefix if not specified.

### Why

This will make the configuration less confusing and more consistent.
