### PR TITLE
[ANCHOR-291] Fix: update Github workflow to remove deprecated commands

### DIFF
--- a/.github/workflows/sub_stellar_anchor_tests.yml
+++ b/.github/workflows/sub_stellar_anchor_tests.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
           echo HOME_DOMAIN=$HOME_DOMAIN
-          echo "::set-output name=HOME_DOMAIN::$HOME_DOMAIN"
+          echo "HOME_DOMAIN=$HOME_DOMAIN" >> $GITHUB_OUTPUT
 
       - name: Install NodeJs
         uses: actions/setup-node@v2

--- a/.github/workflows/wk_push_to_develop.yml
+++ b/.github/workflows/wk_push_to_develop.yml
@@ -42,12 +42,12 @@ jobs:
 
       - name: Get current date
         id: get_date
-        run: echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Calculate Github SHA
         shell: bash
         id: get_sha
-        run: echo ::set-output name=SHA::$(git rev-parse --short ${{ github.sha }} )
+        run: echo "SHA=$(git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
 
       - name: Build and push to DockerHub with tags `edge` and `edge-{date}-{sha}`
         uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Remove `set-output` from Github worflows

### Why

The command is deprecated and will stop to work in 05/31/2023

### Known limitations

N/A