### PR TITLE
Fix tx_bad_seq error caused at Sep24End2EndTest.kt::`withdraw end-to-end flow()`

### DIFF
--- a/kotlin-reference-server/src/main/resources/default-config.yaml
+++ b/kotlin-reference-server/src/main/resources/default-config.yaml
@@ -5,8 +5,9 @@ sep24:
   anchorPlatformUrl: "http://localhost:8080"
   #  URL for horizon server
   horizonUrl: "https://horizon-testnet.stellar.org"
-  #  Secret key used to send funds to user accounts
-  secret: "SCQ2YRUGKBO4Q6RWSXV3SYVGHJB525XVKUP2HDGVW3LV42UBLGTZ24XX"
+  # Secret key used to send funds to user accounts.
+  # Public key: GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP
+  secret: "SAJW2O2NH5QMMVWYAN352OEXS2RUY675A2HPK5HEG2FRR2NXPYA4OLYN"
   # When true, enables test endpoints
   enableTest: true
   # Encryption key for interactive JWT

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -124,7 +124,7 @@ assets:
           "schema": "stellar",
           "code": "USDC",
           "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "distribution_account": "GCHU3RZAECOKGM2YAJLQIIYB2ZPLMFTTGN5D3XZNX4RDOEERVLXO7HU4",
+          "distribution_account": "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
           "significant_decimals": 2,
           "deposit": {
             "enabled": true,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

#### Root cause: 
The Kotlin reference server is using the same account to send deposit money [java-stellar-anchor-sdk/default-config.yaml at develop · stellar/java-stellar-anchor-sdk](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/kotlin-reference-server/src/main/resources/default-config.yaml#L9) as the withdraw flow.

When both transactions are submitted to the same block, the race condition causes tx_bad_seq error.

#### Fix:
The reference server uses the same account as the CLIENT_WALLET_KEY. We should have another account dedicated for the Kotlin reference server.

