### PR TITLE
[ANCHOR-292] Separate the platform API endpoints from the sep server

### DIFF
--- a/.run/Run - Platform Server - no Docker.run.xml
+++ b/.run/Run - Platform Server - no Docker.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run - SepServer - no Docker" type="JetRunConfigurationType">
-    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunSepServer" />
+  <configuration default="false" name="Run - Platform Server - no Docker" type="JetRunConfigurationType">
+    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunPlatformServer" />
     <module name="java-stellar-anchor-sdk.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <method v="2">

--- a/.run/Run - Sep Server - no Docker.run.xml
+++ b/.run/Run - Sep Server - no Docker.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run - Sep Server - no Docker" type="JetRunConfigurationType">
+    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunSepServer" />
+    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <shortenClasspath name="ARGS_FILE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Test - End2End Test - no fullstack.run.xml
+++ b/.run/Test - End2End Test - no fullstack.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Test - End2End Test - with Docker" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="Test - End2End Test - no fullstack" type="JUnit" factoryName="JUnit">
     <module name="java-stellar-anchor-sdk.integration-tests.test" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
@@ -23,9 +23,9 @@
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <envs>
-      <env name="run_docker" value="true" />
-      <env name="run_servers" value="true" />
       <env name="TEST_PROFILE_NAME" value="sep24" />
+      <env name="run_all_servers" value="false" />
+      <env name="run_docker" value="false" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Test - End2End Test - with fullstack.run.xml
+++ b/.run/Test - End2End Test - with fullstack.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Test - Integration Test - with Docker" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="Test - End2End Test - with fullstack" type="JUnit" factoryName="JUnit">
     <module name="java-stellar-anchor-sdk.integration-tests.test" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
@@ -19,13 +19,13 @@
       </ENTRIES>
     </extension>
     <option name="PACKAGE_NAME" value="org.stellar.anchor.platform" />
-    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformIntegrationTest" />
+    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformEnd2EndTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <envs>
-      <env name="TEST_PROFILE_NAME" value="default" />
+      <env name="TEST_PROFILE_NAME" value="sep24" />
+      <env name="run_all_servers" value="true" />
       <env name="run_docker" value="true" />
-      <env name="run_servers" value="true" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Test - Integration Test - no fullstack.run.xml
+++ b/.run/Test - Integration Test - no fullstack.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Test - Integration Test - no Docker" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="Test - Integration Test - no fullstack" type="JUnit" factoryName="JUnit">
     <module name="java-stellar-anchor-sdk.integration-tests.test" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
@@ -24,7 +24,7 @@
     <option name="TEST_OBJECT" value="class" />
     <envs>
       <env name="TEST_PROFILE_NAME" value="default" />
-      <env name="run_servers" value="false" />
+      <env name="run_all_servers" value="false" />
       <env name="run_docker" value="false" />
     </envs>
     <method v="2">

--- a/.run/Test - Integration Test - with fullstack.run.xml
+++ b/.run/Test - Integration Test - with fullstack.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Test - End2End Test - no Docker" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="Test - Integration Test - with fullstack" type="JUnit" factoryName="JUnit">
     <module name="java-stellar-anchor-sdk.integration-tests.test" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
@@ -19,13 +19,13 @@
       </ENTRIES>
     </extension>
     <option name="PACKAGE_NAME" value="org.stellar.anchor.platform" />
-    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformEnd2EndTest" />
+    <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformIntegrationTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <envs>
-      <env name="TEST_PROFILE_NAME" value="sep24" />
-      <env name="run_docker" value="false" />
-      <env name="run_servers" value="true" />
+      <env name="TEST_PROFILE_NAME" value="default" />
+      <env name="run_all_servers" value="true" />
+      <env name="run_docker" value="true" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server-docker-compose-config.yaml
@@ -8,7 +8,7 @@ server:
 #
 anchor.settings:
   version: 0.0.1
-  platformApiEndpoint: http://localhost:8080
+  platformApiEndpoint: http://localhost:8085
 
   # The URL where the anchor reference server can be accessed by the platform.
   hostUrl: http://localhost:8081

--- a/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
+++ b/anchor-reference-server/src/main/resources/anchor-reference-server.yaml
@@ -8,7 +8,7 @@ server:
 #
 anchor.settings:
   version: 0.0.1
-  platformApiEndpoint: http://localhost:8080
+  platformApiEndpoint: http://localhost:8085
 
   # The URL where the anchor reference server can be accessed by the platform.
   hostUrl: http://localhost:8081

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.0.0"
+  version = "2.0.1"
 
   tasks.jar {
     manifest {

--- a/docs/00 - Stellar Anchor Platform.md
+++ b/docs/00 - Stellar Anchor Platform.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v1.1.0/blue?icon=docker)](https://hub.docker.com/layers/stellar/anchor-platform/1.1.0/images/sha256-c9df239014d31a29af4e379aaf035e489cabb4c51623d135500022a10d136fbd?context=explore)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.0.1/blue?icon=docker)](https://hub.docker.com/layers/stellar/anchor-platform/2.0.1/images/sha256-bce3ee60276cef20cb428cf50eed829d9833a9149fa2aedf63c2373f7a40e8a1)
 ![Basic Tests](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/basic_tests.yml/badge.svg?branch=main)
 ![End to end Tests](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/end_to_end_tests.yml/badge.svg?branch=main)
 

--- a/docs/00 - Stellar Anchor Platform.md
+++ b/docs/00 - Stellar Anchor Platform.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.0.1/blue?icon=docker)](https://hub.docker.com/layers/stellar/anchor-platform/2.0.1/images/sha256-bce3ee60276cef20cb428cf50eed829d9833a9149fa2aedf63c2373f7a40e8a1)
+[![Docker](https://badgen.net/badge/Latest%20Release/v1.2.13/blue?icon=docker)](https://hub.docker.com/layers/stellar/anchor-platform/release-1.2.13/images/sha256-7f25219bbe2b932108b0965a5ac9bb9c10a1d329d4760d30750a79daf6c47487)
 ![Basic Tests](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/basic_tests.yml/badge.svg?branch=main)
 ![End to end Tests](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/end_to_end_tests.yml/badge.svg?branch=main)
 

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AbstractIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AbstractIntegrationTest.kt
@@ -15,6 +15,7 @@ open class AbstractIntegrationTest(private val config: TestConfig) {
   lateinit var sep24Tests: Sep24Tests
   lateinit var sep31Tests: Sep31Tests
   lateinit var sep38Tests: Sep38Tests
+  lateinit var sepHealthTests: SepHealthTests
   lateinit var platformApiTests: PlatformApiTests
   lateinit var callbackApiTests: CallbackApiTests
   lateinit var stellarObserverTests: StellarObserverTests
@@ -44,6 +45,7 @@ open class AbstractIntegrationTest(private val config: TestConfig) {
     sep24Tests = Sep24Tests(config, toml, jwt)
     sep31Tests = Sep31Tests(config, toml, jwt)
     sep38Tests = Sep38Tests(config, toml, jwt)
+    sepHealthTests = SepHealthTests(config, toml, jwt)
     platformApiTests = PlatformApiTests(config, toml, jwt)
     callbackApiTests = CallbackApiTests(config, toml, jwt)
     stellarObserverTests = StellarObserverTests()

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformIntegrationTest.kt
@@ -54,18 +54,24 @@ class AnchorPlatformIntegrationTest : AbstractIntegrationTest(TestConfig(profile
 
   @Test
   @Order(6)
+  fun runSepHealthTest() {
+    singleton.sepHealthTests.testAll()
+  }
+
+  @Test
+  @Order(7)
   fun runPlatformApiTest() {
     singleton.platformApiTests.testAll()
   }
 
   @Test
-  @Order(7)
+  @Order(8)
   fun runCallbackApiTest() {
     singleton.callbackApiTests.testAll()
   }
 
   @Test
-  @Order(8)
+  @Order(9)
   fun runStellarObserverTest() {
     singleton.stellarObserverTests.testAll()
   }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
@@ -34,7 +34,7 @@ class ApiKeyAuthIntegrationTest {
   companion object {
     private const val ANCHOR_TO_PLATFORM_SECRET = "myAnchorToPlatformSecret"
     private const val PLATFORM_TO_ANCHOR_SECRET = "myPlatformToAnchorSecret"
-    private const val PLATFORM_SERVER_PORT = 8080
+    private const val PLATFORM_SERVER_PORT = 8085
   }
   private val gson = GsonUtils.getInstance()
   private val httpClient: OkHttpClient =
@@ -65,7 +65,7 @@ class ApiKeyAuthIntegrationTest {
     envMap["secret.callback_api.auth_secret"] = PLATFORM_TO_ANCHOR_SECRET
 
     // Start platform
-    platformServerContext = AnchorPlatformServer().start(envMap)
+    platformServerContext = SepServer().start(envMap)
   }
 
   @AfterAll

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.stellar.anchor.api.sep.sep38.GetPriceResponse
 import org.stellar.anchor.api.sep.sep38.RateFee
@@ -36,6 +35,7 @@ class ApiKeyAuthIntegrationTest {
     private const val PLATFORM_TO_ANCHOR_SECRET = "myPlatformToAnchorSecret"
     private const val PLATFORM_SERVER_PORT = 8085
   }
+
   private val gson = GsonUtils.getInstance()
   private val httpClient: OkHttpClient =
     OkHttpClient.Builder()
@@ -43,6 +43,7 @@ class ApiKeyAuthIntegrationTest {
       .readTimeout(10, TimeUnit.MINUTES)
       .writeTimeout(10, TimeUnit.MINUTES)
       .build()
+  private lateinit var sepServerContext: ConfigurableApplicationContext
   private lateinit var platformServerContext: ConfigurableApplicationContext
   private lateinit var mockBusinessServer: MockWebServer
 
@@ -65,12 +66,14 @@ class ApiKeyAuthIntegrationTest {
     envMap["secret.callback_api.auth_secret"] = PLATFORM_TO_ANCHOR_SECRET
 
     // Start platform
-    platformServerContext = SepServer().start(envMap)
+    sepServerContext = SepServer().start(envMap)
+    platformServerContext = PlatformServer().start(envMap)
   }
 
   @AfterAll
   fun teardown() {
-    SpringApplication.exit(platformServerContext)
+    sepServerContext.stop()
+    platformServerContext.stop()
     mockBusinessServer.shutdown()
     clearAllMocks()
     unmockkAll()
@@ -143,7 +146,7 @@ class ApiKeyAuthIntegrationTest {
             .trimMargin()
         )
     )
-    val sep38Service = platformServerContext.getBean(Sep38Service::class.java)
+    val sep38Service = sepServerContext.getBean(Sep38Service::class.java)
 
     val getPriceRequest =
       Sep38GetPriceRequest.builder()

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
@@ -1,7 +1,5 @@
 package org.stellar.anchor.platform.test
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.stellar.anchor.apiclient.PlatformApiClient
 import org.stellar.anchor.auth.AuthHelper
 import org.stellar.anchor.platform.TestConfig
@@ -11,18 +9,7 @@ class PlatformApiTests(config: TestConfig, toml: TomlContent, jwt: String) {
   private val platformApiClient =
     PlatformApiClient(AuthHelper.forNone(), config.env["platform.server.url"]!!)
 
-  private fun testHealth() {
-    val response = platformApiClient.health(listOf("all"))
-    assertEquals(5, response.size)
-    assertEquals(1.0, response["number_of_checks"])
-    assertNotNull(response["checks"])
-    assertNotNull(response["started_at"])
-    assertNotNull(response["elapsed_time_ms"])
-    assertNotNull(response["number_of_checks"])
-    assertNotNull(response["version"])
-  }
   fun testAll() {
     println("Performing Platform API tests...")
-    testHealth()
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep12Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep12Tests.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.test
 
+import java.lang.Thread.sleep
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.api.exception.SepNotFoundException
@@ -62,6 +63,8 @@ class Sep12Tests(config: TestConfig, toml: Sep1Helper.TomlContent, jwt: String) 
     printRequest("Calling PUT /customer", customer)
     var pr = sep12Client.putCustomer(customer)
     printResponse(pr)
+
+    sleep(1000)
 
     // make sure the customer was uploaded correctly.
     printRequest("Calling GET /customer", customer)

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/SepHealthTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/SepHealthTests.kt
@@ -1,0 +1,28 @@
+package org.stellar.anchor.platform.test
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.stellar.anchor.apiclient.PlatformApiClient
+import org.stellar.anchor.auth.AuthHelper
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.Sep1Helper.TomlContent
+
+class SepHealthTests(config: TestConfig, toml: TomlContent, jwt: String) {
+  private val platformApiClient =
+    PlatformApiClient(AuthHelper.forNone(), config.env["sep.server.url"]!!)
+
+  private fun testHealth() {
+    val response = platformApiClient.health(listOf("all"))
+    assertEquals(5, response.size)
+    assertEquals(1.0, response["number_of_checks"])
+    assertNotNull(response["checks"])
+    assertNotNull(response["started_at"])
+    assertNotNull(response["elapsed_time_ms"])
+    assertNotNull(response["number_of_checks"])
+    assertNotNull(response["version"])
+  }
+  fun testAll() {
+    println("Performing Sep Sever Health tests...")
+    testHealth()
+  }
+}

--- a/kotlin-reference-server/src/main/resources/default-config.yaml
+++ b/kotlin-reference-server/src/main/resources/default-config.yaml
@@ -2,7 +2,7 @@ sep24:
   #  Port this server is being ran on
   port: 8091
   #  URL for anchor platform server
-  anchorPlatformUrl: "http://localhost:8080"
+  anchorPlatformUrl: "http://localhost:8085"
   #  URL for horizon server
   horizonUrl: "https://horizon-testnet.stellar.org"
   # Secret key used to send funds to user accounts.

--- a/platform/src/main/java/org/stellar/anchor/platform/AbstractPlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/AbstractPlatformServer.java
@@ -5,7 +5,9 @@ import static org.stellar.anchor.util.Log.info;
 import java.util.Map;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.format.FormatterRegistry;
 import org.stellar.anchor.platform.configurator.ConfigEnvironment;
+import org.stellar.anchor.platform.utils.StringEnumConverter;
 
 abstract class AbstractPlatformServer {
   ConfigurableApplicationContext ctx;
@@ -20,5 +22,12 @@ abstract class AbstractPlatformServer {
       SpringApplication.exit(ctx);
       ctx = null;
     }
+  }
+
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new StringEnumConverter.TransactionsOrderByConverter());
+    registry.addConverter(new StringEnumConverter.TransactionsSepsConverter());
+    registry.addConverter(new StringEnumConverter.SepTransactionStatusConverter());
+    registry.addConverter(new StringEnumConverter.DirectionConverter());
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/PlatformServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/PlatformServer.java
@@ -12,44 +12,34 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.stellar.anchor.platform.configurator.PlatformConfigManager;
 import org.stellar.anchor.platform.configurator.SecretManager;
-import org.stellar.anchor.platform.configurator.SepConfigManager;
-import org.stellar.anchor.platform.utils.StringEnumConverter;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"org.stellar.anchor.platform.data"})
 @EntityScan(basePackages = {"org.stellar.anchor.platform.data"})
 @ComponentScan(
     basePackages = {
-      "org.stellar.anchor.platform.controller.sep",
-      "org.stellar.anchor.platform.component.sep",
+      "org.stellar.anchor.platform.controller.platform",
+      "org.stellar.anchor.platform.component.platform",
       "org.stellar.anchor.platform.component.share"
     })
 @EnableConfigurationProperties
-public class AnchorPlatformServer extends AbstractPlatformServer implements WebMvcConfigurer {
+public class PlatformServer extends AbstractPlatformServer implements WebMvcConfigurer {
   private ConfigurableApplicationContext ctx;
 
   public ConfigurableApplicationContext start(Map<String, String> environment) {
     buildEnvironment(environment);
 
     SpringApplicationBuilder builder =
-        new SpringApplicationBuilder(AnchorPlatformServer.class).bannerMode(OFF);
+        new SpringApplicationBuilder(PlatformServer.class).bannerMode(OFF);
     SpringApplication springApplication = builder.build();
     info("Adding secret manager as initializers...");
     springApplication.addInitializers(SecretManager.getInstance());
-    info("Adding sep config manager as initializers...");
-    springApplication.addInitializers(SepConfigManager.getInstance());
+    info("Adding platform config manager as initializers...");
+    springApplication.addInitializers(PlatformConfigManager.getInstance());
 
     return ctx = springApplication.run();
-  }
-
-  @Override
-  public void addFormatters(FormatterRegistry registry) {
-    registry.addConverter(new StringEnumConverter.TransactionsOrderByConverter());
-    registry.addConverter(new StringEnumConverter.TransactionsSepsConverter());
-    registry.addConverter(new StringEnumConverter.SepTransactionStatusConverter());
-    registry.addConverter(new StringEnumConverter.DirectionConverter());
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/SepServer.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/SepServer.java
@@ -1,0 +1,45 @@
+package org.stellar.anchor.platform;
+
+import static org.springframework.boot.Banner.Mode.OFF;
+import static org.stellar.anchor.util.Log.info;
+
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.stellar.anchor.platform.configurator.SecretManager;
+import org.stellar.anchor.platform.configurator.SepConfigManager;
+
+@SpringBootApplication
+@EnableJpaRepositories(basePackages = {"org.stellar.anchor.platform.data"})
+@EntityScan(basePackages = {"org.stellar.anchor.platform.data"})
+@ComponentScan(
+    basePackages = {
+      "org.stellar.anchor.platform.controller.sep",
+      "org.stellar.anchor.platform.component.sep",
+      "org.stellar.anchor.platform.component.share"
+    })
+@EnableConfigurationProperties
+public class SepServer extends AbstractPlatformServer implements WebMvcConfigurer {
+  private ConfigurableApplicationContext ctx;
+
+  public ConfigurableApplicationContext start(Map<String, String> environment) {
+    buildEnvironment(environment);
+
+    SpringApplicationBuilder builder =
+        new SpringApplicationBuilder(SepServer.class).bannerMode(OFF);
+    SpringApplication springApplication = builder.build();
+    info("Adding secret manager as initializers...");
+    springApplication.addInitializers(SecretManager.getInstance());
+    info("Adding sep config manager as initializers...");
+    springApplication.addInitializers(SepConfigManager.getInstance());
+
+    return ctx = springApplication.run();
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/ConfigBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/ConfigBeans.java
@@ -1,14 +1,14 @@
-package org.stellar.anchor.platform.component.sep;
+package org.stellar.anchor.platform.component.platform;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.platform.configurator.ConfigManager;
-import org.stellar.anchor.platform.configurator.SepConfigManager;
+import org.stellar.anchor.platform.configurator.PlatformConfigManager;
 
 @Configuration
 public class ConfigBeans {
   @Bean(name = "configManager")
   ConfigManager configManager() {
-    return SepConfigManager.getInstance();
+    return PlatformConfigManager.getInstance();
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformApiBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformApiBeans.java
@@ -1,4 +1,4 @@
-package org.stellar.anchor.platform.component.sep;
+package org.stellar.anchor.platform.component.platform;
 
 import javax.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -79,22 +79,6 @@ public class SepBeans {
     return new PropertySep38Config();
   }
 
-  @Bean
-  @ConfigurationProperties(prefix = "data")
-  PropertyDataConfig dataConfig(SecretConfig secretConfig) {
-    return new PropertyDataConfig(secretConfig);
-  }
-
-  /**
-   * Used by SEP-10 authentication service.
-   *
-   * @return the jwt service used by SEP-10.
-   */
-  @Bean
-  public JwtService jwtService(SecretConfig secretConfig) {
-    return new JwtService(secretConfig);
-  }
-
   /**
    * Register sep-10 token filter.
    *
@@ -113,11 +97,6 @@ public class SepBeans {
     registrationBean.addUrlPatterns("/sep38/quote");
     registrationBean.addUrlPatterns("/sep38/quote/*");
     return registrationBean;
-  }
-
-  @Bean
-  public Horizon horizon(AppConfig appConfig) {
-    return new Horizon(appConfig);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/SharedConfigBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/SharedConfigBeans.java
@@ -3,11 +3,19 @@ package org.stellar.anchor.platform.component.share;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.platform.config.PlatformApiConfig;
+import org.stellar.anchor.platform.config.PropertyDataConfig;
 import org.stellar.anchor.platform.config.PropertySecretConfig;
 
 @Configuration
 public class SharedConfigBeans {
+  @Bean
+  @ConfigurationProperties(prefix = "data")
+  PropertyDataConfig dataConfig(SecretConfig secretConfig) {
+    return new PropertyDataConfig(secretConfig);
+  }
+
   @Bean
   @ConfigurationProperties(prefix = "platform-api")
   PlatformApiConfig platformApiConfig(PropertySecretConfig secretConfig) {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -6,8 +6,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.config.AppConfig;
+import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.healthcheck.HealthCheckable;
+import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.platform.config.PropertyAppConfig;
 import org.stellar.anchor.platform.config.PropertySecretConfig;
 import org.stellar.anchor.platform.service.HealthCheckService;
@@ -38,5 +41,15 @@ public class UtilityBeans {
   @Bean
   PropertySecretConfig secretConfig() {
     return new PropertySecretConfig();
+  }
+
+  @Bean
+  public JwtService jwtService(SecretConfig secretConfig) {
+    return new JwtService(secretConfig);
+  }
+
+  @Bean
+  public Horizon horizon(AppConfig appConfig) {
+    return new Horizon(appConfig);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyEventConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyEventConfig.java
@@ -12,7 +12,7 @@ import org.springframework.validation.Validator;
 import org.stellar.anchor.config.event.EventConfig;
 import org.stellar.anchor.config.event.PublisherConfig;
 import org.stellar.anchor.platform.configurator.ConfigMap;
-import org.stellar.anchor.platform.configurator.SepConfigManager;
+import org.stellar.anchor.platform.configurator.PlatformConfigManager;
 
 @Data
 public class PropertyEventConfig implements EventConfig, Validator {
@@ -21,7 +21,7 @@ public class PropertyEventConfig implements EventConfig, Validator {
   private Map<String, String> eventTypeToQueue = new HashMap<>();
 
   public PropertyEventConfig() {
-    ConfigMap configMap = SepConfigManager.getInstance().getConfigMap();
+    ConfigMap configMap = PlatformConfigManager.getInstance().getConfigMap();
     if (configMap != null) {
       eventTypeToQueue.put(
           "quote_created", configMap.getString("events.event_type_to_queue.quote_created"));

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/PlatformConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/PlatformConfigManager.java
@@ -1,0 +1,51 @@
+package org.stellar.anchor.platform.configurator;
+
+import static org.stellar.anchor.util.Log.info;
+
+import java.util.List;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.stellar.anchor.api.exception.InvalidConfigException;
+
+public class PlatformConfigManager extends ConfigManager {
+  private static final PlatformConfigManager platformConfigManager = new PlatformConfigManager();
+
+  private PlatformConfigManager() {}
+
+  public static PlatformConfigManager getInstance() {
+    return platformConfigManager;
+  }
+
+  @SneakyThrows
+  @Override
+  public void initialize(@NotNull ConfigurableApplicationContext applicationContext) {
+    // Read configuration from system environment variables, configuration file, and default values
+    info("Read and process configurations");
+    configMap = processConfigurations(applicationContext);
+
+    // Make sure no secret is leaked.
+    sanitize(configMap);
+
+    // Send values to Spring
+    sendToSpring(
+        applicationContext,
+        configMap,
+        List.of(
+            new LogConfigAdapter(), new DataConfigAdapter(), new PlatformServerConfigAdapter()));
+  }
+}
+
+class PlatformServerConfigAdapter extends SpringConfigAdapter {
+  @Override
+  void updateSpringEnv(ConfigMap config) throws InvalidConfigException {
+    copy(config, "platform_server.context_path", "server.servlet.context-path");
+    copy(config, "platform_server.port", "server.port");
+    set("spring.mvc.converters.preferred-json-mapper", "gson");
+  }
+
+  @Override
+  void validate(ConfigMap config) throws InvalidConfigException {
+    // noop
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.sep.SepExceptionResponse;
 
-public abstract class ControllerExceptionHandler {
+public abstract class AbstractControllerExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({SepValidationException.class, BadRequestException.class})
   public SepExceptionResponse handleBadRequest(AnchorException ex) {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/observer/ObserverControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/observer/ObserverControllerExceptionHandler.java
@@ -1,8 +1,8 @@
 package org.stellar.anchor.platform.controller.observer;
 
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.stellar.anchor.platform.controller.ControllerExceptionHandler;
+import org.stellar.anchor.platform.controller.AbstractControllerExceptionHandler;
 
 /** The uncaught exception handler. */
 @RestControllerAdvice
-public class ObserverControllerExceptionHandler extends ControllerExceptionHandler {}
+public class ObserverControllerExceptionHandler extends AbstractControllerExceptionHandler {}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
@@ -1,4 +1,4 @@
-package org.stellar.anchor.platform.controller.sep;
+package org.stellar.anchor.platform.controller.platform;
 
 import java.util.List;
 import org.springframework.data.domain.Sort;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformControllerExceptionHandler.java
@@ -1,8 +1,8 @@
-package org.stellar.anchor.platform.controller.sep;
+package org.stellar.anchor.platform.controller.platform;
 
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.stellar.anchor.platform.controller.AbstractControllerExceptionHandler;
 
 /** The uncaught exception handler. */
 @RestControllerAdvice
-public class SepControllerExceptionHandler extends AbstractControllerExceptionHandler {}
+public class PlatformControllerExceptionHandler extends AbstractControllerExceptionHandler {}

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -82,7 +82,7 @@ platform_api:
   ## The base URL of the Anchor Platform server that implements the platform API endpoints described in the
   ## "Platform API.yml" spec.
   #
-  base_url: http://localhost:8080
+  base_url: http://localhost:8085
   ## Authentication config for Anchor server and Anchor Platform server to safely communicate,
   ## particularly when housed in different clusters.
   ## The receiving party should verify that an incoming request token is still valid.
@@ -173,6 +173,15 @@ app_logging:
   ## @type: string
   ## The "org.stellar" logger logging level.
   stellar_level: INFO
+
+######################
+## Platform Server Configuration
+######################
+platform_server:
+  # The context path of the SEP server
+  context_path: /
+  # The listening port of the SEP server
+  port: 8085
 
 ######################
 ## SEP configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -1,3 +1,5 @@
+app_logging.level:
+app_logging.stellar_level:
 assets.type:
 assets.value:
 callback_api.auth.api_key.http_header:
@@ -44,8 +46,6 @@ events.publisher.sqs.use_iam:
 events.publisher.type:
 host_url:
 languages:
-app_logging.level:
-app_logging.stellar_level:
 metrics.enabled:
 metrics.extras_enabled:
 metrics.run_interval:
@@ -64,6 +64,8 @@ platform_api.auth.jwt.expiration_milliseconds:
 platform_api.auth.jwt.http_header:
 platform_api.auth.type:
 platform_api.base_url:
+platform_server.context_path:
+platform_server.port:
 sep1.enabled:
 sep1.toml.type:
 sep1.toml.value:
@@ -72,10 +74,10 @@ sep10.client_attribution_allow_list:
 sep10.client_attribution_deny_list:
 sep10.client_attribution_required:
 sep10.enabled:
-sep10.web_auth_domain:
 sep10.jwt_timeout:
 sep10.omnibus_account_list:
 sep10.require_known_omnibus_account:
+sep10.web_auth_domain:
 sep12.enabled:
 sep24.enabled:
 sep24.features.account_creation:

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -34,7 +34,7 @@ public class ServiceRunner {
         anyServerStarted = true;
       }
 
-      if (cmd.hasOption("sep-server") || cmd.hasOption("all")) {
+      if (cmd.hasOption("platform-server") || cmd.hasOption("all")) {
         startPlatformServer(null);
         anyServerStarted = true;
       }

--- a/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
+++ b/service-runner/src/main/java/org/stellar/anchor/platform/ServiceRunner.java
@@ -16,6 +16,7 @@ public class ServiceRunner {
     options.addOption("h", "help", false, "Print this message.");
     options.addOption("a", "all", false, "Start all servers.");
     options.addOption("s", "sep-server", false, "Start SEP endpoint server.");
+    options.addOption("p", "platform-server", false, "Start Platform API endpoint server.");
     options.addOption(
         "o", "stellar-observer", false, "Start Observer that streams from the Stellar blockchain.");
     options.addOption("e", "event-processor", false, "Start the event processor.");
@@ -30,6 +31,11 @@ public class ServiceRunner {
       boolean anyServerStarted = false;
       if (cmd.hasOption("sep-server") || cmd.hasOption("all")) {
         startSepServer(null);
+        anyServerStarted = true;
+      }
+
+      if (cmd.hasOption("sep-server") || cmd.hasOption("all")) {
+        startPlatformServer(null);
         anyServerStarted = true;
       }
 
@@ -67,7 +73,11 @@ public class ServiceRunner {
   }
 
   public static ConfigurableApplicationContext startSepServer(Map<String, String> env) {
-    return new AnchorPlatformServer().start(env);
+    return new SepServer().start(env);
+  }
+
+  public static ConfigurableApplicationContext startPlatformServer(Map<String, String> env) {
+    return new PlatformServer().start(env);
   }
 
   public static ConfigurableApplicationContext startStellarObserver(Map<String, String> env) {

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -41,6 +41,7 @@ class TestProfileExecutor(val config: TestConfig) {
   private var shouldStartDockerCompose: Boolean = false
   private var shouldStartAllServers: Boolean = false
   private var shouldStartSepServer: Boolean = false
+  private var shouldStartPlatformServer: Boolean = false
   private var shouldStartReferenceServer: Boolean = false
   private var shouldStartObserver: Boolean = false
   private var shouldStartKotlinReferenceServer: Boolean = false
@@ -53,6 +54,7 @@ class TestProfileExecutor(val config: TestConfig) {
     shouldStartDockerCompose = config.env["run_docker"].toBoolean()
     shouldStartAllServers = config.env["run_all_servers"].toBoolean()
     shouldStartSepServer = config.env["run_sep_server"].toBoolean()
+    shouldStartPlatformServer = config.env["run_platform_server"].toBoolean()
     shouldStartReferenceServer = config.env["run_reference_server"].toBoolean()
     shouldStartObserver = config.env["run_observer"].toBoolean()
     shouldStartKotlinReferenceServer = config.env["run_kotlin_reference_server"].toBoolean()
@@ -93,6 +95,10 @@ class TestProfileExecutor(val config: TestConfig) {
       if (shouldStartAllServers || shouldStartSepServer) {
         info("Starting SEP server...")
         jobs += scope.launch { runningServers.add(ServiceRunner.startSepServer(envMap)) }
+      }
+      if (shouldStartAllServers || shouldStartPlatformServer) {
+        info("Starting platform server...")
+        jobs += scope.launch { runningServers.add(ServiceRunner.startPlatformServer(envMap)) }
       }
 
       if (jobs.size > 0) {

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunPlatformServer.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunPlatformServer.kt
@@ -1,0 +1,19 @@
+@file:JvmName("RunPlatformServer")
+
+package org.stellar.anchor.platform.run_profiles
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.platform.TestProfileExecutor
+import org.stellar.anchor.platform.testProfileExecutor
+
+fun main() = runBlocking {
+  testProfileExecutor = TestProfileExecutor(TestConfig(profileName = "default"))
+  launch { registerShutdownHook(testProfileExecutor) }
+  testProfileExecutor.start(true) {
+    it.env["run_docker"] = "false"
+    it.env["run_all_servers"] = "false"
+    it.env["run_platform_server"] = "true"
+  }
+}

--- a/service-runner/src/main/resources/config/java-reference-server-config.yaml
+++ b/service-runner/src/main/resources/config/java-reference-server-config.yaml
@@ -8,7 +8,7 @@ server:
 #
 anchor.settings:
   version: 0.0.1
-  platformApiEndpoint: http://localhost:8080
+  platformApiEndpoint: http://localhost:8085
 
   # The URL where the anchor reference server can be accessed by the platform.
   hostUrl: http://localhost:8081

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -16,7 +16,7 @@ events.publisher.kafka.bootstrap_server=kafka:29092
 # callback API endpoint
 callback_api.base_url=http://reference-server:8081/
 # platform API endpoint
-platform_api.base_url=http://platform:8080/
+platform_api.base_url=http://platform:8085/
 # data
 data.type=postgres
 data.server=db:5432

--- a/service-runner/src/main/resources/profiles/default/test.env
+++ b/service-runner/src/main/resources/profiles/default/test.env
@@ -1,8 +1,9 @@
 # Test configurations
 anchor.domain=http://localhost:8080
+sep.server.url=http://localhost:8080
 reference.server.url=http://localhost:8081
-platform.server.url=http://localhost:8080
 observer.server.url=http://localhost:8083
+platform.server.url=http://localhost:8085
 run_docker=true
 run_all_servers=true
 

--- a/service-runner/src/main/resources/profiles/sep24/config.env
+++ b/service-runner/src/main/resources/profiles/sep24/config.env
@@ -16,7 +16,7 @@ events.publisher.kafka.bootstrap_server=kafka:29092
 # callback API endpoint
 callback_api.base_url=http://reference-server:8081/
 # platform API endpoint
-platform_api.base_url=http://platform:8080/
+platform_api.base_url=http://platform:8085/
 # data
 data.type=postgres
 data.server=db:5432

--- a/service-runner/src/main/resources/profiles/sep24/test.env
+++ b/service-runner/src/main/resources/profiles/sep24/test.env
@@ -1,8 +1,9 @@
 # Test configurations
 anchor.domain=http://localhost:8080
+sep.server.url=http://localhost:8080
 reference.server.url=http://localhost:8089
-platform.server.url=http://localhost:8080
 observer.server.url=http://localhost:8083
+platform.server.url=http://localhost:8085
 run_docker=true
 run_all_servers=true
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Separate the platform API endpoints from the sep server.

### Why

The platform API endpoints are sensitive and should not be exposed with the SEP endpoints which are public.
