### PR TITLE
[ANCHOR-308] fix: Use amounts calculated by rate integration in SEP-38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.2.14
+* Use buy and sell amounts calculated by rate integration in SEP-38 [#911](https://github.com/stellar/java-stellar-anchor-sdk/pull/911)
+
 ## 1.2.13
 * Allow zero fees in `PATCH /transactions` request [#871](https://github.com/stellar/java-stellar-anchor-sdk/pull/871)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.13"
+  version = "1.2.14"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -360,22 +360,19 @@ public class Sep38Service {
 
     // Calculate amounts: sellAmount = buyAmount * totalPrice
     BigDecimal bTotalPrice = decimal(rate.getTotalPrice());
-    BigDecimal bSellAmount = null;
-    BigDecimal bBuyAmount = null;
+    BigDecimal bSellAmount =
+        request.getSellAmount() != null ? decimal(request.getSellAmount()) : null;
+    BigDecimal bBuyAmount = request.getBuyAmount() != null ? decimal(request.getBuyAmount()) : null;
 
+    // Use the rate's buy and sell amounts if they were returned
     if (rate.getSellAmount() != null) {
       bSellAmount = decimal(rate.getSellAmount());
-    } else if (request.getSellAmount() != null) {
-      bSellAmount = decimal(request.getSellAmount());
     }
-
     if (rate.getBuyAmount() != null) {
       bBuyAmount = decimal(rate.getBuyAmount());
-    } else if (request.getBuyAmount() != null) {
-      bBuyAmount = decimal(request.getBuyAmount());
     }
 
-    // TODO: This shouldn't be needed
+    // This should not happen because we previously checked at least one was not null
     if (bBuyAmount == null && bSellAmount == null) {
       throw new ServerErrorException(
           String.format(

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -374,10 +374,7 @@ public class Sep38Service {
 
     // This should not happen because we previously checked at least one was not null
     if (bBuyAmount == null && bSellAmount == null) {
-      throw new ServerErrorException(
-          String.format(
-              "Unable to calculate buy or sell amounts. Got buy_amount = %f, sell_amount = %f",
-              bBuyAmount, bSellAmount));
+      throw new ServerErrorException("Unable to calculate buy and sell amounts, both were null");
     }
 
     if (bSellAmount == null) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This fixes a bug in SEP-38 POST quote where the anchor platform recalculates buy and sell amounts even if a value is returned by `/rate` integration.

### Why

As part of the SEP-38 POST quote flow, `/rate` is called to return buy or sell amounts calculated by the business server.  These amounts should not be recalculated by the platform due to differences in decimal precision between the anchor platform and the business server.

### Known limitations

N/A