### PR TITLE
[ANCHOR-311] Remove host_url and review usages of web_auth_domain

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/AppConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/AppConfig.java
@@ -6,8 +6,6 @@ import java.util.List;
 public interface AppConfig {
   String getStellarNetworkPassphrase();
 
-  String getHostUrl();
-
   String getHorizonUrl();
 
   List<String> getLanguages();

--- a/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
@@ -5,6 +5,8 @@ import java.util.List;
 public interface Sep10Config {
   String getWebAuthDomain();
 
+  String getHomeDomain();
+
   boolean isClientAttributionRequired();
 
   Boolean getEnabled();

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -329,7 +329,7 @@ public class Sep10Service {
     Memo memo = challenge.getTransaction().getMemo();
     Sep10Jwt sep10Jwt =
         Sep10Jwt.of(
-            sep10Config.getHomeDomain(),
+            sep10Config.getWebAuthDomain(),
             (memo == null || memo instanceof MemoNone)
                 ? challenge.getClientAccountId()
                 : challenge.getClientAccountId() + ":" + memo,

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.sep10;
 
 import static org.stellar.anchor.util.Log.*;
-import static org.stellar.anchor.util.NetUtil.getDomainFromURL;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -61,12 +60,9 @@ public class Sep10Service {
     // Validations
     //
     if (challengeRequest.getHomeDomain() == null) {
-      debugF(
-          "home_domain is not specified. Will use the default: {}", sep10Config.getWebAuthDomain());
-      challengeRequest.setHomeDomain(sep10Config.getWebAuthDomain());
-    } else if (!challengeRequest
-        .getHomeDomain()
-        .equalsIgnoreCase(getDomainFromURL(appConfig.getHostUrl()))) {
+      debugF("home_domain is not specified. Will use the default: {}", sep10Config.getHomeDomain());
+      challengeRequest.setHomeDomain(sep10Config.getHomeDomain());
+    } else if (!challengeRequest.getHomeDomain().equalsIgnoreCase(sep10Config.getHomeDomain())) {
       infoF("Bad home_domain: {}", challengeRequest.getHomeDomain());
       throw new SepValidationException(
           String.format("home_domain [%s] is not supported.", challengeRequest.getHomeDomain()));
@@ -201,7 +197,7 @@ public class Sep10Service {
             challengeXdr,
             serverAccountId,
             new Network(appConfig.getStellarNetworkPassphrase()),
-            getDomainFromURL(appConfig.getHostUrl()),
+            sep10Config.getHomeDomain(),
             sep10Config.getWebAuthDomain());
 
     debugF(
@@ -258,7 +254,7 @@ public class Sep10Service {
           challengeXdr,
           serverAccountId,
           new Network(appConfig.getStellarNetworkPassphrase()),
-          getDomainFromURL(appConfig.getHostUrl()),
+          sep10Config.getHomeDomain(),
           sep10Config.getWebAuthDomain(),
           signers);
 
@@ -284,7 +280,7 @@ public class Sep10Service {
         challengeXdr,
         serverAccountId,
         new Network(appConfig.getStellarNetworkPassphrase()),
-        getDomainFromURL(appConfig.getHostUrl()),
+        sep10Config.getHomeDomain(),
         sep10Config.getWebAuthDomain(),
         threshold,
         signers);
@@ -326,14 +322,14 @@ public class Sep10Service {
             challengeXdr,
             serverAccountId,
             new Network(appConfig.getStellarNetworkPassphrase()),
-            getDomainFromURL(appConfig.getHostUrl()),
+            sep10Config.getHomeDomain(),
             sep10Config.getWebAuthDomain());
     debug("challenge:", challenge);
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime();
     Memo memo = challenge.getTransaction().getMemo();
     Sep10Jwt sep10Jwt =
         Sep10Jwt.of(
-            appConfig.getHostUrl() + "/auth",
+            sep10Config.getHomeDomain(),
             (memo == null || memo instanceof MemoNone)
                 ? challenge.getClientAccountId()
                 : challenge.getClientAccountId() + ":" + memo,

--- a/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
@@ -5,10 +5,10 @@ class TestConstants {
     const val TEST_SIGNING_SEED = "SBVEOFAHGJCKGR4AAM7RTDRCP6RMYYV5YUV32ZK7ZD3VPDGGHYLXTZRZ"
     const val TEST_ACCOUNT = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
     const val TEST_MEMO = "123"
-    const val TEST_WEB_AUTH_DOMAIN = "test.stellar.org"
+    const val TEST_WEB_AUTH_DOMAIN = "test.stellar.org/auth"
     const val TEST_CLIENT_DOMAIN = "test.client.stellar.org"
     const val TEST_NETWORK_PASS_PHRASE = "Test SDF Network ; September 2015"
-    const val TEST_HOST_URL = "https://test.stellar.org"
+    const val TEST_HOME_DOMAIN = "test.stellar.org"
     const val TEST_JWT_SECRET = "jwt_secret"
     const val TEST_ASSET = "USDC"
     const val TEST_ASSET_ISSUER_ACCOUNT_ID =

--- a/core/src/test/kotlin/org/stellar/anchor/filter/Sep10JwtFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/Sep10JwtFilterTest.kt
@@ -158,7 +158,7 @@ internal class Sep10JwtFilterTest {
     val slot = slot<Sep10Jwt>()
     every { request.setAttribute(JWT_TOKEN, capture(slot)) } answers {}
 
-    val jwtToken = jwtService.encode(createSep10Jwt(PUBLIC_KEY, null, appConfig.hostUrl))
+    val jwtToken = jwtService.encode(createSep10Jwt(PUBLIC_KEY, null, "stellar.org"))
     every { request.getHeader("Authorization") } returns "Bearer $jwtToken"
     sep10TokenFilter.doFilter(request, response, mockFilterChain)
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_TOML
-import org.stellar.anchor.TestConstants.Companion.TEST_HOST_URL
+import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_JWT_SECRET
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_NETWORK_PASS_PHRASE
@@ -69,7 +69,7 @@ internal class Sep10ServiceTest {
   companion object {
     @JvmStatic
     fun homeDomains(): Stream<String> {
-      return Stream.of(null, TEST_WEB_AUTH_DOMAIN)
+      return Stream.of(null, TEST_HOME_DOMAIN)
     }
 
     val testAccountWithNoncompliantSigner: String =
@@ -99,9 +99,9 @@ internal class Sep10ServiceTest {
     every { sep10Config.clientAttributionAllowList } returns listOf(TEST_CLIENT_DOMAIN)
     every { sep10Config.authTimeout } returns 900
     every { sep10Config.jwtTimeout } returns 900
+    every { sep10Config.homeDomain } returns TEST_HOME_DOMAIN
 
     every { appConfig.stellarNetworkPassphrase } returns TEST_NETWORK_PASS_PHRASE
-    every { appConfig.hostUrl } returns TEST_HOST_URL
 
     every { secretConfig.sep10SigningSeed } returns TEST_SIGNING_SEED
     every { secretConfig.sep10JwtSecretKey } returns TEST_JWT_SECRET
@@ -137,6 +137,7 @@ internal class Sep10ServiceTest {
 
     // serverKP does not exist in the network.
     val serverWebAuthDomain = TEST_WEB_AUTH_DOMAIN
+    val serverHomeDomain = TEST_HOME_DOMAIN
     val serverKP = KeyPair.random()
 
     // clientDomainKP doesn't exist in the network. Refers to the walletAcc (like Lobstr's)
@@ -156,7 +157,7 @@ internal class Sep10ServiceTest {
 
     val sourceAccount = Account(serverKP.accountId, -1L)
     val op1DomainNameMandatory =
-      ManageDataOperation.Builder("$serverWebAuthDomain auth", encodedNonce)
+      ManageDataOperation.Builder("$serverHomeDomain auth", encodedNonce)
         .setSourceAccount(clientAddress)
         .build()
     val op2WebAuthDomainMandatory =
@@ -232,6 +233,7 @@ internal class Sep10ServiceTest {
 
     // serverKP does not exist in the network.
     val serverWebAuthDomain = TEST_WEB_AUTH_DOMAIN
+    val serverHomeDomain = TEST_HOME_DOMAIN
     val serverKP = KeyPair.random()
 
     // clientDomainKP does not exist in the network. It refers to the wallet (like Lobstr's)
@@ -249,7 +251,7 @@ internal class Sep10ServiceTest {
 
     val sourceAccount = Account(serverKP.accountId, -1L)
     val op1DomainNameMandatory =
-      ManageDataOperation.Builder("$serverWebAuthDomain auth", encodedNonce)
+      ManageDataOperation.Builder("$serverHomeDomain auth", encodedNonce)
         .setSourceAccount(clientKP.accountId)
         .build()
     val op2WebAuthDomainMandatory =
@@ -309,6 +311,7 @@ internal class Sep10ServiceTest {
 
     // serverKP does not exist in the network.
     val serverWebAuthDomain = TEST_WEB_AUTH_DOMAIN
+    val serverHomeDomain = TEST_HOME_DOMAIN
     // GDFWZYGUNUFW4H3PP3DSNGTDFBUHO6NUFPQ6FAPMCKEJ6EHDKX2CV2IM
     val serverKP = KeyPair.random()
 
@@ -324,7 +327,7 @@ internal class Sep10ServiceTest {
 
     val sourceAccount = Account(serverKP.accountId, -1L)
     val op1DomainNameMandatory =
-      ManageDataOperation.Builder("$serverWebAuthDomain auth", encodedNonce)
+      ManageDataOperation.Builder("$serverHomeDomain auth", encodedNonce)
         .setSourceAccount(clientKP.accountId)
         .build()
     val op2WebAuthDomainMandatory =
@@ -373,7 +376,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
     cr.clientDomain = if (clientDomain == "null") null else clientDomain
@@ -386,8 +389,8 @@ internal class Sep10ServiceTest {
         any(),
         Network(TEST_NETWORK_PASS_PHRASE),
         TEST_ACCOUNT,
+        TEST_HOME_DOMAIN,
         TEST_WEB_AUTH_DOMAIN,
-        "test.stellar.org",
         any(),
         any(),
         any(),
@@ -405,7 +408,7 @@ internal class Sep10ServiceTest {
         signer,
         Network(TEST_NETWORK_PASS_PHRASE),
         clientKeyPair.accountId,
-        TEST_WEB_AUTH_DOMAIN,
+        TEST_HOME_DOMAIN,
         TEST_WEB_AUTH_DOMAIN,
         TimeBounds(now, now + 900),
         clientDomain,
@@ -504,7 +507,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
     cr.homeDomain = "bad.homedomain.com"
@@ -520,7 +523,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
     cr.homeDomain = homeDomain
@@ -546,7 +549,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
     cr.account = "GXXX"
@@ -562,7 +565,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
     cr.account = TEST_ACCOUNT
@@ -595,7 +598,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(TEST_CLIENT_DOMAIN)
         .build()
 
@@ -614,7 +617,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(null)
         .build()
 
@@ -632,7 +635,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(null)
         .build()
 
@@ -650,7 +653,7 @@ internal class Sep10ServiceTest {
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
         .memo(TEST_MEMO)
-        .homeDomain(TEST_WEB_AUTH_DOMAIN)
+        .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain(null)
         .build()
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -20,6 +20,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_DOMAIN
+import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_JWT_SECRET
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_TRANSACTION_ID_0
@@ -84,7 +85,6 @@ internal class Sep24ServiceTest {
   fun setUp() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { appConfig.stellarNetworkPassphrase } returns TestConstants.TEST_NETWORK_PASS_PHRASE
-    every { appConfig.hostUrl } returns TestConstants.TEST_HOST_URL
     every { secretConfig.sep10JwtSecretKey } returns TEST_JWT_SECRET
     every { secretConfig.sep24MoreInfoUrlJwtSecret } returns TEST_JWT_SECRET
     every { secretConfig.sep24InteractiveUrlJwtSecret } returns TEST_JWT_SECRET
@@ -503,11 +503,11 @@ internal class Sep24ServiceTest {
   }
 
   private fun createTestSep10JwtToken(): Sep10Jwt {
-    return TestHelper.createSep10Jwt(TEST_ACCOUNT, null, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
+    return TestHelper.createSep10Jwt(TEST_ACCOUNT, null, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
   }
 
   private fun createTestSep10JwtWithMemo(): Sep10Jwt {
-    return TestHelper.createSep10Jwt(TEST_ACCOUNT, TEST_MEMO, appConfig.hostUrl, TEST_CLIENT_DOMAIN)
+    return TestHelper.createSep10Jwt(TEST_ACCOUNT, TEST_MEMO, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
   }
 
   private fun createTestInteractiveJwt(

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -293,7 +293,6 @@ class Sep31ServiceTest {
   fun setUp() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { appConfig.stellarNetworkPassphrase } returns TestConstants.TEST_NETWORK_PASS_PHRASE
-    every { appConfig.hostUrl } returns TestConstants.TEST_HOST_URL
     every { secretConfig.sep10JwtSecretKey } returns TestConstants.TEST_JWT_SECRET
     every { appConfig.languages } returns listOf("en")
     every { sep31Config.paymentType } returns STRICT_SEND

--- a/core/src/test/kotlin/org/stellar/anchor/util/LogTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/LogTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.Logger
-import org.stellar.anchor.TestConstants.Companion.TEST_HOST_URL
 import org.stellar.anchor.TestConstants.Companion.TEST_NETWORK_PASS_PHRASE
 import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.PII
@@ -90,10 +89,6 @@ internal class LogTest {
   class TestAppConfig : AppConfig {
     override fun getStellarNetworkPassphrase(): String {
       return TEST_NETWORK_PASS_PHRASE
-    }
-
-    override fun getHostUrl(): String {
-      return TEST_HOST_URL
     }
 
     override fun getHorizonUrl(): String {

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAppConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAppConfig.java
@@ -18,9 +18,6 @@ public class PropertyAppConfig implements AppConfig, Validator {
   @Value("${stellar_network.network_passphrase}")
   private String stellarNetworkPassphrase;
 
-  @Value("${host_url}")
-  private String hostUrl;
-
   @Value("${stellar_network.horizon_url}")
   private String horizonUrl;
 
@@ -46,17 +43,6 @@ public class PropertyAppConfig implements AppConfig, Validator {
         "stellar-network-passphrase-empty",
         "stellar_network.network_passphrase is not defined.");
 
-    if (isEmpty(config.getHostUrl())) {
-      errors.rejectValue("hostUrl", "host-url-empty", "The host_url is not defined.");
-    } else {
-      if (!NetUtil.isUrlValid(config.getHostUrl())) {
-        errors.rejectValue(
-            "hostUrl",
-            "host-url-invalid",
-            String.format("The host_url:%s is not in valid format.", config.getHostUrl()));
-      }
-    }
-
     if (isEmpty(config.getHorizonUrl())) {
       errors.rejectValue(
           "horizonUrl", "horizon-url-empty", "The stellar_network.horizon_url is not defined.");
@@ -64,7 +50,7 @@ public class PropertyAppConfig implements AppConfig, Validator {
       if (!NetUtil.isUrlValid(config.getHorizonUrl())) {
         errors.rejectValue(
             "horizonUrl",
-            "horizon-url-invaliad",
+            "horizon-url-invalid",
             String.format(
                 "The stellar_network.horizon_url:%s is not in valid format.",
                 config.getHorizonUrl()));

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.platform.config;
 
 import static java.lang.String.format;
-import static org.stellar.anchor.util.NetUtil.getDomainFromURL;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 import static org.stellar.anchor.util.StringHelper.isNotEmpty;
 
@@ -23,6 +22,7 @@ import org.stellar.sdk.KeyPair;
 public class PropertySep10Config implements Sep10Config, Validator {
   private Boolean enabled;
   private String webAuthDomain;
+  private String homeDomain;
   private boolean clientAttributionRequired = false;
   private Integer authTimeout = 900;
   private Integer jwtTimeout = 86400;
@@ -41,7 +41,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
   @PostConstruct
   public void postConstruct() throws MalformedURLException {
     if (isEmpty(webAuthDomain)) {
-      webAuthDomain = getDomainFromURL(appConfig.getHostUrl());
+      webAuthDomain = homeDomain;
     }
   }
 
@@ -81,6 +81,18 @@ public class PropertySep10Config implements Sep10Config, Validator {
       errors.reject(
           "sep10-jwt-secret-empty",
           "Please set the secret.sep10.jwt_secret or SECRET_SEP10_JWT_SECRET environment variable");
+    }
+
+    if (isEmpty(homeDomain)) {
+      errors.rejectValue(
+          "homeDomain", "home-domain-empty", "The sep10.home_domain is not defined.");
+    } else {
+      if (!NetUtil.isServerPortValid(homeDomain)) {
+        errors.rejectValue(
+            "homeDomain",
+            "sep10-home-domain-invalid",
+            "The sep10.home_domain does not have valid format.");
+      }
     }
 
     if (isNotEmpty(webAuthDomain)) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -10,12 +10,10 @@ version: 1
 ## Application Configuration
 ##############################
 
-## @param: host_url
-## @type: string
-## @supported_prefixes: http:, https:
-## The anchor platform host url.
+
+
 #
-host_url: http://localhost:8080
+host_url:
 
 stellar_network:
   ## @param: network
@@ -251,9 +249,13 @@ sep10:
   ## @param: web_auth_domain
   ## @type: string
   ## The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
-  ## If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of the value of the `host_url`.
+  ## If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of the value of the `home_domain`.
   #
   web_auth_domain:
+  ## @param: home_domain
+  ## @type: string
+  ## The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
+  home_domain: localhost:8080
   ## @param: client_attribution_required
   ## @type: bool
   ## Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -10,11 +10,6 @@ version: 1
 ## Application Configuration
 ##############################
 
-
-
-#
-host_url:
-
 stellar_network:
   ## @param: network
   ## Whether to use testnet (TESTNET) or pubnet (PUBNET)
@@ -250,11 +245,12 @@ sep10:
   ## @type: string
   ## The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
   ## If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of the value of the `home_domain`.
-  #
+  ## `web_auth_domain` value must be equal to the host of the SEP server.
   web_auth_domain:
   ## @param: home_domain
   ## @type: string
   ## The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
+  ## `home_domain` value must be equal to the host of the toml file. If sep1 is enabled, toml file will be hosted on the SEP server.
   home_domain: localhost:8080
   ## @param: client_attribution_required
   ## @type: bool

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -45,7 +45,6 @@ events.publisher.msk.use_iam:
 events.publisher.sqs.aws_region:
 events.publisher.sqs.use_iam:
 events.publisher.type:
-host_url:
 languages:
 metrics.enabled:
 metrics.extras_enabled:
@@ -82,6 +81,7 @@ sep10.jwt_timeout:
 sep10.omnibus_account_list:
 sep10.require_known_omnibus_account:
 sep10.web_auth_domain:
+sep10.home_domain:
 sep12.enabled:
 sep24.enabled:
 sep24.features.account_creation:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/AppConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/AppConfigTest.kt
@@ -19,33 +19,7 @@ class AppConfigTest {
     config = PropertyAppConfig()
     config.stellarNetworkPassphrase = "Test SDF Network ; September 2015"
     config.horizonUrl = "https://horizon-testnet.stellar.org"
-    config.hostUrl = "http://localhost:8080"
     errors = BindException(config, "config")
-  }
-
-  @ParameterizedTest
-  @NullSource
-  @ValueSource(strings = [""])
-  fun `test empty host_url`(url: String?) {
-    config.hostUrl = url
-    config.validateConfig(config, errors)
-    assertErrorCode(errors, "host-url-empty")
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = ["https://stellar.org", "https://stellar.org:8080"])
-  fun `test valid host_url`(url: String) {
-    config.hostUrl = url
-    config.validateConfig(config, errors)
-    assertFalse(errors.hasErrors())
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = ["https ://stellar.org", "stellar.org", "abc"])
-  fun `test invalid host_url`(url: String) {
-    config.hostUrl = url
-    config.validateConfig(config, errors)
-    assertErrorCode(errors, "host-url-invalid")
   }
 
   @ParameterizedTest
@@ -61,7 +35,7 @@ class AppConfigTest {
     strings = ["https://horizon-testnet.stellar.org", "https://horizon-testnet.stellar.org:8080"]
   )
   fun `test valid horizon_url`(url: String) {
-    config.hostUrl = url
+    config.horizonUrl = url
     config.validateConfig(config, errors)
     assertFalse(errors.hasErrors())
   }
@@ -69,9 +43,9 @@ class AppConfigTest {
   @ParameterizedTest
   @ValueSource(strings = ["https://horizon-testnet.stellar. org", "stellar.org", "abc"])
   fun `test invalid horizon_url`(url: String) {
-    config.hostUrl = url
+    config.horizonUrl = url
     config.validateConfig(config, errors)
-    assertErrorCode(errors, "host-url-invalid")
+    assertErrorCode(errors, "horizon-url-invalid")
   }
 
   @ParameterizedTest


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Remove host_url and review usages of web_auth_domain

### Why

Previously, host_url was not used outside of SEP-10. In addition, in some instances web_auth_domain was incorrectly used in place of home_domain

### Known limitations

N/A