### PR TITLE
SDFSOF-51 / SDFSOF-52 : Add amount check for receive operations / Pass memo of sep transaction to custody service and include it into stellar transaction

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/custody/fireblocks/CreateTransactionRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/custody/fireblocks/CreateTransactionRequest.java
@@ -54,11 +54,8 @@ public class CreateTransactionRequest {
   }
 
   @Data
+  @AllArgsConstructor
   public static class OneTimeAddress {
-    public OneTimeAddress(String address) {
-      this.address = address;
-    }
-
     private String address;
     private String tag;
   }

--- a/integration-tests/src/main/kotlin/org/stellar/anchor/platform/CustodyApiClient.kt
+++ b/integration-tests/src/main/kotlin/org/stellar/anchor/platform/CustodyApiClient.kt
@@ -7,7 +7,7 @@ import org.stellar.anchor.api.custody.GenerateDepositAddressResponse
 class CustodyApiClient(private val endpoint: String, private val jwt: String) : SepClient() {
 
   fun generateDepositAddress(asset: String): GenerateDepositAddressResponse {
-    val url = "$endpoint/transactions/payments/assets/$asset/address"
+    val url = "$endpoint/assets/$asset/addresses"
     val responseBody = httpPost(url, mapOf<String, String>(), jwt)
     return gson.fromJson(responseBody, GenerateDepositAddressResponse::class.java)
   }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
@@ -177,7 +177,8 @@ private const val custodyTransactionPaymentRequest =
       "destination": {
         "type": "ONE_TIME_ADDRESS",
         "oneTimeAddress": {
-          "address": "testToAccount"
+          "address": "testToAccount",
+          "tag": "testMemo"
         }
       },
       "amount": "0.5"

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
@@ -158,7 +158,7 @@ private const val custodyTransactionRequest =
     "protocol": "24",
     "fromAccount": "testFromAccount",
     "toAccount": "testToAccount",
-    "amount": "0.5",
+    "amount": "0.45",
     "amountAsset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
     "kind": "deposit",
     "requestAssetCode": "testRequestAssetCode",

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/CustodyApiTests.kt
@@ -181,7 +181,7 @@ private const val custodyTransactionPaymentRequest =
           "tag": "testMemo"
         }
       },
-      "amount": "0.5"
+      "amount": "0.45"
     }
 """
 

--- a/platform/src/main/java/org/stellar/anchor/platform/apiclient/CustodyApiClient.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/apiclient/CustodyApiClient.java
@@ -27,8 +27,7 @@ public class CustodyApiClient {
   private static final Gson gson = GsonUtils.getInstance();
 
   private static final String CREATE_TRANSACTION_URL_FORMAT = "/transactions";
-  private static final String GENERATE_DEPOSIT_ADDRESS_URL_FORMAT =
-      "/transactions/payments/assets/%s/address";
+  private static final String GENERATE_DEPOSIT_ADDRESS_URL_FORMAT = "/assets/%s/addresses";
   private static final String CREATE_TRANSACTION_PAYMENT_URL_FORMAT = "/transactions/%s/payments";
 
   private final OkHttpClient httpClient;

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyPaymentController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyPaymentController.java
@@ -15,16 +15,16 @@ import org.stellar.anchor.platform.custody.CustodyPaymentService;
 @RestController
 public class CustodyPaymentController {
 
-  private final CustodyPaymentService custodyPaymentService;
+  private final CustodyPaymentService<?> custodyPaymentService;
 
-  public CustodyPaymentController(CustodyPaymentService custodyPaymentService) {
+  public CustodyPaymentController(CustodyPaymentService<?> custodyPaymentService) {
     this.custodyPaymentService = custodyPaymentService;
   }
 
   @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
-      value = "/transactions/payments/assets/{assetId}/address",
+      value = "/assets/{assetId}/addresses",
       method = {RequestMethod.POST})
   public GenerateDepositAddressResponse generateDepositAddress(@PathVariable String assetId)
       throws CustodyException, InvalidConfigException {

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPaymentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPaymentHandler.java
@@ -119,6 +119,8 @@ public abstract class CustodyPaymentHandler {
           formatAmount(gotAmount),
           payment.getId(),
           payment.getExternalTxId());
+      payment.setStatus(CustodyPaymentStatus.ERROR);
+      payment.setMessage("The incoming payment amount was insufficient");
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksPaymentService.java
@@ -112,7 +112,8 @@ public class FireblocksPaymentService implements CustodyPaymentService<Transacti
                 VAULT_ACCOUNT, fireblocksConfig.getVaultAccountId()))
         .destination(
             new CreateTransactionRequest.DestinationTransferPeerPath(
-                ONE_TIME_ADDRESS, new CreateTransactionRequest.OneTimeAddress(txn.getToAccount())))
+                ONE_TIME_ADDRESS,
+                new CreateTransactionRequest.OneTimeAddress(txn.getToAccount(), txn.getMemo())))
         .build();
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyApiClientTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyApiClientTest.kt
@@ -134,7 +134,7 @@ class CustodyApiClientTest {
     val responseAddress = custodyApiClient.generateDepositAddress(ASSET_ID)
 
     Assertions.assertEquals(
-      "http://testbaseurl.com/transactions/payments/assets/TEST_ASSET_ID/address",
+      "http://testbaseurl.com/assets/TEST_ASSET_ID/addresses",
       requestCapture.captured.url.toString()
     )
     Assertions.assertEquals("testApiKeyValue", requestCapture.captured.header("testApiKeyName"))

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyPaymentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyPaymentHandlerTest.kt
@@ -114,6 +114,28 @@ class CustodyPaymentHandlerTest {
   }
 
   @Test
+  fun test_validatePayment_invalidAmount() {
+    val txn =
+      gson.fromJson(
+        getResourceFileAsString(
+          "custody/fireblocks/webhook/handler/custody_transaction_input.json"
+        ),
+        JdbcCustodyTransaction::class.java
+      )
+    val payment =
+      gson.fromJson(
+        getResourceFileAsString(
+          "custody/fireblocks/webhook/handler/custody_payment_invalid_amount.json"
+        ),
+        CustodyPayment::class.java
+      )
+
+    custodyPaymentHandler.validatePayment(txn, payment)
+
+    assertEquals("The incoming payment amount was insufficient", payment.getMessage())
+  }
+
+  @Test
   fun test_validatePayment_validAsset() {
     val txn =
       gson.fromJson(

--- a/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_invalid_amount.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_invalid_amount.json
@@ -1,0 +1,15 @@
+{
+  "id": "12345",
+  "externalTxId": "testEventId",
+  "type": "payment",
+  "from": "testFrom",
+  "to": "testTo",
+  "amount": "0.99",
+  "assetType": "credit_alphanum4",
+  "assetName": "testAmountInAsset",
+  "createdAt": "2023-05-10T10:18:25.778Z",
+  "status": "SUCCESS",
+  "transactionHash": "testTxHash",
+  "transactionMemoType": "none",
+  "transactionEnvelope": "testEnvelopeXdr"
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

SDFSOF-51: Add amount check for receive operations
SDFSOF-52: Pass memo of sep transaction to custody service and include it into stellar transaction

### Why

Contains changes and fixes for Fireblocks deposit memo, payment amount validation and deposit address generation endpoint URL

### Known limitations

[TODO or N/A]