### PR TITLE
[ANCHOR-283] Add RequestLoggerFilter configuration to prevent unintentional PII (sensitive) logs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ subprojects {
       googleJavaFormat()
     }
 
-    kotlin { ktfmt("0.41").googleStyle() }
+    kotlin { ktfmt("0.42").googleStyle() }
   }
 
   dependencies {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/RequestLoggerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/RequestLoggerBeans.java
@@ -4,14 +4,15 @@ import javax.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.platform.config.AppLoggingConfig;
 import org.stellar.anchor.platform.utils.RequestLoggerFilter;
 
 @Configuration
 public class RequestLoggerBeans {
   @Bean
-  public FilterRegistrationBean<Filter> requestLoggerFilter() {
+  public FilterRegistrationBean<Filter> requestLoggerFilter(AppLoggingConfig appLoggingConfig) {
     FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
-    registrationBean.setFilter(new RequestLoggerFilter());
+    registrationBean.setFilter(new RequestLoggerFilter(appLoggingConfig));
     registrationBean.addUrlPatterns("/");
     registrationBean.addUrlPatterns("/*");
     return registrationBean;

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/SharedConfigBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/SharedConfigBeans.java
@@ -4,10 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.config.SecretConfig;
-import org.stellar.anchor.platform.config.PlatformApiConfig;
-import org.stellar.anchor.platform.config.PlatformServerConfig;
-import org.stellar.anchor.platform.config.PropertyDataConfig;
-import org.stellar.anchor.platform.config.PropertySecretConfig;
+import org.stellar.anchor.platform.config.*;
 
 @Configuration
 public class SharedConfigBeans {
@@ -27,5 +24,11 @@ public class SharedConfigBeans {
   @ConfigurationProperties(prefix = "platform-server")
   PlatformServerConfig platformServerConfig(PropertySecretConfig secretConfig) {
     return new PlatformServerConfig(secretConfig);
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "app-logging")
+  AppLoggingConfig appLoggingConfig() {
+    return new AppLoggingConfig();
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/AppLoggingConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/AppLoggingConfig.java
@@ -1,0 +1,8 @@
+package org.stellar.anchor.platform.config;
+
+import lombok.Data;
+
+@Data
+public class AppLoggingConfig {
+  boolean requestLoggerEnabled;
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/LogConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/LogConfigAdapter.java
@@ -24,7 +24,7 @@ public class LogConfigAdapter extends SpringConfigAdapter {
         Configurator.setAllLevels(LogManager.getRootLogger().getName(), rootLevel);
       }
 
-      if (config.get("logging.stellar_level") != null) {
+      if (config.get("app_logging.stellar_level") != null) {
         Level stellarLevel = getLog4j2Level(config.getString("app_logging.stellar_level"));
         Configurator.setAllLevels("org.stellar", stellarLevel);
       }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -166,6 +166,11 @@ app_logging:
   ## @type: string
   ## The "org.stellar" logger logging level.
   stellar_level: INFO
+  ## Enable/disable the request logger that logs all request body
+  ##   Setting the stellar_level to DEBUG will log the request URL
+  ##   Setting the stellar_level to TRACE will log the request body
+  ## Note: By enabling the logger, PII may be logged
+  request_logger_enabled: false
 
 ######################
 ## Platform Server Configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -1,4 +1,5 @@
 app_logging.level:
+app_logging.request_logger_enabled:
 app_logging.stellar_level:
 assets.type:
 assets.value:
@@ -10,9 +11,9 @@ callback_api.base_url:
 callback_api.check_certificate:
 data.database:
 data.ddl_auto:
+data.flyway_baseline_on_migrate:
 data.flyway_enabled:
 data.flyway_location:
-data.flyway_baseline_on_migrate:
 data.initial_connection_pool_size:
 data.max_active_connections:
 data.server:
@@ -77,11 +78,11 @@ sep10.client_attribution_allow_list:
 sep10.client_attribution_deny_list:
 sep10.client_attribution_required:
 sep10.enabled:
+sep10.home_domain:
 sep10.jwt_timeout:
 sep10.omnibus_account_list:
 sep10.require_known_omnibus_account:
 sep10.web_auth_domain:
-sep10.home_domain:
 sep12.enabled:
 sep24.enabled:
 sep24.features.account_creation:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
@@ -1,0 +1,58 @@
+package org.stellar.anchor.platform.utils
+
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import javax.servlet.FilterChain
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.stellar.anchor.platform.config.AppLoggingConfig
+import org.stellar.anchor.util.Log
+
+class RequestLoggerFilterTest {
+  private lateinit var appLoggingConfig: AppLoggingConfig
+  private lateinit var requestLoggerFilter: RequestLoggerFilter
+  private lateinit var request: MockHttpServletRequest
+  private lateinit var response: MockHttpServletResponse
+  private lateinit var filterChain: FilterChain
+
+  @BeforeEach
+  fun setUp() {
+    appLoggingConfig = AppLoggingConfig()
+    requestLoggerFilter = RequestLoggerFilter(appLoggingConfig)
+    request = MockHttpServletRequest()
+    response = MockHttpServletResponse()
+    filterChain = mockk<FilterChain>(relaxed = true)
+    mockkStatic(Log::class)
+  }
+
+  @Test
+  fun `doFilterInternal when RequestLogger disabled should not send debug and trace logs`() {
+    // Arrange
+    appLoggingConfig.isRequestLoggerEnabled = false
+
+    // Act
+    requestLoggerFilter.doFilterInternal(request, response, filterChain)
+
+    // Assert
+    verify(exactly = 1) { filterChain.doFilter(any(), any()) }
+    verify(exactly = 0) { Log.debugF(any(), *varargAny { true }) }
+    verify(exactly = 0) { Log.trace(any()) }
+  }
+
+  @Test
+  fun `doFilterInternal when RequestLogger enabled should send debug and trace logs`() {
+    // Arrange
+    appLoggingConfig.isRequestLoggerEnabled = true
+
+    // Act
+    requestLoggerFilter.doFilterInternal(request, response, filterChain)
+
+    // Assert
+    verify(exactly = 1) { filterChain.doFilter(any(), any()) }
+    verify(exactly = 1) { Log.debugF(any(), *varargAny { true }) }
+    verify(exactly = 1) { Log.trace(any()) }
+  }
+}

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -105,11 +105,11 @@ class TestProfileExecutor(val config: TestConfig) {
 
       if (jobs.size > 0) {
         jobs.forEach { it.join() }
-        if (wait) {
-          while (true) {
-            delay(60000)
-          }
-        }
+        if (wait)
+          do {
+            delay(5000)
+            val anyActive = runningServers.any { it.isActive }
+          } while (anyActive)
       }
     }
 

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -9,6 +9,7 @@ secret.sep24.interactive_url.jwt_secret=secret_sep24_interactive_url_jwt_secret
 secret.sep24.more_info_url.jwt_secret=secret_sep24_more_info_url_jwt_secret
 # logging
 app_logging.stellar_level=DEBUG
+app_logging.request_logger_enabled=true
 # events
 events.enabled=true
 events.publisher.type=kafka

--- a/service-runner/src/main/resources/profiles/sep24/config.env
+++ b/service-runner/src/main/resources/profiles/sep24/config.env
@@ -9,6 +9,7 @@ secret.sep24.interactive_url.jwt_secret=secret_sep24_interactive_url_jwt_secret
 secret.sep24.more_info_url.jwt_secret=secret_sep24_more_info_url_jwt_secret
 # logging
 app_logging.stellar_level=DEBUG
+app_logging.request_logger_enabled=true
 # events
 events.enabled=true
 events.publisher.type=kafka


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

- Add RequestLoggerFilter configuration
- Fix the bug when starting servers fail, the `TestProfileRunner` does not quite.

### Why

Prevent unintentional PII leak.
