### PR TITLE
[ANCHOR-330] Attempt to fix the racing condition where the servers were not shutdown before the next test starts

### DIFF
--- a/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
@@ -2,8 +2,11 @@ package org.stellar.anchor.platform.utils
 
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import io.mockk.verify
 import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockHttpServletRequest
@@ -14,16 +17,16 @@ import org.stellar.anchor.util.Log
 class RequestLoggerFilterTest {
   private lateinit var appLoggingConfig: AppLoggingConfig
   private lateinit var requestLoggerFilter: RequestLoggerFilter
-  private lateinit var request: MockHttpServletRequest
-  private lateinit var response: MockHttpServletResponse
+  private lateinit var request: HttpServletRequest
+  private lateinit var response: HttpServletResponse
   private lateinit var filterChain: FilterChain
 
   @BeforeEach
   fun setUp() {
     appLoggingConfig = AppLoggingConfig()
     requestLoggerFilter = RequestLoggerFilter(appLoggingConfig)
-    request = MockHttpServletRequest()
-    response = MockHttpServletResponse()
+    request = spyk<MockHttpServletRequest>()
+    response = spyk<MockHttpServletResponse>()
     filterChain = mockk<FilterChain>(relaxed = true)
     mockkStatic(Log::class)
   }
@@ -40,6 +43,15 @@ class RequestLoggerFilterTest {
     verify(exactly = 1) { filterChain.doFilter(any(), any()) }
     verify(exactly = 0) { Log.debugF(any(), *varargAny { true }) }
     verify(exactly = 0) { Log.trace(any()) }
+    verify(exactly = 0) { request.method }
+    verify(exactly = 0) { request.requestURI }
+    verify(exactly = 0) { request.requestURL }
+    verify(exactly = 0) { request.queryString }
+    verify(exactly = 0) { request.authType }
+    verify(exactly = 0) { request.remoteAddr }
+    verify(exactly = 0) { request.userPrincipal }
+    verify(exactly = 0) { request.getHeader(any()) }
+    verify(exactly = 0) { request.cookies }
   }
 
   @Test


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

We plan to run the action 10 times to increase the probability of the fix. 

1. test ok
2. test ok

### What

Wait to make sure the servers are properly shutdown.

### Why

Attempt to fix the racing condition where the servers were not shutdown before the next test starts. 
The gradle tests were not stable because we are getting BindException indicating address alreay in useerror. It looks like we are trying to start the servers while the previous tests were properly shutdown.

Here is from the raw log. 

```
2023-06-06T19:09:51.8496047Z JwtAuthIntegrationTest STANDARD_ERROR
2023-06-06T19:09:51.8497189Z     Exception in thread "DefaultDispatcher-worker-3 @coroutine#160" org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop'; nested exception is org.springframework.boot.web.server.PortInUseException: Port 8080 is already in use
2023-06-06T19:09:51.8498298Z     	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:181)
2023-06-06T19:09:51.8499141Z     	at org.springframework.context.support.DefaultLifecycleProcessor.access$200(DefaultLifecycleProcessor.java:54)
2023-06-06T19:09:51.8499991Z     	at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:356)
2023-06-06T19:09:51.8500624Z     	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
2023-06-06T19:09:51.8501490Z     	at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:155)
2023-06-06T19:09:51.8502347Z     	at org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:123)
2023-06-06T19:09:51.8503252Z     	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:935)
2023-06-06T19:09:51.8504153Z     	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:586)
2023-06-06T19:09:51.8505137Z     	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147)
2023-06-06T19:09:51.8505985Z     	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731)
2023-06-06T19:09:51.8506641Z     	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408)
2023-06-06T19:09:51.8507283Z     	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
2023-06-06T19:09:51.8507838Z     	at org.stellar.anchor.platform.SepServer.start(SepServer.java:43)
2023-06-06T19:09:51.8508407Z     	at org.stellar.anchor.platform.ServiceRunner.startSepServer(ServiceRunner.java:76)
2023-06-06T19:09:51.8509071Z     	at org.stellar.anchor.platform.TestProfileExecutor$startServers$1$4.invokeSuspend(TestProfileRunner.kt:99)
2023-06-06T19:09:51.8509760Z     	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2023-06-06T19:09:51.8510344Z     	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2023-06-06T19:09:51.8511148Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
2023-06-06T19:09:51.8511833Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
2023-06-06T19:09:51.8512496Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
2023-06-06T19:09:51.8513129Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
2023-06-06T19:09:51.8513887Z     	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [CoroutineId(160), "coroutine#160":StandaloneCoroutine{Cancelling}@59393b80, Dispatchers.Default]
2023-06-06T19:09:51.8514646Z     Caused by: org.springframework.boot.web.server.PortInUseException: Port 8080 is already in use
2023-06-06T19:09:51.8515392Z     	at org.springframework.boot.web.server.PortInUseException.lambda$throwIfPortBindingException$0(PortInUseException.java:70)
2023-06-06T19:09:51.8516388Z     	at org.springframework.boot.web.server.PortInUseException.lambda$ifPortBindingException$1(PortInUseException.java:85)
2023-06-06T19:09:51.8517185Z     	at org.springframework.boot.web.server.PortInUseException.ifCausedBy(PortInUseException.java:103)
2023-06-06T19:09:51.8518006Z     	at org.springframework.boot.web.server.PortInUseException.ifPortBindingException(PortInUseException.java:82)
2023-06-06T19:09:51.8518921Z     	at org.springframework.boot.web.server.PortInUseException.throwIfPortBindingException(PortInUseException.java:69)
2023-06-06T19:09:51.8519751Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:228)
2023-06-06T19:09:51.8520592Z     	at org.springframework.boot.web.servlet.context.WebServerStartStopLifecycle.start(WebServerStartStopLifecycle.java:43)
2023-06-06T19:09:51.8521538Z     	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:178)
2023-06-06T19:09:51.8522069Z     	... 20 more
2023-06-06T19:09:51.8522487Z     Caused by: java.lang.IllegalArgumentException: standardService.connector.startFailed
2023-06-06T19:09:51.8523104Z     	at org.apache.catalina.core.StandardService.addConnector(StandardService.java:238)
2023-06-06T19:09:51.8523942Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.addPreviouslyRemovedConnectors(TomcatWebServer.java:282)
2023-06-06T19:09:51.8524951Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:213)
2023-06-06T19:09:51.8525427Z     	... 22 more
2023-06-06T19:09:51.8525823Z     Caused by: org.apache.catalina.LifecycleException: Protocol handler start failed
2023-06-06T19:09:51.8526394Z     	at org.apache.catalina.connector.Connector.startInternal(Connector.java:1076)
2023-06-06T19:09:51.8526955Z     	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
2023-06-06T19:09:51.8527552Z     	at org.apache.catalina.core.StandardService.addConnector(StandardService.java:234)
2023-06-06T19:09:51.8527976Z     	... 24 more
2023-06-06T19:09:51.8528291Z     Caused by: java.net.BindException: Address already in use
2023-06-06T19:09:51.8528682Z     	at java.base/sun.nio.ch.Net.bind0(Native Method)
2023-06-06T19:09:51.8529044Z     	at java.base/sun.nio.ch.Net.bind(Net.java:459)
2023-06-06T19:09:51.8529386Z     	at java.base/sun.nio.ch.Net.bind(Net.java:448)
2023-06-06T19:09:51.8529874Z     	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
2023-06-06T19:09:51.8530485Z     	at org.apache.tomcat.util.net.NioEndpoint.initServerSocket(NioEndpoint.java:275)
2023-06-06T19:09:51.8531052Z     	at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:230)
2023-06-06T19:09:51.8531649Z     	at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1227)
2023-06-06T19:09:51.8532287Z     	at org.apache.tomcat.util.net.AbstractEndpoint.start(AbstractEndpoint.java:1313)
2023-06-06T19:09:51.8532846Z     	at org.apache.coyote.AbstractProtocol.start(AbstractProtocol.java:615)
2023-06-06T19:09:51.8533426Z     	at org.apache.catalina.connector.Connector.startInternal(Connector.java:1073)
2023-06-06T19:09:51.8533822Z     	... 26 more
```