### PR TITLE
[ANCHOR-330] Attempt to fix the racing condition where the servers were not shutdown before the next test starts

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
@@ -5,33 +5,33 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 val PostgresConfig =
-    TestConfig("default").also {
-      it.env["run_all_servers"] = "false"
-      it.env["run_sep_server"] = "true"
-      it.env["data.flyway_enabled"] = "true"
-    }
+  TestConfig("default").also {
+    it.env["run_all_servers"] = "false"
+    it.env["run_sep_server"] = "true"
+    it.env["data.flyway_enabled"] = "true"
+  }
 
 val H2Config =
-    TestConfig("default").also {
-      it.env["run_all_servers"] = "false"
-      it.env["run_sep_server"] = "true"
-      it.env["run_docker"] = "false"
-      it.env["data.type"] = "h2"
-      it.env["data.server"] = ""
-      it.env["data.database"] = ""
-      it.env["data.flyway_enabled"] = "true"
-    }
+  TestConfig("default").also {
+    it.env["run_all_servers"] = "false"
+    it.env["run_sep_server"] = "true"
+    it.env["run_docker"] = "false"
+    it.env["data.type"] = "h2"
+    it.env["data.server"] = ""
+    it.env["data.database"] = ""
+    it.env["data.flyway_enabled"] = "true"
+  }
 
 val SQLiteConfig =
-    TestConfig("default").also {
-      it.env["run_all_servers"] = "false"
-      it.env["run_sep_server"] = "true"
-      it.env["run_docker"] = "false"
-      it.env["data.type"] = "sqlite"
-      it.env["data.server"] = ""
-      it.env["data.database"] = "platform-test"
-      it.env["data.flyway_enabled"] = "true"
-    }
+  TestConfig("default").also {
+    it.env["run_all_servers"] = "false"
+    it.env["run_sep_server"] = "true"
+    it.env["run_docker"] = "false"
+    it.env["data.type"] = "sqlite"
+    it.env["data.server"] = ""
+    it.env["data.database"] = "platform-test"
+    it.env["data.flyway_enabled"] = "true"
+  }
 
 class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
   companion object {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
@@ -3,101 +3,101 @@ package org.stellar.anchor.platform
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-//
-//val PostgresConfig =
-//  TestConfig("default").also {
-//    it.env["run_all_servers"] = "false"
-//    it.env["run_sep_server"] = "true"
-//    it.env["data.flyway_enabled"] = "true"
-//  }
-//
-//val H2Config =
-//  TestConfig("default").also {
-//    it.env["run_all_servers"] = "false"
-//    it.env["run_sep_server"] = "true"
-//    it.env["run_docker"] = "false"
-//    it.env["data.type"] = "h2"
-//    it.env["data.server"] = ""
-//    it.env["data.database"] = ""
-//    it.env["data.flyway_enabled"] = "true"
-//  }
-//
-//val SQLiteConfig =
-//  TestConfig("default").also {
-//    it.env["run_all_servers"] = "false"
-//    it.env["run_sep_server"] = "true"
-//    it.env["run_docker"] = "false"
-//    it.env["data.type"] = "sqlite"
-//    it.env["data.server"] = ""
-//    it.env["data.database"] = "platform-test"
-//    it.env["data.flyway_enabled"] = "true"
-//  }
-//
-//class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
-//  companion object {
-//    private val singleton = PostgresMigrationTest()
-//
-//    @BeforeAll
-//    @JvmStatic
-//    fun construct() {
-//      singleton.setUp()
-//    }
-//
-//    @AfterAll
-//    @JvmStatic
-//    fun destroy() {
-//      singleton.tearDown()
-//    }
-//  }
-//
-//  @Test
-//  fun test() {
-//    // Nothing to do
-//  }
-//}
-//
-//class H2MigrationTest : AbstractIntegrationTest(H2Config) {
-//  companion object {
-//    private val singleton = H2MigrationTest()
-//
-//    @BeforeAll
-//    @JvmStatic
-//    fun construct() {
-//      singleton.setUp()
-//    }
-//
-//    @AfterAll
-//    @JvmStatic
-//    fun destroy() {
-//      singleton.tearDown()
-//    }
-//  }
-//
-//  @Test
-//  fun test() {
-//    // Nothing to do
-//  }
-//}
-//
-//class SQLiteMigrationTest : AbstractIntegrationTest(SQLiteConfig) {
-//  companion object {
-//    private val singleton = SQLiteMigrationTest()
-//
-//    @BeforeAll
-//    @JvmStatic
-//    fun construct() {
-//      singleton.setUp()
-//    }
-//
-//    @AfterAll
-//    @JvmStatic
-//    fun destroy() {
-//      singleton.tearDown()
-//    }
-//  }
-//
-//  @Test
-//  fun test() {
-//    // Nothing to do
-//  }
-//}
+
+val PostgresConfig =
+    TestConfig("default").also {
+      it.env["run_all_servers"] = "false"
+      it.env["run_sep_server"] = "true"
+      it.env["data.flyway_enabled"] = "true"
+    }
+
+val H2Config =
+    TestConfig("default").also {
+      it.env["run_all_servers"] = "false"
+      it.env["run_sep_server"] = "true"
+      it.env["run_docker"] = "false"
+      it.env["data.type"] = "h2"
+      it.env["data.server"] = ""
+      it.env["data.database"] = ""
+      it.env["data.flyway_enabled"] = "true"
+    }
+
+val SQLiteConfig =
+    TestConfig("default").also {
+      it.env["run_all_servers"] = "false"
+      it.env["run_sep_server"] = "true"
+      it.env["run_docker"] = "false"
+      it.env["data.type"] = "sqlite"
+      it.env["data.server"] = ""
+      it.env["data.database"] = "platform-test"
+      it.env["data.flyway_enabled"] = "true"
+    }
+
+class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
+  companion object {
+    private val singleton = PostgresMigrationTest()
+
+    @BeforeAll
+    @JvmStatic
+    fun construct() {
+      singleton.setUp()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun destroy() {
+      singleton.tearDown()
+    }
+  }
+
+  @Test
+  fun test() {
+    // Nothing to do
+  }
+}
+
+class H2MigrationTest : AbstractIntegrationTest(H2Config) {
+  companion object {
+    private val singleton = H2MigrationTest()
+
+    @BeforeAll
+    @JvmStatic
+    fun construct() {
+      singleton.setUp()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun destroy() {
+      singleton.tearDown()
+    }
+  }
+
+  @Test
+  fun test() {
+    // Nothing to do
+  }
+}
+
+class SQLiteMigrationTest : AbstractIntegrationTest(SQLiteConfig) {
+  companion object {
+    private val singleton = SQLiteMigrationTest()
+
+    @BeforeAll
+    @JvmStatic
+    fun construct() {
+      singleton.setUp()
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun destroy() {
+      singleton.tearDown()
+    }
+  }
+
+  @Test
+  fun test() {
+    // Nothing to do
+  }
+}

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
@@ -3,101 +3,101 @@ package org.stellar.anchor.platform
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-
-val PostgresConfig =
-  TestConfig("default").also {
-    it.env["run_all_servers"] = "false"
-    it.env["run_sep_server"] = "true"
-    it.env["data.flyway_enabled"] = "true"
-  }
-
-val H2Config =
-  TestConfig("default").also {
-    it.env["run_all_servers"] = "false"
-    it.env["run_sep_server"] = "true"
-    it.env["run_docker"] = "false"
-    it.env["data.type"] = "h2"
-    it.env["data.server"] = ""
-    it.env["data.database"] = ""
-    it.env["data.flyway_enabled"] = "true"
-  }
-
-val SQLiteConfig =
-  TestConfig("default").also {
-    it.env["run_all_servers"] = "false"
-    it.env["run_sep_server"] = "true"
-    it.env["run_docker"] = "false"
-    it.env["data.type"] = "sqlite"
-    it.env["data.server"] = ""
-    it.env["data.database"] = "platform-test"
-    it.env["data.flyway_enabled"] = "true"
-  }
-
-class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
-  companion object {
-    private val singleton = PostgresMigrationTest()
-
-    @BeforeAll
-    @JvmStatic
-    fun construct() {
-      singleton.setUp()
-    }
-
-    @AfterAll
-    @JvmStatic
-    fun destroy() {
-      singleton.tearDown()
-    }
-  }
-
-  @Test
-  fun test() {
-    // Nothing to do
-  }
-}
-
-class H2MigrationTest : AbstractIntegrationTest(H2Config) {
-  companion object {
-    private val singleton = H2MigrationTest()
-
-    @BeforeAll
-    @JvmStatic
-    fun construct() {
-      singleton.setUp()
-    }
-
-    @AfterAll
-    @JvmStatic
-    fun destroy() {
-      singleton.tearDown()
-    }
-  }
-
-  @Test
-  fun test() {
-    // Nothing to do
-  }
-}
-
-class SQLiteMigrationTest : AbstractIntegrationTest(SQLiteConfig) {
-  companion object {
-    private val singleton = SQLiteMigrationTest()
-
-    @BeforeAll
-    @JvmStatic
-    fun construct() {
-      singleton.setUp()
-    }
-
-    @AfterAll
-    @JvmStatic
-    fun destroy() {
-      singleton.tearDown()
-    }
-  }
-
-  @Test
-  fun test() {
-    // Nothing to do
-  }
-}
+//
+//val PostgresConfig =
+//  TestConfig("default").also {
+//    it.env["run_all_servers"] = "false"
+//    it.env["run_sep_server"] = "true"
+//    it.env["data.flyway_enabled"] = "true"
+//  }
+//
+//val H2Config =
+//  TestConfig("default").also {
+//    it.env["run_all_servers"] = "false"
+//    it.env["run_sep_server"] = "true"
+//    it.env["run_docker"] = "false"
+//    it.env["data.type"] = "h2"
+//    it.env["data.server"] = ""
+//    it.env["data.database"] = ""
+//    it.env["data.flyway_enabled"] = "true"
+//  }
+//
+//val SQLiteConfig =
+//  TestConfig("default").also {
+//    it.env["run_all_servers"] = "false"
+//    it.env["run_sep_server"] = "true"
+//    it.env["run_docker"] = "false"
+//    it.env["data.type"] = "sqlite"
+//    it.env["data.server"] = ""
+//    it.env["data.database"] = "platform-test"
+//    it.env["data.flyway_enabled"] = "true"
+//  }
+//
+//class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
+//  companion object {
+//    private val singleton = PostgresMigrationTest()
+//
+//    @BeforeAll
+//    @JvmStatic
+//    fun construct() {
+//      singleton.setUp()
+//    }
+//
+//    @AfterAll
+//    @JvmStatic
+//    fun destroy() {
+//      singleton.tearDown()
+//    }
+//  }
+//
+//  @Test
+//  fun test() {
+//    // Nothing to do
+//  }
+//}
+//
+//class H2MigrationTest : AbstractIntegrationTest(H2Config) {
+//  companion object {
+//    private val singleton = H2MigrationTest()
+//
+//    @BeforeAll
+//    @JvmStatic
+//    fun construct() {
+//      singleton.setUp()
+//    }
+//
+//    @AfterAll
+//    @JvmStatic
+//    fun destroy() {
+//      singleton.tearDown()
+//    }
+//  }
+//
+//  @Test
+//  fun test() {
+//    // Nothing to do
+//  }
+//}
+//
+//class SQLiteMigrationTest : AbstractIntegrationTest(SQLiteConfig) {
+//  companion object {
+//    private val singleton = SQLiteMigrationTest()
+//
+//    @BeforeAll
+//    @JvmStatic
+//    fun construct() {
+//      singleton.setUp()
+//    }
+//
+//    @AfterAll
+//    @JvmStatic
+//    fun destroy() {
+//      singleton.tearDown()
+//    }
+//  }
+//
+//  @Test
+//  fun test() {
+//    // Nothing to do
+//  }
+//}

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -9,13 +9,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.AllArgsConstructor;
 import org.stellar.anchor.platform.data.PaymentObservingAccount;
+import org.stellar.anchor.platform.utils.DaemonExecutors;
 import org.stellar.anchor.util.Log;
 
 public class PaymentObservingAccountsManager {
@@ -38,7 +38,7 @@ public class PaymentObservingAccountsManager {
     }
 
     // Start the eviction task
-    ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    ScheduledExecutorService scheduler = DaemonExecutors.newScheduledThreadPool(1);
     scheduler.scheduleAtFixedRate(
         this::evictAndPersist, 60, getEvictPeriod().getSeconds(), TimeUnit.SECONDS);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +30,7 @@ import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig;
 import org.stellar.anchor.platform.observer.ObservedPayment;
 import org.stellar.anchor.platform.observer.PaymentListener;
+import org.stellar.anchor.platform.utils.DaemonExecutors;
 import org.stellar.anchor.util.ExponentialBackoffTimer;
 import org.stellar.anchor.util.Log;
 import org.stellar.sdk.Server;
@@ -68,8 +68,8 @@ public class StellarPaymentObserver implements HealthCheckable {
 
   Instant lastActivityTime;
 
-  final ScheduledExecutorService silenceWatcher = Executors.newSingleThreadScheduledExecutor();
-  final ScheduledExecutorService statusWatcher = Executors.newSingleThreadScheduledExecutor();
+  final ScheduledExecutorService silenceWatcher = DaemonExecutors.newScheduledThreadPool(1);
+  final ScheduledExecutorService statusWatcher = DaemonExecutors.newScheduledThreadPool(1);
 
   public StellarPaymentObserver(
       String horizonServer,

--- a/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/MetricEmitterService.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.platform.service;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -10,10 +9,11 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.stellar.anchor.platform.config.MetricConfig;
 import org.stellar.anchor.platform.data.JdbcSep31TransactionRepo;
+import org.stellar.anchor.platform.utils.DaemonExecutors;
 import org.stellar.anchor.util.Log;
 
 public class MetricEmitterService {
-  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+  private final ScheduledExecutorService executor = DaemonExecutors.newScheduledThreadPool(1);
   private final MetricConfig metricConfig;
   private final JdbcSep31TransactionRepo sep31TransactionStore;
   final AtomicInteger pendingStellarTxns = new AtomicInteger(0);

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/DaemonExecutors.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/DaemonExecutors.java
@@ -1,0 +1,13 @@
+package org.stellar.anchor.platform.utils;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+public class DaemonExecutors {
+  private static ThreadFactory daemonThreadFactory = new DaemonThreadFactory();
+
+  public static ScheduledExecutorService newScheduledThreadPool(int threadCount) {
+    return Executors.newScheduledThreadPool(threadCount, daemonThreadFactory);
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/DaemonThreadFactory.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/DaemonThreadFactory.java
@@ -1,0 +1,17 @@
+package org.stellar.anchor.platform.utils;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * This class is used to create daemon threads. Daemon threads are threads that do not prevent the
+ * JVM from exiting when the program finishes but the thread is still running.
+ */
+public class DaemonThreadFactory implements ThreadFactory {
+  @Override
+  public Thread newThread(Runnable r) {
+    Thread thread = Executors.defaultThreadFactory().newThread(r);
+    thread.setDaemon(true); // Set the thread as a daemon thread
+    return thread;
+  }
+}

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -36,6 +36,9 @@ fun main() = runBlocking {
 }
 
 class TestProfileExecutor(val config: TestConfig) {
+  companion object {
+    const val MAX_SHUTDOWN_WAIT = 10
+  }
   private lateinit var docker: DockerComposeExtension
   private var runningServers: MutableList<ConfigurableApplicationContext> = mutableListOf()
   private var shouldStartDockerCompose: Boolean = false

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -10,7 +10,6 @@ import java.lang.Thread.sleep
 import java.lang.reflect.Field
 import java.util.*
 import kotlinx.coroutines.*
-import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.stellar.anchor.util.Log.info
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>



We plan to run the action many times to increase the probability of the fix. 

[View List of GitHub Action Results](https://github.com/stellar/java-stellar-anchor-sdk/actions?query=branch%3Afeature%2Fanchor-330-fix-test-instability++). 


### What

- Wait to make sure the servers are properly shutdown.
- Mark watcher threads as daemon to avoid blocking shutdown

### Why

Attempt to fix the racing condition where the servers were not shutdown before the next test starts. 
The gradle tests were not stable because we are getting BindException indicating address alreay in useerror. It looks like we are trying to start the servers while the previous tests were properly shutdown.

Here is from the raw log. 

```
2023-06-06T19:09:51.8496047Z JwtAuthIntegrationTest STANDARD_ERROR
2023-06-06T19:09:51.8497189Z     Exception in thread "DefaultDispatcher-worker-3 @coroutine#160" org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop'; nested exception is org.springframework.boot.web.server.PortInUseException: Port 8080 is already in use
2023-06-06T19:09:51.8498298Z     	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:181)
2023-06-06T19:09:51.8499141Z     	at org.springframework.context.support.DefaultLifecycleProcessor.access$200(DefaultLifecycleProcessor.java:54)
2023-06-06T19:09:51.8499991Z     	at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:356)
2023-06-06T19:09:51.8500624Z     	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
2023-06-06T19:09:51.8501490Z     	at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:155)
2023-06-06T19:09:51.8502347Z     	at org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:123)
2023-06-06T19:09:51.8503252Z     	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:935)
2023-06-06T19:09:51.8504153Z     	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:586)
2023-06-06T19:09:51.8505137Z     	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147)
2023-06-06T19:09:51.8505985Z     	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731)
2023-06-06T19:09:51.8506641Z     	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408)
2023-06-06T19:09:51.8507283Z     	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
2023-06-06T19:09:51.8507838Z     	at org.stellar.anchor.platform.SepServer.start(SepServer.java:43)
2023-06-06T19:09:51.8508407Z     	at org.stellar.anchor.platform.ServiceRunner.startSepServer(ServiceRunner.java:76)
2023-06-06T19:09:51.8509071Z     	at org.stellar.anchor.platform.TestProfileExecutor$startServers$1$4.invokeSuspend(TestProfileRunner.kt:99)
2023-06-06T19:09:51.8509760Z     	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2023-06-06T19:09:51.8510344Z     	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2023-06-06T19:09:51.8511148Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
2023-06-06T19:09:51.8511833Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
2023-06-06T19:09:51.8512496Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
2023-06-06T19:09:51.8513129Z     	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
2023-06-06T19:09:51.8513887Z     	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [CoroutineId(160), "coroutine#160":StandaloneCoroutine{Cancelling}@59393b80, Dispatchers.Default]
2023-06-06T19:09:51.8514646Z     Caused by: org.springframework.boot.web.server.PortInUseException: Port 8080 is already in use
2023-06-06T19:09:51.8515392Z     	at org.springframework.boot.web.server.PortInUseException.lambda$throwIfPortBindingException$0(PortInUseException.java:70)
2023-06-06T19:09:51.8516388Z     	at org.springframework.boot.web.server.PortInUseException.lambda$ifPortBindingException$1(PortInUseException.java:85)
2023-06-06T19:09:51.8517185Z     	at org.springframework.boot.web.server.PortInUseException.ifCausedBy(PortInUseException.java:103)
2023-06-06T19:09:51.8518006Z     	at org.springframework.boot.web.server.PortInUseException.ifPortBindingException(PortInUseException.java:82)
2023-06-06T19:09:51.8518921Z     	at org.springframework.boot.web.server.PortInUseException.throwIfPortBindingException(PortInUseException.java:69)
2023-06-06T19:09:51.8519751Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:228)
2023-06-06T19:09:51.8520592Z     	at org.springframework.boot.web.servlet.context.WebServerStartStopLifecycle.start(WebServerStartStopLifecycle.java:43)
2023-06-06T19:09:51.8521538Z     	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:178)
2023-06-06T19:09:51.8522069Z     	... 20 more
2023-06-06T19:09:51.8522487Z     Caused by: java.lang.IllegalArgumentException: standardService.connector.startFailed
2023-06-06T19:09:51.8523104Z     	at org.apache.catalina.core.StandardService.addConnector(StandardService.java:238)
2023-06-06T19:09:51.8523942Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.addPreviouslyRemovedConnectors(TomcatWebServer.java:282)
2023-06-06T19:09:51.8524951Z     	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:213)
2023-06-06T19:09:51.8525427Z     	... 22 more
2023-06-06T19:09:51.8525823Z     Caused by: org.apache.catalina.LifecycleException: Protocol handler start failed
2023-06-06T19:09:51.8526394Z     	at org.apache.catalina.connector.Connector.startInternal(Connector.java:1076)
2023-06-06T19:09:51.8526955Z     	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
2023-06-06T19:09:51.8527552Z     	at org.apache.catalina.core.StandardService.addConnector(StandardService.java:234)
2023-06-06T19:09:51.8527976Z     	... 24 more
2023-06-06T19:09:51.8528291Z     Caused by: java.net.BindException: Address already in use
2023-06-06T19:09:51.8528682Z     	at java.base/sun.nio.ch.Net.bind0(Native Method)
2023-06-06T19:09:51.8529044Z     	at java.base/sun.nio.ch.Net.bind(Net.java:459)
2023-06-06T19:09:51.8529386Z     	at java.base/sun.nio.ch.Net.bind(Net.java:448)
2023-06-06T19:09:51.8529874Z     	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
2023-06-06T19:09:51.8530485Z     	at org.apache.tomcat.util.net.NioEndpoint.initServerSocket(NioEndpoint.java:275)
2023-06-06T19:09:51.8531052Z     	at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:230)
2023-06-06T19:09:51.8531649Z     	at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1227)
2023-06-06T19:09:51.8532287Z     	at org.apache.tomcat.util.net.AbstractEndpoint.start(AbstractEndpoint.java:1313)
2023-06-06T19:09:51.8532846Z     	at org.apache.coyote.AbstractProtocol.start(AbstractProtocol.java:615)
2023-06-06T19:09:51.8533426Z     	at org.apache.catalina.connector.Connector.startInternal(Connector.java:1073)
2023-06-06T19:09:51.8533822Z     	... 26 more
```