### PR TITLE
custody-service: SDFSOF-55 - Added a memo_type validation when integration with Fireblocks is enabled

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
@@ -14,21 +14,12 @@ import org.stellar.anchor.filter.CustodyAuthJwtFilter;
 import org.stellar.anchor.filter.NoneFilter;
 import org.stellar.anchor.platform.config.CustodyApiConfig;
 import org.stellar.anchor.platform.config.PropertyCustodyConfig;
-import org.stellar.anchor.platform.custody.CustodyPaymentService;
-import org.stellar.anchor.platform.custody.CustodyTransactionService;
 import org.stellar.anchor.platform.custody.Sep24CustodyPaymentHandler;
 import org.stellar.anchor.platform.custody.Sep31CustodyPaymentHandler;
 import org.stellar.anchor.platform.data.JdbcCustodyTransactionRepo;
 
 @Configuration
 public class CustodyBeans {
-
-  @Bean
-  CustodyTransactionService getCustodyTransactionService(
-      JdbcCustodyTransactionRepo custodyTransactionRepo,
-      CustodyPaymentService custodyPaymentService) {
-    return new CustodyTransactionService(custodyTransactionRepo, custodyPaymentService);
-  }
 
   /**
    * Register platform-to-custody token filter.

--- a/platform/src/main/java/org/stellar/anchor/platform/component/custody/FireblocksBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/custody/FireblocksBeans.java
@@ -16,6 +16,7 @@ import org.stellar.anchor.platform.custody.CustodyTransactionService;
 import org.stellar.anchor.platform.custody.Sep24CustodyPaymentHandler;
 import org.stellar.anchor.platform.custody.Sep31CustodyPaymentHandler;
 import org.stellar.anchor.platform.custody.fireblocks.FireblocksApiClient;
+import org.stellar.anchor.platform.custody.fireblocks.FireblocksCustodyTransactionService;
 import org.stellar.anchor.platform.custody.fireblocks.FireblocksEventService;
 import org.stellar.anchor.platform.custody.fireblocks.FireblocksPaymentService;
 import org.stellar.anchor.platform.data.JdbcCustodyTransactionRepo;
@@ -68,5 +69,12 @@ public class FireblocksBeans {
   CustodyPaymentService<TransactionDetails> custodyPaymentService(
       FireblocksApiClient fireblocksApiClient, FireblocksConfig fireblocksConfig) {
     return new FireblocksPaymentService(fireblocksApiClient, fireblocksConfig);
+  }
+
+  @Bean
+  CustodyTransactionService getCustodyTransactionService(
+      JdbcCustodyTransactionRepo custodyTransactionRepo,
+      CustodyPaymentService custodyPaymentService) {
+    return new FireblocksCustodyTransactionService(custodyTransactionRepo, custodyPaymentService);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/custody/FireblocksBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/custody/FireblocksBeans.java
@@ -72,9 +72,9 @@ public class FireblocksBeans {
   }
 
   @Bean
-  CustodyTransactionService getCustodyTransactionService(
+  CustodyTransactionService fireblocksCustodyTransactionService(
       JdbcCustodyTransactionRepo custodyTransactionRepo,
-      CustodyPaymentService custodyPaymentService) {
+      CustodyPaymentService<TransactionDetails> custodyPaymentService) {
     return new FireblocksCustodyTransactionService(custodyTransactionRepo, custodyPaymentService);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
@@ -23,6 +23,7 @@ public class CustodyTransactionController {
     this.custodyTransactionService = custodyTransactionService;
   }
 
+  @SneakyThrows
   @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
@@ -23,7 +23,7 @@ import org.stellar.anchor.platform.data.CustodyTransactionStatus;
 import org.stellar.anchor.platform.data.JdbcCustodyTransaction;
 import org.stellar.anchor.platform.data.JdbcCustodyTransactionRepo;
 
-public class CustodyTransactionService {
+public abstract class CustodyTransactionService {
 
   private final CustodyPaymentService<?> custodyPaymentService;
   private final JdbcCustodyTransactionRepo custodyTransactionRepo;
@@ -35,12 +35,17 @@ public class CustodyTransactionService {
     this.custodyPaymentService = custodyPaymentService;
   }
 
+  protected abstract void validateRequest(CreateCustodyTransactionRequest request)
+      throws CustodyBadRequestException;
+
   /**
    * Create custody transaction
    *
    * @param request custody transaction info
    */
-  public void create(CreateCustodyTransactionRequest request) {
+  public void create(CreateCustodyTransactionRequest request) throws CustodyBadRequestException {
+    validateRequest(request);
+
     custodyTransactionRepo.save(
         JdbcCustodyTransaction.builder()
             .id(request.getId())

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksCustodyTransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksCustodyTransactionService.java
@@ -1,0 +1,30 @@
+package org.stellar.anchor.platform.custody.fireblocks;
+
+import org.stellar.anchor.api.custody.CreateCustodyTransactionRequest;
+import org.stellar.anchor.api.exception.custody.CustodyBadRequestException;
+import org.stellar.anchor.platform.custody.CustodyPaymentService;
+import org.stellar.anchor.platform.custody.CustodyTransactionService;
+import org.stellar.anchor.platform.data.JdbcCustodyTransactionRepo;
+import org.stellar.anchor.util.MemoHelper;
+import org.stellar.sdk.xdr.MemoType;
+
+public class FireblocksCustodyTransactionService extends CustodyTransactionService {
+
+  public FireblocksCustodyTransactionService(
+      JdbcCustodyTransactionRepo custodyTransactionRepo,
+      CustodyPaymentService<?> custodyPaymentService) {
+    super(custodyTransactionRepo, custodyPaymentService);
+  }
+
+  @Override
+  protected void validateRequest(CreateCustodyTransactionRequest request)
+      throws CustodyBadRequestException {
+    // Fireblocks doesn't support memo of type HASH.
+    final String hashMemoType = MemoHelper.memoTypeAsString(MemoType.MEMO_HASH);
+    if (hashMemoType.equals(request.getMemoType())) {
+      throw new CustodyBadRequestException(
+          String.format(
+              "Memo type [%s] is not supported by Fireblocks custody service", hashMemoType));
+    }
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/job/FireblocksTransactionsReconciliationJobTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/job/FireblocksTransactionsReconciliationJobTest.kt
@@ -23,6 +23,7 @@ import org.stellar.anchor.platform.config.FireblocksConfig
 import org.stellar.anchor.platform.custody.CustodyPayment
 import org.stellar.anchor.platform.custody.CustodyPaymentService
 import org.stellar.anchor.platform.custody.CustodyTransactionService
+import org.stellar.anchor.platform.custody.fireblocks.FireblocksCustodyTransactionService
 import org.stellar.anchor.platform.custody.fireblocks.FireblocksEventService
 import org.stellar.anchor.platform.data.CustodyTransactionStatus
 import org.stellar.anchor.platform.data.JdbcCustodyTransaction
@@ -51,7 +52,7 @@ class FireblocksTransactionsReconciliationJobTest {
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     custodyTransactionService =
-      CustodyTransactionService(custodyTransactionRepo, custodyPaymentService)
+      FireblocksCustodyTransactionService(custodyTransactionRepo, custodyPaymentService)
 
     reconciliationJob =
       FireblocksTransactionsReconciliationJob(


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Added a memo_type validation for deposit case when integration with Fireblocks is enabled

### Why

Fireblocks doesn't supports memo of type hash. If send such memo Fireblocks returns 500 error code. That's why it's necessary to add a validation.