### PR TITLE
SDFSOF-31: Add possibility to run Custody End2End tests separately

### DIFF
--- a/.run/Test - Fireblocks End2End Test - no fullstack.run.xml
+++ b/.run/Test - Fireblocks End2End Test - no fullstack.run.xml
@@ -18,11 +18,6 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-    <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
-      <option name="credential" />
-      <option name="region" />
-      <option name="useCurrentConnection" value="false" />
-    </extension>
     <option name="PACKAGE_NAME" value="org.stellar.anchor.platform" />
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformCustodyEnd2EndTest" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Test - Fireblocks End2End Test - with fullstack.run.xml
+++ b/.run/Test - Fireblocks End2End Test - with fullstack.run.xml
@@ -18,11 +18,7 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-    <extension name="software.aws.toolkits.jetbrains.core.execution.JavaAwsConnectionExtension">
-      <option name="credential" />
-      <option name="region" />
-      <option name="useCurrentConnection" value="false" />
-    </extension>
+
     <option name="PACKAGE_NAME" value="org.stellar.anchor.platform" />
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformCustodyEnd2EndTest" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Test - Fireblocks End2End Test - with fullstack.run.xml
+++ b/.run/Test - Fireblocks End2End Test - with fullstack.run.xml
@@ -18,7 +18,6 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-
     <option name="PACKAGE_NAME" value="org.stellar.anchor.platform" />
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.AnchorPlatformCustodyEnd2EndTest" />
     <option name="METHOD_NAME" value="" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,19 @@ subprojects {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
       }
     }
+
+    register<Test>("testFireblocksE2E") {
+      useJUnitPlatform()
+
+      include("**/AnchorPlatformCustodyEnd2EndTest**")
+
+      testLogging {
+        events("SKIPPED", "FAILED")
+        showExceptions = true
+        showStandardStreams = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+      }
+    }
   }
 
   configurations {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -81,6 +81,7 @@ public class SepBeans {
   }
 
   @Bean
+  @ConfigurationProperties(prefix = "sep31")
   Sep31Config sep31Config() {
     return new PropertySep31Config();
   }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

- Add possibility to run Custody End2End tests separately
- Fix issue with SEP-31 deposit info generator type

### Why

- Run Custody End2End tests using personal credentials
- Use Custody Server to generate SEP-31 deposit info

### Known limitations

[TODO or N/A]