### PR TITLE
Fix: Increase timeouts for anchor client in SEP-24 e2e test

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -49,7 +49,14 @@ class Sep24End2EndTest(
         socketTimeoutMillis = 300000
       }
     }
-  private val anchor = wallet.anchor(config.env["anchor.domain"]!!)
+  private val anchor =
+    wallet.anchor(config.env["anchor.domain"]!!) {
+      install(HttpTimeout) {
+        requestTimeoutMillis = 300000
+        connectTimeoutMillis = 300000
+        socketTimeoutMillis = 300000
+      }
+    }
   private val maxTries = 40
 
   private fun `typical deposit end-to-end flow`() = runBlocking {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

The default timeout configuration seems to set the socket timeout to a value too low (or null?) for the tests to run on my machine.

This is what I see when I run the tests. I'm not sure why this is passing in the CI build, maybe it's specific to platform.
```
    io.ktor.client.network.sockets.SocketTimeoutException: Socket timeout has expired [url=http://localhost:8080/sep24/transactions/deposit/interactive, socket_timeout=unknown] ms

	at io.ktor.client.plugins.HttpTimeoutKt.SocketTimeoutException(HttpTimeout.kt:239)
	at io.ktor.client.engine.okhttp.OkUtilsKt.mapOkHttpException(OkUtils.kt:80)
	at io.ktor.client.engine.okhttp.OkUtilsKt.access$mapOkHttpException(OkUtils.kt:1)
	at io.ktor.client.engine.okhttp.OkHttpCallback.onFailure(OkUtils.kt:39)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:525)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```


### Why

Without this change, it is not possible to run the SEP-24 e2e test locally.

### Known limitations

N/A