### PR TITLE
[ANCHOR-328] Add homeDomain and webAuthDomain length validation 

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -127,7 +127,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
           "homeDomain",
           "sep10-home-domain-invalid",
           format(
-              "The sep10.home_domain (%s) does not have valid format. Please make sure it is a valid domain name. Error=%s",
+              "The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
               homeDomain, iaex));
     }
 
@@ -138,7 +138,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
           "webAuthDomain",
           "sep10-web-auth-domain-invalid",
           format(
-              "The sep10.web_auth_domain (%s) does not have valid format. Please make sure it is a valid domain name. Error=%s",
+              "The sep10.web_auth_home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
               webAuthDomain, iaex));
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -16,7 +16,7 @@ import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.util.ListHelper;
 import org.stellar.anchor.util.NetUtil;
-import org.stellar.sdk.KeyPair;
+import org.stellar.sdk.*;
 
 @Data
 public class PropertySep10Config implements Sep10Config, Validator {
@@ -116,6 +116,30 @@ public class PropertySep10Config implements Sep10Config, Validator {
           "jwtTimeout",
           "sep10-jwt-timeout-invalid",
           "The sep10.jwt_timeout must be greater than 0");
+    }
+
+    byte[] nonce = new byte[64];
+
+    try {
+      new ManageDataOperation.Builder(String.format("%s %s", homeDomain, "auth"), nonce).build();
+    } catch (IllegalArgumentException iaex) {
+      errors.rejectValue(
+          "homeDomain",
+          "sep10-home-domain-invalid",
+          format(
+              "The sep10.home_domain (%s) does not have valid format. Please make sure it is a valid domain name. Error=%s",
+              homeDomain, iaex));
+    }
+
+    try {
+      if (webAuthDomain != null) new ManageDataOperation.Builder(webAuthDomain, nonce).build();
+    } catch (IllegalArgumentException iaex) {
+      errors.rejectValue(
+          "webAuthDomain",
+          "sep10-web-auth-domain-invalid",
+          format(
+              "The sep10.web_auth_domain (%s) does not have valid format. Please make sure it is a valid domain name. Error=%s",
+              webAuthDomain, iaex));
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -87,6 +87,18 @@ public class PropertySep10Config implements Sep10Config, Validator {
       errors.rejectValue(
           "homeDomain", "home-domain-empty", "The sep10.home_domain is not defined.");
     } else {
+      try {
+        new ManageDataOperation.Builder(String.format("%s %s", homeDomain, "auth"), new byte[64])
+            .build();
+      } catch (IllegalArgumentException iaex) {
+        errors.rejectValue(
+            "homeDomain",
+            "sep10-home-domain-invalid",
+            format(
+                "The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
+                homeDomain, iaex));
+      }
+
       if (!NetUtil.isServerPortValid(homeDomain)) {
         errors.rejectValue(
             "homeDomain",
@@ -96,6 +108,17 @@ public class PropertySep10Config implements Sep10Config, Validator {
     }
 
     if (isNotEmpty(webAuthDomain)) {
+      try {
+        new ManageDataOperation.Builder(webAuthDomain, new byte[64]).build();
+      } catch (IllegalArgumentException iaex) {
+        errors.rejectValue(
+            "webAuthDomain",
+            "sep10-web-auth-domain-invalid",
+            format(
+                "The sep10.web_auth_home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
+                webAuthDomain, iaex));
+      }
+
       if (!NetUtil.isServerPortValid(webAuthDomain)) {
         errors.rejectValue(
             "webAuthDomain",
@@ -116,30 +139,6 @@ public class PropertySep10Config implements Sep10Config, Validator {
           "jwtTimeout",
           "sep10-jwt-timeout-invalid",
           "The sep10.jwt_timeout must be greater than 0");
-    }
-
-    byte[] nonce = new byte[64];
-
-    try {
-      new ManageDataOperation.Builder(String.format("%s %s", homeDomain, "auth"), nonce).build();
-    } catch (IllegalArgumentException iaex) {
-      errors.rejectValue(
-          "homeDomain",
-          "sep10-home-domain-invalid",
-          format(
-              "The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
-              homeDomain, iaex));
-    }
-
-    try {
-      if (webAuthDomain != null) new ManageDataOperation.Builder(webAuthDomain, nonce).build();
-    } catch (IllegalArgumentException iaex) {
-      errors.rejectValue(
-          "webAuthDomain",
-          "sep10-web-auth-domain-invalid",
-          format(
-              "The sep10.web_auth_home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
-              webAuthDomain, iaex));
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -93,7 +93,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
       } catch (IllegalArgumentException iaex) {
         errors.rejectValue(
             "homeDomain",
-            "sep10-home-domain-invalid",
+            "sep10-home-domain-too-long",
             format(
                 "The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
                 homeDomain, iaex));
@@ -113,7 +113,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
       } catch (IllegalArgumentException iaex) {
         errors.rejectValue(
             "webAuthDomain",
-            "sep10-web-auth-domain-invalid",
+            "sep10-web-auth-domain-too-long",
             format(
                 "The sep10.web_auth_home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
                 webAuthDomain, iaex));

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -138,41 +139,40 @@ class Sep10ConfigTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-    strings =
+  @CsvSource(
+    value =
       [
-        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org",
-        "stellar .org",
-        "abc",
-        "299.0.0.1",
-        "0123456789012345678901234567890123456789012345678912.stellar.org",
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org,sep10-web-auth-domain-too-long",
+        "stellar .org,sep10-web-auth-domain-invalid",
+        "abc,sep10-web-auth-domain-invalid",
+        "299.0.0.1,sep10-web-auth-domain-invalid",
       ]
   )
-  fun `test invalid web auth domains`(value: String) {
+  fun `test invalid web auth domains`(value: String, expectedErrorCode: String) {
     config.webAuthDomain = value
     config.validateConfig(errors)
     assertTrue(errors.hasErrors())
-    assertErrorCode(errors, "sep10-web-auth-domain-invalid")
+    assertErrorCode(errors, expectedErrorCode)
   }
 
   @ParameterizedTest
-  @ValueSource(
-    strings =
+  @CsvSource(
+    value =
       [
-        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org",
-        "stellar .org",
-        "abc",
-        "299.0.0.1",
-        "http://stellar.org",
-        "https://stellar.org",
-        "://stellar.org",
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org,sep10-home-domain-too-long",
+        "stellar .org,sep10-home-domain-invalid",
+        "abc,sep10-home-domain-invalid",
+        "299.0.0.1,sep10-home-domain-invalid",
+        "http://stellar.org,sep10-home-domain-invalid",
+        "https://stellar.org,sep10-home-domain-invalid",
+        "://stellar.org,sep10-home-domain-invalid",
       ]
   )
-  fun `test invalid home domains`(value: String) {
+  fun `test invalid home domains`(value: String, expectedErrorCode: String) {
     config.homeDomain = value
     config.validateConfig(errors)
     assertTrue(errors.hasErrors())
-    assertErrorCode(errors, "sep10-home-domain-invalid")
+    assertErrorCode(errors, expectedErrorCode)
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -138,13 +138,22 @@ class Sep10ConfigTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = ["stellar .org", "abc", "299.0.0.1"])
+  @ValueSource(
+    strings =
+      [
+        "stellar .org",
+        "abc",
+        "299.0.0.1",
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org"
+      ]
+  )
   fun `test invalid web auth domains`(value: String) {
     config.webAuthDomain = value
     config.validateConfig(errors)
     assertTrue(errors.hasErrors())
     assertErrorCode(errors, "sep10-web-auth-domain-invalid")
   }
+
   @ParameterizedTest
   @ValueSource(
     strings =
@@ -154,7 +163,8 @@ class Sep10ConfigTest {
         "299.0.0.1",
         "http://stellar.org",
         "https://stellar.org",
-        "://stellar.org"
+        "://stellar.org",
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org"
       ]
   )
   fun `test invalid home domains`(value: String) {
@@ -163,6 +173,7 @@ class Sep10ConfigTest {
     assertTrue(errors.hasErrors())
     assertErrorCode(errors, "sep10-home-domain-invalid")
   }
+
   @Test
   fun `test if web_auth_domain is not set, default to the domain of the host_url`() {
     config.webAuthDomain = null
@@ -172,7 +183,7 @@ class Sep10ConfigTest {
   }
 
   @Test
-  fun `test if web_auth_domain is  set, it is not default to the domain of the host_url`() {
+  fun `test if web_auth_domain is set, it is not default to the domain of the host_url`() {
     config.webAuthDomain = "localhost:8080"
     config.homeDomain = "www.stellar.org"
     config.postConstruct()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -144,6 +144,7 @@ class Sep10ConfigTest {
         "stellar .org",
         "abc",
         "299.0.0.1",
+        "0123456789012345678901234567890123456789012345678912.stellar.org",
         "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org"
       ]
   )

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -141,11 +141,11 @@ class Sep10ConfigTest {
   @ValueSource(
     strings =
       [
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org",
         "stellar .org",
         "abc",
         "299.0.0.1",
         "0123456789012345678901234567890123456789012345678912.stellar.org",
-        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org"
       ]
   )
   fun `test invalid web auth domains`(value: String) {
@@ -159,13 +159,13 @@ class Sep10ConfigTest {
   @ValueSource(
     strings =
       [
+        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org",
         "stellar .org",
         "abc",
         "299.0.0.1",
         "http://stellar.org",
         "https://stellar.org",
         "://stellar.org",
-        "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org"
       ]
   )
   fun `test invalid home domains`(value: String) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add validation that calls `ManageDataOperation.Builder` to validate the `homeDomain` and `webAuthDomain`.

### Why

Cath the errors early.
