### PR TITLE
[ANCHOR-343] Disable SEP-31 and SEP-38 for native asset

### DIFF
--- a/core/src/main/java/org/stellar/anchor/asset/DefaultAssetService.java
+++ b/core/src/main/java/org/stellar/anchor/asset/DefaultAssetService.java
@@ -103,7 +103,8 @@ public class DefaultAssetService implements AssetService {
   @Override
   public AssetInfo getAsset(String code) {
     for (AssetInfo asset : assets.getAssets()) {
-      if (asset.getCode().equals(code)) {
+      // FIXME: ANCHOR-346
+      if (asset != null && asset.getCode().equals(code)) {
         return asset;
       }
     }

--- a/core/src/main/java/org/stellar/anchor/asset/DefaultAssetService.java
+++ b/core/src/main/java/org/stellar/anchor/asset/DefaultAssetService.java
@@ -75,6 +75,13 @@ public class DefaultAssetService implements AssetService {
       throw new InvalidConfigException(
           "Invalid assets defined in configuration. Please check the logs for details.");
     }
+    // TODO: remove this check once we support SEP-31 and SEP-38 for native asset
+    AssetInfo nativeAsset = assetService.getAsset("native");
+    if (nativeAsset != null && (nativeAsset.getSep31Enabled() || nativeAsset.getSep38Enabled())) {
+      error("Native asset does not support SEP-31 or SEP-38. content=", assetsJson);
+      throw new InvalidConfigException(
+          "Invalid assets defined in configuration. Please check the logs for details.");
+    }
     return assetService;
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -10,9 +10,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode.LENIENT
+import org.stellar.anchor.api.exception.InvalidConfigException
 import org.stellar.anchor.api.exception.SepNotFoundException
 import org.stellar.anchor.util.GsonUtils
-import org.yaml.snakeyaml.scanner.ScannerException
 import shadow.org.apache.commons.io.FilenameUtils
 
 internal class DefaultAssetServiceTest {
@@ -51,8 +51,16 @@ internal class DefaultAssetServiceTest {
     assertThrows<JsonSyntaxException> {
       DefaultAssetService.fromJsonResource("test_assets.json.bad")
     }
+  }
 
-    assertThrows<ScannerException> { DefaultAssetService.fromYamlResource("test_assets.yaml.bad") }
+  @Test
+  fun `test native asset with SEP-31 or SEP-38 enabled`() {
+    assertThrows<InvalidConfigException> {
+      DefaultAssetService.fromJsonResource("test_native_asset_sep31.json.bad")
+    }
+    assertThrows<InvalidConfigException> {
+      DefaultAssetService.fromJsonResource("test_native_asset_sep38.json.bad")
+    }
   }
 
   // This is supposed to match the result from loading test_assets.json file.
@@ -331,8 +339,8 @@ internal class DefaultAssetServiceTest {
               ],
               "decimals": 7
             },
-            "sep31_enabled": true,
-            "sep38_enabled": true
+            "sep31_enabled": false,
+            "sep38_enabled": false 
           }
         ]
       }    

--- a/core/src/test/kotlin/org/stellar/anchor/dto/sep38/InfoResponseTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/dto/sep38/InfoResponseTest.kt
@@ -29,11 +29,11 @@ class InfoResponseTest {
   @Test
   fun `test the InfoResponse construction`() {
     val infoResponse = InfoResponse(assets)
-    assertEquals(4, infoResponse.assets.size)
+    assertEquals(3, infoResponse.assets.size)
 
     val assetMap = HashMap<String, InfoResponse.Asset>()
     infoResponse.assets.forEach { assetMap[it.asset] = it }
-    assertEquals(4, assetMap.size)
+    assertEquals(3, assetMap.size)
 
     val stellarUSDC =
       assetMap["stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"]
@@ -79,14 +79,5 @@ class InfoResponseTest {
       )
     assertTrue(fiatUSD.exchangeableAssetNames.containsAll(wantAssets))
     assertTrue(wantAssets.containsAll(fiatUSD.exchangeableAssetNames))
-
-    val stellarNative = assetMap["stellar:native"]
-    assertNotNull(stellarNative)
-    assertNull(stellarNative!!.countryCodes)
-    assertNull(stellarNative.sellDeliveryMethods)
-    assertNull(stellarNative.buyDeliveryMethods)
-    wantAssets = listOf("stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP")
-    assertTrue(stellarNative.exchangeableAssetNames.containsAll(wantAssets))
-    assertTrue(wantAssets.containsAll(stellarNative.exchangeableAssetNames))
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -88,11 +88,11 @@ class Sep38ServiceTest {
   @Test
   fun `test GET info`() {
     val infoResponse = sep38Service.getInfo()
-    assertEquals(4, infoResponse.assets.size)
+    assertEquals(3, infoResponse.assets.size)
 
     val assetMap = HashMap<String, InfoResponse.Asset>()
     infoResponse.assets.forEach { assetMap[it.asset] = it }
-    assertEquals(4, assetMap.size)
+    assertEquals(3, assetMap.size)
 
     val usdcAsset = assetMap[stellarUSDC]
     assertNotNull(usdcAsset)
@@ -134,15 +134,6 @@ class Sep38ServiceTest {
       listOf("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", stellarUSDC)
     assertTrue(fiatUSD.exchangeableAssetNames.containsAll(wantAssets))
     assertTrue(wantAssets.containsAll(fiatUSD.exchangeableAssetNames))
-
-    val stellarNative = assetMap["stellar:native"]
-    assertNotNull(stellarNative)
-    assertNull(stellarNative!!.countryCodes)
-    assertNull(stellarNative.sellDeliveryMethods)
-    assertNull(stellarNative.buyDeliveryMethods)
-    wantAssets = listOf("stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP")
-    assertTrue(stellarNative.exchangeableAssetNames.containsAll(wantAssets))
-    assertTrue(wantAssets.containsAll(stellarNative.exchangeableAssetNames))
   }
 
   @Test

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -264,8 +264,8 @@
         ],
        "decimals": 7
       },
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      "sep31_enabled": false,
+      "sep38_enabled": false
     }
   ]
 }

--- a/core/src/test/resources/test_assets.json.quotes_required_but_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_required_but_not_supported
@@ -12,6 +12,6 @@
       "sep24_enabled": false,
       "sep31_enabled": true,
       "sep38_enabled": false
-    },
+    }
   ]
 }

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -186,5 +186,5 @@ assets:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       decimals: 7
-    sep31_enabled: true
-    sep38_enabled: true
+    sep31_enabled: false
+    sep38_enabled: false

--- a/core/src/test/resources/test_native_asset_sep31.json.bad
+++ b/core/src/test/resources/test_native_asset_sep31.json.bad
@@ -1,0 +1,79 @@
+{
+  "assets": [
+    {
+      "schema": "stellar",
+      "code": "native",
+      "significant_decimals": 7,
+      "deposit": {
+        "enabled": true,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "withdraw": {
+        "enabled": true,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "send": {
+        "fee_fixed": 0,
+        "fee_percent": 0,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "sep31": {
+        "quotes_supported": true,
+        "quotes_required": true,
+        "sep12": {
+          "sender": {
+            "types": {
+              "sep31-sender": {
+                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
+              },
+              "sep31-large-sender": {
+                "description": "U.S. citizens that do not have sending limits"
+              },
+              "sep31-foreign-sender": {
+                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
+              }
+            }
+          },
+          "receiver": {
+            "types": {
+              "sep31-receiver": {
+                "description": "U.S. citizens receiving USD"
+              },
+              "sep31-foreign-receiver": {
+                "description": "non-U.S. citizens receiving USD"
+              }
+            }
+          }
+        },
+        "fields": {
+          "transaction": {
+            "receiver_routing_number": {
+              "description": "routing number of the destination bank account"
+            },
+            "receiver_account_number": {
+              "description": "bank account number of the destination"
+            },
+            "type": {
+              "description": "type of deposit to make",
+              "choices": [
+                "SEPA",
+                "SWIFT"
+              ]
+            }
+          }
+        }
+      },
+      "sep38": {
+        "exchangeable_assets": [
+          "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+        ],
+        "decimals": 7
+      },
+      "sep31_enabled": true,
+      "sep38_enabled": false
+    }
+  ]
+}

--- a/core/src/test/resources/test_native_asset_sep38.json.bad
+++ b/core/src/test/resources/test_native_asset_sep38.json.bad
@@ -1,0 +1,79 @@
+{
+  "assets": [
+    {
+      "schema": "stellar",
+      "code": "native",
+      "significant_decimals": 7,
+      "deposit": {
+        "enabled": true,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "withdraw": {
+        "enabled": true,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "send": {
+        "fee_fixed": 0,
+        "fee_percent": 0,
+        "min_amount": 1,
+        "max_amount": 1000000
+      },
+      "sep31": {
+        "quotes_supported": true,
+        "quotes_required": true,
+        "sep12": {
+          "sender": {
+            "types": {
+              "sep31-sender": {
+                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
+              },
+              "sep31-large-sender": {
+                "description": "U.S. citizens that do not have sending limits"
+              },
+              "sep31-foreign-sender": {
+                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
+              }
+            }
+          },
+          "receiver": {
+            "types": {
+              "sep31-receiver": {
+                "description": "U.S. citizens receiving USD"
+              },
+              "sep31-foreign-receiver": {
+                "description": "non-U.S. citizens receiving USD"
+              }
+            }
+          }
+        },
+        "fields": {
+          "transaction": {
+            "receiver_routing_number": {
+              "description": "routing number of the destination bank account"
+            },
+            "receiver_account_number": {
+              "description": "bank account number of the destination"
+            },
+            "type": {
+              "description": "type of deposit to make",
+              "choices": [
+                "SEPA",
+                "SWIFT"
+              ]
+            }
+          }
+        }
+      },
+      "sep38": {
+        "exchangeable_assets": [
+          "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+        ],
+        "decimals": 7
+      },
+      "sep31_enabled": false,
+      "sep38_enabled": true
+    }
+  ]
+}

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep31Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep31Tests.kt
@@ -511,59 +511,6 @@ private const val expectedSep31Info =
             }
           }
         }
-      },
-      "native": {
-        "enabled": true,
-        "quotes_supported": true,
-        "quotes_required": true,
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "max_amount": 1000000,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account",
-              "optional": false
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination",
-              "optional": false
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ],
-              "optional": false
-            }
-          }
-        }
       }
     }
   }

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -182,6 +182,6 @@ assets:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       decimals: 7
-    sep31_enabled: true
-    sep38_enabled: true
+    sep31_enabled: false
+    sep38_enabled: false
     sep24_enabled: true


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This disables SEP-31 and SEP-38 support for the native asset. It will be re-enabled again once E2E tests have been added for SEP-31.

### Why

SEP-31 has not been tested end-to-end with the native asset.

### Known limitations

This is not a true feature flag, but we expect anchors to upgrade to a new AP version as E2E tests will likely uncover some bugs.