### PR TITLE
[ANCHOR-351] Add the missing unmock for RequestLoggerFilterTest

### DIFF
--- a/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/utils/RequestLoggerFilterTest.kt
@@ -1,9 +1,8 @@
 package org.stellar.anchor.platform.utils
 
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.verify
+import io.mockk.*
 import javax.servlet.FilterChain
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockHttpServletRequest
@@ -26,6 +25,12 @@ class RequestLoggerFilterTest {
     response = MockHttpServletResponse()
     filterChain = mockk<FilterChain>(relaxed = true)
     mockkStatic(Log::class)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clearAllMocks()
+    unmockkAll()
   }
 
   @Test


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

`RequestLoggerFilterTest` is missing the `mockk` `unmockAll()` and `clearAllMocks()` which may cause subsequent tests to fail. 

### Why

Bug fixing. 
