### PR TITLE
[ANCHOR-342] Add `type` to clients configuration

### DIFF
--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -145,27 +145,42 @@ event_processor:
   callback_api_request:
     enabled: true
 
-# The list of clients for the Anchor server to safely communicate with the outside client domains.
+# The list of clients for the Anchor server to safely communicate with the outside wallet servers or clients.
 # Each item in the list may contain the following fields:
-#   - domain: the domain of the client
-#   - type: the type of the client. The supported values are `custodial` and `non-custodial`
-#   - public_key: the public key of the client. This must match the public key of the TOML file of the client domain
-#   - url: the URL of the client's callback API endpoint
+#   - type: `custodial` or `noncustodial`
+#
+#   If the type is `custodial`,
+#   - account: (required) the custodial account of the client. If the `account` of the transaction is the same as this
+#              account, the callback will be activated.
+#   - url: (required) the URL of the client's callback API endpoint
+#
+#   If the type is `noncustodial`,
+#   - domain: (required) the domain of the client. If the `client_domain` field of the transaction is the same as this
+#             domain, the callback will be activated.
+#   - url: (required) the URL of the client's callback API endpoint
+#   - public_key: (optional) the public key of the client. If the public key is specified, the client domain's TOML
+#                 file will be fetched and the `SIGNING_KEY` of the TOML file will be compared with the public key.
+#                 If they don't match, a validation error will be thrown.
 #
 # Examples:
-#     - domain: lobstr.com
-#       public_key: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
-#       callback_url: https://callback.lobstr.com/api/v1/anchor/callback
-#     - domain: mgi.com
+#     - type: custodial
+#       account: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
+#       url: https://callback.circle.com/api/v1/anchor/callback
+#     - type: noncustodial
+#       domain: lobstr.co
+#       callback_url: https://callback.lobstr.co/api/v2/anchor/callback
+#     - type: noncustodial
+#       domain: vibrant.co
+#       callback_url: https://callback.vibrant.com/api/v2/anchor/callback
 #       public_key: GA22WORKYRXB6AW7XR5GIOAOQUY4KKCENEAI34FN3KJNWHKDZTZSVLTU
-#       callback_url: https://callback.mgi.com/api/v2/anchor/callback
 clients:
-#     - domain: domain1.com
+#     - type: custodial
+#       account:
+#       url:
+#     - type: noncustodial
+#       domain:
+#       url:
 #       public_key:
-#       callback_url:
-#     - domain: domain2.com
-#       public_key:
-#       callback_url:
 
 ## @param: languages
 ## @supported_values: en

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -151,7 +151,8 @@ event_processor:
 #
 #   If the type is `custodial`,
 #   - account: (required) the custodial account of the client. If the `account` of the transaction is the same as this
-#              account, the callback will be activated.
+#              account, the callback will be activated. The `account` field of the transaction is the account that is
+#              used for the SEP-10 authentication.
 #   - callback_url: (required) the URL of the client's callback API endpoint
 #
 #   If the type is `noncustodial`,

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -150,38 +150,37 @@ event_processor:
 #   - type: `custodial` or `noncustodial`
 #
 #   If the type is `custodial`,
-#   - account: (required) the custodial account of the client. If the `account` of the transaction is the same as this
-#              account, the callback will be activated. The `account` field of the transaction is the account that is
-#              used for the SEP-10 authentication.
+#   - signing_key: (required) the custodial SEP-10 signing key of the client. If the signing key of the client
+#                  is the same as the `signing_key`, the callback will be activated.
 #   - callback_url: (required) the URL of the client's callback API endpoint
 #
 #   If the type is `noncustodial`,
 #   - domain: (required) the domain of the client. If the `client_domain` field of the transaction is the same as this
 #             domain, the callback will be activated.
 #   - callback_url: (required) the URL of the client's callback API endpoint
-#   - public_key: (optional) the public key of the client. If the public key is specified, the client domain's TOML
+#   - signing_key: (optional) the signing key of the client. If the public key is specified, the client domain's TOML
 #                 file will be fetched and the `SIGNING_KEY` of the TOML file will be compared with the public key.
 #                 If they don't match, a validation error will be thrown.
 #
 # Examples:
 #     - type: custodial
-#       account: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
+#       signing_key: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
 #       callback_url: https://callback.circle.com/api/v1/anchor/callback
 #     - type: noncustodial
 #       domain: lobstr.co
-#       callback_url: https://callback.lobstr.co/api/v2/anchor/callback
+#       signing_key: https://callback.lobstr.co/api/v2/anchor/callback
 #     - type: noncustodial
 #       domain: vibrant.co
 #       callback_url: https://callback.vibrant.com/api/v2/anchor/callback
-#       public_key: GA22WORKYRXB6AW7XR5GIOAOQUY4KKCENEAI34FN3KJNWHKDZTZSVLTU
+#       signing_key: GA22WORKYRXB6AW7XR5GIOAOQUY4KKCENEAI34FN3KJNWHKDZTZSVLTU
 clients:
 #     - type: custodial
-#       account:
+#       signing_key:
 #       callback_url:
 #     - type: noncustodial
 #       domain:
 #       callback_url:
-#       public_key:
+#       signing_key:
 
 ## @param: languages
 ## @supported_values: en

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -152,12 +152,12 @@ event_processor:
 #   If the type is `custodial`,
 #   - account: (required) the custodial account of the client. If the `account` of the transaction is the same as this
 #              account, the callback will be activated.
-#   - url: (required) the URL of the client's callback API endpoint
+#   - callback_url: (required) the URL of the client's callback API endpoint
 #
 #   If the type is `noncustodial`,
 #   - domain: (required) the domain of the client. If the `client_domain` field of the transaction is the same as this
 #             domain, the callback will be activated.
-#   - url: (required) the URL of the client's callback API endpoint
+#   - callback_url: (required) the URL of the client's callback API endpoint
 #   - public_key: (optional) the public key of the client. If the public key is specified, the client domain's TOML
 #                 file will be fetched and the `SIGNING_KEY` of the TOML file will be compared with the public key.
 #                 If they don't match, a validation error will be thrown.
@@ -165,7 +165,7 @@ event_processor:
 # Examples:
 #     - type: custodial
 #       account: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
-#       url: https://callback.circle.com/api/v1/anchor/callback
+#       callback_url: https://callback.circle.com/api/v1/anchor/callback
 #     - type: noncustodial
 #       domain: lobstr.co
 #       callback_url: https://callback.lobstr.co/api/v2/anchor/callback
@@ -176,10 +176,10 @@ event_processor:
 clients:
 #     - type: custodial
 #       account:
-#       url:
+#       callback_url:
 #     - type: noncustodial
 #       domain:
-#       url:
+#       callback_url:
 #       public_key:
 
 ## @param: languages


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Add `type` field to the client configuration. The required fields will change according to the `type` assigned.

### Why

To clearly distinguish the `custodial` and `noncustodial` wallet clients.
