### PR TITLE
[Anchor-338] Implement static status callback configuration

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
@@ -1,0 +1,46 @@
+package org.stellar.anchor.sep10;
+
+import static org.stellar.anchor.util.Log.debugF;
+import static org.stellar.anchor.util.Log.infoF;
+
+import java.io.IOException;
+import org.stellar.anchor.api.exception.SepException;
+import org.stellar.anchor.util.Sep1Helper;
+import org.stellar.sdk.FormatException;
+import org.stellar.sdk.KeyPair;
+
+public class Sep10Helper {
+
+  /**
+   * Fetch SIGNING_KEY from clint_domain by reading the stellar.toml content.
+   *
+   * @param clientDomain The client's domain. E.g. lobstr.co.
+   * @return The SIGNING_KEY presented in client's TOML file.
+   * @throws SepException if SIGNING_KEY not present or error happens
+   */
+  public static String fetchSigningKeyFromClientDomain(String clientDomain) throws SepException {
+    String clientSigningKey = "";
+    String url = "https://" + clientDomain + "/.well-known/stellar.toml";
+    try {
+      debugF("Fetching {}", url);
+      Sep1Helper.TomlContent toml = Sep1Helper.readToml(url);
+      clientSigningKey = toml.getString("SIGNING_KEY");
+      if (clientSigningKey == null) {
+        infoF("SIGNING_KEY not present in 'client_domain' TOML.");
+        throw new SepException("SIGNING_KEY not present in 'client_domain' TOML");
+      }
+
+      // client key validation
+      debugF("Validating client_domain signing key: {}", clientSigningKey);
+      KeyPair.fromAccountId(clientSigningKey);
+      return clientSigningKey;
+    } catch (IllegalArgumentException | FormatException ex) {
+      infoF("SIGNING_KEY {} is not a valid Stellar account Id.", clientSigningKey);
+      throw new SepException(
+          String.format("SIGNING_KEY %s is not a valid Stellar account Id.", clientSigningKey));
+    } catch (IOException ioex) {
+      infoF("Unable to read from {}", url);
+      throw new SepException(String.format("Unable to read from %s", url), ioex);
+    }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -581,14 +581,14 @@ internal class Sep10ServiceTest {
       "       NETWORK_PASSPHRASE=\"Public Global Stellar Network ; September 2015\"\n"
     mockkStatic(KeyPair::class)
 
-    assertThrows<SepException> { sep10Service.getClientAccountId(TEST_CLIENT_DOMAIN) }
+    assertThrows<SepException> { Sep10Helper.fetchSigningKeyFromClientDomain(TEST_CLIENT_DOMAIN) }
 
     every { NetUtil.fetch(any()) } answers { throw IOException("Cannot connect") }
-    assertThrows<SepException> { sep10Service.getClientAccountId(TEST_CLIENT_DOMAIN) }
+    assertThrows<SepException> { Sep10Helper.fetchSigningKeyFromClientDomain(TEST_CLIENT_DOMAIN) }
 
     every { NetUtil.fetch(any()) } returns TEST_CLIENT_TOML
     every { KeyPair.fromAccountId(any()) } answers { throw FormatException("Bad Format") }
-    assertThrows<SepException> { sep10Service.getClientAccountId(TEST_CLIENT_DOMAIN) }
+    assertThrows<SepException> { Sep10Helper.fetchSigningKeyFromClientDomain(TEST_CLIENT_DOMAIN) }
   }
 
   @Test

--- a/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
@@ -1,0 +1,73 @@
+package org.stellar.anchor.platform.config;
+
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
+import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+import org.stellar.anchor.api.exception.SepException;
+import org.stellar.anchor.sep10.Sep10Helper;
+
+@Data
+public class ClientsConfig implements Validator {
+  ClientType type;
+  String signingKey;
+  String domain;
+  String callbackUrl;
+
+  public enum ClientType {
+    CUSTODIAL,
+    NONCUSTODIAL
+  }
+
+  @Override
+  public boolean supports(@NotNull Class<?> clazz) {
+    return ClientsConfig.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    ClientsConfig config = (ClientsConfig) target;
+
+    if (config.type.equals(ClientType.CUSTODIAL)) {
+      validateCustodialClient(errors);
+    } else {
+      validateNonCustodialClient(errors);
+    }
+  }
+
+  void validateCustodialClient(Errors errors) {
+    ValidationUtils.rejectIfEmptyOrWhitespace(
+        errors,
+        "signingKey",
+        "empty-client-signing-key",
+        "The client.signingKey cannot be empty and must be defined");
+  }
+
+  void validateNonCustodialClient(Errors errors) {
+    ValidationUtils.rejectIfEmptyOrWhitespace(
+        errors,
+        "domain",
+        "empty-client-domain",
+        "The client.domain cannot be empty and must be defined");
+
+    if (!isEmpty(signingKey)) {
+      try {
+        String clientSigningKey = Sep10Helper.fetchSigningKeyFromClientDomain(domain);
+        if (!signingKey.equals(clientSigningKey)) {
+          errors.rejectValue(
+              "signingKey",
+              "client-signing-key-does-not-match",
+              "The client.signingKey does not matched any valid registered keys");
+        }
+      } catch (SepException e) {
+        errors.rejectValue(
+            "signingKey",
+            "client-signing-key-toml-read-failure",
+            "SIGNING_KEY not present in 'client_domain' TOML or TOML file does not exist");
+      }
+    }
+  }
+}

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -152,12 +152,12 @@ event_processor:
 #   If the type is `custodial`,
 #   - signing_key: (required) the custodial SEP-10 signing key of the client. If the signing key of the client
 #                  is the same as the `signing_key`, the callback will be activated.
-#   - callback_url: (required) the URL of the client's callback API endpoint
-#
+#   - callback_url: (optional) the URL of the client's callback API endpoint. Optional due to some wallets may opt to
+#                  poll instead, or may use polling first before implementing callbacks at a later stage.
 #   If the type is `noncustodial`,
 #   - domain: (required) the domain of the client. If the `client_domain` field of the transaction is the same as this
 #             domain, the callback will be activated.
-#   - callback_url: (required) the URL of the client's callback API endpoint
+#   - callback_url: (optional) the URL of the client's callback API endpoint
 #   - signing_key: (optional) the signing key of the client. If the public key is specified, the client domain's TOML
 #                 file will be fetched and the `SIGNING_KEY` of the TOML file will be compared with the public key.
 #                 If they don't match, a validation error will be thrown.
@@ -168,7 +168,7 @@ event_processor:
 #       callback_url: https://callback.circle.com/api/v1/anchor/callback
 #     - type: noncustodial
 #       domain: lobstr.co
-#       signing_key: https://callback.lobstr.co/api/v2/anchor/callback
+#       callback_url: https://callback.lobstr.co/api/v2/anchor/callback
 #     - type: noncustodial
 #       domain: vibrant.co
 #       callback_url: https://callback.vibrant.com/api/v2/anchor/callback

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
@@ -1,0 +1,63 @@
+package org.stellar.anchor.platform.config
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+
+class ClientsConfigTest {
+  private lateinit var config: ClientsConfig
+  private lateinit var errors: Errors
+
+  @BeforeEach
+  fun setUp() {
+    config = ClientsConfig()
+    errors = BindException(config, "config")
+  }
+  @Test
+  fun `test valid custodial client`() {
+    config.type = ClientsConfig.ClientType.CUSTODIAL
+    config.signingKey = "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"
+    config.callbackUrl = "https://callback.circle.com/api/v1/anchor/callback"
+    config.validate(config, errors)
+    Assertions.assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test invalid custodial client with empty signing key`() {
+    config.signingKey = ""
+    config.validateCustodialClient(errors)
+    Assertions.assertEquals(1, errors.errorCount)
+    assertErrorCode(errors, "empty-client-signing-key")
+  }
+
+  @Test
+  fun `test valid non-custodial client`() {
+    config.type = ClientsConfig.ClientType.NONCUSTODIAL
+    config.domain = "lobstr.co"
+    config.callbackUrl = "https://callback.lobstr.co/api/v2/anchor/callback"
+    config.signingKey = "GC4HAYCFQYQLJV5SE6FB3LGC37D6XGIXGMAXCXWNBLH7NWW2JH4OZLHQ"
+    config.validate(config, errors)
+    Assertions.assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test invalid non-custodial client with empty domain`() {
+    config.domain = ""
+    config.callbackUrl = "  "
+    config.validateNonCustodialClient(errors)
+    Assertions.assertEquals(1, errors.errorCount)
+    assertErrorCode(errors, "empty-client-domain")
+  }
+
+  @Test
+  fun `test invalid non-custodial client signing key does not match`() {
+    config.domain = "lobstr.co"
+    config.callbackUrl = "https://callback.lobstr.co/api/v2/anchor/callback"
+    config.signingKey = "Invalid-signing-key"
+    config.validateNonCustodialClient(errors)
+    Assertions.assertEquals(1, errors.errorCount)
+    assertErrorCode(errors, "client-signing-key-does-not-match")
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Create client status call back configuration, validate both `custodial` and `non-custodial` type

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

Note that for non-custodial client with signing_key provided, we need to check it against TOML file. 

The function `fetchSigningKey` is a copy of `getClientAccountId`(which returns signing_key read from toml file) in `Sep10Service`,  I would love to extract this function to a helper class for reuse.