### PR TITLE
Fix: Increase strictness of SEP-24 info test

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24Tests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode.LENIENT
+import org.skyscreamer.jsonassert.JSONCompareMode.NON_EXTENSIBLE
 import org.springframework.web.util.UriComponentsBuilder
 import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.api.platform.PatchTransactionsRequest
@@ -38,7 +39,7 @@ class Sep24Tests(val config: TestConfig, val toml: TomlContent, jwt: String) {
   private fun `test Sep24 info endpoint`() {
     printRequest("Calling GET /info")
     val info = sep24Client.getInfo()
-    JSONAssert.assertEquals(expectedSep24Info, gson.toJson(info), LENIENT)
+    JSONAssert.assertEquals(expectedSep24Info, gson.toJson(info), NON_EXTENSIBLE)
   }
 
   private fun `test Sep24 withdraw`() {
@@ -327,10 +328,17 @@ private const val expectedSep24Info =
         "enabled": true
       },
       "USD": {
-        "enabled": true
+        "enabled": true,
+        "min_amount": 0,
+        "max_amount": 10000
       },
       "USDC": {
-        "enabled": true
+        "enabled": true,
+        "min_amount": 1
+      },
+      "native": {
+        "enabled": true,
+        "max_amount": 1000000
       }
     },
     "withdraw": {
@@ -338,10 +346,17 @@ private const val expectedSep24Info =
         "enabled": true
       },
       "USD": {
-        "enabled": true
+        "enabled": true,
+        "min_amount": 0,
+        "max_amount": 10000
       },
       "USDC": {
-        "enabled": true
+        "enabled": true,
+        "max_amount": 1000000
+      },
+      "native": {
+        "enabled": true,
+        "max_amount": 1000000
       }
     },
     "fee": {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Update the test so that expected info response includes all assets and fields specified in `assets.yaml`.

### Why

This test would have quietly failed if `native` asset was not included in the response for some reason.

### Known limitations

N/A