### PR TITLE
[ANCHOR-372] Add latest block metrics to payment observer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 # JAVA_OPTIONS="${JAVA_OPTIONS} -javaagent:/app/dd-java-agent.jar"
 ARG DATADOG_JAVA_AGENT_VERSION=0.75.0
 RUN wget --quiet --retry-connrefused --waitretry=1 --read-timeout=10 --timeout=10 --output-document /app/dd-java-agent.jar \
-    https://repository.sonatype.org/service/local/repositories/central-proxy/content/com/datadoghq/dd-java-agent/${DATADOG_JAVA_AGENT_VERSION}/dd-java-agent-${DATADOG_JAVA_AGENT_VERSION}.jar && \
+    https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${DATADOG_JAVA_AGENT_VERSION}/dd-java-agent-${DATADOG_JAVA_AGENT_VERSION}.jar && \
     chmod +x /app/dd-java-agent.jar
 
 ENTRYPOINT ["java", "-jar", "/app/anchor-platform-runner.jar"]

--- a/platform/src/main/java/org/stellar/anchor/platform/StellarObservingService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/StellarObservingService.java
@@ -36,6 +36,8 @@ public class StellarObservingService implements WebMvcConfigurer {
                 // this allows a developer to use a .env file for local development
                 "spring.config.import=optional:classpath:example.env[.properties]",
                 "spring.profiles.active=stellar-observer",
+                "management.endpoints.web.exposure.include=health,info,prometheus",
+                String.format("management.server.port=%d", port + 10000),
                 String.format("server.port=%d", port),
                 String.format("server.contextPath=%s", contextPath));
 

--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -2,7 +2,7 @@ package org.stellar.anchor.platform.payment.observer.stellar;
 
 import static org.stellar.anchor.api.platform.HealthCheckStatus.*;
 import static org.stellar.anchor.platform.payment.observer.stellar.ObserverStatus.*;
-import static org.stellar.anchor.platform.service.AnchorMetrics.STElLAR_PAYMENT_OBSERVER;
+import static org.stellar.anchor.platform.service.AnchorMetrics.STELLAR_PAYMENT_OBSERVER;
 import static org.stellar.anchor.util.Log.*;
 import static org.stellar.anchor.util.ReflectionUtil.getField;
 
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 import lombok.Builder;
@@ -174,11 +173,11 @@ public class StellarPaymentObserver implements HealthCheckable {
     if (metricLatestBlock == null) {
       metricLatestBlock = new AtomicLong(operationResponse.getTransaction().get().getLedger());
       Metrics.gauge(
-          STElLAR_PAYMENT_OBSERVER.toString(),
+          STELLAR_PAYMENT_OBSERVER.toString(),
           Tags.of("status", AnchorMetrics.TAG_OBSERVER_LATEST_BLOCK.toString()),
           metricLatestBlock);
     }
-    Log.debugF("Update metrics {}: {}", STElLAR_PAYMENT_OBSERVER, operationResponse.getTransaction().get().getLedger());
+    Log.debugF("Update metrics {}: {}", STELLAR_PAYMENT_OBSERVER, operationResponse.getTransaction().get().getLedger());
     metricLatestBlock.set(operationResponse.getTransaction().get().getLedger());
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.payment.observer.stellar;
 
 import static org.stellar.anchor.api.platform.HealthCheckStatus.*;
 import static org.stellar.anchor.platform.payment.observer.stellar.ObserverStatus.*;
+import static org.stellar.anchor.platform.service.AnchorMetrics.STElLAR_PAYMENT_OBSERVER;
 import static org.stellar.anchor.util.Log.*;
 import static org.stellar.anchor.util.ReflectionUtil.getField;
 
@@ -173,11 +174,11 @@ public class StellarPaymentObserver implements HealthCheckable {
     if (metricLatestBlock == null) {
       metricLatestBlock = new AtomicLong(operationResponse.getTransaction().get().getLedger());
       Metrics.gauge(
-          AnchorMetrics.STElLAR_PAYMENT_OBSERVER.toString(),
+          STElLAR_PAYMENT_OBSERVER.toString(),
           Tags.of("status", AnchorMetrics.TAG_OBSERVER_LATEST_BLOCK.toString()),
           metricLatestBlock);
     }
-    System.out.println(operationResponse.getTransaction().get().getLedger());
+    Log.debugF("Update metrics {}: {}", STElLAR_PAYMENT_OBSERVER, operationResponse.getTransaction().get().getLedger());
     metricLatestBlock.set(operationResponse.getTransaction().get().getLedger());
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/payment/observer/stellar/StellarPaymentObserver.java
@@ -142,10 +142,10 @@ public class StellarPaymentObserver implements HealthCheckable {
         new EventListener<>() {
           @Override
           public void onEvent(OperationResponse operationResponse) {
+            // update the received metrics when the events are received and before they are handled.
             updateReceivedMetrics(operationResponse);
             if (isHealthy()) {
               debugF("Received event {}", operationResponse.getId());
-              updateProcessedMetrics(operationResponse);
               // clear stream timeout/reconnect status
               lastActivityTime = Instant.now();
               silenceTimeoutCount = 0;
@@ -153,6 +153,8 @@ public class StellarPaymentObserver implements HealthCheckable {
               try {
                 debugF("Dispatching event {}", operationResponse.getId());
                 handleEvent(operationResponse);
+                // update processed metrics when the events are handled successfully.
+                updateProcessedMetrics(operationResponse);
               } catch (TransactionException ex) {
                 errorEx("Error handling events", ex);
                 setStatus(DATABASE_ERROR);

--- a/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
@@ -5,7 +5,7 @@ public enum AnchorMetrics {
   SEP31_TRANSACTION_DB("sep31.transaction.db"),
   PAYMENT_RECEIVED("payment.received"),
   LOGGER("logger"),
-  STElLAR_PAYMENT_OBSERVER("stellar_payment_observer"),
+  STELLAR_PAYMENT_OBSERVER("stellar_payment_observer"),
 
   // Metric Tags
   TAG_SEP31_STATUS_PENDING_STELLAR("pending_stellar"),

--- a/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
@@ -15,7 +15,8 @@ public enum AnchorMetrics {
   TAG_SEP31_STATUS_PENDING_EXTERNAL("pending_external"),
   TAG_SEP31_STATUS_COMPLETED("completed"),
   TAG_SEP31_STATUS_ERROR("error"),
-  TAG_OBSERVER_LATEST_BLOCK("latest_block");
+  TAG_OBSERVER_LATEST_BLOCK_RECEIVED("latest_block_read"),
+  TAG_OBSERVER_LATEST_BLOCK_PROCESSED("latest_block_processed");
 
   private final String name;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
@@ -5,6 +5,7 @@ public enum AnchorMetrics {
   SEP31_TRANSACTION_DB("sep31.transaction.db"),
   PAYMENT_RECEIVED("payment.received"),
   LOGGER("logger"),
+  STElLAR_PAYMENT_OBSERVER("stellar_payment_observer"),
 
   // Metric Tags
   TAG_SEP31_STATUS_PENDING_STELLAR("pending_stellar"),
@@ -13,7 +14,8 @@ public enum AnchorMetrics {
   TAG_SEP31_STATUS_PENDING_RECEIVER("pending_receiver"),
   TAG_SEP31_STATUS_PENDING_EXTERNAL("pending_external"),
   TAG_SEP31_STATUS_COMPLETED("completed"),
-  TAG_SEP31_STATUS_ERROR("error");
+  TAG_SEP31_STATUS_ERROR("error"),
+  TAG_OBSERVER_LATEST_BLOCK("latest_block");
 
   private final String name;
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Bitso requested the observer to publish the latest block as a metric.

**Prometheus endpoint:**
```
http://localhost:18083/actuator/prometheus
```

**Response:**
```
# HELP stellar_payment_observer  
# TYPE stellar_payment_observer gauge
stellar_payment_observer{status="latest_block_processed",} 386954.0
stellar_payment_observer{status="latest_block_read",} 386954.0
```

### Why

To detect if the observer is working and processing transactions.
