### PR TITLE
SDFSOF-118 - Renamed notify_refund_initiated to notify_refund_pending

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/ActionMethod.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/ActionMethod.java
@@ -17,8 +17,8 @@ public enum ActionMethod {
   @SerializedName("notify_offchain_funds_received")
   NOTIFY_OFFCHAIN_FUNDS_RECEIVED("notify_offchain_funds_received"),
 
-  @SerializedName("notify_refund_initiated")
-  NOTIFY_REFUND_INITIATED("notify_refund_initiated"),
+  @SerializedName("notify_refund_pending")
+  NOTIFY_REFUND_PENDING("notify_refund_pending"),
 
   @SerializedName("notify_refund_sent")
   NOTIFY_REFUND_SENT("notify_refund_sent"),

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundPendingRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundPendingRequest.java
@@ -12,7 +12,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class NotifyRefundInitiatedRequest extends RpcActionParamsRequest {
+public class NotifyRefundPendingRequest extends RpcActionParamsRequest {
 
   @NotNull private Refund refund;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
@@ -3,7 +3,7 @@ package org.stellar.anchor.platform.action;
 import static java.util.Collections.emptySet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
-import static org.stellar.anchor.api.rpc.action.ActionMethod.NOTIFY_REFUND_INITIATED;
+import static org.stellar.anchor.api.rpc.action.ActionMethod.NOTIFY_REFUND_PENDING;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_EXTERNAL;
 import static org.stellar.anchor.util.AssetHelper.getAssetCode;
@@ -20,7 +20,7 @@ import org.stellar.anchor.api.platform.PlatformTransactionData.Kind;
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep;
 import org.stellar.anchor.api.rpc.action.ActionMethod;
 import org.stellar.anchor.api.rpc.action.AmountAssetRequest;
-import org.stellar.anchor.api.rpc.action.NotifyRefundInitiatedRequest;
+import org.stellar.anchor.api.rpc.action.NotifyRefundPendingRequest;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.asset.AssetService;
@@ -35,19 +35,18 @@ import org.stellar.anchor.sep24.Sep24Refunds;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
 
-public class NotifyRefundInitiatedHandler extends ActionHandler<NotifyRefundInitiatedRequest> {
+public class NotifyRefundPendingHandler extends ActionHandler<NotifyRefundPendingRequest> {
 
-  public NotifyRefundInitiatedHandler(
+  public NotifyRefundPendingHandler(
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
       AssetService assetService) {
-    super(
-        txn24Store, txn31Store, requestValidator, assetService, NotifyRefundInitiatedRequest.class);
+    super(txn24Store, txn31Store, requestValidator, assetService, NotifyRefundPendingRequest.class);
   }
 
   @Override
-  protected void validate(JdbcSepTransaction txn, NotifyRefundInitiatedRequest request)
+  protected void validate(JdbcSepTransaction txn, NotifyRefundPendingRequest request)
       throws InvalidParamsException, InvalidRequestException, BadRequestException {
     super.validate(txn, request);
 
@@ -70,12 +69,12 @@ public class NotifyRefundInitiatedHandler extends ActionHandler<NotifyRefundInit
 
   @Override
   public ActionMethod getActionType() {
-    return NOTIFY_REFUND_INITIATED;
+    return NOTIFY_REFUND_PENDING;
   }
 
   @Override
   protected SepTransactionStatus getNextStatus(
-      JdbcSepTransaction txn, NotifyRefundInitiatedRequest request) throws InvalidParamsException {
+      JdbcSepTransaction txn, NotifyRefundPendingRequest request) throws InvalidParamsException {
     JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
     AssetInfo assetInfo = assetService.getAsset(getAssetCode(txn.getAmountInAsset()));
 
@@ -111,10 +110,10 @@ public class NotifyRefundInitiatedHandler extends ActionHandler<NotifyRefundInit
 
   @Override
   protected void updateTransactionWithAction(
-      JdbcSepTransaction txn, NotifyRefundInitiatedRequest request) {
+      JdbcSepTransaction txn, NotifyRefundPendingRequest request) {
     JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
 
-    NotifyRefundInitiatedRequest.Refund refund = request.getRefund();
+    NotifyRefundPendingRequest.Refund refund = request.getRefund();
     Sep24RefundPayment refundPayment =
         JdbcSep24RefundPayment.builder()
             .id(refund.getId())

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
@@ -105,7 +105,7 @@ public class NotifyRefundSentHandler extends ActionHandler<NotifyRefundSentReque
         } else {
           List<Sep24RefundPayment> payments = sep24Refunds.getRefundPayments();
 
-          // make sure refund, provided in request, was sent on refund_initialized
+          // make sure refund, provided in request, was sent on refund_pending
           payments.stream()
               .map(Sep24RefundPayment::getId)
               .filter(id -> id.equals(request.getRefund().getId()))

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/ActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/ActionBeans.java
@@ -18,7 +18,7 @@ import org.stellar.anchor.platform.action.NotifyOffchainFundsReceivedHandler;
 import org.stellar.anchor.platform.action.NotifyOffchainFundsSentHandler;
 import org.stellar.anchor.platform.action.NotifyOnchainFundsReceivedHandler;
 import org.stellar.anchor.platform.action.NotifyOnchainFundsSentHandler;
-import org.stellar.anchor.platform.action.NotifyRefundInitiatedHandler;
+import org.stellar.anchor.platform.action.NotifyRefundPendingHandler;
 import org.stellar.anchor.platform.action.NotifyRefundSentHandler;
 import org.stellar.anchor.platform.action.NotifyTransactionErrorHandler;
 import org.stellar.anchor.platform.action.NotifyTransactionExpiredHandler;
@@ -156,12 +156,12 @@ public class ActionBeans {
   }
 
   @Bean
-  NotifyRefundInitiatedHandler notifyRefundInitiatedHandler(
+  NotifyRefundPendingHandler notifyRefundPendingHandler(
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
       AssetService assetService) {
-    return new NotifyRefundInitiatedHandler(txn24Store, txn31Store, requestValidator, assetService);
+    return new NotifyRefundPendingHandler(txn24Store, txn31Store, requestValidator, assetService);
   }
 
   @Bean


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Renamed notify_refund_initiated to notify_refund_pending

### Why

To be consistent with other events

### Known limitations

[TODO or N/A]