### PR TITLE
SDFSOF-120: Allow asset attribute in refund object

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/DoStellarRefundRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/DoStellarRefundRequest.java
@@ -20,10 +20,10 @@ public class DoStellarRefundRequest extends RpcActionParamsRequest {
   @Builder
   public static class Refund {
 
-    @NotNull private AmountRequest amount;
+    @NotNull private AmountAssetRequest amount;
 
     @SerializedName("amount_fee")
     @NotNull
-    private AmountRequest amountFee;
+    private AmountAssetRequest amountFee;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundPendingRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundPendingRequest.java
@@ -19,11 +19,12 @@ public class NotifyRefundPendingRequest extends RpcActionParamsRequest {
   @Data
   @Builder
   public static class Refund {
+
     @NotNull private String id;
-    @NotNull private AmountRequest amount;
+    @NotNull private AmountAssetRequest amount;
 
     @SerializedName("amount_fee")
     @NotNull
-    private AmountRequest amountFee;
+    private AmountAssetRequest amountFee;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundSentRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/action/NotifyRefundSentRequest.java
@@ -21,10 +21,10 @@ public class NotifyRefundSentRequest extends RpcActionParamsRequest {
   public static class Refund {
 
     @NotNull private String id;
-    @NotNull private AmountRequest amount;
+    @NotNull private AmountAssetRequest amount;
 
     @SerializedName("amount_fee")
     @NotNull
-    private AmountRequest amountFee;
+    private AmountAssetRequest amountFee;
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/action/DoStellarRefundHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/DoStellarRefundHandler.java
@@ -73,7 +73,7 @@ public class DoStellarRefundHandler extends ActionHandler<DoStellarRefundRequest
 
     if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
       throw new InvalidParamsException(
-          "refund.amount.asset does not match transaction amount_fee_asset");
+          "refund.amount.asset does not match transaction amount_in_asset");
     }
     if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
       throw new InvalidParamsException(

--- a/platform/src/main/java/org/stellar/anchor/platform/action/DoStellarRefundHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/DoStellarRefundHandler.java
@@ -70,6 +70,15 @@ public class DoStellarRefundHandler extends ActionHandler<DoStellarRefundRequest
             .build(),
         true,
         assetService);
+
+    if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
+      throw new InvalidParamsException(
+          "refund.amount.asset does not match transaction amount_fee_asset");
+    }
+    if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
+      throw new InvalidParamsException(
+          "refund.amount_fee.asset does not match match transaction amount_fee_asset");
+    }
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
@@ -68,7 +68,7 @@ public class NotifyRefundPendingHandler extends ActionHandler<NotifyRefundPendin
 
     if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
       throw new InvalidParamsException(
-          "refund.amount.asset does not match transaction amount_fee_asset");
+          "refund.amount.asset does not match transaction amount_in_asset");
     }
     if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
       throw new InvalidParamsException(

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundPendingHandler.java
@@ -65,6 +65,15 @@ public class NotifyRefundPendingHandler extends ActionHandler<NotifyRefundPendin
             .build(),
         true,
         assetService);
+
+    if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
+      throw new InvalidParamsException(
+          "refund.amount.asset does not match transaction amount_fee_asset");
+    }
+    if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
+      throw new InvalidParamsException(
+          "refund.amount_fee.asset does not match match transaction amount_fee_asset");
+    }
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
@@ -70,6 +70,15 @@ public class NotifyRefundSentHandler extends ActionHandler<NotifyRefundSentReque
               .build(),
           true,
           assetService);
+
+      if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
+        throw new InvalidParamsException(
+            "refund.amount.asset does not match transaction amount_fee_asset");
+      }
+      if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
+        throw new InvalidParamsException(
+            "refund.amount_fee.asset does not match match transaction amount_fee_asset");
+      }
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyRefundSentHandler.java
@@ -73,7 +73,7 @@ public class NotifyRefundSentHandler extends ActionHandler<NotifyRefundSentReque
 
       if (!txn.getAmountInAsset().equals(request.getRefund().getAmount().getAsset())) {
         throw new InvalidParamsException(
-            "refund.amount.asset does not match transaction amount_fee_asset");
+            "refund.amount.asset does not match transaction amount_in_asset");
       }
       if (!txn.getAmountFeeAsset().equals(request.getRefund().getAmountFee().getAsset())) {
         throw new InvalidParamsException(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/action/DoStellarRefundHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/action/DoStellarRefundHandlerTest.kt
@@ -231,7 +231,7 @@ class DoStellarRefundHandlerTest {
 
     request.refund.amount.asset = FIAT_USD
     var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("refund.amount.asset does not match transaction amount_fee_asset", ex.message)
+    assertEquals("refund.amount.asset does not match transaction amount_in_asset", ex.message)
     request.refund.amount.asset = STELLAR_USDC
 
     request.refund.amountFee.asset = STELLAR_USDC

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundPendingHandlerTest.kt
@@ -1,11 +1,7 @@
 package org.stellar.anchor.platform.action
 
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.slot
-import io.mockk.spyk
-import io.mockk.verify
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -21,11 +17,9 @@ import org.stellar.anchor.api.platform.GetTransactionResponse
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
-import org.stellar.anchor.api.rpc.action.AmountRequest
+import org.stellar.anchor.api.rpc.action.AmountAssetRequest
 import org.stellar.anchor.api.rpc.action.NotifyRefundPendingRequest
-import org.stellar.anchor.api.sep.SepTransactionStatus
-import org.stellar.anchor.api.sep.SepTransactionStatus.INCOMPLETE
-import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR
+import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.api.shared.RefundPayment
 import org.stellar.anchor.api.shared.Refunds
@@ -143,8 +137,8 @@ class NotifyRefundPendingHandlerTest {
         .transactionId(TX_ID)
         .refund(
           NotifyRefundPendingRequest.Refund.builder()
-            .amount(AmountRequest("-1"))
-            .amountFee(AmountRequest("-0.1"))
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
             .id("1")
             .build()
         )
@@ -158,12 +152,50 @@ class NotifyRefundPendingHandlerTest {
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
+    request.refund.amount.amount = "-1"
     var ex = assertThrows<BadRequestException> { handler.handle(request) }
     assertEquals("refund.amount.amount should be positive", ex.message)
-    request.refund.amount = AmountRequest("1")
+    request.refund.amount.amount = "1"
 
+    request.refund.amountFee.amount = "-0.1"
     ex = assertThrows { handler.handle(request) }
     assertEquals("refund.amountFee.amount should be non-negative", ex.message)
+  }
+
+  @Test
+  fun test_handle_invalidAssets() {
+    val request =
+      NotifyRefundPendingRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundPendingRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+            .id("1")
+            .build()
+        )
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.amountInAsset = STELLAR_USDC
+    txn24.amountFeeAsset = FIAT_USD
+    txn24.transferReceivedAt = Instant.now()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    request.refund.amount.asset = FIAT_USD
+    var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("refund.amount.asset does not match transaction amount_fee_asset", ex.message)
+    request.refund.amount.asset = STELLAR_USDC
+
+    request.refund.amountFee.asset = STELLAR_USDC
+    ex = assertThrows { handler.handle(request) }
+    assertEquals(
+      "refund.amount_fee.asset does not match match transaction amount_fee_asset",
+      ex.message
+    )
   }
 
   @Test
@@ -174,8 +206,8 @@ class NotifyRefundPendingHandlerTest {
         .transactionId(TX_ID)
         .refund(
           NotifyRefundPendingRequest.Refund.builder()
-            .amount(AmountRequest("1"))
-            .amountFee(AmountRequest("0"))
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0", FIAT_USD))
             .id("1")
             .build()
         )
@@ -188,6 +220,8 @@ class NotifyRefundPendingHandlerTest {
     txn24.requestAssetCode = FIAT_USD_CODE
     txn24.amountIn = "1"
     txn24.amountInAsset = STELLAR_USDC
+    txn24.amountFee = "0.1"
+    txn24.amountFeeAsset = FIAT_USD
 
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val payment = JdbcSep24RefundPayment()
@@ -207,11 +241,13 @@ class NotifyRefundPendingHandlerTest {
 
     val expectedSep24Txn = JdbcSep24Transaction()
     expectedSep24Txn.kind = DEPOSIT.kind
-    expectedSep24Txn.status = SepTransactionStatus.PENDING_EXTERNAL.toString()
+    expectedSep24Txn.status = PENDING_EXTERNAL.toString()
     expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
     expectedSep24Txn.requestAssetCode = FIAT_USD_CODE
     expectedSep24Txn.amountIn = "1"
     expectedSep24Txn.amountInAsset = STELLAR_USDC
+    expectedSep24Txn.amountFee = "0.1"
+    expectedSep24Txn.amountFeeAsset = FIAT_USD
     expectedSep24Txn.transferReceivedAt = transferReceivedAt
     val expectedRefunds = JdbcSep24Refunds()
     expectedRefunds.amountRefunded = "1"
@@ -228,9 +264,10 @@ class NotifyRefundPendingHandlerTest {
     val expectedResponse = GetTransactionResponse()
     expectedResponse.sep = PlatformTransactionData.Sep.SEP_24
     expectedResponse.kind = DEPOSIT
-    expectedResponse.status = SepTransactionStatus.PENDING_EXTERNAL
+    expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.amountIn = Amount("1", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     val refundPayment = RefundPayment()
@@ -260,8 +297,8 @@ class NotifyRefundPendingHandlerTest {
         .transactionId(TX_ID)
         .refund(
           NotifyRefundPendingRequest.Refund.builder()
-            .amount(AmountRequest("1"))
-            .amountFee(AmountRequest("0.1"))
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
             .id("1")
             .build()
         )
@@ -270,10 +307,11 @@ class NotifyRefundPendingHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = transferReceivedAt
-    txn24.amountInAsset = STELLAR_USDC
     txn24.requestAssetCode = FIAT_USD_CODE
     txn24.amountIn = "2.2"
     txn24.amountInAsset = STELLAR_USDC
+    txn24.amountFee = "0.1"
+    txn24.amountFeeAsset = FIAT_USD
 
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val payment = JdbcSep24RefundPayment()
@@ -298,11 +336,13 @@ class NotifyRefundPendingHandlerTest {
 
     val expectedSep24Txn = JdbcSep24Transaction()
     expectedSep24Txn.kind = DEPOSIT.kind
-    expectedSep24Txn.status = SepTransactionStatus.PENDING_EXTERNAL.toString()
+    expectedSep24Txn.status = PENDING_EXTERNAL.toString()
     expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
     expectedSep24Txn.requestAssetCode = FIAT_USD_CODE
     expectedSep24Txn.amountIn = "2.2"
     expectedSep24Txn.amountInAsset = STELLAR_USDC
+    expectedSep24Txn.amountFee = "0.1"
+    expectedSep24Txn.amountFeeAsset = FIAT_USD
     expectedSep24Txn.transferReceivedAt = transferReceivedAt
     val expectedRefunds = JdbcSep24Refunds()
     expectedRefunds.amountRefunded = "2.2"
@@ -319,9 +359,10 @@ class NotifyRefundPendingHandlerTest {
     val expectedResponse = GetTransactionResponse()
     expectedResponse.sep = PlatformTransactionData.Sep.SEP_24
     expectedResponse.kind = DEPOSIT
-    expectedResponse.status = SepTransactionStatus.PENDING_EXTERNAL
+    expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.amountIn = Amount("2.2", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     val refundPayment = RefundPayment()
@@ -351,8 +392,8 @@ class NotifyRefundPendingHandlerTest {
         .transactionId(TX_ID)
         .refund(
           NotifyRefundPendingRequest.Refund.builder()
-            .amount(AmountRequest("1"))
-            .amountFee(AmountRequest("0.1"))
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
             .id("1")
             .build()
         )
@@ -361,10 +402,11 @@ class NotifyRefundPendingHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = transferReceivedAt
-    txn24.amountInAsset = STELLAR_USDC
     txn24.requestAssetCode = FIAT_USD_CODE
     txn24.amountIn = "1"
     txn24.amountInAsset = STELLAR_USDC
+    txn24.amountFee = "0.1"
+    txn24.amountFeeAsset = FIAT_USD
 
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundPendingHandlerTest.kt
@@ -187,7 +187,7 @@ class NotifyRefundPendingHandlerTest {
 
     request.refund.amount.asset = FIAT_USD
     var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("refund.amount.asset does not match transaction amount_fee_asset", ex.message)
+    assertEquals("refund.amount.asset does not match transaction amount_in_asset", ex.message)
     request.refund.amount.asset = STELLAR_USDC
 
     request.refund.amountFee.asset = STELLAR_USDC

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyRefundSentHandlerTest.kt
@@ -198,7 +198,7 @@ class NotifyRefundSentHandlerTest {
 
     request.refund.amount.asset = FIAT_USD
     var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("refund.amount.asset does not match transaction amount_fee_asset", ex.message)
+    assertEquals("refund.amount.asset does not match transaction amount_in_asset", ex.message)
     request.refund.amount.asset = STELLAR_USDC
 
     request.refund.amountFee.asset = STELLAR_USDC


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Added validation for assets in actions

### Why

We should validate refund assets

### Known limitations

[TODO or N/A]