### PR TITLE
[ANCHOR-393] Set JsonProperty for nested AnchorEvent types

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarPayment.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarPayment.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.api.shared;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,19 +19,24 @@ public class StellarPayment {
 
   Amount amount;
 
+  @JsonProperty("payment_type")
   @SerializedName("payment_type")
   Type paymentType;
 
+  @JsonProperty("source_account")
   @SerializedName("source_account")
   String sourceAccount;
 
+  @JsonProperty("destination_account")
   @SerializedName("destination_account")
   String destinationAccount;
 
   public enum Type {
+    @JsonProperty("payment")
     @SerializedName("payment")
     PAYMENT("payment"),
 
+    @JsonProperty("path_payment")
     @SerializedName("path_payment")
     PATH_PAYMENT("path_payment");
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarTransaction.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarTransaction.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.api.shared;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -18,9 +19,11 @@ public class StellarTransaction {
   String id;
   String memo;
 
+  @JsonProperty("memo_type")
   @SerializedName("memo_type")
   String memoType;
 
+  @JsonProperty("created_at")
   @SerializedName("created_at")
   Instant createdAt;
 

--- a/api-schema/src/test/kotlin/org/stellar/anchor/api/shared/StellarPaymentTest.kt
+++ b/api-schema/src/test/kotlin/org/stellar/anchor/api/shared/StellarPaymentTest.kt
@@ -1,7 +1,9 @@
 package org.stellar.anchor.api.shared
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
 
 class StellarPaymentTest {
   companion object {
@@ -77,5 +79,27 @@ class StellarPaymentTest {
     val wantPaymentList = listOf(mockPayment1, mockPayment2, mockPayment3)
 
     assertEquals(wantPaymentList, paymentList)
+  }
+
+  @Test
+  fun `test Kafka serialization`() {
+    // Kafka uses Jackson for serialization
+    val mapper = ObjectMapper()
+    val expected =
+      """
+      {
+          "id": "1111",
+          "amount": {
+              "amount": "100.0000",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+          },
+          "payment_type": "payment",
+          "source_account": "GAS4OW4HKJCC2D6VWUHVFR3MJRRVQBXBFQ3LCZJXBR7TWOOBJWE4SRWZ",
+          "destination_account": "GBQC7NCZMQIPWN6ASUJYIDKDPRK34IOIZNQE5WOHPQH536VMOMQVJTN7"
+      }
+    """.trimIndent()
+    val actual = mapper.writeValueAsString(mockPayment1)
+
+    JSONAssert.assertEquals(expected, actual, true)
   }
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This adds the `JsonProperty` annotation to the nested `AnchorEvent` types so that Kafka's `JsonSerializer` can correctly serialize camel case fields.

### Why

Field names are incorrectly serialized for some parts of the AnchorEvent.

### Known limitations

N/A