### PR TITLE
SDFSOF-64 - Transaction status can't be changed to Expired after funds were received

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/action/NotifyTransactionExpiredHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/action/NotifyTransactionExpiredHandler.java
@@ -48,9 +48,11 @@ public class NotifyTransactionExpiredHandler
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     if (SEP_24 == Sep.from(txn.getProtocol())) {
-      return Arrays.stream(SepTransactionStatus.values())
-          .filter(s -> !isErrorStatus(s) && !isFinalStatus(s))
-          .collect(toSet());
+      if (txn.getTransferReceivedAt() == null) {
+        return Arrays.stream(SepTransactionStatus.values())
+            .filter(s -> !isErrorStatus(s) && !isFinalStatus(s))
+            .collect(toSet());
+      }
     }
     return emptySet();
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyTransactionExpiredHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/action/NotifyTransactionExpiredHandlerTest.kt
@@ -114,6 +114,24 @@ class NotifyTransactionExpiredHandlerTest {
   }
 
   @Test
+  fun test_handle_set_expired_after_receiving_funds() {
+    val request =
+      NotifyTransactionExpiredRequest.builder().transactionId(TX_ID).message(TX_MESSAGE).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "Action[notify_transaction_expired] is not supported for status[pending_anchor], kind[null] and protocol[24]",
+      ex.message
+    )
+  }
+
+  @Test
   fun test_handle_invalidRequest() {
     val request = NotifyTransactionExpiredRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Transaction status can't be changed to Expired after funds were received

### Why

If funds were received business should do refund

### Known limitations

[TODO or N/A]