### PR TITLE
[ANCHOR-399] Disable release to latest in 1.x branch

### DIFF
--- a/.github/workflows/release_main.yml
+++ b/.github/workflows/release_main.yml
@@ -32,7 +32,7 @@ jobs:
       uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
       with:
         push: true
-        tags: stellar/anchor-platform:${{ github.event.release.tag_name }},stellar/anchor-platform:latest
+        tags: stellar/anchor-platform:${{ github.event.release.tag_name }}
         file: Dockerfile
 
   complete:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Disable the release to latest in 1.x branch.

Example bad workflow: https://github.com/stellar/java-stellar-anchor-sdk/actions/runs/5693240869

### Why

1.x releases are currently overwriting 2.x releases.

### Known limitations

N/A