### PR TITLE
[ANCHOR-244] Use Sep24GetTransactionResponse as response body in ClientStatusCallback

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/eventprocessor/EventProcessorBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/eventprocessor/EventProcessorBeans.java
@@ -2,21 +2,34 @@ package org.stellar.anchor.platform.component.eventprocessor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.platform.config.CallbackApiConfig;
 import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.platform.config.EventProcessorConfig;
 import org.stellar.anchor.platform.event.EventProcessorManager;
+import org.stellar.anchor.sep24.MoreInfoUrlConstructor;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
 
 @Configuration
 public class EventProcessorBeans {
+
   @Bean
   EventProcessorManager eventProcessorManager(
       EventProcessorConfig eventProcessorConfig,
       CallbackApiConfig callbackApiConfig,
       ClientsConfig clientsConfig,
-      EventService eventService) {
+      EventService eventService,
+      AssetService assetService,
+      Sep24TransactionStore sep24TransactionStore,
+      MoreInfoUrlConstructor moreInfoUrlConstructor) {
     return new EventProcessorManager(
-        eventProcessorConfig, callbackApiConfig, clientsConfig, eventService);
+        eventProcessorConfig,
+        callbackApiConfig,
+        clientsConfig,
+        eventService,
+        assetService,
+        sep24TransactionStore,
+        moreInfoUrlConstructor);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -23,7 +23,6 @@ import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountsMana
 import org.stellar.anchor.platform.service.Sep31DepositInfoGeneratorApi;
 import org.stellar.anchor.platform.service.Sep31DepositInfoGeneratorSelf;
 import org.stellar.anchor.platform.service.SimpleInteractiveUrlConstructor;
-import org.stellar.anchor.platform.service.SimpleMoreInfoUrlConstructor;
 import org.stellar.anchor.sep1.Sep1Service;
 import org.stellar.anchor.sep10.Sep10Service;
 import org.stellar.anchor.sep12.Sep12Service;
@@ -169,12 +168,6 @@ public class SepBeans {
       CustomerIntegration customerIntegration,
       JwtService jwtService) {
     return new SimpleInteractiveUrlConstructor(sep24Config, customerIntegration, jwtService);
-  }
-
-  @Bean
-  MoreInfoUrlConstructor moreInfoUrlConstructor(
-      PropertySep24Config sep24Config, JwtService jwtService) {
-    return new SimpleMoreInfoUrlConstructor(sep24Config.getMoreInfoUrl(), jwtService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -70,12 +70,6 @@ public class SepBeans {
   }
 
   @Bean
-  @ConfigurationProperties(prefix = "sep24")
-  PropertySep24Config sep24Config(SecretConfig secretConfig) {
-    return new PropertySep24Config(secretConfig);
-  }
-
-  @Bean
   @ConfigurationProperties(prefix = "sep31")
   Sep31Config sep31Config() {
     return new PropertySep31Config();

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -45,6 +45,12 @@ public class UtilityBeans {
     return new SimpleMoreInfoUrlConstructor(sep24Config.getMoreInfoUrl(), jwtService);
   }
 
+  @Bean
+  @ConfigurationProperties(prefix = "sep24")
+  PropertySep24Config sep24Config(SecretConfig secretConfig) {
+    return new PropertySep24Config(secretConfig);
+  }
+
   /**********************************
    * Secret configurations
    */

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -14,7 +14,10 @@ import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.platform.config.PropertyAppConfig;
 import org.stellar.anchor.platform.config.PropertySecretConfig;
+import org.stellar.anchor.platform.config.PropertySep24Config;
 import org.stellar.anchor.platform.service.HealthCheckService;
+import org.stellar.anchor.platform.service.SimpleMoreInfoUrlConstructor;
+import org.stellar.anchor.sep24.MoreInfoUrlConstructor;
 import org.stellar.anchor.util.GsonUtils;
 
 @Configuration
@@ -34,6 +37,12 @@ public class UtilityBeans {
   @ConfigurationProperties(prefix = "")
   AppConfig appConfig() {
     return new PropertyAppConfig();
+  }
+
+  @Bean
+  MoreInfoUrlConstructor moreInfoUrlConstructor(
+      PropertySep24Config sep24Config, JwtService jwtService) {
+    return new SimpleMoreInfoUrlConstructor(sep24Config.getMoreInfoUrl(), jwtService);
   }
 
   /**********************************

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -1,10 +1,13 @@
 package org.stellar.anchor.platform.event;
 
+import static org.stellar.anchor.sep24.Sep24Helper.fromTxn;
 import static org.stellar.anchor.util.Log.debugF;
 import static org.stellar.anchor.util.NetUtil.getDomainFromURL;
 import static org.stellar.anchor.util.OkHttpUtil.buildJsonRequestBody;
 import static org.stellar.anchor.util.StringHelper.json;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
@@ -12,8 +15,14 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.stellar.anchor.api.event.AnchorEvent;
+import org.stellar.anchor.api.exception.SepException;
+import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.platform.config.ClientsConfig.ClientConfig;
 import org.stellar.anchor.platform.config.PropertySecretConfig;
+import org.stellar.anchor.sep24.MoreInfoUrlConstructor;
+import org.stellar.anchor.sep24.Sep24Transaction;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.sdk.KeyPair;
 
 public class ClientStatusCallbackHandler extends EventHandler {
@@ -25,20 +34,32 @@ public class ClientStatusCallbackHandler extends EventHandler {
           .callTimeout(10, TimeUnit.MINUTES)
           .build();
   private final ClientConfig clientConfig;
+  private final Sep24TransactionStore sep24TransactionStore;
+  private final AssetService assetService;
+  private final MoreInfoUrlConstructor moreInfoUrlConstructor;
 
-  public ClientStatusCallbackHandler(ClientConfig clientConfig) {
+  public ClientStatusCallbackHandler(
+      ClientConfig clientConfig,
+      Sep24TransactionStore sep24TransactionStore,
+      AssetService assetService,
+      MoreInfoUrlConstructor moreInfoUrlConstructor) {
     super();
     this.clientConfig = clientConfig;
+    this.sep24TransactionStore = sep24TransactionStore;
+    this.assetService = assetService;
+    this.moreInfoUrlConstructor = moreInfoUrlConstructor;
   }
 
   @SneakyThrows
   @Override
   void handleEvent(AnchorEvent event) {
-    KeyPair signer = KeyPair.fromSecretSeed(new PropertySecretConfig().getSep10SigningSeed());
-    Request request = buildSignedCallbackRequest(signer, event);
-    httpClient.newCall(request).execute();
-    debugF(
-        "Sending event: {} to client status api: {}", json(event), clientConfig.getCallbackUrl());
+    if (event.getTransaction() != null) {
+      KeyPair signer = KeyPair.fromSecretSeed(new PropertySecretConfig().getSep10SigningSeed());
+      Request request = buildSignedCallbackRequest(signer, event);
+      httpClient.newCall(request).execute();
+      debugF(
+          "Sending event: {} to client status api: {}", json(event), clientConfig.getCallbackUrl());
+    }
   }
 
   @SneakyThrows
@@ -46,7 +67,8 @@ public class ClientStatusCallbackHandler extends EventHandler {
     // Prepare the payload to sign
     String currentTs = String.valueOf(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
     String domain = getDomainFromURL(clientConfig.getCallbackUrl());
-    RequestBody requestBody = buildJsonRequestBody(json(event));
+    String txnPayload = getPayload(event);
+    RequestBody requestBody = buildJsonRequestBody(txnPayload);
     String payload = currentTs + "." + domain + "." + requestBody;
     // Sign the payload using the Anchor private key
     // Base64 encode the signature
@@ -59,5 +81,19 @@ public class ClientStatusCallbackHandler extends EventHandler {
         .header("Signature", String.format("t=%s, s=%s", currentTs, encodedSignature))
         .post(requestBody)
         .build();
+  }
+
+  private String getPayload(AnchorEvent event)
+      throws SepException, MalformedURLException, URISyntaxException {
+    switch (event.getTransaction().getSep()) {
+      case SEP_24:
+        Sep24Transaction sep24Txn =
+            sep24TransactionStore.findByTransactionId(event.getTransaction().getId());
+        Sep24GetTransactionResponse txnResponse =
+            Sep24GetTransactionResponse.of(fromTxn(assetService, moreInfoUrlConstructor, sep24Txn));
+        return json(txnResponse);
+      default:
+        throw new SepException("Only SEP-24 is supported");
+    }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
@@ -16,12 +16,15 @@ import lombok.SneakyThrows;
 import org.stellar.anchor.api.event.AnchorEvent;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.InternalServerErrorException;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.event.EventService.EventQueue;
 import org.stellar.anchor.platform.config.CallbackApiConfig;
 import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.platform.config.EventProcessorConfig;
 import org.stellar.anchor.platform.utils.DaemonExecutors;
+import org.stellar.anchor.sep24.MoreInfoUrlConstructor;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.util.Log;
 
 public class EventProcessorManager {
@@ -32,6 +35,9 @@ public class EventProcessorManager {
   private final CallbackApiConfig callbackApiConfig;
   private final ClientsConfig clientsConfig;
   private final EventService eventService;
+  private final AssetService assetService;
+  private final Sep24TransactionStore sep24TransactionStore;
+  private final MoreInfoUrlConstructor moreInfoUrlConstructor;
 
   private final List<EventProcessor> processors = new ArrayList<>();
 
@@ -39,11 +45,17 @@ public class EventProcessorManager {
       EventProcessorConfig eventProcessorConfig,
       CallbackApiConfig callbackApiConfig,
       ClientsConfig clientsConfig,
-      EventService eventService) {
+      EventService eventService,
+      AssetService assetService,
+      Sep24TransactionStore sep24TransactionStore,
+      MoreInfoUrlConstructor moreInfoUrlConstructor) {
     this.eventProcessorConfig = eventProcessorConfig;
     this.callbackApiConfig = callbackApiConfig;
     this.clientsConfig = clientsConfig;
     this.eventService = eventService;
+    this.assetService = assetService;
+    this.sep24TransactionStore = sep24TransactionStore;
+    this.moreInfoUrlConstructor = moreInfoUrlConstructor;
   }
 
   @PostConstruct
@@ -85,7 +97,8 @@ public class EventProcessorManager {
               new EventProcessor(
                   processorName,
                   EventQueue.TRANSACTION,
-                  new ClientStatusCallbackHandler(clientConfig)));
+                  new ClientStatusCallbackHandler(
+                      clientConfig, sep24TransactionStore, assetService, moreInfoUrlConstructor)));
         }
       }
     }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.event
 
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -8,8 +9,11 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.platform.config.ClientsConfig
 import org.stellar.anchor.platform.config.PropertySecretConfig
+import org.stellar.anchor.sep24.MoreInfoUrlConstructor
+import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.util.NetUtil
 import org.stellar.anchor.util.StringHelper.json
 import org.stellar.sdk.KeyPair
@@ -23,13 +27,23 @@ class ClientStatusCallbackHandlerTest {
   private lateinit var event: AnchorEvent
   private lateinit var payload: String
 
+  @MockK(relaxed = true) private lateinit var sep24TransactionStore: Sep24TransactionStore
+  @MockK(relaxed = true) private lateinit var assetService: AssetService
+  @MockK(relaxed = true) lateinit var moreInfoUrlConstructor: MoreInfoUrlConstructor
+
   @BeforeEach
   fun setUp() {
     clientConfig = ClientsConfig.ClientConfig()
     clientConfig.type = ClientsConfig.ClientType.CUSTODIAL
     clientConfig.signingKey = "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"
     clientConfig.callbackUrl = "https://callback.circle.com/api/v1/anchor/callback"
-    handler = ClientStatusCallbackHandler(clientConfig)
+    handler =
+      ClientStatusCallbackHandler(
+        clientConfig,
+        sep24TransactionStore,
+        assetService,
+        moreInfoUrlConstructor
+      )
 
     secretConfig = mockk()
     every { secretConfig.sep10SigningSeed } returns


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This is to fix the request body used in client status callback is not a Sep24GetTransactionResponse

original pr: https://github.com/stellar/java-stellar-anchor-sdk/pull/988

### Why

According to Sep24Controller, response from `/trasaction` is of `Sep24GetTransactionResponse` type, which should be the correct body format used in  callback 