### PR TITLE
[ANCHOR-397] Add missing claims to SEP-24 JWTs

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -16,7 +16,10 @@ import org.stellar.anchor.config.SecretConfig;
 
 @Getter
 public class JwtService {
+  // SEP-24 specific claims
   public static final String CLIENT_DOMAIN = "client_domain";
+  public static final String CLIENT_NAME = "client_name";
+
   String sep10JwtSecret;
   String sep24InteractiveUrlJwtSecret;
   String sep24MoreInfoUrlJwtSecret;
@@ -94,7 +97,11 @@ public class JwtService {
     }
     Calendar calExp = Calendar.getInstance();
     calExp.setTimeInMillis(1000L * token.getExp());
-    JwtBuilder builder = Jwts.builder().setId(token.getJti()).setExpiration(calExp.getTime());
+    JwtBuilder builder =
+        Jwts.builder()
+            .setId(token.getJti())
+            .setExpiration(calExp.getTime())
+            .setSubject(token.getSub());
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
     }

--- a/core/src/main/java/org/stellar/anchor/auth/Sep24InteractiveUrlJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/Sep24InteractiveUrlJwt.java
@@ -1,17 +1,20 @@
 package org.stellar.anchor.auth;
 
 import static org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN;
+import static org.stellar.anchor.auth.JwtService.CLIENT_NAME;
 
 import io.jsonwebtoken.Jwt;
 import org.stellar.anchor.api.exception.SepException;
 
 public class Sep24InteractiveUrlJwt extends AbstractJwt {
-  public Sep24InteractiveUrlJwt(String sub, String jti, long exp, String clientDomain)
+  public Sep24InteractiveUrlJwt(
+      String sub, String jti, long exp, String clientDomain, String clientName)
       throws SepException {
     super.sub = sub;
     super.jti = jti;
     super.exp = exp;
     super.claim(CLIENT_DOMAIN, clientDomain);
+    super.claim(CLIENT_NAME, clientName);
   }
 
   public Sep24InteractiveUrlJwt(Jwt jwt) {

--- a/core/src/main/java/org/stellar/anchor/auth/Sep24MoreInfoUrlJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/Sep24MoreInfoUrlJwt.java
@@ -1,11 +1,20 @@
 package org.stellar.anchor.auth;
 
+import static org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN;
+import static org.stellar.anchor.auth.JwtService.CLIENT_NAME;
+
 import io.jsonwebtoken.Jwt;
+import org.stellar.anchor.api.exception.SepException;
 
 public class Sep24MoreInfoUrlJwt extends AbstractJwt {
-  public Sep24MoreInfoUrlJwt(String jti, long exp) {
+  public Sep24MoreInfoUrlJwt(
+      String sub, String jti, long exp, String clientDomain, String clientName)
+      throws SepException {
+    super.sub = sub;
     super.jti = jti;
     super.exp = exp;
+    super.claim(CLIENT_DOMAIN, clientDomain);
+    super.claim(CLIENT_NAME, clientName);
   }
 
   public Sep24MoreInfoUrlJwt(Jwt jwt) {

--- a/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
@@ -7,6 +7,7 @@ class TestConstants {
     const val TEST_MEMO = "123"
     const val TEST_WEB_AUTH_DOMAIN = "test.stellar.org/auth"
     const val TEST_CLIENT_DOMAIN = "test.client.stellar.org"
+    const val TEST_CLIENT_NAME = "test_client"
     const val TEST_HOME_DOMAIN = "test.stellar.org"
     const val TEST_JWT_SECRET = "jwt_secret"
     const val TEST_ASSET = "USDC"

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_NAME
 import org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN
+import org.stellar.anchor.auth.JwtService.CLIENT_NAME
 import org.stellar.anchor.config.SecretConfig
 
 internal class JwtServiceTest {
@@ -68,24 +70,31 @@ internal class JwtServiceTest {
   @Test
   fun `test apply Sep24MoreInfoUrlJwt encoding and decoding and make sure the original values are not changed`() {
     val jwtService = JwtService(secretConfig)
-    val token = Sep24MoreInfoUrlJwt(TEST_ISS, TEST_EXP)
+    val token =
+      Sep24MoreInfoUrlJwt(TEST_ACCOUNT, TEST_ISS, TEST_EXP, TEST_CLIENT_DOMAIN, TEST_CLIENT_NAME)
     val cipher = jwtService.encode(token)
     val sep24MoreInfoUrlJwt = jwtService.decode(cipher, Sep24MoreInfoUrlJwt::class.java)
 
+    assertEquals(sep24MoreInfoUrlJwt.sub, token.sub)
     assertEquals(sep24MoreInfoUrlJwt.iss, token.iss)
     assertEquals(sep24MoreInfoUrlJwt.exp, token.exp)
+    assertEquals(sep24MoreInfoUrlJwt.claims[CLIENT_DOMAIN], token.claims[CLIENT_DOMAIN])
+    assertEquals(sep24MoreInfoUrlJwt.claims[CLIENT_NAME], token.claims[CLIENT_NAME])
   }
 
   @Test
   fun `test apply Sep24InteractiveUrlJwt encoding and decoding and make sure the original values are not changed`() {
     val jwtService = JwtService(secretConfig)
-    val token = Sep24InteractiveUrlJwt(TEST_ACCOUNT, TEST_ISS, TEST_EXP, TEST_CLIENT_DOMAIN)
+    val token =
+      Sep24InteractiveUrlJwt(TEST_ACCOUNT, TEST_ISS, TEST_EXP, TEST_CLIENT_DOMAIN, TEST_CLIENT_NAME)
     val cipher = jwtService.encode(token)
     val sep24InteractiveUrlJwt = jwtService.decode(cipher, Sep24InteractiveUrlJwt::class.java)
 
+    assertEquals(sep24InteractiveUrlJwt.sub, token.sub)
     assertEquals(sep24InteractiveUrlJwt.iss, token.iss)
     assertEquals(sep24InteractiveUrlJwt.exp, token.exp)
     assertEquals(sep24InteractiveUrlJwt.claims[CLIENT_DOMAIN], token.claims[CLIENT_DOMAIN])
+    assertEquals(sep24InteractiveUrlJwt.claims[CLIENT_NAME], token.claims[CLIENT_NAME])
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -19,6 +19,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_DOMAIN
+import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_NAME
 import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_JWT_SECRET
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
@@ -534,7 +535,8 @@ internal class Sep24ServiceTest {
         if (accountMemo == null) account else "$account:$accountMemo",
         TEST_TRANSACTION_ID_0,
         Instant.now().epochSecond + 1000,
-        TEST_CLIENT_DOMAIN
+        TEST_CLIENT_DOMAIN,
+        TEST_CLIENT_NAME,
       )
     jwt.claim("asset", "stellar:${TEST_ASSET}:${TEST_ASSET_ISSUER_ACCOUNT_ID}")
     return jwt

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -158,10 +158,12 @@ public class SepBeans {
 
   @Bean
   InteractiveUrlConstructor interactiveUrlConstructor(
+      ClientsConfig clientsConfig,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
       JwtService jwtService) {
-    return new SimpleInteractiveUrlConstructor(sep24Config, customerIntegration, jwtService);
+    return new SimpleInteractiveUrlConstructor(
+        clientsConfig, sep24Config, customerIntegration, jwtService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -12,6 +12,7 @@ import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.horizon.Horizon;
+import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.platform.config.PropertyAppConfig;
 import org.stellar.anchor.platform.config.PropertySecretConfig;
 import org.stellar.anchor.platform.config.PropertySep24Config;
@@ -41,8 +42,9 @@ public class UtilityBeans {
 
   @Bean
   MoreInfoUrlConstructor moreInfoUrlConstructor(
-      PropertySep24Config sep24Config, JwtService jwtService) {
-    return new SimpleMoreInfoUrlConstructor(sep24Config.getMoreInfoUrl(), jwtService);
+      ClientsConfig clientsConfig, PropertySep24Config sep24Config, JwtService jwtService) {
+    return new SimpleMoreInfoUrlConstructor(
+        clientsConfig, sep24Config.getMoreInfoUrl(), jwtService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
@@ -21,6 +21,7 @@ import org.stellar.anchor.sep10.Sep10Helper;
 public class ClientsConfig implements Validator {
   List<ClientConfig> clients = Lists.newLinkedList();
   Map<String, ClientConfig> clientMap = null;
+  Map<String, String> domainToClientNameMap = null;
 
   @Data
   @AllArgsConstructor
@@ -36,6 +37,19 @@ public class ClientsConfig implements Validator {
   public enum ClientType {
     CUSTODIAL,
     NONCUSTODIAL
+  }
+
+  public ClientConfig getClientConfigByDomain(String domain) {
+    if (domainToClientNameMap == null) {
+      domainToClientNameMap = Maps.newHashMap();
+      clients.forEach(
+          clientConfig -> {
+            if (clientConfig.domain != null) {
+              domainToClientNameMap.put(clientConfig.domain, clientConfig.name);
+            }
+          });
+    }
+    return getClientConfigByName(domainToClientNameMap.get(domain));
   }
 
   public ClientConfig getClientConfigByName(String name) {

--- a/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/ClientsConfig.java
@@ -22,6 +22,7 @@ public class ClientsConfig implements Validator {
   List<ClientConfig> clients = Lists.newLinkedList();
   Map<String, ClientConfig> clientMap = null;
   Map<String, String> domainToClientNameMap = null;
+  Map<String, String> signingKeyToClientNameMap = null;
 
   @Data
   @AllArgsConstructor
@@ -37,6 +38,19 @@ public class ClientsConfig implements Validator {
   public enum ClientType {
     CUSTODIAL,
     NONCUSTODIAL
+  }
+
+  public ClientConfig getClientConfigBySigningKey(String signingKey) {
+    if (signingKeyToClientNameMap == null) {
+      signingKeyToClientNameMap = Maps.newHashMap();
+      clients.forEach(
+          clientConfig -> {
+            if (clientConfig.signingKey != null) {
+              signingKeyToClientNameMap.put(clientConfig.signingKey, clientConfig.name);
+            }
+          });
+    }
+    return getClientConfigByName(signingKeyToClientNameMap.get(signingKey));
   }
 
   public ClientConfig getClientConfigByDomain(String domain) {

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -17,6 +17,7 @@ import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt;
+import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.platform.config.PropertySep24Config;
 import org.stellar.anchor.sep24.InteractiveUrlConstructor;
 import org.stellar.anchor.sep24.Sep24Transaction;
@@ -24,14 +25,18 @@ import org.stellar.anchor.util.GsonUtils;
 
 public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   public static final String FORWARD_KYC_CUSTOMER_TYPE = "sep24-customer";
+
+  private final ClientsConfig clientsConfig;
   private final PropertySep24Config sep24Config;
   private final CustomerIntegration customerIntegration;
   private final JwtService jwtService;
 
   public SimpleInteractiveUrlConstructor(
+      ClientsConfig clientsConfig,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
       JwtService jwtService) {
+    this.clientsConfig = clientsConfig;
     this.sep24Config = sep24Config;
     this.customerIntegration = customerIntegration;
     this.jwtService = jwtService;
@@ -70,12 +75,15 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
         (isEmpty(txn.getSep10AccountMemo()))
             ? txn.getSep10Account()
             : txn.getSep10Account() + ":" + txn.getSep10AccountMemo();
+    ClientsConfig.ClientConfig clientConfig =
+        clientsConfig.getClientConfigByDomain(txn.getClientDomain());
     Sep24InteractiveUrlJwt token =
         new Sep24InteractiveUrlJwt(
             account,
             txn.getTransactionId(),
             Instant.now().getEpochSecond() + sep24Config.getInteractiveUrl().getJwtExpiration(),
-            txn.getClientDomain());
+            txn.getClientDomain(),
+            clientConfig != null ? clientConfig.getName() : null);
 
     // Add required JWT fields from request
     Map<String, String> data = new HashMap<>(extractRequiredJwtFieldsFromRequest(request));

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -70,16 +70,12 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
 
   @SneakyThrows
   String constructToken(Sep24Transaction txn, Map<String, String> request) {
-
-    String account =
-        (isEmpty(txn.getSep10AccountMemo()))
-            ? txn.getSep10Account()
-            : txn.getSep10Account() + ":" + txn.getSep10AccountMemo();
     ClientsConfig.ClientConfig clientConfig =
-        clientsConfig.getClientConfigByDomain(txn.getClientDomain());
+        UrlConstructorHelper.getClientConfig(clientsConfig, txn);
+
     Sep24InteractiveUrlJwt token =
         new Sep24InteractiveUrlJwt(
-            account,
+            UrlConstructorHelper.getAccount(txn),
             txn.getTransactionId(),
             Instant.now().getEpochSecond() + sep24Config.getInteractiveUrl().getJwtExpiration(),
             txn.getClientDomain(),

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
@@ -1,10 +1,9 @@
 package org.stellar.anchor.platform.service;
 
 import static org.stellar.anchor.platform.config.PropertySep24Config.MoreInfoUrlConfig;
+import static org.stellar.anchor.util.StringHelper.isEmpty;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,24 +11,38 @@ import lombok.SneakyThrows;
 import org.apache.http.client.utils.URIBuilder;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep24MoreInfoUrlJwt;
+import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.sep24.MoreInfoUrlConstructor;
 import org.stellar.anchor.sep24.Sep24Transaction;
 
 public class SimpleMoreInfoUrlConstructor extends MoreInfoUrlConstructor {
+  private final ClientsConfig clientsConfig;
   private final MoreInfoUrlConfig config;
   private final JwtService jwtService;
 
-  public SimpleMoreInfoUrlConstructor(MoreInfoUrlConfig config, JwtService jwtService) {
+  public SimpleMoreInfoUrlConstructor(
+      ClientsConfig clientsConfig, MoreInfoUrlConfig config, JwtService jwtService) {
+    this.clientsConfig = clientsConfig;
     this.config = config;
     this.jwtService = jwtService;
   }
 
   @Override
   @SneakyThrows
-  public String construct(Sep24Transaction txn) throws URISyntaxException, MalformedURLException {
+  public String construct(Sep24Transaction txn) {
+    String account =
+        isEmpty(txn.getSep10AccountMemo())
+            ? txn.getSep10Account()
+            : txn.getSep10Account() + ":" + txn.getSep10AccountMemo();
+    ClientsConfig.ClientConfig clientConfig =
+        clientsConfig.getClientConfigByDomain(txn.getClientDomain());
     Sep24MoreInfoUrlJwt token =
         new Sep24MoreInfoUrlJwt(
-            txn.getTransactionId(), Instant.now().getEpochSecond() + config.getJwtExpiration());
+            account,
+            txn.getTransactionId(),
+            Instant.now().getEpochSecond() + config.getJwtExpiration(),
+            txn.getClientDomain(),
+            clientConfig != null ? clientConfig.getName() : null);
 
     Map<String, String> data = new HashMap<>();
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.platform.service;
 
 import static org.stellar.anchor.platform.config.PropertySep24Config.MoreInfoUrlConfig;
-import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import java.net.URI;
 import java.time.Instant;
@@ -30,15 +29,12 @@ public class SimpleMoreInfoUrlConstructor extends MoreInfoUrlConstructor {
   @Override
   @SneakyThrows
   public String construct(Sep24Transaction txn) {
-    String account =
-        isEmpty(txn.getSep10AccountMemo())
-            ? txn.getSep10Account()
-            : txn.getSep10Account() + ":" + txn.getSep10AccountMemo();
     ClientsConfig.ClientConfig clientConfig =
-        clientsConfig.getClientConfigByDomain(txn.getClientDomain());
+        UrlConstructorHelper.getClientConfig(clientsConfig, txn);
+
     Sep24MoreInfoUrlJwt token =
         new Sep24MoreInfoUrlJwt(
-            account,
+            UrlConstructorHelper.getAccount(txn),
             txn.getTransactionId(),
             Instant.now().getEpochSecond() + config.getJwtExpiration(),
             txn.getClientDomain(),

--- a/platform/src/main/java/org/stellar/anchor/platform/service/UrlConstructorHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/UrlConstructorHelper.java
@@ -1,11 +1,12 @@
 package org.stellar.anchor.platform.service;
 
-import static org.stellar.anchor.util.StringHelper.camelToSnake;
-import static org.stellar.anchor.util.StringHelper.snakeToCamelCase;
+import static org.stellar.anchor.util.StringHelper.*;
 
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.beanutils.BeanUtils;
+import org.stellar.anchor.api.exception.SepValidationException;
+import org.stellar.anchor.platform.config.ClientsConfig;
 import org.stellar.anchor.sep24.Sep24Transaction;
 import org.stellar.anchor.util.StringHelper;
 
@@ -31,5 +32,25 @@ public class UrlConstructorHelper {
         // give up. no need to add the field
       }
     }
+  }
+
+  public static String getAccount(Sep24Transaction txn) {
+    return isEmpty(txn.getSep10AccountMemo())
+        ? txn.getSep10Account()
+        : txn.getSep10Account() + ":" + txn.getSep10AccountMemo();
+  }
+
+  public static ClientsConfig.ClientConfig getClientConfig(
+      ClientsConfig clientsConfig, Sep24Transaction txn) throws SepValidationException {
+    ClientsConfig.ClientConfig clientConfig;
+    if (isEmpty(txn.getClientDomain())) {
+      clientConfig = clientsConfig.getClientConfigBySigningKey(txn.getSep10Account());
+      if (clientConfig != null && clientConfig.getType() == ClientsConfig.ClientType.NONCUSTODIAL) {
+        throw new SepValidationException("Non-custodial clients must specify a client_domain");
+      }
+    } else {
+      clientConfig = clientsConfig.getClientConfigByDomain(txn.getClientDomain());
+    }
+    return clientConfig;
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -2,7 +2,6 @@ package org.stellar.anchor.platform.config
 
 import io.mockk.every
 import io.mockk.mockk
-import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -100,6 +99,23 @@ class Sep10ConfigTest {
     assertEquals(clientsConfig.getClientConfigByDomain("unknown"), null)
     assertEquals(clientsConfig.getClientConfigByDomain("lobstr.co"), clientsConfig.clients[1])
     assertEquals(clientsConfig.getClientConfigByDomain("circle.com"), clientsConfig.clients[2])
+  }
+
+  @Test
+  fun `test ClientsConfig getClientConfigBySigningKey`() {
+    assertEquals(clientsConfig.getClientConfigBySigningKey("unknown"), null)
+    assertEquals(
+      clientsConfig.getClientConfigBySigningKey(
+        "GC4HAYCFQYQLJV5SE6FB3LGC37D6XGIXGMAXCXWNBLH7NWW2JH4OZLHQ"
+      ),
+      clientsConfig.clients[1]
+    )
+    assertEquals(
+      clientsConfig.getClientConfigBySigningKey(
+        "GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE"
+      ),
+      clientsConfig.clients[2]
+    )
   }
 
   @Test
@@ -207,53 +223,5 @@ class Sep10ConfigTest {
     config.homeDomain = "www.stellar.org"
     config.postConstruct()
     assertEquals("localhost:8080", config.webAuthDomain)
-  }
-
-  companion object {
-    @JvmStatic
-    fun validOmnibusAccounts(): Stream<List<String>> {
-      return Stream.of(
-        listOf(),
-        listOf("GAU2XSVTXY6GADVFFLDJLWO44SC6MAWPMHZTI4QHYUKV6BGGJFAIEYGB"),
-        listOf(
-          "GCS2KBEGIWILNKFYY6ORT72Y2HUFYG6IIIOESHVQC3E5NIYT3L2I5F5E",
-          "GAU2XSVTXY6GADVFFLDJLWO44SC6MAWPMHZTI4QHYUKV6BGGJFAIEYGB"
-        )
-      )
-    }
-    @JvmStatic
-    fun invalidOmnibusAccounts(): Stream<List<String>> {
-      return Stream.of(
-        listOf("SBBGHY3KIEI4XM2G2MD76DB3F3EPC6A2NR57CY2PFJVE66T7UTAE3SKD"),
-        listOf(
-          "GCS2KBEGIWILNKFYY6ORT72Y2HUFYG6IIIOESHVQC3E5NIYT3L2I5F5E",
-          "SBBGHY3KIEI4XM2G2MD76DB3F3EPC6A2NR57CY2PFJVE66T7UTAE3SKD"
-        ),
-        listOf("1234")
-      )
-    }
-
-    val TEST_CLIENTS_CONFIG =
-      """
-        {
-          "clients": [
-            {
-              "name": "lobstr",
-              "type": "NONCUSTODIAL",
-              "signingKey": "0x1234",
-              "domain": "lobstr.co",
-              "callbackUrl": "https://lobstr.co/callback"
-            },
-            {
-              "name": "circle",
-              "type": "CUSTODIAL",
-              "signingKey": "0x5678",
-              "domain": "circle.com",
-              "callbackUrl": "https://circle.com/callback"
-            }
-          ]
-        }          
-    """
-        .trimIndent()
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -96,6 +96,13 @@ class Sep10ConfigTest {
   }
 
   @Test
+  fun `test ClientsConfig getClientConfigByDomain`() {
+    assertEquals(clientsConfig.getClientConfigByDomain("unknown"), null)
+    assertEquals(clientsConfig.getClientConfigByDomain("lobstr.co"), clientsConfig.clients[1])
+    assertEquals(clientsConfig.getClientConfigByDomain("circle.com"), clientsConfig.clients[2])
+  }
+
+  @Test
   fun `test when clientAllowList is not defined, clientAttributionAllowList equals to the list of all clients`() {
     val config = PropertySep10Config(appConfig, clientsConfig, secretConfig)
     assertEquals(config.clientAttributionAllowList, listOf("lobstr.co", "circle.com"))

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -21,6 +21,7 @@ import org.stellar.anchor.api.callback.PutCustomerResponse
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
 import org.stellar.anchor.config.SecretConfig
+import org.stellar.anchor.platform.config.ClientsConfig
 import org.stellar.anchor.platform.config.PropertySep24Config
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.service.SimpleInteractiveUrlConstructor.FORWARD_KYC_CUSTOMER_TYPE
@@ -36,6 +37,7 @@ class SimpleInteractiveUrlConstructorTest {
   }
 
   @MockK(relaxed = true) private lateinit var secretConfig: SecretConfig
+  @MockK(relaxed = true) private lateinit var clientsConfig: ClientsConfig
   @MockK(relaxed = true) private lateinit var customerIntegration: CustomerIntegration
   private lateinit var jwtService: JwtService
   private lateinit var sep24Config: PropertySep24Config
@@ -46,6 +48,14 @@ class SimpleInteractiveUrlConstructorTest {
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { secretConfig.sep24InteractiveUrlJwtSecret } returns "sep24_jwt_secret"
+    every { clientsConfig.getClientConfigByDomain("lobstr.co") } returns
+      ClientsConfig.ClientConfig(
+        "lobstr",
+        ClientsConfig.ClientType.CUSTODIAL,
+        "secret",
+        "lobstr.co",
+        "https://callback.lobstr.co/api/v2/anchor/callback"
+      )
     jwtService = JwtService(secretConfig)
     sep24Config = gson.fromJson(SEP24_CONFIG_JSON_1, PropertySep24Config::class.java)
     request = gson.fromJson(REQUEST_JSON_1, HashMap::class.java) as HashMap<String, String>
@@ -59,17 +69,25 @@ class SimpleInteractiveUrlConstructorTest {
     val testRequest = gson.fromJson(requestJson, HashMap::class.java)
     val testTxn = gson.fromJson(txnJson, JdbcSep24Transaction::class.java)
 
-    val constructor = SimpleInteractiveUrlConstructor(testConfig, customerIntegration, jwtService)
+    val constructor =
+      SimpleInteractiveUrlConstructor(clientsConfig, testConfig, customerIntegration, jwtService)
 
     var jwt =
       parseJwtFromUrl(constructor.construct(testTxn, testRequest as HashMap<String, String>?))
     testJwt(jwt)
+    var claims = jwt.claims
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO:1234", jwt.sub)
+    assertEquals("lobstr.co", claims["client_domain"] as String)
+    assertEquals("lobstr", claims["client_name"] as String)
 
     testTxn.sep10AccountMemo = null
+    testTxn.clientDomain = "unknown.com"
     jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest))
+    claims = jwt.claims
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
+    assertEquals("unknown.com", claims["client_domain"] as String)
+    assertEquals("", claims["client_name"] as String)
   }
 
   @Test
@@ -78,7 +96,8 @@ class SimpleInteractiveUrlConstructorTest {
     val capturedPutCustomerRequest = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(capturedPutCustomerRequest)) } returns
       PutCustomerResponse()
-    val constructor = SimpleInteractiveUrlConstructor(sep24Config, customerIntegration, jwtService)
+    val constructor =
+      SimpleInteractiveUrlConstructor(clientsConfig, sep24Config, customerIntegration, jwtService)
     sep24Config.kycFieldsForwarding.isEnabled = true
     constructor.construct(txn, request as HashMap<String, String>?)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
@@ -90,7 +109,8 @@ class SimpleInteractiveUrlConstructorTest {
   @Test
   fun `when kycFieldsForwarding is disabled, the customerIntegration should not receive the kyc fields`() {
     val customerIntegration: CustomerIntegration = mockk()
-    val constructor = SimpleInteractiveUrlConstructor(sep24Config, customerIntegration, jwtService)
+    val constructor =
+      SimpleInteractiveUrlConstructor(clientsConfig, sep24Config, customerIntegration, jwtService)
     sep24Config.kycFieldsForwarding.isEnabled = false
     constructor.construct(txn, request as HashMap<String, String>?)
     verify(exactly = 0) { customerIntegration.putCustomer(any()) }
@@ -106,6 +126,8 @@ class SimpleInteractiveUrlConstructorTest {
     val claims = jwt.claims()
     assertEquals("txn_123", jwt.jti as String)
     assertTrue(Instant.ofEpochSecond(jwt.exp).isAfter(Instant.now()))
+
+    // Transaction data
     val data = claims["data"] as Map<String, String>
     assertEquals("deposit", data["kind"] as String)
     assertEquals("100", data["amount"] as String)
@@ -164,6 +186,7 @@ private const val TXN_JSON_1 =
   "sep10_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
   "sep10_account_memo": "1234",
   "amount_in": "100",
-  "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+  "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+  "client_domain": "lobstr.co"
 }  
 """

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.web.util.UriComponentsBuilder
+import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.Sep24MoreInfoUrlJwt
 import org.stellar.anchor.config.SecretConfig
@@ -30,13 +32,30 @@ class SimpleMoreInfoUrlConstructorTest {
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { secretConfig.sep24MoreInfoUrlJwtSecret } returns "sep24_jwt_secret"
-    every { clientsConfig.getClientConfigByDomain("lobstr.co") } returns
+
+    val clientConfig =
       ClientsConfig.ClientConfig(
         "lobstr",
-        ClientsConfig.ClientType.CUSTODIAL,
-        "secret",
+        ClientsConfig.ClientType.NONCUSTODIAL,
+        "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
         "lobstr.co",
         "https://callback.lobstr.co/api/v2/anchor/callback"
+      )
+    every { clientsConfig.getClientConfigByDomain(any()) } returns null
+    every { clientsConfig.getClientConfigByDomain(clientConfig.domain) } returns clientConfig
+    every { clientsConfig.getClientConfigBySigningKey(clientConfig.signingKey) } returns
+      clientConfig
+    every {
+      clientsConfig.getClientConfigBySigningKey(
+        "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+      )
+    } returns
+      ClientsConfig.ClientConfig(
+        "some-wallet",
+        ClientsConfig.ClientType.CUSTODIAL,
+        "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        null,
+        null
       )
 
     jwtService = JwtService(secretConfig)
@@ -80,7 +99,40 @@ class SimpleMoreInfoUrlConstructorTest {
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
     assertEquals("unknown.com", claims["client_domain"])
-    assertEquals("", claims["client_name"])
+    assertEquals(null, claims["client_name"])
+  }
+
+  @Test
+  fun `test custodial wallet`() {
+    val config =
+      gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
+    val constructor = SimpleMoreInfoUrlConstructor(clientsConfig, config, jwtService)
+    val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
+    txn.sep10Account = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    txn.clientDomain = null
+
+    val url = constructor.construct(txn)
+
+    val params = UriComponentsBuilder.fromUriString(url).build().queryParams
+    val cipher = params["token"]!![0]
+
+    val jwt = jwtService.decode(cipher, Sep24MoreInfoUrlJwt::class.java)
+    val claims = jwt.claims()
+    testJwt(jwt)
+    assertEquals("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP:1234", jwt.sub)
+    assertEquals(null, claims["client_domain"])
+    assertEquals("some-wallet", claims["client_name"])
+  }
+
+  @Test
+  fun `test non-custodial wallet with missing client domain`() {
+    val config =
+      gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
+    val constructor = SimpleMoreInfoUrlConstructor(clientsConfig, config, jwtService)
+    val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
+    txn.clientDomain = null
+
+    assertThrows<SepValidationException> { constructor.construct(txn) }
   }
 
   private fun testJwt(jwt: Sep24MoreInfoUrlJwt) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.util.UriComponentsBuilder
 import org.stellar.anchor.auth.JwtService
-import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.Sep24MoreInfoUrlJwt
 import org.stellar.anchor.config.SecretConfig
+import org.stellar.anchor.platform.config.ClientsConfig
 import org.stellar.anchor.platform.config.PropertySep24Config
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.util.GsonUtils
@@ -23,30 +23,67 @@ class SimpleMoreInfoUrlConstructorTest {
   }
 
   @MockK(relaxed = true) private lateinit var secretConfig: SecretConfig
+  @MockK(relaxed = true) private lateinit var clientsConfig: ClientsConfig
   private lateinit var jwtService: JwtService
-  private lateinit var sep10Jwt: Sep10Jwt
-  private lateinit var txn: JdbcSep24Transaction
 
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { secretConfig.sep24MoreInfoUrlJwtSecret } returns "sep24_jwt_secret"
+    every { clientsConfig.getClientConfigByDomain("lobstr.co") } returns
+      ClientsConfig.ClientConfig(
+        "lobstr",
+        ClientsConfig.ClientType.CUSTODIAL,
+        "secret",
+        "lobstr.co",
+        "https://callback.lobstr.co/api/v2/anchor/callback"
+      )
 
     jwtService = JwtService(secretConfig)
-    txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
   }
 
   @Test
   fun `test correct config`() {
     val config =
       gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
-    val constructor = SimpleMoreInfoUrlConstructor(config, jwtService)
+    val constructor = SimpleMoreInfoUrlConstructor(clientsConfig, config, jwtService)
+    val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
     val url = constructor.construct(txn)
 
     val params = UriComponentsBuilder.fromUriString(url).build().queryParams
     val cipher = params["token"]!![0]
-    val jwt = jwtService.decode(cipher, Sep24MoreInfoUrlJwt::class.java)
 
+    val jwt = jwtService.decode(cipher, Sep24MoreInfoUrlJwt::class.java)
+    val claims = jwt.claims()
+    testJwt(jwt)
+    assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO:1234", jwt.sub)
+    assertEquals("lobstr.co", claims["client_domain"])
+    assertEquals("lobstr", claims["client_name"])
+  }
+
+  @Test
+  fun `test unknown client domain`() {
+    val config =
+      gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
+    val constructor = SimpleMoreInfoUrlConstructor(clientsConfig, config, jwtService)
+    val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
+    txn.clientDomain = "unknown.com"
+    txn.sep10AccountMemo = null
+
+    val url = constructor.construct(txn)
+
+    val params = UriComponentsBuilder.fromUriString(url).build().queryParams
+    val cipher = params["token"]!![0]
+
+    val jwt = jwtService.decode(cipher, Sep24MoreInfoUrlJwt::class.java)
+    val claims = jwt.claims()
+    testJwt(jwt)
+    assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
+    assertEquals("unknown.com", claims["client_domain"])
+    assertEquals("", claims["client_name"])
+  }
+
+  private fun testJwt(jwt: Sep24MoreInfoUrlJwt) {
     assertEquals("txn_123", jwt.jti as String)
     Assertions.assertTrue(Instant.ofEpochSecond(jwt.exp).isAfter(Instant.now()))
   }
@@ -72,6 +109,9 @@ private const val TXN_JSON =
   "status": "incomplete",
   "kind" : "deposit",
   "amount_in": "100",
-  "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+  "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+  "sep10_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+  "sep10_account_memo": "1234",
+  "client_domain": "lobstr.co"
 }  
 """


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This sets `client_name` and `client_domain` for the JWTs generated by SEP-24. It also adds the missing `sub` claim to the more info URL JWT.

### Why

These claims are used to identify the wallet and user.

### Known limitations

N/A