### PR TITLE
ANCHOR-408 helm-charts/sep-service helm chart observer metrics

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.91
+version: 0.3.95

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -193,7 +193,7 @@ data:
       {{- end }}
       metrics-service:
         optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).runInterval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: false   # optional metrics that periodically query the database
-        runInterval: 30                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -201,6 +201,9 @@ spec:
           - name: http
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
+          - name: metrics
+            containerPort: 8082
+            protocol: TCP
           {{- if (.Values.deployment).env }}
           env:
 {{ toYaml .Values.deployment.env | indent 12 }}


### PR DESCRIPTION
This change updates the legacy/main-1.2 helm chart to externalize the optionalMetricsEnabled parameter and also add metrics port for the stellar observer.

### PR Structure

* [x ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

I have tested this PR using helm template command.  Results verified using example-values file and uncommenting the stellar observer section.

### What

helm chart updates.

### Why

partner needs to access metrics port for observer in order to integrate with datadog.
also needs to enable the optionalmetrics and need this parameter available in helm chart values.

### Known limitations

Test Evidence:
helm template sepservice . -f example_values.yaml > ~/out
```      metrics-service:
        optionalMetricsEnabled: true  # optional metrics that periodically query the database
        runInterval: 30                 # interval to query the database to generate the optional metrics
```


```
# Stellar Observer
apiVersion: apps/v1
kind: Deployment
metadata:
  name: anchor-platform-observer
---snip---
          ports:
          - name: http
            containerPort: 8083
            protocol: TCP
          - name: metrics
            containerPort: 8082
            protocol: TCP

```
