### PR TITLE
Remove hostname lookup from Sep10Config validation

### DIFF
--- a/core/src/main/java/org/stellar/anchor/util/NetUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/NetUtil.java
@@ -35,11 +35,11 @@ public class NetUtil {
     }
   }
 
-  public static boolean isServerPortValid(String serverPort) {
+  public static boolean isServerPortValid(String serverPort, boolean hostnameLookup) {
     if (isEmpty(serverPort)) return false;
     String[] tokens = Strings.split(serverPort, ":");
     if (tokens == null) {
-      return isHostnameValid(serverPort);
+      return true;
     }
     switch (tokens.length) {
       case 2:
@@ -47,13 +47,13 @@ public class NetUtil {
         try {
           int port = Integer.parseInt(strPort);
           if (port > 65535 || port < 0) {
-            return false;
+            return !hostnameLookup || isHostnameResolvable(serverPort);
           }
         } catch (NumberFormatException ex) {
           return false;
         }
       case 1:
-        return isHostnameValid(tokens[0]);
+        return !hostnameLookup || isHostnameResolvable(serverPort);
       case 0:
       default:
         return false;
@@ -68,7 +68,7 @@ public class NetUtil {
     return uri.getHost() + ":" + uri.getPort();
   }
 
-  static boolean isHostnameValid(String hostname) {
+  static boolean isHostnameResolvable(String hostname) {
     try {
       InetAddress.getAllByName(hostname);
       return true;

--- a/core/src/main/java/org/stellar/anchor/util/NetUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/NetUtil.java
@@ -39,7 +39,7 @@ public class NetUtil {
     if (isEmpty(serverPort)) return false;
     String[] tokens = Strings.split(serverPort, ":");
     if (tokens == null) {
-      return true;
+      return !hostnameLookup || isHostnameResolvable(serverPort);
     }
     switch (tokens.length) {
       case 2:

--- a/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
@@ -129,7 +129,7 @@ internal class NetUtilTest {
       ]
   )
   fun `test valid server port with isServerPortValid`(testValue: String) {
-    assertTrue(isServerPortValid(testValue))
+    assertTrue(isServerPortValid(testValue, false))
   }
 
   @ParameterizedTest
@@ -147,7 +147,7 @@ internal class NetUtilTest {
       ]
   )
   fun `test bad server port with isServerPortValid`(testValue: String?) {
-    assertFalse(isServerPortValid(testValue))
+    assertFalse(isServerPortValid(testValue, true))
   }
 
   @ParameterizedTest

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -119,7 +119,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
                 homeDomain, iaex));
       }
 
-      if (!NetUtil.isServerPortValid(homeDomain)) {
+      if (!NetUtil.isServerPortValid(homeDomain, false)) {
         errors.rejectValue(
             "homeDomain",
             "sep10-home-domain-invalid",
@@ -139,7 +139,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
                 webAuthDomain, iaex));
       }
 
-      if (!NetUtil.isServerPortValid(webAuthDomain)) {
+      if (!NetUtil.isServerPortValid(webAuthDomain, false)) {
         errors.rejectValue(
             "webAuthDomain",
             "sep10-web-auth-domain-invalid",
@@ -172,7 +172,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
 
       if (!ListHelper.isEmpty(getDefaultAllowClientDomain())) {
         for (String clientDomain : getDefaultAllowClientDomain()) {
-          if (!NetUtil.isServerPortValid(clientDomain)) {
+          if (!NetUtil.isServerPortValid(clientDomain, false)) {
             errors.rejectValue(
                 "clientAttributionAllowList",
                 "sep10-client_attribution_allow_list_invalid",

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -177,9 +177,7 @@ class Sep10ConfigTest {
     value =
       [
         "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-web-auth-domain.stellar.org,sep10-web-auth-domain-too-long",
-        "stellar .org,sep10-web-auth-domain-invalid",
-        "abc,sep10-web-auth-domain-invalid",
-        "299.0.0.1,sep10-web-auth-domain-invalid",
+        "stellar.org:1000:1000,sep10-web-auth-domain-invalid",
       ]
   )
   fun `test invalid web auth domains`(value: String, expectedErrorCode: String) {
@@ -194,9 +192,6 @@ class Sep10ConfigTest {
     value =
       [
         "this-is-longer-than-64-bytes-which-is-the-maximum-length-for-a-home-domain.stellar.org,sep10-home-domain-too-long",
-        "stellar .org,sep10-home-domain-invalid",
-        "abc,sep10-home-domain-invalid",
-        "299.0.0.1,sep10-home-domain-invalid",
         "http://stellar.org,sep10-home-domain-invalid",
         "https://stellar.org,sep10-home-domain-invalid",
         "://stellar.org,sep10-home-domain-invalid",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Remove hostname lookup from Sep10Config validation

### Why

After discussion, we don't think this being necessary

### Known limitations