### PR TITLE
ANCHOR-408 helm-chart/sep-service observer metrics port fix

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.95
+version: 0.3.96

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.91
+version: 0.3.95

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -193,7 +193,7 @@ data:
       {{- end }}
       metrics-service:
         optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).runInterval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: false   # optional metrics that periodically query the database
-        runInterval: 30                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -201,6 +201,9 @@ spec:
           - name: http
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
+          - name: metrics
+            containerPort: 8082
+            protocol: TCP
           {{- if (.Values.deployment).env }}
           env:
 {{ toYaml .Values.deployment.env | indent 12 }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -202,7 +202,7 @@ spec:
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
           - name: metrics
-            containerPort: 8082
+            containerPort: 18083
             protocol: TCP
           {{- if (.Values.deployment).env }}
           env:


### PR DESCRIPTION
This is an update the the previous PR related to the change. Once the previous PR was deployed and helm chart published, we discovered that the metrics were not being exposed on 8082.  Upon investigating we learned that the observer metrics port is currently hardcoded to 18083.  This change exposes that metrics port for the observer service.  We will determine whether or not to refactor the helm chart to make this consistent and configurable for 1.X.

### PR Structure

* [x ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x ] This PR adds tests for the most critical parts of the new functionality or fixes.
Deployed and tested
❯ kubectl exec -it anchor-platform-sep-preview-id-observer-86d6bb557d-hnjd5 -- /bin/bash

root@anchor-platform-sep-preview-id-observer-86d6bb557d-hnjd5:/app# wget http://localhost:18083/actuator/prometheus

root@anchor-platform-sep-preview-id-observer-86d6bb557d-hnjd5:/app# cat prometheus | grep block
jvm_threads_states_threads{state="blocked",} 0.0
stellar_payment_observer{status="latest_block_processed",} 899217.0
stellar_payment_observer{status="latest_block_read",} 899217.0
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
root@anchor-platform-sep-preview-id-observer-86d6bb557d-hnjd5:/app#

