### PR TITLE
[ANCHOR-407] Fix client config override

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -13,8 +13,11 @@ import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.skyscreamer.jsonassert.JSONAssert
+import org.springframework.web.util.UriComponentsBuilder
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
 import org.stellar.anchor.platform.CLIENT_WALLET_SECRET
 import org.stellar.anchor.platform.TestConfig
 import org.stellar.anchor.util.GsonUtils
@@ -23,6 +26,7 @@ import org.stellar.anchor.util.StringHelper.json
 import org.stellar.reference.client.AnchorReferenceServerClient
 import org.stellar.reference.wallet.WalletServerClient
 import org.stellar.walletsdk.ApplicationConfiguration
+import org.stellar.walletsdk.InteractiveFlowResponse
 import org.stellar.walletsdk.StellarConfiguration
 import org.stellar.walletsdk.Wallet
 import org.stellar.walletsdk.anchor.DepositTransaction
@@ -65,23 +69,38 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
   private val anchorReferenceServerClient =
     AnchorReferenceServerClient(Url(config.env["reference.server.url"]!!))
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
+  private val jwtService: JwtService =
+    JwtService(
+      config.env["secret.sep10.jwt_secret"]!!,
+      config.env["secret.sep24.interactive_url.jwt_secret"]!!,
+      config.env["secret.sep24.more_info_url.jwt_secret"]!!,
+      config.env["secret.callback_api.auth_secret"]!!,
+      config.env["secret.platform_api.auth_secret"]!!
+    )
 
   private fun `test typical deposit end-to-end flow`(asset: StellarAssetId, amount: String) =
     runBlocking {
       walletServerClient.clearCallbacks()
       val token = anchor.auth().authenticate(keypair)
-      val txnId = makeDeposit(asset, amount, token)
+      val response = makeDeposit(asset, amount, token)
+
+      // Assert the interactive URL JWT is valid
+      val params = UriComponentsBuilder.fromUriString(response.url).build().queryParams
+      val cipher = params["token"]!![0]
+      val interactiveJwt = jwtService.decode(cipher, Sep24InteractiveUrlJwt::class.java)
+      assertEquals("referenceCustodial", interactiveJwt.claims[JwtService.CLIENT_NAME])
+
       // Wait for the status to change to COMPLETED
-      waitForTxnStatus(txnId, COMPLETED, token)
+      waitForTxnStatus(response.id, COMPLETED, token)
 
       // Check if the transaction can be listed by stellar transaction id
-      val fetchedTxn = anchor.getTransaction(txnId, token) as DepositTransaction
+      val fetchedTxn = anchor.getTransaction(response.id, token) as DepositTransaction
       val transactionByStellarId =
         anchor.getTransactionBy(token, stellarTransactionId = fetchedTxn.stellarTransactionId)
       assertEquals(fetchedTxn.id, transactionByStellarId.id)
 
       // Check the events sent to the reference server are recorded correctly
-      val actualEvents = waitForBusinessServerEvents(txnId, 4)
+      val actualEvents = waitForBusinessServerEvents(response.id, 4)
       assertNotNull(actualEvents)
       actualEvents?.let { assertEquals(4, it.size) }
       val expectedEvents: List<AnchorEvent> =
@@ -89,7 +108,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       compareAndAssertEvents(asset, expectedEvents, actualEvents!!)
 
       // Check the callbacks sent to the wallet reference server are recorded correctly
-      val actualCallbacks = waitForWalletServerCallbacks(txnId, 4)
+      val actualCallbacks = waitForWalletServerCallbacks(response.id, 4)
       actualCallbacks?.let {
         assertEquals(4, it.size)
         val expectedCallbacks: List<Sep24GetTransactionResponse> =
@@ -101,9 +120,14 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       }
     }
 
-  private suspend fun makeDeposit(asset: StellarAssetId, amount: String, token: AuthToken): String {
+  private suspend fun makeDeposit(
+    asset: StellarAssetId,
+    amount: String,
+    token: AuthToken
+  ): InteractiveFlowResponse {
     // Start interactive deposit
     val deposit = anchor.interactive().deposit(asset, token, mapOf("amount" to amount))
+
     // Get transaction status and make sure it is INCOMPLETE
     val transaction = anchor.getTransaction(deposit.id, token)
     assertEquals(INCOMPLETE, transaction.status)
@@ -113,7 +137,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     info("accessing ${deposit.url}...")
     assertEquals(200, resp.status.value)
 
-    return transaction.id
+    return deposit
   }
 
   private fun compareAndAssertEvents(
@@ -323,7 +347,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     val token = anchor.auth().authenticate(newAcc)
     val deposits =
       (0..1).map {
-        val txnId = makeDeposit(asset, amount, token)
+        val txnId = makeDeposit(asset, amount, token).id
         waitForTxnStatus(txnId, COMPLETED, token)
         txnId
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
@@ -5,16 +5,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Data;
-import lombok.Getter;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 
 public class ConfigMap {
-  @Getter int version;
+  int version;
   final Map<String, ConfigEntry> data;
 
   // ConfigMap keys will be in normalized form (dot separated hierarchy)
   public ConfigMap() {
     data = new HashMap<>();
+  }
+
+  public int getVersion() {
+    return version;
   }
 
   public void setVersion(int version) {

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
@@ -71,10 +71,12 @@ public class ConfigMap {
         .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getValue()));
   }
 
+  // TODO: instead of merging, create a property source with higher precedence
   public void merge(ConfigMap config) {
-    // TODO: instead of merging, create a property source with higher precedence
     // Matches any string of the form: <listName>[<index>].<elementName>
-    Pattern pattern = Pattern.compile("^([a-zA-Z0-9_]+)\\[([0-9]+)]\\.([a-zA-Z0-9_]+)$");
+    // <listName> can be a dot separated hierarchy of names.
+    Pattern pattern =
+        Pattern.compile("^([a-zA-Z0-9_]+(?:\\.[a-zA-Z0-9_]+)*)\\[(\\d+)](?:\\.[a-zA-Z0-9_]+)*$");
     for (String name : config.names()) {
       Matcher matcher = pattern.matcher(name);
       // If the name is a list element, remove potential conflicting list names.

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigMapTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigMapTest.kt
@@ -1,11 +1,14 @@
 package org.stellar.anchor.platform.configurator
 
+import javax.xml.bind.annotation.XmlType.DEFAULT
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.api.exception.InvalidConfigException
+import org.stellar.anchor.platform.configurator.ConfigMap.ConfigEntry
 
 class ConfigMapTest {
   @Test
@@ -49,5 +52,30 @@ class ConfigMapTest {
     val cm = ConfigMap()
     cm.put(testKey, value, ConfigMap.ConfigSource.ENV)
     Assertions.assertEquals(false, cm.getBoolean(testKey))
+  }
+
+  @Test
+  fun `test merge`() {
+    val cm = ConfigMap()
+    cm.put("clients", "", ConfigMap.ConfigSource.DEFAULT)
+    cm.put("my.property", "", ConfigMap.ConfigSource.DEFAULT)
+    cm.put("other", "", ConfigMap.ConfigSource.DEFAULT)
+    val override = ConfigMap()
+    override.put("clients[0]", "a", ConfigMap.ConfigSource.ENV)
+    override.put("clients[1]", "b", ConfigMap.ConfigSource.ENV)
+    override.put("my.property[0]", "c", ConfigMap.ConfigSource.ENV)
+
+    cm.merge(override)
+
+    assert(
+      cm.data.equals(
+        mapOf(
+          "clients[0]" to ConfigEntry("a", ConfigMap.ConfigSource.ENV),
+          "clients[1]" to ConfigEntry("b", ConfigMap.ConfigSource.ENV),
+          "my.property[0]" to ConfigEntry("c", ConfigMap.ConfigSource.ENV),
+          "other" to ConfigEntry("", ConfigMap.ConfigSource.DEFAULT)
+        )
+      )
+    )
   }
 }

--- a/service-runner/src/main/resources/profiles/sep24/config.env
+++ b/service-runner/src/main/resources/profiles/sep24/config.env
@@ -46,3 +46,4 @@ clients[0].callback_url=http://wallet-server:8092/callbacks
 clients[1].name=referenceCustodial
 clients[1].type=custodial
 clients[1].signing_key=GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG
+clients[1].callback_url=http://wallet-server:8092/callbacks


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

All configs are loaded into a map before being sent to Spring. Currently, client configs are being overwritten at the client level with the format `clients[0].property` which will not overwrite the `clients` property from the default config. This commit fixes the property merging logic such that if it discovers an indexed property, it will attempt to remove any non-indexed property with the same name.

### Why

This is a bug in the configuration override logic.

### Known limitations

The fix is ugly but I didn't want to spend too much time refactoring the configurator. A better fix would be to set the overriding properties at different precedence levels and just let Spring handle it.