### PR TITLE
Anchor-408 helm-charts/sep-service fix observer annotations

### DIFF
--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.95
+version: 0.3.96

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.96
+version: 0.3.97

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 sources:
   - https://github.com/stellar/java-stellar-anchor-sdk
 name: sep
-version: 0.3.91
+version: 0.3.95

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -193,7 +193,7 @@ data:
       {{- end }}
       metrics-service:
         optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).runInterval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: false   # optional metrics that periodically query the database
-        runInterval: 30                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -192,8 +192,8 @@ data:
         publisherType: kafka
       {{- end }}
       metrics-service:
-        optionalMetricsEnabled: {{ .Values.stellar.app_config.metrics_service.enabled | default "false" }}  # optional metrics that periodically query the database
-        runInterval: {{ .Values.stellar.app_config.metrics_service.run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
+        optionalMetricsEnabled: {{ (.Values.stellar.app_config.metrics_service).enabled | default "false" }}  # optional metrics that periodically query the database
+        runInterval: {{ (.Values.stellar.app_config.metrics_service).run_interval | default 30 }}                 # interval to query the database to generate the optional metrics
       {{- if (.Values.stellar.app_config).kafka_publisher }}
       kafka.publisher:
         bootstrapServer: {{ .Values.stellar.app_config.kafka_publisher.bootstrapServer | default "missing_bootstrapServer:port" }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -201,6 +201,9 @@ spec:
           - name: http
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
+          - name: metrics
+            containerPort: 8082
+            protocol: TCP
           {{- if (.Values.deployment).env }}
           env:
 {{ toYaml .Values.deployment.env | indent 12 }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
       {{- if (.Values.deployment).annotations }}
       annotations:
       {{- range $key, $value := .Values.deployment.annotations }}
-          {{ $key }}: {{ $value | quote }}
-          {{- end }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if (.Values.deployment).serviceAccountName }}
@@ -146,11 +146,11 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
         {{- end }}
-      {{- if (.Values.deployment).annotations }}
+      {{- if (.Values.stellarObserver.deployment).annotations }}
       annotations:
-        {{- range $key, $value := .Values.deployment.annotations }}
-          {{ $key }}: {{ $value | quote }}
-          {{- end }}
+        {{- range $key, $value := .Values.stellarObserver.deployment.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if (.Values.deployment).serviceAccountName }}

--- a/helm-charts/sep-service/templates/deployment.yaml
+++ b/helm-charts/sep-service/templates/deployment.yaml
@@ -202,7 +202,7 @@ spec:
             containerPort: {{ $stellarObserverDeployment.port | default 8083 }}
             protocol: TCP
           - name: metrics
-            containerPort: 8082
+            containerPort: 18083
             protocol: TCP
           {{- if (.Values.deployment).env }}
           env:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
This PR fixes Stellar Observer Deployment Annotations.  Currently they use the SEP Service Deployment annotations, due to a bug in the helm chart template.  Fixing indentation for annotation as well.

### PR Structure

* [ x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Testing
```
helm template sep ~/dev/anchor-platform-1.x/java-stellar-anchor-sdk/helm-charts/sep-service -f ./values.yaml
values.yaml
...
stellarObserver:
  enabled: true
  deployment:
    port: 8083
    annotations:
      prometheus.io/path: /actuator/prometheus
      prometheus.io/port: "18083"
      prometheus.io/scrape: "true"
```

```
helm template sep ~/dev/anchor-platform-1.x/java-stellar-anchor-sdk/helm-charts/sep-service -f ./values.yaml

spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: anchor-platform-sep-preview-id-observer
  template:
    metadata:
      labels:
        app.kubernetes.io/name: anchor-platform-sep-preview-id-observer
        app.kubernetes.io/instance: sep
        test_label_a: test_value_a
        test_label_b: test_value_b
      annotations:
        prometheus.io/path: "/actuator/prometheus"
        prometheus.io/port: "18083"
        prometheus.io/scrape: "true"
---snip---
```

```
tested in helm install
❯ kubectl describe deployment anchor-platform-sep-preview-id-observer
Name:                   anchor-platform-sep-preview-id-observer
Namespace:              default
CreationTimestamp:      Tue, 08 Aug 2023 16:47:20 -0700
Labels:                 app.kubernetes.io/instance=sep
                        app.kubernetes.io/managed-by=Helm
                        app.kubernetes.io/name=anchor-platform-sep-preview-id-observer
                        helm.sh/chart=sep-0.3.96
Annotations:            deployment.kubernetes.io/revision: 1
                        meta.helm.sh/release-name: sep
                        meta.helm.sh/release-namespace: default
Selector:               app.kubernetes.io/name=anchor-platform-sep-preview-id-observer
Replicas:               1 desired | 1 updated | 1 total | 0 available | 1 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:       app.kubernetes.io/instance=sep
                app.kubernetes.io/name=anchor-platform-sep-preview-id-observer
                test_label_a=test_value_a
                test_label_b=test_value_b
  Annotations:  prometheus.io/path: /actuator/prometheus
                prometheus.io/port: 18083
                prometheus.io/scrape: true
  Containers:
   sep-observer:
    Image:       stellar/anchor-platform:release-1.2.16
    Ports:       8083/TCP, 18083/TCP
    Host Ports:  0/TCP, 0/TCP
    Args:
      --stellar-observer
    Liveness:   http-get http://:8083/health delay=300s timeout=1s period=30s #success=1 #failure=3
    Readiness:  http-get http://:8083/health delay=300s timeout=1s period=30s #success=1 #failure=3
    Startup:    http-get http://:8083/health delay=0s timeout=1s period=30s #success=1 #failure=20
    Environment Variables from:
      anchor-platform-secret-common-previews  Secret  Optional: false
    Environment:
      STELLAR_ANCHOR_CONFIG:  file:/config/anchor-config.yaml
    Mounts:
      /config from sep-config-volume (ro)
      assets from anchor-platform-sep-preview-id-assets-volume (rw)
  Volumes:
   sep-config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      anchor-platform-sep-preview-id
    Optional:  false
   anchor-platform-sep-preview-id-assets-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      anchor-platform-sep-preview-id-assets
    Optional:  false
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      False   MinimumReplicasUnavailable
  Progressing    True    ReplicaSetUpdated
OldReplicaSets:  <none>
NewReplicaSet:   anchor-platform-sep-preview-id-observer-65f85bdf6d (1/1 replicas created)
Events:
  Type    Reason             Age    From                   Message
  ----    ------             ----   ----                   -------
  Normal  ScalingReplicaSet  2m22s  deployment-controller  Scaled up replica set anchor-platform-sep-preview-id-observer-65f85bdf6d to 1
❯ kubectl get deployments
NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
anchor-platform-sep-preview-id            0/1     1            0           2m26s
anchor-platform-sep-preview-id-observer   0/1     1            0           2m26s
```