### PR TITLE
[ANCHOR-396] Use Gson for Kafka serialization/deserialization

### DIFF
--- a/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
+++ b/anchor-reference-server/src/main/java/org/stellar/anchor/reference/event/KafkaListener.java
@@ -27,13 +27,14 @@ import org.stellar.anchor.api.platform.HealthCheckResult;
 import org.stellar.anchor.api.platform.HealthCheckStatus;
 import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.reference.config.KafkaListenerSettings;
+import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.Log;
 
 public class KafkaListener extends AbstractEventListener implements HealthCheckable {
   private final KafkaListenerSettings kafkaListenerSettings;
   private final AnchorEventProcessor processor;
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
-  private Consumer<String, AnchorEvent> consumer;
+  private Consumer<String, String> consumer;
 
   public KafkaListener(
       KafkaListenerSettings kafkaListenerSettings, AnchorEventProcessor processor) {
@@ -56,7 +57,7 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
     executor.shutdown();
   }
 
-  Consumer<String, AnchorEvent> createKafkaConsumer() {
+  Consumer<String, String> createKafkaConsumer() {
     Properties props = new Properties();
 
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaListenerSettings.getBootStrapServer());
@@ -66,7 +67,7 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
     props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
     props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     if (kafkaListenerSettings.isUseIAM()) {
       props.put("security.protocol", "SASL_SSL");
       props.put("sasl.mechanism", "AWS_MSK_IAM");
@@ -82,7 +83,7 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
   public void listen() {
     Log.info("Kafka event consumer server started ");
 
-    Consumer<String, AnchorEvent> consumer = createKafkaConsumer();
+    Consumer<String, String> consumer = createKafkaConsumer();
 
     KafkaListenerSettings.Queues q = kafkaListenerSettings.getEventTypeToQueue();
     consumer.subscribe(
@@ -96,12 +97,12 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
 
     while (!Thread.interrupted()) {
       try {
-        ConsumerRecords<String, AnchorEvent> consumerRecords =
-            consumer.poll(Duration.ofSeconds(10));
+        ConsumerRecords<String, String> consumerRecords = consumer.poll(Duration.ofSeconds(10));
         Log.info(String.format("Messages received: %s", consumerRecords.count()));
         consumerRecords.forEach(
             record -> {
-              AnchorEvent event = record.value();
+              AnchorEvent event =
+                  GsonUtils.getInstance().fromJson(record.value(), AnchorEvent.class);
               processor.handleEvent(event);
             });
       } catch (Exception ex) {
@@ -149,7 +150,7 @@ public class KafkaListener extends AbstractEventListener implements HealthChecka
   }
 
   boolean validateKafka() {
-    try (Consumer<String, AnchorEvent> csm = createKafkaConsumer()) {
+    try (Consumer<String, String> csm = createKafkaConsumer()) {
       csm.listTopics();
       return true;
     } catch (Throwable throwable) {

--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.api.event;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.*;
 import org.stellar.anchor.api.platform.GetQuoteResponse;
 import org.stellar.anchor.api.platform.GetTransactionResponse;
@@ -27,11 +26,10 @@ public class AnchorEvent {
   public enum Type {
     TRANSACTION_CREATED("transaction_created"),
     TRANSACTION_STATUS_CHANGED("transaction_status_changed"),
-    @SuppressWarnings("unused")
     TRANSACTION_ERROR("transaction_error"),
     QUOTE_CREATED("quote_created");
 
-    @JsonValue public final String type;
+    public final String type;
 
     Type(String type) {
       this.type = type;


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This fixes the same thing that https://github.com/stellar/java-stellar-anchor-sdk/pull/1011 does but uses Gson instead of adding the missing `JsonProperty` annotations.

### Why

I realized we can just use `StringSerializer` instead of `JsonSerialization` and manually serialize using Gson ourselves before sending it to Kafka.

### Known limitations

N/A