### PR TITLE
Fix: Use lowercase type names in AnchorEvent

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.api.event;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.*;
 import org.stellar.anchor.api.platform.GetQuoteResponse;
 import org.stellar.anchor.api.platform.GetTransactionResponse;
@@ -24,9 +25,13 @@ public class AnchorEvent {
   GetQuoteResponse quote;
 
   public enum Type {
+    @SerializedName("transaction_created")
     TRANSACTION_CREATED("transaction_created"),
+    @SerializedName("transaction_status_changed")
     TRANSACTION_STATUS_CHANGED("transaction_status_changed"),
+    @SerializedName("transaction_error")
     TRANSACTION_ERROR("transaction_error"),
+    @SerializedName("quote_created")
     QUOTE_CREATED("quote_created");
 
     public final String type;

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -375,7 +375,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       """
 [
   {
-    "type": "TRANSACTION_CREATED",
+    "type": "transaction_created",
     "sep": "24",
     "transaction": {
       "sep": "24",
@@ -387,7 +387,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "type": "TRANSACTION_STATUS_CHANGED",
+    "type": "transaction_status_changed",
     "sep": "24",
     "transaction": {
       "sep": "24",
@@ -407,7 +407,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "type": "TRANSACTION_STATUS_CHANGED",
+    "type": "transaction_status_changed",
     "sep": "24",
     "transaction": {
       "sep": "24",
@@ -427,7 +427,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "type": "TRANSACTION_STATUS_CHANGED",
+    "type": "transaction_status_changed",
     "sep": "24",
     "transaction": {
       "sep": "24",
@@ -467,7 +467,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     """
     [
       {
-        "type": "TRANSACTION_CREATED",
+        "type": "transaction_created",
         "sep": "24",
         "transaction": {
           "sep": "24",
@@ -481,7 +481,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "type": "TRANSACTION_STATUS_CHANGED",
+        "type": "transaction_status_changed",
         "sep": "24",
         "transaction": {
           "sep": "24",
@@ -502,7 +502,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "type": "TRANSACTION_STATUS_CHANGED",
+        "type": "transaction_status_changed",
         "id": "f0b75f9e-1b53-442a-91dd-d6c002a51bfc",
         "sep": "24",
         "transaction": {
@@ -544,7 +544,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "type": "TRANSACTION_STATUS_CHANGED",
+        "type": "transaction_status_changed",
         "id": "b44d90ec-2d9a-4768-a952-085026f5b3da",
         "sep": "24",
         "transaction": {
@@ -586,7 +586,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "type": "TRANSACTION_STATUS_CHANGED",
+        "type": "transaction_status_changed",
         "id": "0556b75c-b054-49a0-b778-654050a6cba4",
         "sep": "24",
         "transaction": {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

This updates the `AnchorEvent`'s `type` serialization to use lowercase letters. This does not break anything because status callback has not been released yet.

### Why

`types` are lowercased in the docs. https://github.com/stellar/stellar-docs/blob/fa78b1f185b02cd17f3d38ae7ea93765a7c70c7f/openapi/anchor-platform/schemas.yml#L757C1-L760

### Known limitations

N/A