### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,31 +2,18 @@
 template and use a short description, but in your description aim to include both what the
 change is, and why it is being made, with enough context for anyone to understand. -->
 
-<details>
-  <summary>PR Checklist</summary>
+### Description
 
-### PR Structure
+<!-- Short statement about what is changing. -->
 
-* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
-* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
-  otherwise).
-* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
-  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
-  packages.
+### Context
 
-### Thoroughness
+<!-- Why this change is being made. Include any context required to understand the why. -->
 
-* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
-</details>
+### Testing
 
-### What
-
-[TODO: Short statement about what is changing.]
-
-### Why
-
-[TODO: Why this change is being made. Include any context required to understand the why.]
+<!-- How was this change tested? -->
 
 ### Known limitations
 
-[TODO or N/A]
+<!-- Any known limitations or edge cases. -->


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

This PR updates the PR template.

### Context

We've recently enabled a setting that sets the default commit message to the PR's body and title when merging PRs. This PR updates the default template so that it's more commit-body-friendly.

### Testing

N/A

### Known limitations

N/A