### PR TITLE
[ANCHOR-416] Remove `more_info_url` from sep24 database table

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24Transaction.java
@@ -33,10 +33,6 @@ public class JdbcSep24Transaction extends JdbcSepTransaction
   @Column(name = "status_eta")
   String statusEta;
 
-  @SerializedName("more_info_url")
-  @Column(name = "more_info_url")
-  String moreInfoUrl;
-
   @SerializedName("transaction_id")
   @Column(name = "transaction_id")
   String transactionId;

--- a/platform/src/main/resources/db/migration/V8__sep24_field_updates.sql
+++ b/platform/src/main/resources/db/migration/V8__sep24_field_updates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sep24_transaction DROP COLUMN more_info_url;


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Remove `more_info_url` from sep24 database table. 

### Context

This field is not used.

### Testing

./gradlew test

