### PR TITLE
[ANCHOR-426] Make database migration tests not require the servers to get up-running

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/DatabaseMigrationTests.kt
@@ -42,13 +42,13 @@ class PostgresMigrationTest : AbstractIntegrationTest(PostgresConfig) {
     @JvmStatic
     fun construct() {
       println("Running PostgresMigrationTest")
-      singleton.setUp()
+      singleton.testProfileRunner.start()
     }
 
     @AfterAll
     @JvmStatic
     fun destroy() {
-      singleton.tearDown()
+      singleton.testProfileRunner.shutdown()
     }
   }
 
@@ -66,13 +66,13 @@ class H2MigrationTest : AbstractIntegrationTest(H2Config) {
     @JvmStatic
     fun construct() {
       println("Running H2MigrationTest")
-      singleton.setUp()
+      singleton.testProfileRunner.start()
     }
 
     @AfterAll
     @JvmStatic
     fun destroy() {
-      singleton.tearDown()
+      singleton.testProfileRunner.start()
     }
   }
 
@@ -90,13 +90,13 @@ class SQLiteMigrationTest : AbstractIntegrationTest(SQLiteConfig) {
     @JvmStatic
     fun construct() {
       println("Running SQLiteMigrationTest")
-      singleton.setUp()
+      singleton.testProfileRunner.start()
     }
 
     @AfterAll
     @JvmStatic
     fun destroy() {
-      singleton.tearDown()
+      singleton.testProfileRunner.shutdown()
     }
   }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

The PostgresMigrationTest requires the SEP server up and running. This causes race condition where we  try to access the SEP1 toml while the server is still starting up.  

This PR removes the need to read the SEP-1 toml file in database migration tests.

### Context

To improve the test stability.

### Testing

`./gradlew test`

### Known limitations

<!-- Any known limitations or edge cases. -->