### PR TITLE
[ANCHOR-295] Cleanup Kotlin referencer server implementation

### DIFF
--- a/.github/workflows/sub_gradle_test_and_build.yml
+++ b/.github/workflows/sub_gradle_test_and_build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.5.12 --home-domain http://host.docker.internal:8080 --seps 1 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json
+          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.5.12 --home-domain http://host.docker.internal:8080 --seps 1 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/sub_gradle_test_and_build.yml
+++ b/.github/workflows/sub_gradle_test_and_build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.5.12 --home-domain http://host.docker.internal:8080 --seps 1 10 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json
+          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.5.12 --home-domain http://host.docker.internal:8080 --seps 1 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json
 
   analyze:
     name: CodeQL Analysis

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/ReferenceServer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/ReferenceServer.kt
@@ -41,6 +41,7 @@ fun startServer(envMap: Map<String, String>?, wait: Boolean) {
           allowHeader(HttpHeaders.ContentType)
         }
         install(RequestLoggerPlugin)
+        install(RequestExceptionHandlerPlugin)
       }
       .start(wait)
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.*
 import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.callback.PutCustomerRequest
 import org.stellar.anchor.util.GsonUtils
+import org.stellar.reference.callbacks.BadRequestException
 import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
 
 /**
@@ -40,9 +41,13 @@ fun Route.customer(customerService: CustomerService) {
         call.respond(response)
       }
       delete("{id}") {
-        val id = call.parameters["id"]!!
-        customerService.deleteCustomer(id)
-        call.respond(HttpStatusCode.NoContent)
+        try {
+          val id = call.parameters["id"]!!
+          customerService.deleteCustomer(id)
+          call.respond(HttpStatusCode.NoContent)
+        } catch (e: NullPointerException) {
+          throw BadRequestException("id must be provided")
+        }
       }
     }
   }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
@@ -9,9 +9,6 @@ import io.ktor.server.routing.*
 import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.callback.PutCustomerRequest
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.reference.callbacks.BadRequestException
-import org.stellar.reference.callbacks.NotFoundException
-import org.stellar.reference.log
 import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
 
 /**
@@ -33,54 +30,27 @@ fun Route.customer(customerService: CustomerService) {
             .type(call.parameters["type"])
             .lang(call.parameters["lang"])
             .build()
-        try {
-          val response = GsonUtils.getInstance().toJson(customerService.getCustomer(request))
-          call.respond(response)
-        } catch (e: BadRequestException) {
-          call.respond(HttpStatusCode.BadRequest, e)
-        } catch (e: NotFoundException) {
-          call.respond(HttpStatusCode.NotFound, e)
-        } catch (e: Exception) {
-          log.error("Unexpected exception", e)
-          call.respond(HttpStatusCode.InternalServerError)
-        }
+        val response = GsonUtils.getInstance().toJson(customerService.getCustomer(request))
+        call.respond(response)
       }
       put {
         val request =
           GsonUtils.getInstance().fromJson(call.receive<String>(), PutCustomerRequest::class.java)
-        try {
-          val response = GsonUtils.getInstance().toJson(customerService.upsertCustomer(request))
-          call.respond(response)
-        } catch (e: BadRequestException) {
-          call.respond(HttpStatusCode.BadRequest, e)
-        } catch (e: Exception) {
-          call.respond(HttpStatusCode.InternalServerError)
-        }
+        val response = GsonUtils.getInstance().toJson(customerService.upsertCustomer(request))
+        call.respond(response)
       }
       delete("{id}") {
         val id = call.parameters["id"]!!
-        try {
-          customerService.deleteCustomer(id)
-          call.respond(HttpStatusCode.NoContent)
-        } catch (e: NotFoundException) {
-          call.respond(HttpStatusCode.NotFound, e)
-        } catch (e: Exception) {
-          call.respond(HttpStatusCode.InternalServerError)
-        }
+        customerService.deleteCustomer(id)
+        call.respond(HttpStatusCode.NoContent)
       }
     }
     route("/invalidate_clabe") {
       // TODO: Consider to enable this endpoint only when testing
       get("{id}") {
         val id = call.parameters["id"]!!
-        try {
-          customerService.invalidateClabe(id)
-          call.respond(HttpStatusCode.OK)
-        } catch (e: NotFoundException) {
-          call.respond(HttpStatusCode.NotFound, e)
-        } catch (e: Exception) {
-          call.respond(HttpStatusCode.InternalServerError)
-        }
+        customerService.invalidateClabe(id)
+        call.respond(HttpStatusCode.OK)
       }
     }
   }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
@@ -45,13 +45,5 @@ fun Route.customer(customerService: CustomerService) {
         call.respond(HttpStatusCode.NoContent)
       }
     }
-    route("/invalidate_clabe") {
-      // TODO: Consider to enable this endpoint only when testing
-      get("{id}") {
-        val id = call.parameters["id"]!!
-        customerService.invalidateClabe(id)
-        call.respond(HttpStatusCode.OK)
-      }
-    }
   }
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/fee/FeeRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/fee/FeeRoute.kt
@@ -7,9 +7,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.stellar.anchor.api.callback.GetFeeRequest
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.reference.callbacks.BadRequestException
-import org.stellar.reference.callbacks.UnprocessableEntityException
-import org.stellar.reference.log
 import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
 
 /**
@@ -31,17 +28,8 @@ fun Route.fee(feeService: FeeService) {
           .senderId(call.parameters["sender_id"])
           .receiverId(call.parameters["receiver_id"])
           .build()
-      try {
-        val response = GsonUtils.getInstance().toJson(feeService.getFee(request))
-        call.respond(response)
-      } catch (e: BadRequestException) {
-        call.respond(HttpStatusCode.BadRequest, e)
-      } catch (e: UnprocessableEntityException) {
-        call.respond(HttpStatusCode.UnprocessableEntity, e)
-      } catch (e: Exception) {
-        log.error("Unexpected exception", e)
-        call.respond(HttpStatusCode.InternalServerError)
-      }
+      val response = GsonUtils.getInstance().toJson(feeService.getFee(request))
+      call.respond(response)
     }
   }
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateRoute.kt
@@ -7,10 +7,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.stellar.anchor.api.callback.GetRateRequest
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.reference.callbacks.BadRequestException
-import org.stellar.reference.callbacks.NotFoundException
-import org.stellar.reference.callbacks.UnprocessableEntityException
-import org.stellar.reference.log
 import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
 
 /**
@@ -36,19 +32,8 @@ fun Route.rate(rateService: RateService) {
           .clientId(call.parameters["client_id"])
           .id(call.parameters["id"])
           .build()
-      try {
-        val response = GsonUtils.getInstance().toJson(rateService.getRate(request))
-        call.respond(response)
-      } catch (e: BadRequestException) {
-        call.respond(HttpStatusCode.BadRequest, e)
-      } catch (e: NotFoundException) {
-        call.respond(HttpStatusCode.NotFound, e)
-      } catch (e: UnprocessableEntityException) {
-        call.respond(HttpStatusCode.UnprocessableEntity, e)
-      } catch (e: Exception) {
-        log.error("Unexpected exception", e)
-        call.respond(HttpStatusCode.InternalServerError)
-      }
+      val response = GsonUtils.getInstance().toJson(rateService.getRate(request))
+      call.respond(response)
     }
   }
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
@@ -11,7 +11,6 @@ import org.stellar.anchor.api.callback.GetRateRequest
 import org.stellar.anchor.api.callback.GetRateResponse
 import org.stellar.anchor.api.sep.sep38.RateFee
 import org.stellar.anchor.api.sep.sep38.RateFeeDetail
-import org.stellar.reference.callbacks.BadRequestException
 import org.stellar.reference.callbacks.NotFoundException
 import org.stellar.reference.dao.QuoteRepository
 import org.stellar.reference.model.Quote
@@ -22,7 +21,7 @@ class RateService(private val quoteRepository: QuoteRepository) {
     val rate =
       when {
         request.id != null -> getRate(request.id)
-        request.sellAmount != null || request.buyAmount != null -> {
+        else -> {
           validateRequest(request)
           val price =
             getPrice(request.sellAsset!!, request.buyAsset!!)?.let { getDecimal(it, scale) }
@@ -107,9 +106,6 @@ class RateService(private val quoteRepository: QuoteRepository) {
               .fee(fee)
               .build()
           return GetRateResponse(rate)
-        }
-        else -> {
-          throw BadRequestException("Either id or sell and buy assets must be provided")
         }
       }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
@@ -11,6 +11,7 @@ import org.stellar.anchor.api.callback.GetRateRequest
 import org.stellar.anchor.api.callback.GetRateResponse
 import org.stellar.anchor.api.sep.sep38.RateFee
 import org.stellar.anchor.api.sep.sep38.RateFeeDetail
+import org.stellar.reference.callbacks.BadRequestException
 import org.stellar.reference.callbacks.NotFoundException
 import org.stellar.reference.dao.QuoteRepository
 import org.stellar.reference.model.Quote
@@ -136,26 +137,26 @@ class RateService(private val quoteRepository: QuoteRepository) {
 
   private fun validateRequest(request: GetRateRequest) {
     if (request.type == null) {
-      throw RuntimeException("Type must be provided")
+      throw BadRequestException("Type must be provided")
     }
 
     if (!listOf(GetRateRequest.Type.INDICATIVE, GetRateRequest.Type.FIRM).contains(request.type)) {
-      throw RuntimeException("Type must be either indicative or firm")
+      throw BadRequestException("Type must be either indicative or firm")
     }
 
     if (request.sellAsset == null) {
-      throw RuntimeException("Sell asset must be provided")
+      throw BadRequestException("Sell asset must be provided")
     }
 
     if (request.buyAsset == null) {
-      throw RuntimeException("Buy asset must be provided")
+      throw BadRequestException("Buy asset must be provided")
     }
 
     if (
       (request.sellAmount == null && request.buyAmount == null) ||
         (request.sellAmount != null && request.buyAmount != null)
     ) {
-      throw RuntimeException("Either sell amount or buy amount must be provided but not both")
+      throw BadRequestException("Either sell amount or buy amount must be provided but not both")
     }
   }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/test/TestCustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/test/TestCustomerRoute.kt
@@ -1,0 +1,21 @@
+package org.stellar.reference.callbacks.test
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.stellar.reference.callbacks.customer.CustomerService
+import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
+
+fun Route.testCustomer(customerService: CustomerService) {
+  authenticate(AUTH_CONFIG_ENDPOINT) {
+    route("/invalidate_clabe") {
+      get("{id}") {
+        val id = call.parameters["id"]!!
+        customerService.invalidateClabe(id)
+        call.respond(HttpStatusCode.OK)
+      }
+    }
+  }
+}

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/uniqueaddress/UniqueAddressRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/uniqueaddress/UniqueAddressRoute.kt
@@ -7,7 +7,6 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.stellar.anchor.api.callback.GetUniqueAddressRequest
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.reference.log
 import org.stellar.reference.plugins.AUTH_CONFIG_ENDPOINT
 
 /**
@@ -20,14 +19,8 @@ fun Route.uniqueAddress(uniqueAddressService: UniqueAddressService) {
   authenticate(AUTH_CONFIG_ENDPOINT) {
     get("/unique_address") {
       val request = GetUniqueAddressRequest(call.parameters["transaction_id"]!!)
-      try {
-        val response =
-          GsonUtils.getInstance().toJson(uniqueAddressService.getUniqueAddress(request))
-        call.respond(response)
-      } catch (e: Exception) {
-        log.error("Unexpected exception", e)
-        call.respond(HttpStatusCode.InternalServerError)
-      }
+      val response = GsonUtils.getInstance().toJson(uniqueAddressService.getUniqueAddress(request))
+      call.respond(response)
     }
   }
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/QuoteRepository.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/QuoteRepository.kt
@@ -1,6 +1,5 @@
 package org.stellar.reference.dao
 
-import java.io.Closeable
 import java.time.Instant
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
@@ -11,7 +10,7 @@ import org.stellar.anchor.util.GsonUtils
 import org.stellar.reference.model.Quote
 import org.stellar.reference.model.RateFee
 
-interface QuoteRepository : Closeable {
+interface QuoteRepository {
   fun get(id: String): Quote?
   fun create(quote: Quote): String?
 }
@@ -70,6 +69,4 @@ class JdbcQuoteRepository(private val db: Database) : QuoteRepository {
       .resultedValues
       ?.firstOrNull()
       ?.get(Quotes.id)
-
-  override fun close() {}
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
@@ -17,6 +17,7 @@ data class Sep24(val enableTest: Boolean, val secret: String, val interactiveJwt
 
 data class AppSettings(
   val version: String,
+  val isTest: Boolean,
   val port: Int,
   val horizonEndpoint: String,
   val platformApiEndpoint: String,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/ConfigureRouting.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/ConfigureRouting.kt
@@ -10,6 +10,7 @@ import org.stellar.reference.callbacks.fee.fee
 import org.stellar.reference.callbacks.interactive.sep24Interactive
 import org.stellar.reference.callbacks.rate.RateService
 import org.stellar.reference.callbacks.rate.rate
+import org.stellar.reference.callbacks.test.testCustomer
 import org.stellar.reference.callbacks.uniqueaddress.UniqueAddressService
 import org.stellar.reference.callbacks.uniqueaddress.uniqueAddress
 import org.stellar.reference.dao.JdbcCustomerRepository
@@ -52,5 +53,8 @@ fun Application.configureRouting(cfg: Config) = routing {
 
   if (cfg.sep24.enableTest) {
     testSep24(helper, depositService, withdrawalService, cfg.sep24.interactiveJwtKey)
+  }
+  if (cfg.appSettings.isTest) {
+    testCustomer(customerService)
   }
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/RequestExceptionHandlerPlugin.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/plugins/RequestExceptionHandlerPlugin.kt
@@ -1,0 +1,26 @@
+package org.stellar.reference.plugins
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.application.hooks.*
+import io.ktor.server.response.*
+import org.stellar.reference.callbacks.BadRequestException
+import org.stellar.reference.callbacks.NotFoundException
+import org.stellar.reference.callbacks.UnprocessableEntityException
+import org.stellar.reference.log
+
+val RequestExceptionHandlerPlugin =
+  createApplicationPlugin(name = "RequestExceptionHandlerPlugin") {
+    on(CallFailed) { call, throwable ->
+      when (throwable) {
+        is BadRequestException -> call.respond(HttpStatusCode.BadRequest, throwable)
+        is NotFoundException -> call.respond(HttpStatusCode.NotFound, throwable)
+        is UnprocessableEntityException ->
+          call.respond(HttpStatusCode.UnprocessableEntity, throwable)
+        else -> {
+          log.error("Unexpected exception", throwable)
+          call.respond(HttpStatusCode.InternalServerError)
+        }
+      }
+    }
+  }

--- a/kotlin-reference-server/src/main/resources/default-config.yaml
+++ b/kotlin-reference-server/src/main/resources/default-config.yaml
@@ -1,5 +1,7 @@
 app:
   version: 0.0.1
+  # Enables test endpoints.
+  isTest: true
   # The port on which the server will listen for requests.
   port: 8091
   # The URL of the Stellar network to which the Anchor will connect.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

The changes include:
1. Introduces a new plugin to catch and map exceptions to a HTTP error code.
2. Put the `/invalidate_clabe` endpoint behind a configuration.
3. Re-introduces the SEP-12 validation from stellar-anchor-tests. Previously, when a GET /customer request does not include an account/memo, the query does not assert that they are null. This caused a race when updating an account that maps to many customers.

### Context

Address the comments from the previous PR https://github.com/stellar/java-stellar-anchor-sdk/pull/1060.

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`

### Known limitations

N/A