### PR TITLE
Fix the mistakenly removed `printVersionName` Gradle task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,7 +142,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.2.0"
+  version = "2.2.1"
 
   tasks.jar {
     manifest {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,3 +152,7 @@ allprojects {
     }
   }
 }
+
+tasks.register("printVersionName") {
+  println(rootProject.version.toString())
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.2.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=release-2.2.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.2.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=release-2.2.1)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/wk_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.2.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=release-2.2.1)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.2.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.2.1)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/wk_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Fix the mistakenly removed `printVersionName` Gradle task

### Context

The missing `printVersionName` causes docker publication failure.

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`

### Known limitations
NA