### PR TITLE
[ANCHOR-410] Add tear down process for the uncleared static mocks in SepServiceTest

### DIFF
--- a/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
@@ -2,11 +2,10 @@
 
 package org.stellar.anchor.sep1
 
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockkStatic
 import java.nio.file.Files
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -23,6 +22,12 @@ internal class Sep1ServiceTest {
   @BeforeEach
   fun setUp() {
     MockKAnnotations.init(this, relaxUnitFun = true)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clearAllMocks()
+    unmockkAll()
   }
 
   @Test


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Add missing `clearAllMocks()` calls in `Sep1ServiceTest`.

### Context

The `RequestLoggerFilterTest` fails from time to time. We suspect it is caused by some un-cleared static mocks from previous tests. 

However, I am not able to re-produce the issue at this moment. I made a fix based on possible un-cleared static mocks that may affect the stability of the tests. If the bug happens again, we should re-open this bug with detailed log messages.

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`