### PR TITLE
ANCHOR-427: add status filter and use destination accounts for matching transactions in observer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ subprojects {
     mavenLocal()
     mavenCentral()
     maven { url = uri("https://packages.confluent.io/maven") }
-    maven { url = uri("https://reposdeitory.mulesoft.org/nexus/content/repositories/public/") }
+    maven { url = uri("https://repository.mulesoft.org/nexus/content/repositories/public/") }
     maven { url = uri("https://jitpack.io") }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -19,13 +19,11 @@ public interface JdbcSep24TransactionRepo
 
   JdbcSep24Transaction findOneByStellarTransactionId(String stellarTransactionId);
 
-  JdbcSep24Transaction findOneBySep10AccountAndMemo(String accountId, String memo);
+  JdbcSep24Transaction findOneByToAccountAndMemoAndStatus(
+      String toAccount, String memo, String status);
 
   List<Sep24Transaction> findBySep10AccountAndRequestAssetCodeOrderByStartedAtDesc(
       String stellarAccount, String assetCode);
 
   Page<JdbcSep24Transaction> findByStatusIn(List<String> allowedStatuses, Pageable pageable);
-
-  JdbcSep24Transaction findOneBySep10AccountAndMemoAndStatus(
-      String sourceAccount, String memo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -25,4 +25,7 @@ public interface JdbcSep24TransactionRepo
       String stellarAccount, String assetCode);
 
   Page<JdbcSep24Transaction> findByStatusIn(List<String> allowedStatuses, Pageable pageable);
+
+  JdbcSep24Transaction findOneBySep10AccountAndMemoAndStatus(
+      String sourceAccount, String memo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -53,17 +53,10 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return txnRepo.findOneByExternalTransactionId(externalTransactionId);
   }
 
-  public JdbcSep24Transaction findByStellarAccountIdAndMemo(String accountId, String memo) {
+  public JdbcSep24Transaction findOneByToAccountAndMemoAndStatus(
+      String toAccount, String memo, String status) {
     Optional<JdbcSep24Transaction> optTxn =
-        Optional.ofNullable(txnRepo.findOneBySep10AccountAndMemo(accountId, memo));
-    return optTxn.orElse(null);
-  }
-
-  public JdbcSep24Transaction findByStellarAccountIdAndMemoAndStatus(
-      String sourceAccount, String memo, String status) {
-    Optional<JdbcSep24Transaction> optTxn =
-        Optional.ofNullable(
-            txnRepo.findOneBySep10AccountAndMemoAndStatus(sourceAccount, memo, status));
+        Optional.ofNullable(txnRepo.findOneByToAccountAndMemoAndStatus(toAccount, memo, status));
     return optTxn.orElse(null);
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -59,6 +59,14 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return optTxn.orElse(null);
   }
 
+  public JdbcSep24Transaction findByStellarAccountIdAndMemoAndStatus(
+      String sourceAccount, String memo, String status) {
+    Optional<JdbcSep24Transaction> optTxn =
+        Optional.ofNullable(
+            txnRepo.findOneBySep10AccountAndMemoAndStatus(sourceAccount, memo, status));
+    return optTxn.orElse(null);
+  }
+
   @Override
   public List<Sep24Transaction> findTransactions(
       String accountId, String accountMemo, GetTransactionsRequest tr)

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
@@ -24,10 +24,8 @@ public interface JdbcSep31TransactionRepo
   @Query(value = "SELECT COUNT(t) FROM JdbcSep31Transaction t WHERE t.status = :status")
   Integer findByStatusCount(@Param("status") String status);
 
-  Optional<JdbcSep31Transaction> findByStellarAccountIdAndStellarMemo(
-      @Param("stellar_account_id") String stellarAccountId,
-      @Param("stellar_memo") String stellarMemo);
-
   Optional<JdbcSep31Transaction> findByStellarAccountIdAndStellarMemoAndStatus(
-      String accountId, String memo, String status);
+      @Param("stellar_account_id") String accountId,
+      @Param("stellar_memo") String memo,
+      String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
@@ -27,4 +27,7 @@ public interface JdbcSep31TransactionRepo
   Optional<JdbcSep31Transaction> findByStellarAccountIdAndStellarMemo(
       @Param("stellar_account_id") String stellarAccountId,
       @Param("stellar_memo") String stellarMemo);
+
+  Optional<JdbcSep31Transaction> findByStellarAccountIdAndStellarMemoAndStatus(
+      String accountId, String memo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -71,12 +71,6 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
     return optTxn.orElse(null);
   }
 
-  public JdbcSep31Transaction findByStellarAccountIdAndMemo(String accountId, String memo) {
-    Optional<JdbcSep31Transaction> optTxn =
-        transactionRepo.findByStellarAccountIdAndStellarMemo(accountId, memo);
-    return optTxn.orElse(null);
-  }
-
   public JdbcSep31Transaction findByStellarAccountIdAndMemoAndStatus(
       String accountId, String memo, String status) {
     Optional<JdbcSep31Transaction> optTxn =

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -77,6 +77,13 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
     return optTxn.orElse(null);
   }
 
+  public JdbcSep31Transaction findByStellarAccountIdAndMemoAndStatus(
+      String accountId, String memo, String status) {
+    Optional<JdbcSep31Transaction> optTxn =
+        transactionRepo.findByStellarAccountIdAndStellarMemoAndStatus(accountId, memo, status);
+    return optTxn.orElse(null);
+  }
+
   public Integer findByStatusCount(String status) {
     return transactionRepo.findByStatusCount(status);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -79,7 +79,7 @@ public class PaymentOperationToEventListener implements PaymentListener {
     try {
       sep31Txn =
           sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-              payment.getSourceAccount(), memo, SepTransactionStatus.PENDING_SENDER.toString());
+              payment.getTo(), memo, SepTransactionStatus.PENDING_SENDER.toString());
     } catch (Exception ex) {
       errorEx(ex);
     }
@@ -98,10 +98,8 @@ public class PaymentOperationToEventListener implements PaymentListener {
     JdbcSep24Transaction sep24Txn;
     try {
       sep24Txn =
-          sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-              payment.getSourceAccount(),
-              memo,
-              SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+          sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
+              payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
     } catch (Exception ex) {
       errorEx(ex);
       return;

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -78,7 +78,8 @@ public class PaymentOperationToEventListener implements PaymentListener {
     JdbcSep31Transaction sep31Txn = null;
     try {
       sep31Txn =
-          sep31TransactionStore.findByStellarAccountIdAndMemo(payment.getSourceAccount(), memo);
+          sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+              payment.getSourceAccount(), memo, SepTransactionStatus.PENDING_SENDER.toString());
     } catch (Exception ex) {
       errorEx(ex);
     }
@@ -97,7 +98,10 @@ public class PaymentOperationToEventListener implements PaymentListener {
     JdbcSep24Transaction sep24Txn;
     try {
       sep24Txn =
-          sep24TransactionStore.findByStellarAccountIdAndMemo(payment.getSourceAccount(), memo);
+          sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+              payment.getSourceAccount(),
+              memo,
+              SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
     } catch (Exception ex) {
       errorEx(ex);
       return;

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -98,12 +98,12 @@ class PaymentOperationToEventListenerTest {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
         "my_memo_2",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
     assertEquals("my_memo_2", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
-    assertEquals("PENDING_SENDER", slotStatus.captured)
+    assertEquals("pending_sender", slotStatus.captured)
 
     // If findByStellarAccountIdAndMemoAndStatus throws an exception, we shouldn't trigger an event
     slotMemo = slot()
@@ -120,12 +120,12 @@ class PaymentOperationToEventListenerTest {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
         "my_memo_3",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
     assertEquals("my_memo_3", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
-    assertEquals("PENDING_SENDER", slotStatus.captured)
+    assertEquals("pending_sender", slotStatus.captured)
 
     // If asset code from the fetched tx is different, don't trigger event
     slotMemo = slot()
@@ -145,12 +145,12 @@ class PaymentOperationToEventListenerTest {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
         "my_memo_4",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
     assertEquals("my_memo_4", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
-    assertEquals("PENDING_SENDER", slotStatus.captured)
+    assertEquals("pending_sender", slotStatus.captured)
   }
 
   @ParameterizedTest
@@ -217,7 +217,7 @@ class PaymentOperationToEventListenerTest {
     sep31TxMock.transferReceivedAt = null // the event should have a valid `transferReceivedAt`
     sep31TxMock.stellarMemo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
     sep31TxMock.stellarMemoType = "hash"
-    sep31TxMock.status = SepTransactionStatus.PENDING_SENDER.status
+    sep31TxMock.status = SepTransactionStatus.pending_sender.status
     sep31TxMock.senderId = senderId
     sep31TxMock.receiverId = receiverId
     sep31TxMock.creator =
@@ -267,7 +267,7 @@ class PaymentOperationToEventListenerTest {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
 
@@ -331,7 +331,7 @@ class PaymentOperationToEventListenerTest {
     sep31TxMock.transferReceivedAt = null // the event should have a valid `transferReceivedAt`
     sep31TxMock.stellarMemo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
     sep31TxMock.stellarMemoType = "hash"
-    sep31TxMock.status = SepTransactionStatus.PENDING_SENDER.name
+    sep31TxMock.status = SepTransactionStatus.pending_sender.name
     sep31TxMock.senderId = senderId
     sep31TxMock.receiverId = receiverId
     sep31TxMock.creator =
@@ -383,7 +383,7 @@ class PaymentOperationToEventListenerTest {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
 
@@ -493,7 +493,7 @@ class PaymentOperationToEventListenerTest {
       sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
-        "PENDING_SENDER"
+        "pending_sender"
       )
     }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -380,7 +380,7 @@ class PaymentOperationToEventListenerTest {
 
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
         "PENDING_SENDER"
@@ -453,7 +453,7 @@ class PaymentOperationToEventListenerTest {
 
     val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
     every {
-      sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+      sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         capture(slotMemo),
         capture(slotStatus)
@@ -490,7 +490,7 @@ class PaymentOperationToEventListenerTest {
 
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+      sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
         "PENDING_SENDER"

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -217,7 +217,7 @@ class PaymentOperationToEventListenerTest {
     sep31TxMock.transferReceivedAt = null // the event should have a valid `transferReceivedAt`
     sep31TxMock.stellarMemo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
     sep31TxMock.stellarMemoType = "hash"
-    sep31TxMock.status = SepTransactionStatus.pending_sender.status
+    sep31TxMock.status = SepTransactionStatus.PENDING_SENDER.status
     sep31TxMock.senderId = senderId
     sep31TxMock.receiverId = receiverId
     sep31TxMock.creator =
@@ -331,7 +331,7 @@ class PaymentOperationToEventListenerTest {
     sep31TxMock.transferReceivedAt = null // the event should have a valid `transferReceivedAt`
     sep31TxMock.stellarMemo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
     sep31TxMock.stellarMemoType = "hash"
-    sep31TxMock.status = SepTransactionStatus.pending_sender.name
+    sep31TxMock.status = SepTransactionStatus.PENDING_SENDER.name
     sep31TxMock.senderId = senderId
     sep31TxMock.receiverId = receiverId
     sep31TxMock.creator =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -83,6 +83,7 @@ class PaymentOperationToEventListenerTest {
     p.transactionMemo = "my_memo_2"
     p.assetType = "credit_alphanum4"
     p.sourceAccount = "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5"
+    p.to = "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364"
     var slotMemo = slot<String>()
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
@@ -96,13 +97,13 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_2",
         "pending_sender"
       )
     }
     assertEquals("my_memo_2", slotMemo.captured)
-    assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364", slotAccount.captured)
     assertEquals("pending_sender", slotStatus.captured)
 
     // If findByStellarAccountIdAndMemoAndStatus throws an exception, we shouldn't trigger an event
@@ -118,13 +119,13 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_sender"
       )
     }
     assertEquals("my_memo_3", slotMemo.captured)
-    assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364", slotAccount.captured)
     assertEquals("pending_sender", slotStatus.captured)
 
     // If asset code from the fetched tx is different, don't trigger event
@@ -143,13 +144,13 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_4",
         "pending_sender"
       )
     }
     assertEquals("my_memo_4", slotMemo.captured)
-    assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364", slotAccount.captured)
     assertEquals("pending_sender", slotStatus.captured)
   }
 
@@ -265,7 +266,7 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
         "pending_sender"
       )
@@ -342,7 +343,7 @@ class PaymentOperationToEventListenerTest {
     val sep31TxCopy = gson.fromJson(gson.toJson(sep31TxMock), JdbcSep31Transaction::class.java)
     every {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         capture(slotMemo),
         capture(slotStatus)
       )
@@ -381,7 +382,7 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
         "pending_sender"
       )
@@ -454,7 +455,7 @@ class PaymentOperationToEventListenerTest {
     val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
     every {
       sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         capture(slotMemo),
         capture(slotStatus)
       )
@@ -491,7 +492,7 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
         "pending_sender"
       )

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -494,7 +494,7 @@ class PaymentOperationToEventListenerTest {
       sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
-        "pending_sender"
+        "pending_user_transfer_start"
       )
     }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -85,34 +85,47 @@ class PaymentOperationToEventListenerTest {
     p.sourceAccount = "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5"
     var slotMemo = slot<String>()
     val slotAccount = slot<String>()
+    val slotStatus = slot<String>()
     every {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(capture(slotAccount), capture(slotMemo))
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+        capture(slotAccount),
+        capture(slotMemo),
+        capture(slotStatus)
+      )
     } returns null
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
-        "my_memo_2"
+        "my_memo_2",
+        "PENDING_SENDER"
       )
     }
     assertEquals("my_memo_2", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("PENDING_SENDER", slotStatus.captured)
 
-    // If findByStellarAccountIdAndMemo throws an exception, we shouldn't trigger an event
+    // If findByStellarAccountIdAndMemoAndStatus throws an exception, we shouldn't trigger an event
     slotMemo = slot()
     p.transactionMemo = "my_memo_3"
     every {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(capture(slotAccount), capture(slotMemo))
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+        capture(slotAccount),
+        capture(slotMemo),
+        capture(slotStatus)
+      )
     } throws SepException("Something went wrong")
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
-        "my_memo_3"
+        "my_memo_3",
+        "PENDING_SENDER"
       )
     }
     assertEquals("my_memo_3", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("PENDING_SENDER", slotStatus.captured)
 
     // If asset code from the fetched tx is different, don't trigger event
     slotMemo = slot()
@@ -121,17 +134,23 @@ class PaymentOperationToEventListenerTest {
     val sep31TxMock = JdbcSep31Transaction()
     sep31TxMock.amountInAsset = "BAR"
     every {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(capture(slotAccount), capture(slotMemo))
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+        capture(slotAccount),
+        capture(slotMemo),
+        capture(slotStatus)
+      )
     } returns sep31TxMock
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5",
-        "my_memo_4"
+        "my_memo_4",
+        "PENDING_SENDER"
       )
     }
     assertEquals("my_memo_4", slotMemo.captured)
     assertEquals("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5", slotAccount.captured)
+    assertEquals("PENDING_SENDER", slotStatus.captured)
   }
 
   @ParameterizedTest
@@ -182,6 +201,7 @@ class PaymentOperationToEventListenerTest {
 
     val slotAccountId = slot<String>()
     val slotMemo = slot<String>()
+    val slotStatus = slot<String>()
     val sep31TxMock = JdbcSep31Transaction()
     sep31TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
     sep31TxMock.amountExpected = "10"
@@ -207,7 +227,11 @@ class PaymentOperationToEventListenerTest {
 
     val sep31TxCopy = gson.fromJson(gson.toJson(sep31TxMock), JdbcSep31Transaction::class.java)
     every {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(capture(slotAccountId), capture(slotMemo))
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
+        capture(slotAccountId),
+        capture(slotMemo),
+        capture(slotStatus)
+      )
     } returns sep31TxCopy
 
     val patchTxnRequestSlot = slot<PatchTransactionsRequest>()
@@ -240,9 +264,10 @@ class PaymentOperationToEventListenerTest {
 
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
-        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
+        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
+        "PENDING_SENDER"
       )
     }
 
@@ -290,6 +315,7 @@ class PaymentOperationToEventListenerTest {
     val receiverId = "137938d4-43a7-4252-a452-842adcee474c"
 
     val slotMemo = slot<String>()
+    val slotStatus = slot<String>()
     val sep31TxMock = JdbcSep31Transaction()
     sep31TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
     sep31TxMock.amountExpected = "10"
@@ -315,9 +341,10 @@ class PaymentOperationToEventListenerTest {
 
     val sep31TxCopy = gson.fromJson(gson.toJson(sep31TxMock), JdbcSep31Transaction::class.java)
     every {
-      sep31TransactionStore.findByStellarAccountIdAndMemo(
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
-        capture(slotMemo)
+        capture(slotMemo),
+        capture(slotStatus)
       )
     } returns sep31TxCopy
 
@@ -355,7 +382,8 @@ class PaymentOperationToEventListenerTest {
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemo(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
-        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
+        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
+        "PENDING_SENDER"
       )
     }
 
@@ -409,6 +437,7 @@ class PaymentOperationToEventListenerTest {
         .build()
 
     val slotMemo = slot<String>()
+    val slotStatus = slot<String>()
     val sep24TxMock = JdbcSep24Transaction()
     sep24TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
     sep24TxMock.requestAssetCode = assetCode
@@ -418,13 +447,16 @@ class PaymentOperationToEventListenerTest {
     sep24TxMock.memoType = "hash"
 
     // TODO: this shouldn't be necessary
-    every { sep31TransactionStore.findByStellarAccountIdAndMemo(any(), any()) } returns null
+    every {
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(any(), any(), any())
+    } returns null
 
     val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
     every {
-      sep24TransactionStore.findByStellarAccountIdAndMemo(
+      sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
-        capture(slotMemo)
+        capture(slotMemo),
+        capture(slotStatus)
       )
     } returns sep24TxnCopy
 
@@ -458,9 +490,10 @@ class PaymentOperationToEventListenerTest {
 
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep24TransactionStore.findByStellarAccountIdAndMemo(
+      sep24TransactionStore.findByStellarAccountIdAndMemoAndStatus(
         "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
-        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
+        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
+        "PENDING_SENDER"
       )
     }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

This PR does two things:

- The queries to fetch transactions from the database now uses the status that the transaction should be in as an additional filter in addition to the account and memo filters
- They also check for matches using the destination account of the payment rather than the source account of the payment

### Context

There is no reason to check for matches against transactions that are not in the status that indicates the transaction is ready to receive the payment.

We also need to match against the destination account because that is the account we're monitoring. The source accounts of payments are unpredictable.

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`

### Known limitations

<!-- Any known limitations or edge cases. If no known limitations, put NA here.-->

We'll need to port this to 1.x