### PR TITLE
remove SEP suite validation in 1.x actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ change is, and why it is being made, with enough context for anyone to understan
 ### Thoroughness
 
 * [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
+* [ ] All tests from the SEP test suite against this branch locally
 </details>
 
 ### What

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ change is, and why it is being made, with enough context for anyone to understan
 ### Thoroughness
 
 * [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
-* [ ] All tests from the SEP test suite against this branch locally
+* [ ] All tests from the anchor test suite pass against this branch locally
 </details>
 
 ### What

--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -38,44 +38,9 @@ jobs:
         echo "\n\n*** Anchor reference server test report ***\n"
         cat /home/runner/work/java-stellar-anchor-sdk/java-stellar-anchor-sdk/anchor-reference-server/build/reports/tests/test/index.html
 
-  sep_validation_suite:
-    needs: [build_and_test]
-    runs-on: ubuntu-latest
-    name: Validate SEPs (1, 10, 12, 31, 38)
-    env:
-      PR_NUMBER: ${{github.event.pull_request.number}}
-    steps:
-      - uses: actions/checkout@v3
-
-      # Find the server endpoint home domain to run the SEP tests.
-      - name: Find Home Domain (Preview or Dev)
-        id: endpoint-finder
-        run: |
-          echo ${{github.event.pull_request.number}}
-          echo $PR_NUMBER
-          export HOME_DOMAIN=https://anchor-sep-server-dev.stellar.org
-          if [ ! -z "$PR_NUMBER" ]
-          then
-            export HOME_DOMAIN=https://anchor-sep-pr$PR_NUMBER.previews.kube001.services.stellar-ops.com
-          fi
-          echo HOME_DOMAIN=$HOME_DOMAIN
-          echo "::set-output name=HOME_DOMAIN::$HOME_DOMAIN"
-
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - name: Run Validation Tool
-        env:
-          HOME_DOMAIN: ${{ steps.endpoint-finder.outputs.HOME_DOMAIN }}
-        run: |
-          npm install -g @stellar/anchor-tests
-          stellar-anchor-tests --home-domain $HOME_DOMAIN --seps 1 10 12 31 38 --sep-config platform/src/test/resources/stellar-anchor-tests-sep-config.json
-
   complete:
     if: always()
-    needs: [build_and_test, sep_validation_suite]
+    needs: [build_and_test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Removes the SEP validation test suite from our CI pipeline.

### Context

Maintaining working preview deployments and using them for our SEP validation test suite is too high of a maintenance burden for the usage 1.x has in the ecosystem. We can run the same tests locally before releasing.