### PR TITLE
[ANCHOR-435]: Update event callback schema

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
@@ -11,10 +11,14 @@ import org.stellar.anchor.api.event.AnchorEvent;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SendEventRequest {
+  /** The ID of the event */
+  String id;
   /** The seconds since the Unix epoch, UTC. */
-  Long timestamp;
+  String timestamp;
+  /** The type of event */
+  String type;
   /** The event payload. */
-  AnchorEvent payload;
+  SendEventRequestPayload payload;
 
   /**
    * Creates a SendEventRequest from an AnchorEvent.
@@ -24,8 +28,10 @@ public class SendEventRequest {
    */
   public static SendEventRequest from(AnchorEvent event) {
     SendEventRequest request = new SendEventRequest();
-    request.setTimestamp(Instant.now().getEpochSecond());
-    request.setPayload(event);
+    request.setId(event.getId());
+    request.setType(event.getType().toString());
+    request.setTimestamp(Instant.now().toString());
+    request.setPayload(SendEventRequestPayload.from(event));
     return request;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
@@ -13,7 +13,7 @@ import org.stellar.anchor.api.event.AnchorEvent;
 public class SendEventRequest {
   /** The ID of the event */
   String id;
-  /** The seconds since the Unix epoch, UTC. */
+  /** The ISO 8601 UTC datetime string */
   String timestamp;
   /** The type of event */
   String type;

--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequest.java
@@ -29,7 +29,7 @@ public class SendEventRequest {
   public static SendEventRequest from(AnchorEvent event) {
     SendEventRequest request = new SendEventRequest();
     request.setId(event.getId());
-    request.setType(event.getType().toString());
+    request.setType(event.getType().toString().toLowerCase());
     request.setTimestamp(Instant.now().toString());
     request.setPayload(SendEventRequestPayload.from(event));
     return request;

--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
@@ -1,0 +1,37 @@
+package org.stellar.anchor.api.callback;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.stellar.anchor.api.event.AnchorEvent;
+import org.stellar.anchor.api.platform.GetQuoteResponse;
+import org.stellar.anchor.api.platform.GetTransactionResponse;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SendEventRequestPayload {
+  GetTransactionResponse transaction;
+  GetQuoteResponse quote;
+
+  /**
+   * Creates a SendEventRequestPayload from an AnchorEvent.
+   *
+   * @param event
+   * @return a SendEventRequestPayload
+   */
+  public static SendEventRequestPayload from(AnchorEvent event) {
+    SendEventRequestPayload payload = new SendEventRequestPayload();
+    switch (event.getType()) {
+      case QUOTE_CREATED:
+        payload.setQuote(event.getQuote());
+      case TRANSACTION_CREATED:
+        payload.setTransaction(event.getTransaction());
+      case TRANSACTION_ERROR:
+        payload.setTransaction(event.getTransaction());
+      case TRANSACTION_STATUS_CHANGED:
+        payload.setTransaction(event.getTransaction());
+    }
+    return payload;
+  }
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/GetTransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/GetTransactionResponse.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.api.platform;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -10,6 +11,7 @@ import lombok.experimental.SuperBuilder;
  *     href="https://github.com/stellar/stellar-docs/blob/main/openapi/anchor-platform/Platform%20API.yml">Platform
  *     API</a>
  */
+@Getter
 @SuperBuilder
 @NoArgsConstructor
 public class GetTransactionResponse extends PlatformTransactionData {}

--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/GetTransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/GetTransactionResponse.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.api.platform;
 
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -11,7 +10,6 @@ import lombok.experimental.SuperBuilder;
  *     href="https://github.com/stellar/stellar-docs/blob/main/openapi/anchor-platform/Platform%20API.yml">Platform
  *     API</a>
  */
-@Getter
 @SuperBuilder
 @NoArgsConstructor
 public class GetTransactionResponse extends PlatformTransactionData {}

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/KotlinReferenceServerIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/KotlinReferenceServerIntegrationTest.kt
@@ -41,16 +41,16 @@ internal class KotlinReferenceServerIntegrationTest {
       client.sendEvent(sendEventRequest1)
       var latestEvent = client.getLatestEvent()
       Assertions.assertNotNull(latestEvent)
-      JSONAssert.assertEquals(json(latestEvent), json(sendEventRequest1.payload), true)
+      JSONAssert.assertEquals(json(latestEvent), json(sendEventRequest1), true)
       // send event2
       client.sendEvent(sendEventRequest2)
       latestEvent = client.getLatestEvent()
       Assertions.assertNotNull(latestEvent)
-      JSONAssert.assertEquals(json(latestEvent), json(sendEventRequest2.payload), true)
+      JSONAssert.assertEquals(json(latestEvent), json(sendEventRequest2), true)
       // check if there are totally two events recorded
       assertEquals(client.getEvents().size, 2)
-      JSONAssert.assertEquals(json(client.getEvents()[0]), json(sendEventRequest1.payload), true)
-      JSONAssert.assertEquals(json(client.getEvents()[1]), json(sendEventRequest2.payload), true)
+      JSONAssert.assertEquals(json(client.getEvents()[0]), json(sendEventRequest1), true)
+      JSONAssert.assertEquals(json(client.getEvents()[1]), json(sendEventRequest2), true)
     }
   }
 
@@ -58,17 +58,16 @@ internal class KotlinReferenceServerIntegrationTest {
     val sendEventRequestJson =
       """
       {
-          "timestamp": 1000000,
+          "timestamp": "2011-10-05T14:48:00.000Z",
+          "id": "2a419880-0dde-4821-90cb-f3bfcb671ea3",
+          "type": "transaction_created",
           "payload": {
-              "type": "TRANSACTION_CREATED",
-              "id": 100,
-              "sep": 24,
-              "transaction": {
-                "amount_in": {
-                  "amount": "10.0",
-                  "asset": "USDC"
-                }
+            "transaction": {
+              "amount_in": {
+                "amount": "10.0",
+                "asset": "USDC"
               }
+            }
           }
       }
     """
@@ -77,11 +76,10 @@ internal class KotlinReferenceServerIntegrationTest {
     val sendEventRequestJson2 =
       """
 {
-  "timestamp": 1000000,
+  "id": "2a419880-0dde-4821-90cb-f3bfcb671ea3",
+  "timestamp": "2011-10-05T14:48:00.000Z",
+  "type": "quote_created",
   "payload": {
-    "type": "TRANSACTION_CREATED",
-    "id": 100,
-    "sep": 24,
     "quote": {
       "sell_amount": "10.0",
       "buy_amount": "1"

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -388,9 +388,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       """
 [
   {
-    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_created",
-    "timestamp": "2023-07-19T20:21:01Z",
     "payload": {
       "transaction": {
         "sep": "24",
@@ -403,9 +401,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "timestamp": "2023-07-19T20:21:01Z",
     "payload": {
       "transaction": {
         "sep": "24",
@@ -426,9 +422,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "timestamp": "2023-07-19T20:21:01Z",
     "payload": {
       "transaction": {
         "sep": "24",
@@ -449,9 +443,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     }
   },
   {
-    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "timestamp": "2023-07-19T20:21:01Z",
     "payload": {
       "transaction": {
         "sep": "24",
@@ -492,9 +484,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     """
     [
       {
-        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_created",
-        "timestamp": "2023-07-19T20:21:01Z",
         "payload": {
           "transaction": {
             "sep": "24",
@@ -509,9 +499,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_status_changed",
-        "timestamp": "2023-07-19T20:21:01Z",
         "payload": {
           "transaction": {
             "sep": "24",
@@ -533,9 +521,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       },
       {
-        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_status_changed",
-        "timestamp": "2023-07-19T20:21:01Z",
         "payload": {
           "transaction": {
             "id": "14882409-757c-4c66-9da1-3dddef11953a",
@@ -578,8 +564,6 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       },
       {
         "type": "transaction_status_changed",
-        "id": "b44d90ec-2d9a-4768-a952-085026f5b3da",
-        "timestamp": "2023-07-19T20:21:01Z",
         "payload": {
           "transaction": {
             "id": "14882409-757c-4c66-9da1-3dddef11953a",
@@ -622,8 +606,6 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       },
       {
         "type": "transaction_status_changed",
-        "id": "0556b75c-b054-49a0-b778-654050a6cba4",
-        "timestamp": "2023-07-19T20:21:01Z",
         "payload": {
           "transaction": {
             "id": "14882409-757c-4c66-9da1-3dddef11953a",

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.web.util.UriComponentsBuilder
+import org.stellar.anchor.api.callback.SendEventRequest
 import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
@@ -23,7 +24,6 @@ import org.stellar.anchor.util.GsonUtils
 import org.stellar.anchor.util.Log.info
 import org.stellar.anchor.util.StringHelper.json
 import org.stellar.reference.client.AnchorReferenceServerClient
-import org.stellar.reference.data.SendEventRequestPayload
 import org.stellar.reference.wallet.WalletServerClient
 import org.stellar.walletsdk.ApplicationConfiguration
 import org.stellar.walletsdk.InteractiveFlowResponse
@@ -103,10 +103,10 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       val actualEvents = waitForBusinessServerEvents(response.id, 4)
       assertNotNull(actualEvents)
       actualEvents?.let { assertEquals(4, it.size) }
-      val expectedEvents: List<SendEventRequestPayload> =
+      val expectedEvents: List<SendEventRequest> =
         gson.fromJson(
           expectedDepositEventsJson,
-          object : TypeToken<List<SendEventRequestPayload>>() {}.type
+          object : TypeToken<List<SendEventRequest>>() {}.type
         )
       compareAndAssertEvents(asset, expectedEvents, actualEvents!!)
 
@@ -145,34 +145,38 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
 
   private fun compareAndAssertEvents(
     asset: StellarAssetId,
-    expectedEvents: List<SendEventRequestPayload>,
-    actualEvents: List<SendEventRequestPayload>
+    expectedEvents: List<SendEventRequest>,
+    actualEvents: List<SendEventRequest>
   ) {
     expectedEvents.forEachIndexed { index, expectedEvent ->
       actualEvents[index].let { actualEvent ->
         expectedEvent.id = actualEvent.id
-        expectedEvent.transaction.id = actualEvent.transaction.id
-        expectedEvent.transaction.startedAt = actualEvent.transaction.startedAt
-        expectedEvent.transaction.updatedAt = actualEvent.transaction.updatedAt
-        expectedEvent.transaction.stellarTransactions = actualEvent.transaction.stellarTransactions
-        expectedEvent.transaction.memo = actualEvent.transaction.memo
-        expectedEvent.transaction.amountExpected.asset = asset.id
-        actualEvent.transaction.amountIn?.let {
-          expectedEvent.transaction.amountIn.amount = actualEvent.transaction.amountIn.amount
-          expectedEvent.transaction.amountIn.asset = asset.sep38
+        expectedEvent.payload.transaction.id = actualEvent.payload.transaction.id
+        expectedEvent.payload.transaction.startedAt = actualEvent.payload.transaction.startedAt
+        expectedEvent.payload.transaction.updatedAt = actualEvent.payload.transaction.updatedAt
+        expectedEvent.payload.transaction.stellarTransactions =
+          actualEvent.payload.transaction.stellarTransactions
+        expectedEvent.payload.transaction.memo = actualEvent.payload.transaction.memo
+        expectedEvent.payload.transaction.amountExpected.asset = asset.id
+        actualEvent.payload.transaction.amountIn?.let {
+          expectedEvent.payload.transaction.amountIn.amount =
+            actualEvent.payload.transaction.amountIn.amount
+          expectedEvent.payload.transaction.amountIn.asset = asset.sep38
         }
-        actualEvent.transaction.amountOut?.let {
-          expectedEvent.transaction.amountOut.amount = actualEvent.transaction.amountOut.amount
-          expectedEvent.transaction.amountOut.asset = asset.sep38
+        actualEvent.payload.transaction.amountOut?.let {
+          expectedEvent.payload.transaction.amountOut.amount =
+            actualEvent.payload.transaction.amountOut.amount
+          expectedEvent.payload.transaction.amountOut.asset = asset.sep38
         }
-        actualEvent.transaction.amountFee?.let {
-          expectedEvent.transaction.amountFee.amount = actualEvent.transaction.amountFee.amount
-          expectedEvent.transaction.amountFee.asset = asset.sep38
+        actualEvent.payload.transaction.amountFee?.let {
+          expectedEvent.payload.transaction.amountFee.amount =
+            actualEvent.payload.transaction.amountFee.amount
+          expectedEvent.payload.transaction.amountFee.asset = asset.sep38
         }
-        actualEvent.transaction.amountExpected?.let {
-          expectedEvent.transaction.amountExpected.amount =
-            actualEvent.transaction.amountExpected.amount
-          expectedEvent.transaction.amountExpected.asset = asset.sep38
+        actualEvent.payload.transaction.amountExpected?.let {
+          expectedEvent.payload.transaction.amountExpected.amount =
+            actualEvent.payload.transaction.amountExpected.amount
+          expectedEvent.payload.transaction.amountExpected.asset = asset.sep38
         }
       }
     }
@@ -251,10 +255,10 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     assertNotNull(actualEvents)
     actualEvents?.let {
       assertEquals(5, it.size)
-      val expectedEvents: List<SendEventRequestPayload> =
+      val expectedEvents: List<SendEventRequest> =
         gson.fromJson(
           expectedWithdrawEventJson,
-          object : TypeToken<List<SendEventRequestPayload>>() {}.type
+          object : TypeToken<List<SendEventRequest>>() {}.type
         )
       compareAndAssertEvents(asset, expectedEvents, actualEvents)
     }
@@ -291,7 +295,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
   private suspend fun waitForBusinessServerEvents(
     txnId: String,
     count: Int
-  ): List<SendEventRequestPayload>? {
+  ): List<SendEventRequest>? {
     var retries = 5
     while (retries > 0) {
       val events = anchorReferenceServerClient.getEvents(txnId)
@@ -384,87 +388,99 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
       """
 [
   {
+    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_created",
-    "sep": "24",
-    "transaction": {
-      "sep": "24",
-      "kind": "deposit",
-      "status": "incomplete",
-      "amount_expected": {
-      },
-      "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
+    "timestamp": "2023-07-19T20:21:01Z",
+    "payload": {
+      "transaction": {
+        "sep": "24",
+        "kind": "deposit",
+        "status": "incomplete",
+        "amount_expected": {
+        },
+        "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
+      }
     }
   },
   {
+    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "sep": "24",
-    "transaction": {
-      "sep": "24",
-      "kind": "deposit",
-      "status": "pending_user_transfer_start",
-      "amount_expected": {
-      },
-      "amount_in": {
-      },
-      "amount_out": {
-      },
-      "amount_fee": {
-      },
-      "message": "waiting on the user to transfer funds",
-      "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "memo_type": "hash"
+    "timestamp": "2023-07-19T20:21:01Z",
+    "payload": {
+      "transaction": {
+        "sep": "24",
+        "kind": "deposit",
+        "status": "pending_user_transfer_start",
+        "amount_expected": {
+        },
+        "amount_in": {
+        },
+        "amount_out": {
+        },
+        "amount_fee": {
+        },
+        "message": "waiting on the user to transfer funds",
+        "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+        "memo_type": "hash"
+      }
     }
   },
   {
+    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "sep": "24",
-    "transaction": {
-      "sep": "24",
-      "kind": "deposit",
-      "status": "pending_anchor",
-      "amount_expected": {
-      },
-      "amount_in": {
-      },
-      "amount_out": {
-      },
-      "amount_fee": {
-      },
-      "message": "funds received, transaction is being processed",
-      "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "memo_type": "hash"
+    "timestamp": "2023-07-19T20:21:01Z",
+    "payload": {
+      "transaction": {
+        "sep": "24",
+        "kind": "deposit",
+        "status": "pending_anchor",
+        "amount_expected": {
+        },
+        "amount_in": {
+        },
+        "amount_out": {
+        },
+        "amount_fee": {
+        },
+        "message": "funds received, transaction is being processed",
+        "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+        "memo_type": "hash"
+      }
     }
   },
   {
+    "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
     "type": "transaction_status_changed",
-    "sep": "24",
-    "transaction": {
-      "sep": "24",
-      "kind": "deposit",
-      "status": "completed",
-      "amount_expected": {
-      },
-      "amount_in": {
-      },
-      "amount_out": {
-      },
-      "amount_fee": {
-      },
-      "message": "completed",
-      "stellar_transactions": [
-        {
-          "id": "111129e48806cdc4873c98e769c8c736a0d157d4e6a24c5ecb4c64b3b0e4a890",
-          "payments": [
-            {
-              "id": "2499297304129537",
-              "amount": {
+    "timestamp": "2023-07-19T20:21:01Z",
+    "payload": {
+      "transaction": {
+        "sep": "24",
+        "kind": "deposit",
+        "status": "completed",
+        "amount_expected": {
+        },
+        "amount_in": {
+        },
+        "amount_out": {
+        },
+        "amount_fee": {
+        },
+        "message": "completed",
+        "stellar_transactions": [
+          {
+            "id": "111129e48806cdc4873c98e769c8c736a0d157d4e6a24c5ecb4c64b3b0e4a890",
+            "payments": [
+              {
+                "id": "2499297304129537",
+                "amount": {
+                }
               }
-            }
-          ]
-        }
-      ],
-      "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "memo_type": "hash"
+            ]
+          }
+        ],
+        "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+        "memo_type": "hash"
+      }
     }
   }
 ]
@@ -476,164 +492,176 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     """
     [
       {
+        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_created",
-        "sep": "24",
-        "transaction": {
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "incomplete",
-          "amount_expected": {
-          },
-          "started_at": "2023-07-19T20:20:51.792908200Z",
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+        "timestamp": "2023-07-19T20:21:01Z",
+        "payload": {
+          "transaction": {
+            "sep": "24",
+            "kind": "withdrawal",
+            "status": "incomplete",
+            "amount_expected": {
+            },
+            "started_at": "2023-07-19T20:20:51.792908200Z",
+            "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+            "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+          }
         }
       },
       {
+        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_status_changed",
-        "sep": "24",
-        "transaction": {
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_user_transfer_start",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "waiting on the user to transfer funds",
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+        "timestamp": "2023-07-19T20:21:01Z",
+        "payload": {
+          "transaction": {
+            "sep": "24",
+            "kind": "withdrawal",
+            "status": "pending_user_transfer_start",
+            "amount_expected": {
+            },
+            "amount_in": {
+            },
+            "amount_out": {
+            },
+            "amount_fee": {
+            },
+            "message": "waiting on the user to transfer funds",
+            "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+            "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+            "memo_type": "hash"
+          }
         }
       },
       {
+        "id": "f664ed78-6321-4726-b2fb-efc2c36429ff",
         "type": "transaction_status_changed",
-        "id": "f0b75f9e-1b53-442a-91dd-d6c002a51bfc",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_anchor",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "waiting on the user to transfer funds",
-          "stellar_transactions": [
-            {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
-            }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+        "timestamp": "2023-07-19T20:21:01Z",
+        "payload": {
+          "transaction": {
+            "id": "14882409-757c-4c66-9da1-3dddef11953a",
+            "sep": "24",
+            "kind": "withdrawal",
+            "status": "pending_anchor",
+            "amount_expected": {
+            },
+            "amount_in": {
+            },
+            "amount_out": {
+            },
+            "amount_fee": {
+            },
+            "message": "waiting on the user to transfer funds",
+            "stellar_transactions": [
+              {
+                "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
+                "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
+                "memo_type": "hash",
+                "created_at": "2023-07-19T20:21:01Z",
+                "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
+                "payments": [
+                  {
+                    "id": "2504876466638849",
+                    "amount": {
+                    },
+                    "payment_type": "payment",
+                    "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+                    "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+                  }
+                ]
+              }
+            ],
+            "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+            "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+            "memo_type": "hash"
+          }
         }
       },
       {
         "type": "transaction_status_changed",
         "id": "b44d90ec-2d9a-4768-a952-085026f5b3da",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_external",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "pending external transfer",
-          "stellar_transactions": [
-            {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
-            }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+        "timestamp": "2023-07-19T20:21:01Z",
+        "payload": {
+          "transaction": {
+            "id": "14882409-757c-4c66-9da1-3dddef11953a",
+            "sep": "24",
+            "kind": "withdrawal",
+            "status": "pending_external",
+            "amount_expected": {
+            },
+            "amount_in": {
+            },
+            "amount_out": {
+            },
+            "amount_fee": {
+            },
+            "message": "pending external transfer",
+            "stellar_transactions": [
+              {
+                "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
+                "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
+                "memo_type": "hash",
+                "created_at": "2023-07-19T20:21:01Z",
+                "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
+                "payments": [
+                  {
+                    "id": "2504876466638849",
+                    "amount": {
+                    },
+                    "payment_type": "payment",
+                    "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+                    "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+                  }
+                ]
+              }
+            ],
+            "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+            "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+            "memo_type": "hash"
+          }
         }
       },
       {
         "type": "transaction_status_changed",
         "id": "0556b75c-b054-49a0-b778-654050a6cba4",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "completed",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "completed",
-          "stellar_transactions": [
-            {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
-            }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+        "timestamp": "2023-07-19T20:21:01Z",
+        "payload": {
+          "transaction": {
+            "id": "14882409-757c-4c66-9da1-3dddef11953a",
+            "sep": "24",
+            "kind": "withdrawal",
+            "status": "completed",
+            "amount_expected": {
+            },
+            "amount_in": {
+            },
+            "amount_out": {
+            },
+            "amount_fee": {
+            },
+            "message": "completed",
+            "stellar_transactions": [
+              {
+                "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
+                "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
+                "memo_type": "hash",
+                "created_at": "2023-07-19T20:21:01Z",
+                "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
+                "payments": [
+                  {
+                    "id": "2504876466638849",
+                    "amount": {
+                    },
+                    "payment_type": "payment",
+                    "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+                    "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+                  }
+                ]
+              }
+            ],
+            "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+            "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+            "memo_type": "hash"
+          }
         }
       }
     ]

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -151,7 +151,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     expectedEvents.forEachIndexed { index, expectedEvent ->
       actualEvents[index].let { actualEvent ->
         expectedEvent.id = actualEvent.id
-        expectedEvent.type = actualEvent.type
+        expectedEvent.timestamp = actualEvent.timestamp
         expectedEvent.payload.transaction.id = actualEvent.payload.transaction.id
         expectedEvent.payload.transaction.startedAt = actualEvent.payload.transaction.startedAt
         expectedEvent.payload.transaction.updatedAt = actualEvent.payload.transaction.updatedAt
@@ -181,6 +181,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       }
     }
+    JSONAssert.assertEquals(json(expectedEvents), gson.toJson(actualEvents), true)
   }
 
   private fun compareAndAssertCallbacks(

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24End2EndTests.kt
@@ -151,6 +151,7 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
     expectedEvents.forEachIndexed { index, expectedEvent ->
       actualEvents[index].let { actualEvent ->
         expectedEvent.id = actualEvent.id
+        expectedEvent.type = actualEvent.type
         expectedEvent.payload.transaction.id = actualEvent.payload.transaction.id
         expectedEvent.payload.transaction.startedAt = actualEvent.payload.transaction.startedAt
         expectedEvent.payload.transaction.updatedAt = actualEvent.payload.transaction.updatedAt
@@ -180,7 +181,6 @@ class Sep24End2EndTest(config: TestConfig, val jwt: String) {
         }
       }
     }
-    JSONAssert.assertEquals(json(expectedEvents), gson.toJson(actualEvents), true)
   }
 
   private fun compareAndAssertCallbacks(

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/AnchorReferenceServerClient.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/AnchorReferenceServerClient.kt
@@ -7,8 +7,8 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import org.stellar.anchor.api.callback.SendEventRequest
 import org.stellar.anchor.api.callback.SendEventResponse
-import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.util.GsonUtils
+import org.stellar.reference.data.SendEventRequestPayload
 
 class AnchorReferenceServerClient(val endpoint: Url) {
   val gson = GsonUtils.getInstance()
@@ -28,7 +28,7 @@ class AnchorReferenceServerClient(val endpoint: Url) {
 
     return gson.fromJson(response.body<String>(), SendEventResponse::class.java)
   }
-  suspend fun getEvents(txnId: String? = null): List<AnchorEvent> {
+  suspend fun getEvents(txnId: String? = null): List<SendEventRequestPayload> {
     val response =
       client.get {
         url {
@@ -41,10 +41,13 @@ class AnchorReferenceServerClient(val endpoint: Url) {
       }
 
     // Parse the JSON string into a list of Person objects
-    return gson.fromJson(response.body<String>(), object : TypeToken<List<AnchorEvent>>() {}.type)
+    return gson.fromJson(
+      response.body<String>(),
+      object : TypeToken<List<SendEventRequestPayload>>() {}.type
+    )
   }
 
-  suspend fun getLatestEvent(): AnchorEvent? {
+  suspend fun getLatestEvent(): SendEventRequestPayload? {
     val response =
       client.get {
         url {
@@ -54,7 +57,7 @@ class AnchorReferenceServerClient(val endpoint: Url) {
           encodedPath = "/events/latest"
         }
       }
-    return gson.fromJson(response.body<String>(), AnchorEvent::class.java)
+    return gson.fromJson(response.body<String>(), SendEventRequestPayload::class.java)
   }
 
   suspend fun clearEvents() {

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/AnchorReferenceServerClient.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/AnchorReferenceServerClient.kt
@@ -8,7 +8,6 @@ import io.ktor.http.*
 import org.stellar.anchor.api.callback.SendEventRequest
 import org.stellar.anchor.api.callback.SendEventResponse
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.reference.data.SendEventRequestPayload
 
 class AnchorReferenceServerClient(val endpoint: Url) {
   val gson = GsonUtils.getInstance()
@@ -28,7 +27,7 @@ class AnchorReferenceServerClient(val endpoint: Url) {
 
     return gson.fromJson(response.body<String>(), SendEventResponse::class.java)
   }
-  suspend fun getEvents(txnId: String? = null): List<SendEventRequestPayload> {
+  suspend fun getEvents(txnId: String? = null): List<SendEventRequest> {
     val response =
       client.get {
         url {
@@ -43,11 +42,11 @@ class AnchorReferenceServerClient(val endpoint: Url) {
     // Parse the JSON string into a list of Person objects
     return gson.fromJson(
       response.body<String>(),
-      object : TypeToken<List<SendEventRequestPayload>>() {}.type
+      object : TypeToken<List<SendEventRequest>>() {}.type
     )
   }
 
-  suspend fun getLatestEvent(): SendEventRequestPayload? {
+  suspend fun getLatestEvent(): SendEventRequest? {
     val response =
       client.get {
         url {
@@ -57,7 +56,7 @@ class AnchorReferenceServerClient(val endpoint: Url) {
           encodedPath = "/events/latest"
         }
       }
-    return gson.fromJson(response.body<String>(), SendEventRequestPayload::class.java)
+    return gson.fromJson(response.body<String>(), SendEventRequest::class.java)
   }
 
   suspend fun clearEvents() {

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
@@ -1,5 +1,16 @@
 package org.stellar.reference.data
 
-import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.api.platform.GetQuoteResponse
+import org.stellar.anchor.api.platform.GetTransactionResponse
 
-data class SendEventRequest(val timestamp: Long, val payload: AnchorEvent)
+public data class SendEventRequest(
+  val id: String,
+  val type: String,
+  val timestamp: String,
+  val payload: SendEventRequestPayload
+)
+
+public data class SendEventRequestPayload(
+  val transaction: GetTransactionResponse,
+  val quote: GetQuoteResponse
+)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
@@ -10,7 +10,7 @@ data class SendEventRequest(
   val payload: SendEventRequestPayload
 )
 
-data class SendEventRequestPayload(
+public data class SendEventRequestPayload(
   val transaction: GetTransactionResponse,
   val quote: GetQuoteResponse
 )

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
@@ -3,14 +3,14 @@ package org.stellar.reference.data
 import org.stellar.anchor.api.platform.GetQuoteResponse
 import org.stellar.anchor.api.platform.GetTransactionResponse
 
-public data class SendEventRequest(
+data class SendEventRequest(
   val id: String,
   val type: String,
   val timestamp: String,
   val payload: SendEventRequestPayload
 )
 
-public data class SendEventRequestPayload(
+data class SendEventRequestPayload(
   val transaction: GetTransactionResponse,
   val quote: GetQuoteResponse
 )

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
@@ -4,16 +4,16 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.reference.data.SendEventRequest
+import org.stellar.reference.data.SendEventRequestPayload
 import org.stellar.reference.log
 
 class EventService {
   private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-  private val receivedEvents: MutableList<AnchorEvent> = mutableListOf()
+  private val receivedEvents: MutableList<SendEventRequestPayload> = mutableListOf()
 
   fun processEvent(receivedEvent: SendEventRequest) {
-    val instant = Instant.ofEpochSecond(receivedEvent.timestamp)
+    val instant = Instant.parse(receivedEvent.timestamp)
     val dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
 
     log.trace("Received event created on ${dateTime.format(formatter)}")
@@ -22,7 +22,7 @@ class EventService {
 
   // Get all events. This is for testing purpose.
   // If txnId is not null, the events are filtered.
-  fun getEvents(txnId: String?): List<AnchorEvent> {
+  fun getEvents(txnId: String?): List<SendEventRequestPayload> {
     if (txnId != null) {
       // filter events with txnId
       return receivedEvents.filter { it.transaction.id == txnId }
@@ -32,7 +32,7 @@ class EventService {
   }
 
   // Get the latest event recevied. This is for testing purpose
-  fun getLatestEvent(): AnchorEvent? {
+  fun getLatestEvent(): SendEventRequestPayload? {
     return receivedEvents.lastOrNull()
   }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
@@ -5,34 +5,35 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import org.stellar.reference.data.SendEventRequest
-import org.stellar.reference.data.SendEventRequestPayload
 import org.stellar.reference.log
 
 class EventService {
   private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-  private val receivedEvents: MutableList<SendEventRequestPayload> = mutableListOf()
+  private val receivedEvents: MutableList<SendEventRequest> = mutableListOf()
 
   fun processEvent(receivedEvent: SendEventRequest) {
     val instant = Instant.parse(receivedEvent.timestamp)
     val dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
 
-    log.trace("Received event created on ${dateTime.format(formatter)}")
-    receivedEvents.add(receivedEvent.payload)
+    log.info(
+      "Received event ${receivedEvent.id} of type ${receivedEvent.type} at ${dateTime.format(formatter)}"
+    )
+    receivedEvents.add(receivedEvent)
   }
 
   // Get all events. This is for testing purpose.
   // If txnId is not null, the events are filtered.
-  fun getEvents(txnId: String?): List<SendEventRequestPayload> {
+  fun getEvents(txnId: String?): List<SendEventRequest> {
     if (txnId != null) {
       // filter events with txnId
-      return receivedEvents.filter { it.transaction.id == txnId }
+      return receivedEvents.filter { it.payload.transaction.id == txnId }
     }
     // return all events
     return receivedEvents
   }
 
   // Get the latest event recevied. This is for testing purpose
-  fun getLatestEvent(): SendEventRequestPayload? {
+  fun getLatestEvent(): SendEventRequest? {
     return receivedEvents.lastOrNull()
   }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

**Lets hold off on this until we merge everything from SoftServe**

### Description

Updates the schema used when sending event callbacks to the business server.

### Context

Current schema:

```js
{
  timestamp: 1693524508,
  payload: {
    type: 'transaction_created',
    id: '19f8caad-0214-4ef3-99a6-134f59a3dbbe',
    sep: '24',
    transaction: {
      id: '29f84658-7090-47b7-874d-5d4ffa592a39',
      sep: '24',
      kind: 'deposit',
      status: 'incomplete',
      amount_expected: [Object],
      started_at: '2023-08-31T23:28:25.120858Z',
      destination_account: 'GA57OTKBRMLNMYIMK3VL23HI6XVCB7P2H5Q353U3ZEQR6HIE5TBAXY3O'
    }
  }
}
```

New schema:

```js
{
  id: '19f8caad-0214-4ef3-99a6-134f59a3dbbe',
  timestamp: '2023-08-31T23:28:25.120858Z',
  type: 'transaction_created',
  payload: {
    transaction: {
      id: '29f84658-7090-47b7-874d-5d4ffa592a39',
      sep: '24',
      kind: 'deposit',
      status: 'incomplete',
      amount_expected: [Object],
      started_at: '2023-08-31T23:28:25.120858Z',
      destination_account: 'GA57OTKBRMLNMYIMK3VL23HI6XVCB7P2H5Q353U3ZEQR6HIE5TBAXY3O'
    }
  }
}
```

In the current schema, the `sep` field is duplicated, the `timestamp` uses a unix timestamp instead a properly formatted datetime string, and the `id` and `type` fields are inside `payload` when they are really metadata that should be outside `payload`.

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`

### Known limitations

<!-- Any known limitations or edge cases. If no known limitations, put NA here.-->