### PR TITLE
[ANCHOR-420] Add missing `client_id` to rate callback in SEP38 `/price` and `/prices` endpoints

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -62,6 +62,7 @@ public class Sep38Service {
   }
 
   public GetPricesResponse getPrices(
+      JwtToken token,
       String sellAssetName,
       String sellAmount,
       String sellDeliveryMethod,
@@ -97,6 +98,7 @@ public class Sep38Service {
             .sellAsset(sellAssetName)
             .sellAmount(sellAmount)
             .countryCode(countryCode)
+            .clientId(token.getAccount())
             .sellDeliveryMethod(sellDeliveryMethod)
             .buyDeliveryMethod(buyDeliveryMethod);
     GetPricesResponse response = new GetPricesResponse();
@@ -127,7 +129,8 @@ public class Sep38Service {
     }
   }
 
-  public GetPriceResponse getPrice(Sep38GetPriceRequest getPriceRequest) throws AnchorException {
+  public GetPriceResponse getPrice(JwtToken token, Sep38GetPriceRequest getPriceRequest)
+      throws AnchorException {
     String sellAssetName = getPriceRequest.getSellAssetName();
     String sellAmount = getPriceRequest.getSellAmount();
     String sellDeliveryMethod = getPriceRequest.getSellDeliveryMethod();
@@ -214,6 +217,7 @@ public class Sep38Service {
             .buyAmount(buyAmount)
             .buyDeliveryMethod(buyDeliveryMethod)
             .countryCode(countryCode)
+            .clientId(token.getAccount())
             .build();
     GetRateResponse rateResponse = this.rateIntegration.getRate(request);
     GetRateResponse.Rate rate = rateResponse.getRate();

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -98,7 +98,7 @@ public class Sep38Service {
             .sellAsset(sellAssetName)
             .sellAmount(sellAmount)
             .countryCode(countryCode)
-            .clientId(token.getAccount())
+            .clientId((token == null) ? null : token.getAccount())
             .sellDeliveryMethod(sellDeliveryMethod)
             .buyDeliveryMethod(buyDeliveryMethod);
     GetPricesResponse response = new GetPricesResponse();
@@ -217,7 +217,7 @@ public class Sep38Service {
             .buyAmount(buyAmount)
             .buyDeliveryMethod(buyDeliveryMethod)
             .countryCode(countryCode)
-            .clientId(token.getAccount())
+            .clientId((token == null) ? null : token.getAccount())
             .build();
     GetRateResponse rateResponse = this.rateIntegration.getRate(request);
     GetRateResponse.Rate rate = rateResponse.getRate();
@@ -348,7 +348,7 @@ public class Sep38Service {
             .buyDeliveryMethod(request.getBuyDeliveryMethod())
             .countryCode(request.getCountryCode())
             .expireAfter(request.getExpireAfter())
-            .clientId(account)
+            .clientId((token == null) ? null : token.getAccount())
             .build();
     GetRateResponse.Rate rate = this.rateIntegration.getRate(getRateRequest).getRate();
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -42,10 +42,10 @@ class Sep38ServiceTest {
   companion object {
     private const val PUBLIC_KEY = "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
     private const val stellarUSDC =
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     private const val fiatUSD = "iso4217:USD"
     private const val stellarJPYC =
-        "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
   }
 
   private lateinit var sep38Service: Sep38Service
@@ -60,7 +60,7 @@ class Sep38ServiceTest {
   @MockK(relaxed = true) private lateinit var appConfig: AppConfig
 
   private val sep10Token =
-      createJwtToken("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG")
+    createJwtToken("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG")
 
   @BeforeEach
   fun setUp() {
@@ -100,12 +100,12 @@ class Sep38ServiceTest {
     assertNull(usdcAsset.sellDeliveryMethods)
     assertNull(usdcAsset.buyDeliveryMethods)
     var wantAssets =
-        listOf(fiatUSD, "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
+      listOf(fiatUSD, "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
     assertTrue(usdcAsset.exchangeableAssetNames.containsAll(wantAssets))
     assertTrue(wantAssets.containsAll(usdcAsset.exchangeableAssetNames))
 
     val stellarJPYC =
-        assetMap["stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"]
+      assetMap["stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"]
     assertNotNull(stellarJPYC)
     assertNull(stellarJPYC!!.countryCodes)
     assertNull(stellarJPYC.sellDeliveryMethods)
@@ -119,15 +119,19 @@ class Sep38ServiceTest {
     assertNotNull(fiatUSD)
     assertEquals(listOf("USA"), fiatUSD!!.countryCodes)
     val wantSellDeliveryMethod =
-        AssetInfo.Sep38Operation.DeliveryMethod(
-            "WIRE", "Send USD directly to the Anchor's bank account.")
+      AssetInfo.Sep38Operation.DeliveryMethod(
+        "WIRE",
+        "Send USD directly to the Anchor's bank account."
+      )
     assertEquals(listOf(wantSellDeliveryMethod), fiatUSD.sellDeliveryMethods)
     val wantBuyDeliveryMethod =
-        AssetInfo.Sep38Operation.DeliveryMethod(
-            "WIRE", "Have USD sent directly to your bank account.")
+      AssetInfo.Sep38Operation.DeliveryMethod(
+        "WIRE",
+        "Have USD sent directly to your bank account."
+      )
     assertEquals(listOf(wantBuyDeliveryMethod), fiatUSD.buyDeliveryMethods)
     wantAssets =
-        listOf("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", stellarUSDC)
+      listOf("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", stellarUSDC)
     assertTrue(fiatUSD.exchangeableAssetNames.containsAll(wantAssets))
     assertTrue(wantAssets.containsAll(fiatUSD.exchangeableAssetNames))
   }
@@ -144,8 +148,13 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     val token = createJwtToken("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG")
 
@@ -195,29 +204,34 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq1 =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICES)
-            .sellAsset(fiatUSD)
-            .buyAsset("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
-            .sellAmount("100")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICES)
+        .sellAsset(fiatUSD)
+        .buyAsset("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
+        .sellAmount("100")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq1) } returns
-        GetRateResponse.indicativePrices("1", "100", "100")
+      GetRateResponse.indicativePrices("1", "100", "100")
 
     val getRateReq2 =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICES)
-            .sellAsset(fiatUSD)
-            .buyAsset(stellarUSDC)
-            .sellAmount("100")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICES)
+        .sellAsset(fiatUSD)
+        .buyAsset(stellarUSDC)
+        .sellAmount("100")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq2) } returns
-        GetRateResponse.indicativePrices("2", "100", "200")
+      GetRateResponse.indicativePrices("2", "100", "200")
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with the minimum parameters
     var gotResponse: GetPricesResponse? = null
@@ -235,33 +249,38 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq1 =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICES)
-            .sellAsset(fiatUSD)
-            .buyAsset("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
-            .sellAmount("100")
-            .countryCode("USA")
-            .sellDeliveryMethod("WIRE")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICES)
+        .sellAsset(fiatUSD)
+        .buyAsset("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
+        .sellAmount("100")
+        .countryCode("USA")
+        .sellDeliveryMethod("WIRE")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq1) } returns
-        GetRateResponse.indicativePrices("1.1", "100", "110")
+      GetRateResponse.indicativePrices("1.1", "100", "110")
 
     val getRateReq2 =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICES)
-            .sellAsset(fiatUSD)
-            .buyAsset(stellarUSDC)
-            .sellAmount("100")
-            .countryCode("USA")
-            .sellDeliveryMethod("WIRE")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICES)
+        .sellAsset(fiatUSD)
+        .buyAsset(stellarUSDC)
+        .sellAmount("100")
+        .countryCode("USA")
+        .sellDeliveryMethod("WIRE")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq2) } returns
-        GetRateResponse.indicativePrices("2.1", "100", "210")
+      GetRateResponse.indicativePrices("2.1", "100", "210")
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with all the parameters
 
@@ -280,19 +299,24 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq1 =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICES)
-            .sellAsset(stellarUSDC)
-            .buyAsset(fiatUSD)
-            .sellAmount("100")
-            .buyDeliveryMethod("WIRE")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICES)
+        .sellAsset(stellarUSDC)
+        .buyAsset(fiatUSD)
+        .sellAmount("100")
+        .buyDeliveryMethod("WIRE")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq1) } returns
-        GetRateResponse.indicativePrices("1", "100", "100")
+      GetRateResponse.indicativePrices("1", "100", "100")
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with the minimum parameters and specify buy_delivery_method
     var gotResponse: GetPricesResponse? = null
@@ -318,8 +342,13 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // empty sell_asset
     ex = assertThrows { sep38Service.getPrice(sep10Token, getPriceRequestBuilder.build()) }
@@ -435,8 +464,13 @@ class Sep38ServiceTest {
     getPriceRequestBuilder = getPriceRequestBuilder.sellAmount(null)
     getPriceRequestBuilder = getPriceRequestBuilder.buyAssetName(stellarUSDC).buyAmount("100000000")
     every { mockRateIntegration.getRate(any()) } returns
-        GetRateResponse.indicativePrice(
-            "1.02", "1.03", "102000000", "100000000", mockSellAssetFee(fiatUSD))
+      GetRateResponse.indicativePrice(
+        "1.02",
+        "1.03",
+        "102000000",
+        "100000000",
+        mockSellAssetFee(fiatUSD)
+      )
     ex = assertThrows { sep38Service.getPrice(sep10Token, getPriceRequestBuilder.build()) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount exceeds max limit", ex.message)
@@ -457,38 +491,43 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICE)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .buyAsset(stellarUSDC)
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICE)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .buyAsset(stellarUSDC)
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq) } returns
-        GetRateResponse.indicativePrice("1.02", "1.03", "100", "97.0874", mockFee)
+      GetRateResponse.indicativePrice("1.02", "1.03", "100", "97.0874", mockFee)
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with the minimum parameters using sellAmount
     val getPriceRequest =
-        Sep38GetPriceRequest.builder()
-            .sellAssetName(fiatUSD)
-            .sellAmount("100")
-            .buyAssetName(stellarUSDC)
-            .context(SEP31)
-            .build()
+      Sep38GetPriceRequest.builder()
+        .sellAssetName(fiatUSD)
+        .sellAmount("100")
+        .buyAssetName(stellarUSDC)
+        .context(SEP31)
+        .build()
     var gotResponse: GetPriceResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrice(sep10Token, getPriceRequest) }
     val wantResponse =
-        GetPriceResponse.builder()
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAmount("100")
-            .buyAmount("97.0874")
-            .fee(mockFee)
-            .build()
+      GetPriceResponse.builder()
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAmount("100")
+        .buyAmount("97.0874")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -499,38 +538,43 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICE)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .buyAmount("100")
-            .buyAsset(stellarUSDC)
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICE)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .buyAmount("100")
+        .buyAsset(stellarUSDC)
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq) } returns
-        GetRateResponse.indicativePrice("1.02", "1.03", "103", "100", mockFee)
+      GetRateResponse.indicativePrice("1.02", "1.03", "103", "100", mockFee)
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with the minimum parameters using buyAmount
     val getPriceRequest =
-        Sep38GetPriceRequest.builder()
-            .sellAssetName(fiatUSD)
-            .buyAssetName(stellarUSDC)
-            .buyAmount("100")
-            .context(SEP31)
-            .build()
+      Sep38GetPriceRequest.builder()
+        .sellAssetName(fiatUSD)
+        .buyAssetName(stellarUSDC)
+        .buyAmount("100")
+        .context(SEP31)
+        .build()
     var gotResponse: GetPriceResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrice(sep10Token, getPriceRequest) }
     val wantResponse =
-        GetPriceResponse.builder()
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAmount("103")
-            .buyAmount("100")
-            .fee(mockFee)
-            .build()
+      GetPriceResponse.builder()
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAmount("103")
+        .buyAmount("100")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -541,42 +585,47 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICE)
-            .context(SEP6)
-            .sellAsset(fiatUSD)
-            .buyAsset(stellarUSDC)
-            .sellAmount("100")
-            .countryCode("USA")
-            .sellDeliveryMethod("WIRE")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICE)
+        .context(SEP6)
+        .sellAsset(fiatUSD)
+        .buyAsset(stellarUSDC)
+        .sellAmount("100")
+        .countryCode("USA")
+        .sellDeliveryMethod("WIRE")
+        .clientId(sep10Token.account)
+        .build()
     every { mockRateIntegration.getRate(getRateReq) } returns
-        GetRateResponse.indicativePrice("1.02", "1.03", "100", "97.0873786", mockFee)
+      GetRateResponse.indicativePrice("1.02", "1.03", "100", "97.0873786", mockFee)
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with all the parameters using sellAmount
     val getPriceRequest =
-        Sep38GetPriceRequest.builder()
-            .sellAssetName(fiatUSD)
-            .sellAmount("100")
-            .sellDeliveryMethod("WIRE")
-            .buyAssetName(stellarUSDC)
-            .countryCode("USA")
-            .context(SEP6)
-            .build()
+      Sep38GetPriceRequest.builder()
+        .sellAssetName(fiatUSD)
+        .sellAmount("100")
+        .sellDeliveryMethod("WIRE")
+        .buyAssetName(stellarUSDC)
+        .countryCode("USA")
+        .context(SEP6)
+        .build()
     var gotResponse: GetPriceResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrice(sep10Token, getPriceRequest) }
     val wantResponse =
-        GetPriceResponse.builder()
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAmount("100")
-            .buyAmount("97.0873786")
-            .fee(mockFee)
-            .build()
+      GetPriceResponse.builder()
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAmount("100")
+        .buyAmount("97.0873786")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -587,44 +636,48 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(INDICATIVE_PRICE)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .countryCode("USA")
-            .sellDeliveryMethod("WIRE")
-            .clientId(sep10Token.account)
-            .build()
+      GetRateRequest.builder()
+        .type(INDICATIVE_PRICE)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .countryCode("USA")
+        .sellDeliveryMethod("WIRE")
+        .clientId(sep10Token.account)
+        .build()
 
     every { mockRateIntegration.getRate(getRateReq) } returns
-        GetRateResponse.indicativePrice(
-            "1.02345678901", "1.03345679", "103.3456789", "100", mockFee)
+      GetRateResponse.indicativePrice("1.02345678901", "1.03345679", "103.3456789", "100", mockFee)
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // test happy path with all the parameters using buyAmount
     val getPriceRequest =
-        Sep38GetPriceRequest.builder()
-            .sellAssetName(fiatUSD)
-            .sellDeliveryMethod("WIRE")
-            .buyAssetName(stellarUSDC)
-            .buyAmount("100")
-            .countryCode("USA")
-            .context(SEP31)
-            .build()
+      Sep38GetPriceRequest.builder()
+        .sellAssetName(fiatUSD)
+        .sellDeliveryMethod("WIRE")
+        .buyAssetName(stellarUSDC)
+        .buyAmount("100")
+        .countryCode("USA")
+        .context(SEP31)
+        .build()
     var gotResponse: GetPriceResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrice(sep10Token, getPriceRequest) }
     val wantResponse =
-        GetPriceResponse.builder()
-            .price("1.02345678901")
-            .totalPrice("1.03345679")
-            .sellAmount("103.3456789")
-            .buyAmount("100")
-            .fee(mockFee)
-            .build()
+      GetPriceResponse.builder()
+        .price("1.02345678901")
+        .totalPrice("1.03345679")
+        .sellAmount("103.3456789")
+        .buyAmount("100")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -640,8 +693,13 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config, sep38Service.assetService, mockRateIntegration, null, null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        null,
+        null
+      )
 
     // empty sep38QuoteStore should throw an error
     ex = assertThrows { sep38Service.postQuote(null, Sep38PostQuoteRequest.builder().build()) }
@@ -650,12 +708,13 @@ class Sep38ServiceTest {
 
     // mocked quote store
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            null)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        null
+      )
 
     // empty token
     ex = assertThrows { sep38Service.postQuote(null, Sep38PostQuoteRequest.builder().build()) }
@@ -675,238 +734,282 @@ class Sep38ServiceTest {
     assertEquals("sell_asset cannot be empty", ex.message)
 
     // nonexistent sell_asset
-    ex = assertThrows {
-      sep38Service.postQuote(
-          token, Sep38PostQuoteRequest.builder().sellAssetName("foo:bar").build())
-    }
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder().sellAssetName("foo:bar").build()
+        )
+      }
     assertInstanceOf(NotFoundException::class.java, ex)
     assertEquals("sell_asset not found", ex.message)
 
     // empty buy_asset
-    ex = assertThrows {
-      sep38Service.postQuote(token, Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).build())
-    }
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("buy_asset cannot be empty", ex.message)
 
     // nonexistent buy_asset
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
-          Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName("foo:bar").build())
-    }
+          Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName("foo:bar").build()
+        )
+      }
     assertInstanceOf(NotFoundException::class.java, ex)
     assertEquals("buy_asset not found", ex.message)
 
     // both sell_amount & buy_amount are empty
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
-          Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName(stellarUSDC).build())
-    }
+          Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName(stellarUSDC).build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Please provide either sell_amount or buy_amount", ex.message)
 
     // both sell_amount & buy_amount are filled
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("100")
-              .buyAssetName(stellarUSDC)
-              .buyAmount("100")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("100")
+            .buyAssetName(stellarUSDC)
+            .buyAmount("100")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Please provide either sell_amount or buy_amount", ex.message)
 
     // invalid (not a number) sell_amount
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("foo")
-              .buyAssetName(stellarUSDC)
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("foo")
+            .buyAssetName(stellarUSDC)
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount is invalid", ex.message)
 
     // sell_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("-0.01")
-              .buyAssetName(stellarUSDC)
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("-0.01")
+            .buyAssetName(stellarUSDC)
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount should be positive", ex.message)
 
     // sell_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("0")
-              .buyAssetName(stellarUSDC)
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("0")
+            .buyAssetName(stellarUSDC)
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount should be positive", ex.message)
 
     // invalid (not a number) buy_amount
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .buyAssetName(stellarUSDC)
-              .buyAmount("bar")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .buyAssetName(stellarUSDC)
+            .buyAmount("bar")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("buy_amount is invalid", ex.message)
 
     // buy_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .buyAssetName(stellarUSDC)
-              .buyAmount("-0.02")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .buyAssetName(stellarUSDC)
+            .buyAmount("-0.02")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("buy_amount should be positive", ex.message)
 
     // buy_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .buyAssetName(stellarUSDC)
-              .buyAmount("0")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .buyAssetName(stellarUSDC)
+            .buyAmount("0")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("buy_amount should be positive", ex.message)
 
     // unsupported sell_delivery_method
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("1.23")
-              .sellDeliveryMethod("FOO")
-              .buyAssetName(stellarUSDC)
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("1.23")
+            .sellDeliveryMethod("FOO")
+            .buyAssetName(stellarUSDC)
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported sell delivery method", ex.message)
 
     // unsupported buy_delivery_method
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("1.23")
-              .sellDeliveryMethod("WIRE")
-              .buyAssetName(stellarUSDC)
-              .buyDeliveryMethod("BAR")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("1.23")
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .buyDeliveryMethod("BAR")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported buy delivery method", ex.message)
 
     // unsupported country_code
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("1.23")
-              .sellDeliveryMethod("WIRE")
-              .buyAssetName(stellarUSDC)
-              .countryCode("BRA")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("1.23")
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .countryCode("BRA")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported country code", ex.message)
 
     // unsupported expire_after
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("1.23")
-              .sellDeliveryMethod("WIRE")
-              .buyAssetName(stellarUSDC)
-              .countryCode("USA")
-              .expireAfter("2022-04-18T23:33:24.629719Z")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("1.23")
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .countryCode("USA")
+            .expireAfter("2022-04-18T23:33:24.629719Z")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported context. Should be one of [sep6, sep31].", ex.message)
 
     // sell_amount should be within limit
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("100000000")
-              .sellDeliveryMethod("WIRE")
-              .context(SEP31)
-              .buyAssetName(stellarUSDC)
-              .countryCode("USA")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("100000000")
+            .sellDeliveryMethod("WIRE")
+            .context(SEP31)
+            .buyAssetName(stellarUSDC)
+            .countryCode("USA")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount exceeds max limit", ex.message)
 
     // sell_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellAmount("0.5")
-              .sellDeliveryMethod("WIRE")
-              .context(SEP31)
-              .buyAssetName(stellarUSDC)
-              .countryCode("USA")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellAmount("0.5")
+            .sellDeliveryMethod("WIRE")
+            .context(SEP31)
+            .buyAssetName(stellarUSDC)
+            .countryCode("USA")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount less than min limit", ex.message)
 
     // buy_amount specified, but resulting sell_amount should be within limit
     every { mockRateIntegration.getRate(any()) } returns
-        GetRateResponse.indicativePrice(
-            "1.02", "1.03", "102000000", "100000000", mockSellAssetFee(fiatUSD))
-    ex = assertThrows {
-      sep38Service.postQuote(
+      GetRateResponse.indicativePrice(
+        "1.02",
+        "1.03",
+        "102000000",
+        "100000000",
+        mockSellAssetFee(fiatUSD)
+      )
+    ex =
+      assertThrows {
+        sep38Service.postQuote(
           token,
           Sep38PostQuoteRequest.builder()
-              .sellAssetName(fiatUSD)
-              .sellDeliveryMethod("WIRE")
-              .context(SEP31)
-              .buyAssetName(stellarUSDC)
-              .buyAmount("100000000")
-              .countryCode("USA")
-              .build())
-    }
+            .sellAssetName(fiatUSD)
+            .sellDeliveryMethod("WIRE")
+            .context(SEP31)
+            .buyAssetName(stellarUSDC)
+            .buyAmount("100000000")
+            .countryCode("USA")
+            .build()
+        )
+      }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_amount exceeds max limit", ex.message)
   }
@@ -918,35 +1021,36 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(FIRM)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .clientId(PUBLIC_KEY)
-            .build()
+      GetRateRequest.builder()
+        .type(FIRM)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .clientId(PUBLIC_KEY)
+        .build()
     val tomorrow = Instant.now().plus(1, ChronoUnit.DAYS)
 
     val rate =
-        GetRateResponse.Rate.builder()
-            .id("123")
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAmount("103")
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .fee(mockFee)
-            .build()
+      GetRateResponse.Rate.builder()
+        .id("123")
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAmount("103")
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .fee(mockFee)
+        .build()
     val wantRateResponse = GetRateResponse(rate)
     every { mockRateIntegration.getRate(getRateReq) } returns wantRateResponse
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            eventService)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        eventService
+      )
 
     val slotQuote = slot<Sep38Quote>()
     every { quoteStore.save(capture(slotQuote)) } returns null
@@ -960,27 +1064,28 @@ class Sep38ServiceTest {
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
-          sep38Service.postQuote(
-              token,
-              Sep38PostQuoteRequest.builder()
-                  .context(SEP31)
-                  .sellAssetName(fiatUSD)
-                  .sellAmount("103")
-                  .buyAssetName(stellarUSDC)
-                  .build())
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder()
+            .context(SEP31)
+            .sellAssetName(fiatUSD)
+            .sellAmount("103")
+            .buyAssetName(stellarUSDC)
+            .build()
+        )
     }
     val wantResponse =
-        Sep38QuoteResponse.builder()
-            .id("123")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("123")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
 
     // verify the saved quote
@@ -1001,22 +1106,22 @@ class Sep38ServiceTest {
     // verify the published event
     verify(exactly = 1) { eventService.publish(any()) }
     val wantEvent =
-        QuoteEvent.builder()
-            .eventId(slotEvent.captured.eventId)
-            .type(QuoteEvent.Type.QUOTE_CREATED)
-            .id("123")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .creator(StellarId.builder().account(PUBLIC_KEY).build())
-            .transactionId(null)
-            .createdAt(savedQuote.createdAt)
-            .fee(mockFee)
-            .build()
+      QuoteEvent.builder()
+        .eventId(slotEvent.captured.eventId)
+        .type(QuoteEvent.Type.QUOTE_CREATED)
+        .id("123")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .creator(StellarId.builder().account(PUBLIC_KEY).build())
+        .transactionId(null)
+        .createdAt(savedQuote.createdAt)
+        .fee(mockFee)
+        .build()
     assertEquals(wantEvent, slotEvent.captured)
   }
 
@@ -1027,36 +1132,36 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(FIRM)
-            .context(SEP6)
-            .sellAsset(fiatUSD)
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .clientId(PUBLIC_KEY)
-            .build()
+      GetRateRequest.builder()
+        .type(FIRM)
+        .context(SEP6)
+        .sellAsset(fiatUSD)
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .clientId(PUBLIC_KEY)
+        .build()
 
     val tomorrow = Instant.now().plus(1, ChronoUnit.DAYS)
     val rate =
-        GetRateResponse.Rate.builder()
-            .id("456")
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAmount("103")
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .fee(mockFee)
-            .build()
+      GetRateResponse.Rate.builder()
+        .id("456")
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAmount("103")
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .fee(mockFee)
+        .build()
     val wantRateResponse = GetRateResponse(rate)
     every { mockRateIntegration.getRate(getRateReq) } returns wantRateResponse
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            eventService,
-        )
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        eventService,
+      )
 
     val slotQuote = slot<Sep38Quote>()
     every { quoteStore.save(capture(slotQuote)) } returns null
@@ -1070,27 +1175,28 @@ class Sep38ServiceTest {
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
-          sep38Service.postQuote(
-              token,
-              Sep38PostQuoteRequest.builder()
-                  .context(SEP6)
-                  .sellAssetName(fiatUSD)
-                  .buyAssetName(stellarUSDC)
-                  .buyAmount("100")
-                  .build())
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder()
+            .context(SEP6)
+            .sellAssetName(fiatUSD)
+            .buyAssetName(stellarUSDC)
+            .buyAmount("100")
+            .build()
+        )
     }
     val wantResponse =
-        Sep38QuoteResponse.builder()
-            .id("456")
-            .expiresAt(tomorrow)
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("456")
+        .expiresAt(tomorrow)
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
 
     // verify the saved quote
@@ -1110,22 +1216,22 @@ class Sep38ServiceTest {
     // verify the published event
     verify(exactly = 1) { eventService.publish(any()) }
     val wantEvent =
-        QuoteEvent.builder()
-            .eventId(slotEvent.captured.eventId)
-            .type(QuoteEvent.Type.QUOTE_CREATED)
-            .id("456")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .creator(StellarId.builder().account(PUBLIC_KEY).build())
-            .transactionId(null)
-            .createdAt(savedQuote.createdAt)
-            .fee(mockFee)
-            .build()
+      QuoteEvent.builder()
+        .eventId(slotEvent.captured.eventId)
+        .type(QuoteEvent.Type.QUOTE_CREATED)
+        .id("456")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .creator(StellarId.builder().account(PUBLIC_KEY).build())
+        .transactionId(null)
+        .createdAt(savedQuote.createdAt)
+        .fee(mockFee)
+        .build()
     assertEquals(wantEvent, slotEvent.captured)
   }
 
@@ -1138,37 +1244,38 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(FIRM)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .sellDeliveryMethod("WIRE")
-            .buyAsset(stellarUSDC)
-            .countryCode("USA")
-            .clientId(PUBLIC_KEY)
-            .expireAfter(now.toString())
-            .build()
+      GetRateRequest.builder()
+        .type(FIRM)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .sellDeliveryMethod("WIRE")
+        .buyAsset(stellarUSDC)
+        .countryCode("USA")
+        .clientId(PUBLIC_KEY)
+        .expireAfter(now.toString())
+        .build()
 
     val rate =
-        GetRateResponse.Rate.builder()
-            .id("123")
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAmount("100")
-            .buyAmount("97.0873786")
-            .expiresAt(tomorrow)
-            .fee(mockFee)
-            .build()
+      GetRateResponse.Rate.builder()
+        .id("123")
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAmount("100")
+        .buyAmount("97.0873786")
+        .expiresAt(tomorrow)
+        .fee(mockFee)
+        .build()
     val wantRateResponse = GetRateResponse(rate)
     every { mockRateIntegration.getRate(getRateReq) } returns wantRateResponse
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            eventService)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        eventService
+      )
 
     val slotQuote = slot<Sep38Quote>()
     every { quoteStore.save(capture(slotQuote)) } returns null
@@ -1182,30 +1289,31 @@ class Sep38ServiceTest {
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
-          sep38Service.postQuote(
-              token,
-              Sep38PostQuoteRequest.builder()
-                  .context(SEP31)
-                  .sellAssetName(fiatUSD)
-                  .sellAmount("100")
-                  .sellDeliveryMethod("WIRE")
-                  .buyAssetName(stellarUSDC)
-                  .countryCode("USA")
-                  .expireAfter(now.toString())
-                  .build())
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder()
+            .context(SEP31)
+            .sellAssetName(fiatUSD)
+            .sellAmount("100")
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .countryCode("USA")
+            .expireAfter(now.toString())
+            .build()
+        )
     }
     val wantResponse =
-        Sep38QuoteResponse.builder()
-            .id("123")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .buyAsset(stellarUSDC)
-            .buyAmount("97.0873786")
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("123")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .buyAsset(stellarUSDC)
+        .buyAmount("97.0873786")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
 
     // verify the saved quote
@@ -1227,22 +1335,22 @@ class Sep38ServiceTest {
     // verify the published event
     verify(exactly = 1) { eventService.publish(any()) }
     val wantEvent =
-        QuoteEvent.builder()
-            .eventId(slotEvent.captured.eventId)
-            .type(QuoteEvent.Type.QUOTE_CREATED)
-            .id("123")
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .buyAsset(stellarUSDC)
-            .buyAmount("97.0873786")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .creator(StellarId.builder().account(PUBLIC_KEY).build())
-            .transactionId(null)
-            .createdAt(savedQuote.createdAt)
-            .fee(mockFee)
-            .build()
+      QuoteEvent.builder()
+        .eventId(slotEvent.captured.eventId)
+        .type(QuoteEvent.Type.QUOTE_CREATED)
+        .id("123")
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .buyAsset(stellarUSDC)
+        .buyAmount("97.0873786")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .creator(StellarId.builder().account(PUBLIC_KEY).build())
+        .transactionId(null)
+        .createdAt(savedQuote.createdAt)
+        .fee(mockFee)
+        .build()
     assertEquals(wantEvent, slotEvent.captured)
   }
 
@@ -1255,37 +1363,38 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(FIRM)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .sellDeliveryMethod("WIRE")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .countryCode("USA")
-            .clientId(PUBLIC_KEY)
-            .expireAfter(now.toString())
-            .build()
+      GetRateRequest.builder()
+        .type(FIRM)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .sellDeliveryMethod("WIRE")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .countryCode("USA")
+        .clientId(PUBLIC_KEY)
+        .expireAfter(now.toString())
+        .build()
 
     val rate =
-        GetRateResponse.Rate.builder()
-            .id("456")
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAmount("103")
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .fee(mockFee)
-            .build()
+      GetRateResponse.Rate.builder()
+        .id("456")
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAmount("103")
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .fee(mockFee)
+        .build()
     val wantRateResponse = GetRateResponse(rate)
     every { mockRateIntegration.getRate(getRateReq) } returns wantRateResponse
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            eventService)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        eventService
+      )
 
     val slotQuote = slot<Sep38Quote>()
     every { quoteStore.save(capture(slotQuote)) } returns null
@@ -1299,30 +1408,31 @@ class Sep38ServiceTest {
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
-          sep38Service.postQuote(
-              token,
-              Sep38PostQuoteRequest.builder()
-                  .context(SEP31)
-                  .sellAssetName(fiatUSD)
-                  .sellDeliveryMethod("WIRE")
-                  .buyAssetName(stellarUSDC)
-                  .buyAmount("100")
-                  .countryCode("USA")
-                  .expireAfter(now.toString())
-                  .build())
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder()
+            .context(SEP31)
+            .sellAssetName(fiatUSD)
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .buyAmount("100")
+            .countryCode("USA")
+            .expireAfter(now.toString())
+            .build()
+        )
     }
     val wantResponse =
-        Sep38QuoteResponse.builder()
-            .id("456")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("456")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
 
     // verify the saved quote
@@ -1344,22 +1454,22 @@ class Sep38ServiceTest {
     // verify the published event
     verify(exactly = 1) { eventService.publish(any()) }
     val wantEvent =
-        QuoteEvent.builder()
-            .eventId(slotEvent.captured.eventId)
-            .type(QuoteEvent.Type.QUOTE_CREATED)
-            .id("456")
-            .sellAsset(fiatUSD)
-            .sellAmount("103")
-            .buyAsset(stellarUSDC)
-            .buyAmount("100")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .creator(StellarId.builder().account(PUBLIC_KEY).build())
-            .transactionId(null)
-            .createdAt(savedQuote.createdAt)
-            .fee(mockFee)
-            .build()
+      QuoteEvent.builder()
+        .eventId(slotEvent.captured.eventId)
+        .type(QuoteEvent.Type.QUOTE_CREATED)
+        .id("456")
+        .sellAsset(fiatUSD)
+        .sellAmount("103")
+        .buyAsset(stellarUSDC)
+        .buyAmount("100")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .creator(StellarId.builder().account(PUBLIC_KEY).build())
+        .transactionId(null)
+        .createdAt(savedQuote.createdAt)
+        .fee(mockFee)
+        .build()
     assertEquals(wantEvent, slotEvent.captured)
   }
 
@@ -1378,37 +1488,38 @@ class Sep38ServiceTest {
     // mock rate integration
     val mockRateIntegration = mockk<MockRateIntegration>()
     val getRateReq =
-        GetRateRequest.builder()
-            .type(FIRM)
-            .context(SEP31)
-            .sellAsset(fiatUSD)
-            .sellDeliveryMethod("WIRE")
-            .buyAsset(stellarUSDC)
-            .buyAmount(requestBuyAmount)
-            .countryCode("USA")
-            .clientId(PUBLIC_KEY)
-            .expireAfter(now.toString())
-            .build()
+      GetRateRequest.builder()
+        .type(FIRM)
+        .context(SEP31)
+        .sellAsset(fiatUSD)
+        .sellDeliveryMethod("WIRE")
+        .buyAsset(stellarUSDC)
+        .buyAmount(requestBuyAmount)
+        .countryCode("USA")
+        .clientId(PUBLIC_KEY)
+        .expireAfter(now.toString())
+        .build()
 
     val rate =
-        GetRateResponse.Rate.builder()
-            .id("456")
-            .totalPrice("1.03")
-            .price("1.02")
-            .sellAmount(anchorCalculatedSellAmount)
-            .buyAmount(anchorCalculatedBuyAmount)
-            .expiresAt(tomorrow)
-            .fee(mockFee)
-            .build()
+      GetRateResponse.Rate.builder()
+        .id("456")
+        .totalPrice("1.03")
+        .price("1.02")
+        .sellAmount(anchorCalculatedSellAmount)
+        .buyAmount(anchorCalculatedBuyAmount)
+        .expiresAt(tomorrow)
+        .fee(mockFee)
+        .build()
     val wantRateResponse = GetRateResponse(rate)
     every { mockRateIntegration.getRate(getRateReq) } returns wantRateResponse
     sep38Service =
-        Sep38Service(
-            sep38Service.sep38Config,
-            sep38Service.assetService,
-            mockRateIntegration,
-            quoteStore,
-            eventService)
+      Sep38Service(
+        sep38Service.sep38Config,
+        sep38Service.assetService,
+        mockRateIntegration,
+        quoteStore,
+        eventService
+      )
 
     val slotQuote = slot<Sep38Quote>()
     every { quoteStore.save(capture(slotQuote)) } returns null
@@ -1422,30 +1533,31 @@ class Sep38ServiceTest {
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
-          sep38Service.postQuote(
-              token,
-              Sep38PostQuoteRequest.builder()
-                  .context(SEP31)
-                  .sellAssetName(fiatUSD)
-                  .sellDeliveryMethod("WIRE")
-                  .buyAssetName(stellarUSDC)
-                  .buyAmount(requestBuyAmount)
-                  .countryCode("USA")
-                  .expireAfter(now.toString())
-                  .build())
+        sep38Service.postQuote(
+          token,
+          Sep38PostQuoteRequest.builder()
+            .context(SEP31)
+            .sellAssetName(fiatUSD)
+            .sellDeliveryMethod("WIRE")
+            .buyAssetName(stellarUSDC)
+            .buyAmount(requestBuyAmount)
+            .countryCode("USA")
+            .expireAfter(now.toString())
+            .build()
+        )
     }
     val wantResponse =
-        Sep38QuoteResponse.builder()
-            .id("456")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount(anchorCalculatedSellAmount)
-            .buyAsset(stellarUSDC)
-            .buyAmount(anchorCalculatedBuyAmount)
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("456")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount(anchorCalculatedSellAmount)
+        .buyAsset(stellarUSDC)
+        .buyAmount(anchorCalculatedBuyAmount)
+        .fee(mockFee)
+        .build()
     assertEquals(wantResponse, gotResponse)
 
     // verify the saved quote
@@ -1467,22 +1579,22 @@ class Sep38ServiceTest {
     // verify the published event
     verify(exactly = 1) { eventService.publish(any()) }
     val wantEvent =
-        QuoteEvent.builder()
-            .eventId(slotEvent.captured.eventId)
-            .type(QuoteEvent.Type.QUOTE_CREATED)
-            .id("456")
-            .sellAsset(fiatUSD)
-            .sellAmount(anchorCalculatedSellAmount)
-            .buyAsset(stellarUSDC)
-            .buyAmount(anchorCalculatedBuyAmount)
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .creator(StellarId.builder().account(PUBLIC_KEY).build())
-            .transactionId(null)
-            .createdAt(savedQuote.createdAt)
-            .fee(mockFee)
-            .build()
+      QuoteEvent.builder()
+        .eventId(slotEvent.captured.eventId)
+        .type(QuoteEvent.Type.QUOTE_CREATED)
+        .id("456")
+        .sellAsset(fiatUSD)
+        .sellAmount(anchorCalculatedSellAmount)
+        .buyAsset(stellarUSDC)
+        .buyAmount(anchorCalculatedBuyAmount)
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .creator(StellarId.builder().account(PUBLIC_KEY).build())
+        .transactionId(null)
+        .createdAt(savedQuote.createdAt)
+        .fee(mockFee)
+        .build()
     assertEquals(wantEvent, slotEvent.captured)
   }
 
@@ -1495,7 +1607,7 @@ class Sep38ServiceTest {
 
     // mocked quote store
     sep38Service =
-        Sep38Service(sep38Service.sep38Config, sep38Service.assetService, null, quoteStore, null)
+      Sep38Service(sep38Service.sep38Config, sep38Service.assetService, null, quoteStore, null)
 
     // empty token
     ex = assertThrows { sep38Service.getQuote(null, null) }
@@ -1519,15 +1631,15 @@ class Sep38ServiceTest {
     val tomorrow = now.plus(1, ChronoUnit.DAYS)
     val mockQuoteBuilder: () -> Sep38QuoteBuilder = {
       Sep38QuoteBuilder(quoteStore)
-          .id("123")
-          .expiresAt(tomorrow)
-          .price("1.02")
-          .sellAsset(fiatUSD)
-          .sellAmount("100")
-          .sellDeliveryMethod("WIRE")
-          .buyAsset(stellarUSDC)
-          .buyAmount("98.0392157")
-          .createdAt(now)
+        .id("123")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .sellDeliveryMethod("WIRE")
+        .buyAsset(stellarUSDC)
+        .buyAmount("98.0392157")
+        .createdAt(now)
     }
 
     // jwt token account is different from quote account
@@ -1553,7 +1665,7 @@ class Sep38ServiceTest {
 
     // jwt token memo is different from quote memo
     mockQuote =
-        mockQuoteBuilder().creatorAccountId(PUBLIC_KEY).creatorMemoType("wrong memoType!").build()
+      mockQuoteBuilder().creatorAccountId(PUBLIC_KEY).creatorMemoType("wrong memoType!").build()
     slotQuoteId = slot()
     every { quoteStore.findByQuoteId(capture(slotQuoteId)) } returns mockQuote
     ex = assertThrows { sep38Service.getQuote(token, "123") }
@@ -1577,26 +1689,26 @@ class Sep38ServiceTest {
 
     // mocked quote store
     sep38Service =
-        Sep38Service(sep38Service.sep38Config, sep38Service.assetService, null, quoteStore, null)
+      Sep38Service(sep38Service.sep38Config, sep38Service.assetService, null, quoteStore, null)
 
     // mock quote store response
     val now = Instant.now()
     val tomorrow = now.plus(1, ChronoUnit.DAYS)
     val mockQuote =
-        Sep38QuoteBuilder(quoteStore)
-            .id("123")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .sellDeliveryMethod("WIRE")
-            .buyAsset(stellarUSDC)
-            .buyAmount("97.0873786")
-            .createdAt(now)
-            .creatorAccountId(PUBLIC_KEY)
-            .fee(mockFee)
-            .build()
+      Sep38QuoteBuilder(quoteStore)
+        .id("123")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .sellDeliveryMethod("WIRE")
+        .buyAsset(stellarUSDC)
+        .buyAmount("97.0873786")
+        .createdAt(now)
+        .creatorAccountId(PUBLIC_KEY)
+        .fee(mockFee)
+        .build()
     val slotQuoteId = slot<String>()
     every { quoteStore.findByQuoteId(capture(slotQuoteId)) } returns mockQuote
 
@@ -1611,17 +1723,17 @@ class Sep38ServiceTest {
 
     // verify results
     val wantQuoteResponse =
-        Sep38QuoteResponse.builder()
-            .id("123")
-            .expiresAt(tomorrow)
-            .price("1.02")
-            .totalPrice("1.03")
-            .sellAsset(fiatUSD)
-            .sellAmount("100")
-            .buyAsset(stellarUSDC)
-            .buyAmount("97.0873786")
-            .fee(mockFee)
-            .build()
+      Sep38QuoteResponse.builder()
+        .id("123")
+        .expiresAt(tomorrow)
+        .price("1.02")
+        .totalPrice("1.03")
+        .sellAsset(fiatUSD)
+        .sellAmount("100")
+        .buyAsset(stellarUSDC)
+        .buyAmount("97.0873786")
+        .fee(mockFee)
+        .build()
     assertEquals(wantQuoteResponse, gotQuoteResponse)
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
@@ -27,6 +27,7 @@ import org.stellar.anchor.api.sep.sep38.GetPriceResponse
 import org.stellar.anchor.api.sep.sep38.RateFee
 import org.stellar.anchor.api.sep.sep38.Sep38Context
 import org.stellar.anchor.api.sep.sep38.Sep38GetPriceRequest
+import org.stellar.anchor.auth.JwtToken
 import org.stellar.anchor.sep38.Sep38Service
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.anchor.util.OkHttpUtil
@@ -59,6 +60,26 @@ class ApiKeyAuthIntegrationTest {
       .readTimeout(10, TimeUnit.MINUTES)
       .writeTimeout(10, TimeUnit.MINUTES)
       .build()
+
+  private val sep10Token =
+    createJwtToken("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG")
+
+  private fun createJwtToken(
+    account: String,
+    accountMemo: String? = null,
+    hostUrl: String = "",
+    clientDomain: String = "vibrant.stellar.org"
+  ): JwtToken {
+    val issuedAt: Long = System.currentTimeMillis() / 1000L
+    return JwtToken.of(
+      "$hostUrl/auth",
+      if (accountMemo == null) account else "$account:$accountMemo",
+      issuedAt,
+      issuedAt + 60,
+      "",
+      clientDomain
+    )
+  }
 
   private fun getDummyRequestBody(method: String): RequestBody? {
     return if (method != "PATCH") null
@@ -174,7 +195,7 @@ class ApiKeyAuthIntegrationTest {
         .buyAssetName("stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP")
         .context(Sep38Context.SEP31)
         .build()
-    val gotResponse = sep38Service.getPrice(getPriceRequest)
+    val gotResponse = sep38Service.getPrice(sep10Token, getPriceRequest)
 
     val wantResponse =
       GetPriceResponse.builder()

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/ApiKeyAuthIntegrationTest.kt
@@ -219,6 +219,7 @@ class ApiKeyAuthIntegrationTest {
         &sell_asset=iso4217%3AUSD
         &sell_amount=100
         &buy_asset=stellar%3AUSDC%3AGDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+        &client_id=GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG
         """.replace(
         "\n        ",
         ""

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -49,7 +49,7 @@ public class Sep38Controller {
       value = "/prices",
       method = {RequestMethod.GET})
   public GetPricesResponse getPrices(
-          HttpServletRequest servletRequest,
+      HttpServletRequest servletRequest,
       @RequestParam(name = "sell_asset") String sellAssetName,
       @RequestParam(name = "sell_amount") String sellAmount,
       @RequestParam(name = "sell_delivery_method", required = false) String sellDeliveryMethod,
@@ -77,7 +77,6 @@ public class Sep38Controller {
   @RequestMapping(
       value = "/price",
       method = {RequestMethod.GET})
-
   public GetPriceResponse getPrice(
       HttpServletRequest servletRequest, @RequestParam Map<String, String> params) {
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -83,7 +83,7 @@ public class Sep38Controller {
     debugF("GET /price params={}", params);
     Sep38GetPriceRequest getPriceRequest =
         gson.fromJson(gson.toJson(params), Sep38GetPriceRequest.class);
-    return sep38Service.getPrice(getPriceRequest);
+    return sep38Service.getPrice(getSep10Token(servletRequest), getPriceRequest);
   }
 
   @SneakyThrows

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -63,8 +63,13 @@ public class Sep38Controller {
         sellDeliveryMethod,
         buyDeliveryMethod,
         countryCode);
-    return sep38Service.getPrices(getSep10Token(servletRequest),
-        sellAssetName, sellAmount, sellDeliveryMethod, buyDeliveryMethod, countryCode);
+    return sep38Service.getPrices(
+        getSep10Token(servletRequest),
+        sellAssetName,
+        sellAmount,
+        sellDeliveryMethod,
+        buyDeliveryMethod,
+        countryCode);
   }
 
   @SneakyThrows
@@ -72,7 +77,8 @@ public class Sep38Controller {
   @RequestMapping(
       value = "/price",
       method = {RequestMethod.GET})
-  public GetPriceResponse getPrice(HttpServletRequest servletRequest, @RequestParam Map<String, String> params) {
+  public GetPriceResponse getPrice(
+      HttpServletRequest servletRequest, @RequestParam Map<String, String> params) {
     debugF("GET /price params={}", params);
     Sep38GetPriceRequest getPriceRequest =
         gson.fromJson(gson.toJson(params), Sep38GetPriceRequest.class);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/Sep38Controller.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller;
 
+import static org.stellar.anchor.filter.JwtTokenFilter.JWT_TOKEN;
 import static org.stellar.anchor.platform.controller.Sep10Helper.getSep10Token;
 import static org.stellar.anchor.util.Log.debugF;
 import static org.stellar.anchor.util.Log.errorEx;
@@ -63,13 +64,9 @@ public class Sep38Controller {
         sellDeliveryMethod,
         buyDeliveryMethod,
         countryCode);
+    JwtToken token = (JwtToken) servletRequest.getAttribute(JWT_TOKEN);
     return sep38Service.getPrices(
-        getSep10Token(servletRequest),
-        sellAssetName,
-        sellAmount,
-        sellDeliveryMethod,
-        buyDeliveryMethod,
-        countryCode);
+        token, sellAssetName, sellAmount, sellDeliveryMethod, buyDeliveryMethod, countryCode);
   }
 
   @SneakyThrows
@@ -83,7 +80,8 @@ public class Sep38Controller {
     debugF("GET /price params={}", params);
     Sep38GetPriceRequest getPriceRequest =
         gson.fromJson(gson.toJson(params), Sep38GetPriceRequest.class);
-    return sep38Service.getPrice(getSep10Token(servletRequest), getPriceRequest);
+    JwtToken token = (JwtToken) servletRequest.getAttribute(JWT_TOKEN);
+    return sep38Service.getPrice(token, getPriceRequest);
   }
 
   @SneakyThrows


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Add missing client_id to rate callback in SEP38 /price and /prices endpoints

### Context

Bug fix

### Testing
<!-- How was this change tested? -->
<!-- Default to `./gradlew test` but if there are other steps required to test, include them here. -->
`./gradlew test`

### Known limitations

<!-- Any known limitations or edge cases. If no known limitations, put NA here.-->