### PR TITLE
[ANCHOR-357] SEP-6: Implement deposit-exchange

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -132,6 +132,8 @@ public class PlatformTransactionData {
     RECEIVE("receive"),
     @SerializedName("deposit")
     DEPOSIT("deposit"),
+    @SerializedName("deposit-exchange")
+    DEPOSIT_EXCHANGE("deposit-exchange"),
     @SerializedName("withdrawal")
     WITHDRAWAL("withdrawal"),
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositExchangeRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositExchangeRequest.java
@@ -1,0 +1,71 @@
+package org.stellar.anchor.api.sep.sep6;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+/**
+ * The request body of the GET /deposit-exchange endpoint.
+ *
+ * @see <a
+ *     href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#request-2">GET
+ *     /deposit-exchange</a>
+ */
+@Builder
+@Data
+public class StartDepositExchangeRequest {
+  /**
+   * The asset code of the on-chain asset the user wants to get from the Anchor after doing an
+   * off-chain deposit.
+   */
+  @NonNull
+  @SerializedName("destination_asset")
+  String destinationAsset;
+
+  /** The SEP-38 identification of the off-chain asset the Anchor will receive from the user. */
+  @NonNull
+  @SerializedName("source_asset")
+  String sourceAsset;
+
+  /**
+   * The ID returned from a SEP-38 POST /quote response. If this parameter is provided and the user
+   * delivers the deposit funds to the Anchor before the quote expiration, the Anchor should respect
+   * the conversion rate agreed in that quote.
+   */
+  @SerializedName("quote_id")
+  String quoteId;
+
+  /** The amount of the source asset the user would like to deposit to the Anchor's off-chain. */
+  @NonNull String amount;
+
+  /** The Stellar account ID of the user to deposit to */
+  @NonNull String account;
+
+  /** The memo type to use for the deposit. */
+  @SerializedName("memo_type")
+  String memoType;
+
+  /** The memo to use for the deposit. */
+  String memo;
+
+  /** Type of deposit. */
+  @NonNull String type;
+
+  /**
+   * Defaults to en if not specified or if the specified language is not supported. Currently,
+   * ignored.
+   */
+  String lang;
+
+  /** The ISO 3166-1 alpha-3 code of the user's current address. */
+  @SerializedName("country_code")
+  String countryCode;
+
+  /**
+   * Whether the client supports receiving deposit transactions as a claimable balance. Currently,
+   * unsupported.
+   */
+  @SerializedName("claimable_balances_supported")
+  Boolean claimableBalancesSupported;
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -135,6 +135,11 @@ class Sep6ServiceTest {
 
     // Verify response
     assertEquals(slotTxn.captured.id, response.id)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.depositResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
   }
 
   @Test
@@ -175,6 +180,11 @@ class Sep6ServiceTest {
 
     // Verify response
     assertEquals(slotTxn.captured.id, response.id)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.depositResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
   }
 
   @Test
@@ -810,8 +820,6 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount(badAmount)
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
     every { requestValidator.validateAmount(badAmount, TEST_ASSET, any(), any(), any()) } throws
       SepValidationException("bad amount")
 
@@ -852,8 +860,6 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount("100")
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
 
     assertThrows<java.lang.RuntimeException> {
       sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
@@ -910,9 +916,6 @@ class Sep6ServiceTest {
         .refundMemo("some text")
         .refundMemoType("text")
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
-
     val response = sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
 
     // Verify validations
@@ -998,9 +1001,6 @@ class Sep6ServiceTest {
         .refundMemo("some text")
         .refundMemoType("text")
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
-
     val response = sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
 
     // Verify validations
@@ -1090,8 +1090,6 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount("100")
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
 
     assertThrows<SepValidationException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
@@ -1111,8 +1109,6 @@ class Sep6ServiceTest {
         .type(unsupportedType)
         .amount("100")
         .build()
-    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
-      assetService.getAsset(TEST_ASSET)
     every { requestValidator.validateTypes(unsupportedType, TEST_ASSET, any()) } throws
       SepValidationException("unsupported type")
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -199,6 +199,14 @@ class Sep6ServiceTest {
     """
       .trimIndent()
 
+  val depositResJson =
+    """
+      {
+          "how": "Check the transaction for more information about how to deposit."
+      }
+    """
+      .trimIndent()
+
   val depositTxnJson =
     """
       {
@@ -225,6 +233,112 @@ class Sep6ServiceTest {
               "status": "incomplete",
               "amount_expected": {
                   "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          }
+      }
+    """
+      .trimIndent()
+
+  val depositExchangeTxnJson =
+    """
+      {
+          "status": "incomplete",
+          "kind": "deposit-exchange",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountIn": "100",
+          "amountInAsset": "iso4217:USD",
+          "amountOut": "98",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "2",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "quoteId": "test-quote-id"
+      }
+    """
+      .trimIndent()
+
+  val depositExchangeTxnEventJson =
+    """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "deposit-exchange",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_in": {
+                  "amount": "100",
+                  "asset": "iso4217:USD"
+              },
+              "amount_out": {
+                  "amount": "98",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_fee": {
+                  "amount": "2",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "quote_id": "test-quote-id",
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          }
+      }
+    """
+      .trimIndent()
+
+  val depositExchangeTxnWithoutQuoteJson =
+    """
+      {
+          "status": "incomplete",
+          "kind": "deposit-exchange",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountIn": "100",
+          "amountInAsset": "iso4217:USD",
+          "amountOut": "98",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "2",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+      }
+    """
+      .trimIndent()
+
+  val depositExchangeTxnEventWithoutQuoteJson =
+    """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "deposit-exchange",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_in": {
+                  "amount": "100",
+                  "asset": "iso4217:USD"
+              },
+              "amount_out": {
+                  "amount": "98",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_fee": {
+                  "amount": "2",
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
@@ -486,6 +600,231 @@ class Sep6ServiceTest {
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
+    verify { eventSession wasNot called }
+  }
+
+  @Test
+  fun `test deposit-exchange with quote`() {
+    val sourceAsset = "iso4217:USD"
+    val destinationAsset = TEST_ASSET
+    val amount = "100"
+
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    every { exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any()) } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset(sourceAsset)
+        .amountOut("98")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .amountFee("2")
+        .amountFeeAsset(TEST_ASSET_SEP38_FORMAT)
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(destinationAsset)
+        .sourceAsset(sourceAsset)
+        .quoteId(TEST_QUOTE_ID)
+        .amount(amount)
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+    val response = sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify effects
+    verify(exactly = 1) {
+      exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), "100")
+    }
+    verify(exactly = 1) { txnStore.save(any()) }
+    verify(exactly = 1) { eventSession.publish(any()) }
+
+    JSONAssert.assertEquals(
+      depositExchangeTxnJson,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotTxn.captured.id.isNotEmpty())
+    assertNotNull(slotTxn.captured.startedAt)
+
+    JSONAssert.assertEquals(
+      depositExchangeTxnEventJson,
+      gson.toJson(slotEvent.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotEvent.captured.id.isNotEmpty())
+    assert(slotEvent.captured.transaction.id.isNotEmpty())
+    assertNotNull(slotEvent.captured.transaction.startedAt)
+
+    // Verify response
+    assertEquals(slotTxn.captured.id, response.id)
+    JSONAssert.assertEquals(depositResJson, gson.toJson(response), JSONCompareMode.LENIENT)
+  }
+
+  @Test
+  fun `test deposit-exchange without quote`() {
+    val sourceAsset = "iso4217:USD"
+    val destinationAsset = TEST_ASSET
+    val amount = "100"
+
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    every { exchangeAmountsCalculator.calculate(any(), any(), "100", TEST_ACCOUNT) } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset(sourceAsset)
+        .amountOut("98")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .amountFee("2")
+        .amountFeeAsset(TEST_ASSET_SEP38_FORMAT)
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(destinationAsset)
+        .sourceAsset(sourceAsset)
+        .amount(amount)
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+    val response = sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify effects
+    verify(exactly = 1) { exchangeAmountsCalculator.calculate(any(), any(), "100", TEST_ACCOUNT) }
+    verify(exactly = 1) { txnStore.save(any()) }
+    verify(exactly = 1) { eventSession.publish(any()) }
+
+    JSONAssert.assertEquals(
+      depositExchangeTxnWithoutQuoteJson,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotTxn.captured.id.isNotEmpty())
+    assertNotNull(slotTxn.captured.startedAt)
+
+    JSONAssert.assertEquals(
+      depositExchangeTxnEventWithoutQuoteJson,
+      gson.toJson(slotEvent.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotEvent.captured.id.isNotEmpty())
+    assert(slotEvent.captured.transaction.id.isNotEmpty())
+    assertNotNull(slotEvent.captured.transaction.startedAt)
+
+    // Verify response
+    assertEquals(slotTxn.captured.id, response.id)
+    JSONAssert.assertEquals(depositResJson, gson.toJson(response), JSONCompareMode.LENIENT)
+  }
+
+  @Test
+  fun `test deposit-exchange with unsupported destination asset`() {
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset("???")
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+
+    assertThrows<SepValidationException> {
+      sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+    verify { exchangeAmountsCalculator wasNot Called }
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test deposit-exchange with unsupported source asset`() {
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("???")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+
+    assertThrows<SepValidationException> {
+      sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+    verify { exchangeAmountsCalculator wasNot Called }
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test deposit-exchange with unsupported type`() {
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .type("unsupported_Type")
+        .build()
+
+    assertThrows<SepValidationException> {
+      sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+    verify { exchangeAmountsCalculator wasNot Called }
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @ValueSource(strings = ["0", "-1", "0.0", "0.0000000001"])
+  @ParameterizedTest
+  fun `test deposit-exchange with bad amount`(amount: String) {
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount(amount)
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+
+    assertThrows<SepValidationException> {
+      sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+    verify { exchangeAmountsCalculator wasNot Called }
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test deposit-exchange does not send event if transaction fails`() {
+    every { txnStore.save(any()) } throws RuntimeException("unexpected failure")
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .build()
+    assertThrows<java.lang.RuntimeException> {
+      sep6Service.depositExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify effects
     verify { eventSession wasNot called }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -92,6 +92,7 @@ public class SepBeans {
     FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
     registrationBean.setFilter(new Sep10JwtFilter(jwtService));
     registrationBean.addUrlPatterns("/sep6/deposit/*");
+    registrationBean.addUrlPatterns("/sep6/deposit-exchange/*");
     registrationBean.addUrlPatterns("/sep6/withdraw/*");
     registrationBean.addUrlPatterns("/sep6/withdraw-exchange/*");
     registrationBean.addUrlPatterns("/sep6/transaction");

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -74,6 +74,44 @@ public class Sep6Controller {
 
   @CrossOrigin(origins = "*")
   @RequestMapping(
+      value = "/deposit-exchange",
+      method = {RequestMethod.GET})
+  public StartDepositResponse depositExchange(
+      HttpServletRequest request,
+      @RequestParam(value = "destination_asset") String destinationAsset,
+      @RequestParam(value = "source_asset") String sourceAsset,
+      @RequestParam(value = "quote_id", required = false) String quoteId,
+      @RequestParam(value = "amount") String amount,
+      @RequestParam(value = "account") String account,
+      @RequestParam(value = "memo_type", required = false) String memoType,
+      @RequestParam(value = "memo", required = false) String memo,
+      @RequestParam(value = "type") String type,
+      @RequestParam(value = "lang", required = false) String lang,
+      @RequestParam(value = "country_code", required = false) String countryCode,
+      @RequestParam(value = "claimable_balances_supported", required = false)
+          Boolean claimableBalancesSupported)
+      throws AnchorException {
+    debugF("GET /deposit-exchange");
+    Sep10Jwt token = getSep10Token(request);
+    StartDepositExchangeRequest startDepositExchangeRequest =
+        StartDepositExchangeRequest.builder()
+            .destinationAsset(destinationAsset)
+            .sourceAsset(sourceAsset)
+            .quoteId(quoteId)
+            .amount(amount)
+            .account(account)
+            .memoType(memoType)
+            .memo(memo)
+            .type(type)
+            .lang(lang)
+            .countryCode(countryCode)
+            .claimableBalancesSupported(claimableBalancesSupported)
+            .build();
+    return sep6Service.depositExchange(token, startDepositExchangeRequest);
+  }
+
+  @CrossOrigin(origins = "*")
+  @RequestMapping(
       value = "/withdraw",
       method = {RequestMethod.GET})
   public StartWithdrawResponse withdraw(


### PR DESCRIPTION
### Description

This implements the GET `deposit-exchange` endpoint. There's a lot of duplicated code that could be shared with `deposit` and `withdraw`/`withdraw-exchange`. Once the integration and end-to-end tests have been implemented, I will focus on cleaning up the code.

### Context

SEP-6 implementation.

### Testing

`./gradlew test`

### Known limitations

Integration and end-to-end tests are missing, they will be added in another PR.