### PR TITLE
[Anchor-418] Support auth with SEP10 in SEP38

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
@@ -4,5 +4,5 @@ package org.stellar.anchor.config;
 public interface Sep38Config {
   boolean isEnabled();
 
-  boolean isRequiresSep10();
+  boolean isSep10Enforced();
 }

--- a/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
@@ -3,4 +3,6 @@ package org.stellar.anchor.config;
 @SuppressWarnings("SameReturnValue")
 public interface Sep38Config {
   boolean isEnabled();
+
+  boolean isRequiresSep10();
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -43,7 +43,8 @@ class Sep38ServiceTest {
     override fun isEnabled(): Boolean {
       return true
     }
-    override fun isRequiresSep10(): Boolean {
+
+    override fun isSep10Enforced(): Boolean {
       return false
     }
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -44,7 +44,7 @@ class Sep38ServiceTest {
       return true
     }
     override fun isRequiresSep10(): Boolean {
-      return true
+      return false
     }
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -43,6 +43,9 @@ class Sep38ServiceTest {
     override fun isEnabled(): Boolean {
       return true
     }
+    override fun isRequiresSep10(): Boolean {
+      return true
+    }
   }
 
   companion object {

--- a/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep38Client.kt
+++ b/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep38Client.kt
@@ -13,7 +13,7 @@ import org.stellar.anchor.api.sep.sep38.Sep38QuoteResponse
 class Sep38Client(private val endpoint: String, private val jwt: String) : SepClient() {
   fun getInfo(): InfoResponse {
     println("GET $endpoint/info")
-    val responseBody = httpGet("$endpoint/info")
+    val responseBody = httpGet("$endpoint/info", jwt)
     return gson.fromJson(responseBody, InfoResponse::class.java)
   }
 
@@ -28,7 +28,7 @@ class Sep38Client(private val endpoint: String, private val jwt: String) : SepCl
         .addQueryParameter("sell_amount", sellAmount)
     println(urlBuilder.build().toString())
 
-    val responseBody = httpGet(urlBuilder.build().toString())
+    val responseBody = httpGet(urlBuilder.build().toString(), jwt)
     return gson.fromJson(responseBody, GetPricesResponse::class.java)
   }
 
@@ -50,7 +50,7 @@ class Sep38Client(private val endpoint: String, private val jwt: String) : SepCl
         .addQueryParameter("context", context.toString())
     println(urlBuilder.build().toString())
 
-    val responseBody = httpGet(urlBuilder.build().toString())
+    val responseBody = httpGet(urlBuilder.build().toString(), jwt)
     return gson.fromJson(responseBody, GetPriceResponse::class.java)
   }
 

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.api.exception.SepException
-import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
 import org.stellar.anchor.platform.Sep38Client
 import org.stellar.anchor.platform.TestConfig
@@ -88,14 +87,21 @@ class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
     }
   }
 
-  fun `test endpoints failed when authenticate requried but token missing`() {
-    assertThrows<SepNotAuthorizedException> { sep38ClientWithoutJwt.getInfo() }
+  fun `test endpoints does not required valid token when auth is disabled`() {
+    sep38ClientWithoutJwt.getInfo()
+    sep38ClientWithoutJwt.getPrices("iso4217:USD", "100")
+    sep38ClientWithoutJwt.getPrice(
+      "iso4217:USD",
+      "100",
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      SEP31
+    )
   }
 
   fun testAll() {
     println("Performing SEP38 tests...")
     `test sep38 info, price and prices endpoints`()
     `test selling over asset limit throws an exception`()
-    `test endpoints failed when authenticate requried but token missing`()
+    `test endpoints does not required valid token when auth is disabled`()
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.api.exception.SepException
+import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
 import org.stellar.anchor.platform.Sep38Client
 import org.stellar.anchor.platform.TestConfig
@@ -14,9 +15,11 @@ import org.stellar.anchor.util.Sep1Helper.TomlContent
 
 class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
   private val sep38Client: Sep38Client
+  private val sep38ClientWithoutJwt: Sep38Client
 
   init {
     sep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), jwt)
+    sep38ClientWithoutJwt = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), "Invalid Token")
   }
 
   fun `test sep38 info, price and prices endpoints`() {
@@ -84,9 +87,14 @@ class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
       )
     }
   }
+
+  fun `test endpoints failed when authenticate requried but token missing`() {
+    assertThrows<SepNotAuthorizedException> { sep38ClientWithoutJwt.getInfo() }
+  }
   fun testAll() {
     println("Performing SEP38 tests...")
     `test sep38 info, price and prices endpoints`()
     `test selling over asset limit throws an exception`()
+    `test endpoints failed when authenticate requried but token missing`()
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
@@ -91,6 +91,7 @@ class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
   fun `test endpoints failed when authenticate requried but token missing`() {
     assertThrows<SepNotAuthorizedException> { sep38ClientWithoutJwt.getInfo() }
   }
+
   fun testAll() {
     println("Performing SEP38 tests...")
     `test sep38 info, price and prices endpoints`()

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep38Tests.kt
@@ -14,11 +14,9 @@ import org.stellar.anchor.util.Sep1Helper.TomlContent
 
 class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
   private val sep38Client: Sep38Client
-  private val sep38ClientWithoutJwt: Sep38Client
 
   init {
     sep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), jwt)
-    sep38ClientWithoutJwt = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), "Invalid Token")
   }
 
   fun `test sep38 info, price and prices endpoints`() {
@@ -87,21 +85,9 @@ class Sep38Tests(config: TestConfig, toml: TomlContent, jwt: String) {
     }
   }
 
-  fun `test endpoints does not required valid token when auth is disabled`() {
-    sep38ClientWithoutJwt.getInfo()
-    sep38ClientWithoutJwt.getPrices("iso4217:USD", "100")
-    sep38ClientWithoutJwt.getPrice(
-      "iso4217:USD",
-      "100",
-      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-      SEP31
-    )
-  }
-
   fun testAll() {
     println("Performing SEP38 tests...")
     `test sep38 info, price and prices endpoints`()
     `test selling over asset limit throws an exception`()
-    `test endpoints does not required valid token when auth is disabled`()
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -92,7 +92,8 @@ public class SepBeans {
    * @return Spring Filter Registration Bean
    */
   @Bean
-  public FilterRegistrationBean<Filter> sep10TokenFilter(JwtService jwtService) {
+  public FilterRegistrationBean<Filter> sep10TokenFilter(
+      JwtService jwtService, Sep38Config sep38Config) {
     FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
     registrationBean.setFilter(new Sep10JwtFilter(jwtService));
     registrationBean.addUrlPatterns("/sep6/transaction");
@@ -106,6 +107,11 @@ public class SepBeans {
     registrationBean.addUrlPatterns("/sep31/transactions/*");
     registrationBean.addUrlPatterns("/sep38/quote");
     registrationBean.addUrlPatterns("/sep38/quote/*");
+    if (sep38Config.isRequiresSep10()) {
+      registrationBean.addUrlPatterns("/sep38/info");
+      registrationBean.addUrlPatterns("/sep38/price");
+      registrationBean.addUrlPatterns("/sep38/prices");
+    }
     return registrationBean;
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -107,7 +107,7 @@ public class SepBeans {
     registrationBean.addUrlPatterns("/sep31/transactions/*");
     registrationBean.addUrlPatterns("/sep38/quote");
     registrationBean.addUrlPatterns("/sep38/quote/*");
-    if (sep38Config.isRequiresSep10()) {
+    if (sep38Config.isSep10Enforced()) {
       registrationBean.addUrlPatterns("/sep38/info");
       registrationBean.addUrlPatterns("/sep38/price");
       registrationBean.addUrlPatterns("/sep38/prices");

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
@@ -1,9 +1,13 @@
 package org.stellar.anchor.platform.config;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import org.stellar.anchor.config.Sep38Config;
 
 @Data
 public class PropertySep38Config implements Sep38Config {
   boolean enabled;
+
+  @SerializedName("requires_sep10")
+  boolean requiresSep10;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
@@ -8,6 +8,6 @@ import org.stellar.anchor.config.Sep38Config;
 public class PropertySep38Config implements Sep38Config {
   boolean enabled;
 
-  @SerializedName("requires_sep10")
-  boolean requiresSep10;
+  @SerializedName("sep10_enforced")
+  boolean sep10Enforced;
 }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -451,6 +451,8 @@ sep38:
   # Whether to enable SEP-38
   #
   enabled: false
+  # Whether to require SEP-10 authentication for SEP-38 requests.
+  requires_sep10: true
 
 ######################
 ## Custody Server configuration

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -451,8 +451,8 @@ sep38:
   # Whether to enable SEP-38
   #
   enabled: false
-  # Whether to require SEP-10 authentication for SEP-38 requests.
-  requires_sep10: false
+  # Whether to enforce SEP-10 authentication for SEP-38 /info, /price, /prices endpoints.
+  sep10_enforced: false
 
 ######################
 ## Custody Server configuration

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -452,7 +452,7 @@ sep38:
   #
   enabled: false
   # Whether to require SEP-10 authentication for SEP-38 requests.
-  requires_sep10: true
+  requires_sep10: false
 
 ######################
 ## Custody Server configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -93,6 +93,7 @@ sep31.deposit_info_generator_type:
 sep31.enabled:
 sep31.payment_type:
 sep38.enabled:
+sep38.requires_sep10:
 sep6.enabled:
 sep6.features.account_creation:
 sep6.features.claimable_balances:

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -93,7 +93,7 @@ sep31.deposit_info_generator_type:
 sep31.enabled:
 sep31.payment_type:
 sep38.enabled:
-sep38.requires_sep10:
+sep38.sep10_enforced:
 sep6.enabled:
 sep6.features.account_creation:
 sep6.features.claimable_balances:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansTest.kt
@@ -1,0 +1,44 @@
+package org.stellar.anchor.platform.component
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.config.*
+import org.stellar.anchor.platform.component.sep.SepBeans
+
+class SepBeansTest {
+  @MockK(relaxed = true) private lateinit var secretConfig: SecretConfig
+  @MockK(relaxed = true) lateinit var custodySecretConfig: CustodySecretConfig
+  @MockK(relaxed = true) lateinit var sep38Config: Sep38Config
+  private lateinit var jwtService: JwtService
+  private lateinit var sepBeans: SepBeans
+
+  @BeforeEach
+  fun setUp() {
+    secretConfig = mockk(relaxed = true)
+    custodySecretConfig = mockk(relaxed = true)
+    sep38Config = mockk(relaxed = true)
+    jwtService = JwtService(secretConfig, custodySecretConfig)
+    sepBeans = SepBeans()
+  }
+
+  @Test
+  fun `test info, price, prices were excluded in filter when auth not required`() {
+    val sep10TokenFilter = sepBeans.sep10TokenFilter(jwtService, sep38Config)
+    assert(!sep10TokenFilter.urlPatterns.contains("/sep38/info"))
+    assert(!sep10TokenFilter.urlPatterns.contains("/sep38/price"))
+    assert(!sep10TokenFilter.urlPatterns.contains("/sep38/prices"))
+  }
+
+  @Test
+  fun `test info, price, prices endpoints were included in filter when auth required`() {
+    every { sep38Config.isSep10Enforced } returns true
+    val sep10TokenFilter = sepBeans.sep10TokenFilter(jwtService, sep38Config)
+    assert(sep10TokenFilter.urlPatterns.contains("/sep38/info"))
+    assert(sep10TokenFilter.urlPatterns.contains("/sep38/price"))
+    assert(sep10TokenFilter.urlPatterns.contains("/sep38/prices"))
+  }
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

### Description

Add sep38.requires_sep10 configuration with default value to FALSE

### Context

Currently, according to the SEP-38 spec, some of the SEP38 endpoints have SEP-10 as optional. This task seeks ensure we support this optionality by add configurability to these endpoints' SEP-10 requirements.

### Testing
Tests were added to verify url pattern was added to filter if auth is required