### PR TITLE
[ANCHOR-353] SEP-6: Refactor request validation

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositRequest.java
@@ -33,7 +33,7 @@ public class StartDepositRequest {
   String emailAddress;
 
   /** Type of deposit. */
-  @NonNull String type;
+  String type;
 
   /** Name of wallet to deposit to. Currently, ignored. */
   @SerializedName("wallet_name")
@@ -53,7 +53,7 @@ public class StartDepositRequest {
   String lang;
 
   /** The amount to deposit. */
-  @NonNull String amount;
+  String amount;
 
   /** The ISO 3166-1 alpha-3 code of the user's current address. */
   @SerializedName("country_code")

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
@@ -21,10 +21,10 @@ public class StartWithdrawRequest {
   String assetCode;
 
   /** Type of withdrawal. */
-  @NonNull String type;
+  String type;
 
   /** The amount to withdraw. */
-  @NonNull String amount;
+  String amount;
 
   /** The ISO 3166-1 alpha-3 code of the user's current address. */
   @SerializedName("country_code")

--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -1,0 +1,112 @@
+package org.stellar.anchor.sep6;
+
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.stellar.anchor.api.exception.SepValidationException;
+import org.stellar.anchor.api.sep.AssetInfo;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.sdk.KeyPair;
+
+/** SEP-6 request validations */
+@RequiredArgsConstructor
+public class RequestValidator {
+  @NonNull private final AssetService assetService;
+
+  /**
+   * Validates that the requested asset is valid and enabled for deposit.
+   *
+   * @param assetCode the requested asset code
+   * @return the asset if its valid and enabled for deposit
+   * @throws SepValidationException if the asset is invalid or not enabled for deposit
+   */
+  public AssetInfo getDepositAsset(String assetCode) throws SepValidationException {
+    AssetInfo asset = assetService.getAsset(assetCode);
+    if (asset == null || !asset.getSep6Enabled() || !asset.getDeposit().getEnabled()) {
+      throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
+    }
+    return asset;
+  }
+
+  /**
+   * Validates that the requested asset is valid and enabled for withdrawal.
+   *
+   * @param assetCode the requested asset code
+   * @return the asset if its valid and enabled for withdrawal
+   * @throws SepValidationException if the asset is invalid or not enabled for withdrawal
+   */
+  public AssetInfo getWithdrawAsset(String assetCode) throws SepValidationException {
+    AssetInfo asset = assetService.getAsset(assetCode);
+    if (asset == null || !asset.getSep6Enabled() || !asset.getWithdraw().getEnabled()) {
+      throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
+    }
+    return asset;
+  }
+
+  /**
+   * Validates that the requested amount is within bounds.
+   *
+   * @param requestAmount the requested amount
+   * @param assetCode the requested asset code
+   * @param scale the scale of the asset
+   * @param minAmount the minimum amount
+   * @param maxAmount the maximum amount
+   * @throws SepValidationException if the amount is not within bounds
+   */
+  public void validateAmount(
+      String requestAmount, String assetCode, int scale, Long minAmount, Long maxAmount)
+      throws SepValidationException {
+    BigDecimal amount = new BigDecimal(requestAmount);
+    if (amount.scale() > scale) {
+      throw new SepValidationException(
+          String.format(
+              "invalid amount %s for asset %s, significant decimals is %s",
+              requestAmount, assetCode, scale));
+    }
+    if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new SepValidationException(
+          String.format("invalid amount %s for asset %s", requestAmount, assetCode));
+    }
+    if (minAmount != null && amount.compareTo(BigDecimal.valueOf(minAmount)) < 0) {
+      throw new SepValidationException(
+          String.format("invalid amount %s for asset %s", requestAmount, assetCode));
+    }
+    if (maxAmount != null && amount.compareTo(BigDecimal.valueOf(maxAmount)) > 0) {
+      throw new SepValidationException(
+          String.format("invalid amount %s for asset %s", requestAmount, assetCode));
+    }
+  }
+
+  /**
+   * Validates that the requested deposit/withdrawal type is valid.
+   *
+   * @param requestType the requested type
+   * @param assetCode the requested asset code
+   * @param validTypes the valid types
+   * @throws SepValidationException if the type is invalid
+   */
+  public void validateTypes(String requestType, String assetCode, List<String> validTypes)
+      throws SepValidationException {
+    if (!validTypes.contains(requestType)) {
+      throw new SepValidationException(
+          String.format(
+              "invalid type %s for asset %s, supported types are %s",
+              requestType, assetCode, validTypes));
+    }
+  }
+
+  /**
+   * Validates that the account is a valid Stellar account.
+   *
+   * @param account the account
+   * @throws SepValidationException if the account is invalid
+   */
+  public void validateAccount(String account) throws SepValidationException {
+    try {
+      KeyPair.fromAccountId(account);
+    } catch (RuntimeException ex) {
+      throw new SepValidationException(String.format("invalid account %s", account));
+    }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -1,0 +1,150 @@
+package org.stellar.anchor.sep6
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
+import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
+import org.stellar.anchor.api.exception.SepValidationException
+import org.stellar.anchor.api.sep.AssetInfo
+import org.stellar.anchor.asset.AssetService
+
+class RequestValidatorTest {
+  @MockK(relaxed = true) lateinit var assetService: AssetService
+
+  private lateinit var requestValidator: RequestValidator
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    requestValidator = RequestValidator(assetService)
+  }
+
+  @Test
+  fun `test getDepositAsset`() {
+    val asset = mockk<AssetInfo>()
+    val deposit = mockk<AssetInfo.DepositOperation>()
+    every { asset.sep6Enabled } returns true
+    every { asset.deposit } returns deposit
+    every { deposit.enabled } returns true
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    requestValidator.getDepositAsset(TEST_ASSET)
+  }
+
+  @Test
+  fun `test getDepositAsset with invalid asset code`() {
+    every { assetService.getAsset(TEST_ASSET) } returns null
+    assertThrows<SepValidationException> { requestValidator.getDepositAsset(TEST_ASSET) }
+  }
+
+  @Test
+  fun `test getDepositAsset with deposit disabled asset`() {
+    val asset = mockk<AssetInfo>()
+    val deposit = mockk<AssetInfo.DepositOperation>()
+    every { asset.sep6Enabled } returns true
+    every { asset.deposit } returns deposit
+    every { deposit.enabled } returns false
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    assertThrows<SepValidationException> { requestValidator.getDepositAsset(TEST_ASSET) }
+  }
+
+  @Test
+  fun `test getDepositAsset with sep6 disabled asset`() {
+    val asset = mockk<AssetInfo>()
+    every { asset.sep6Enabled } returns false
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    assertThrows<SepValidationException> { requestValidator.getDepositAsset(TEST_ASSET) }
+  }
+
+  @Test
+  fun `test getWithdrawAsset`() {
+    val asset = mockk<AssetInfo>()
+    val withdraw = mockk<AssetInfo.WithdrawOperation>()
+    every { asset.sep6Enabled } returns true
+    every { asset.withdraw } returns withdraw
+    every { withdraw.enabled } returns true
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    requestValidator.getWithdrawAsset(TEST_ASSET)
+  }
+
+  @Test
+  fun `test getWithdrawAsset with invalid asset code`() {
+    every { assetService.getAsset(TEST_ASSET) } returns null
+    assertThrows<SepValidationException> { requestValidator.getWithdrawAsset(TEST_ASSET) }
+  }
+
+  @Test
+  fun `test getWithdrawAsset with withdraw disabled asset`() {
+    val asset = mockk<AssetInfo>()
+    val withdraw = mockk<AssetInfo.WithdrawOperation>()
+    every { asset.sep6Enabled } returns true
+    every { asset.withdraw } returns withdraw
+    every { withdraw.enabled } returns false
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    assertThrows<SepValidationException> { requestValidator.getWithdrawAsset(TEST_ASSET) }
+  }
+
+  @Test
+  fun `test getWithdrawAsset with sep6 disabled asset`() {
+    val asset = mockk<AssetInfo>()
+    every { asset.sep6Enabled } returns false
+    every { assetService.getAsset(TEST_ASSET) } returns asset
+    assertThrows<SepValidationException> { requestValidator.getWithdrawAsset(TEST_ASSET) }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["1", "100", "1.00", "100.00", "50"])
+  fun `test validateAmount`(amount: String) {
+    requestValidator.validateAmount(amount, TEST_ASSET, 2, 1L, 100L)
+  }
+
+  @Test
+  fun `test validateAmount with too high precision`() {
+    assertThrows<SepValidationException> {
+      requestValidator.validateAmount("1.000001", TEST_ASSET, 2, 1L, 100L)
+    }
+  }
+
+  @Test
+  fun `test validateAmount with too high value`() {
+    assertThrows<SepValidationException> {
+      requestValidator.validateAmount("101", TEST_ASSET, 2, 1L, 100L)
+    }
+  }
+
+  @Test
+  fun `test validateAmount with too low value`() {
+    assertThrows<SepValidationException> {
+      requestValidator.validateAmount("0", TEST_ASSET, 2, 1L, 100L)
+    }
+  }
+
+  @ValueSource(strings = ["bank_account", "cash"])
+  @ParameterizedTest
+  fun `test validateTypes`(type: String) {
+    requestValidator.validateTypes(type, TEST_ASSET, listOf("bank_account", "cash"))
+  }
+
+  @Test
+  fun `test validateTypes with invalid type`() {
+    assertThrows<SepValidationException> {
+      requestValidator.validateTypes("??", TEST_ASSET, listOf("bank_account", "cash"))
+    }
+  }
+
+  @Test
+  fun `test validateAccount`() {
+    requestValidator.validateAccount(TEST_ACCOUNT)
+  }
+
+  @Test
+  fun `test validateAccount with invalid account`() {
+    assertThrows<SepValidationException> { requestValidator.validateAccount("??") }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -7,12 +7,9 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
@@ -43,6 +40,7 @@ class Sep6ServiceTest {
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
 
   @MockK(relaxed = true) lateinit var sep6Config: Sep6Config
+  @MockK(relaxed = true) lateinit var requestValidator: RequestValidator
   @MockK(relaxed = true) lateinit var txnStore: Sep6TransactionStore
   @MockK(relaxed = true) lateinit var exchangeAmountsCalculator: ExchangeAmountsCalculator
   @MockK(relaxed = true) lateinit var eventService: EventService
@@ -57,366 +55,28 @@ class Sep6ServiceTest {
     every { sep6Config.features.isClaimableBalances } returns false
     every { txnStore.newInstance() } returns PojoSep6Transaction()
     every { eventService.createSession(any(), any()) } returns eventSession
+    every { requestValidator.getDepositAsset(TEST_ASSET) } returns asset
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns asset
     sep6Service =
-      Sep6Service(sep6Config, assetService, txnStore, exchangeAmountsCalculator, eventService)
+      Sep6Service(
+        sep6Config,
+        assetService,
+        requestValidator,
+        txnStore,
+        exchangeAmountsCalculator,
+        eventService
+      )
   }
 
-  @AfterEach
-  fun teardown() {
-    clearAllMocks()
-    unmockkAll()
-  }
-
-  private val infoJson =
-    """
-      {
-          "deposit": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
-              }
-          },
-          "deposit-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
-              }
-          },
-          "withdraw": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "withdraw-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "fee": {
-              "enabled": false,
-              "description": "Fee endpoint is not supported."
-          },
-          "transactions": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "transaction": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "features": {
-              "account_creation": false,
-              "claimable_balances": false
-          }
-      }
-    """
-      .trimIndent()
-
-  val transactionsJson =
-    """
-      {
-          "transactions": [
-              {
-                  "id": "2cb630d3-030b-4a0e-9d9d-f26b1df25d12",
-                  "kind": "deposit",
-                  "status": "complete",
-                  "status_eta": 5,
-                  "more_info_url": "https://example.com/more_info",
-                  "amount_in": "100",
-                  "amount_in_asset": "USD",
-                  "amount_out": "98",
-                  "amount_out_asset": "stellar:USDC:GABCD",
-                  "amount_fee": "2",
-                  "from": "GABCD",
-                  "to": "GABCD",
-                  "deposit_memo": "some memo",
-                  "deposit_memo_type": "text",
-                  "started_at": "2023-08-01T16:53:20Z",
-                  "updated_at": "2023-08-01T16:53:20Z",
-                  "completed_at": "2023-08-01T16:53:20Z",
-                  "stellar_transaction_id": "stellar-id",
-                  "external_transaction_id": "external-id",
-                  "message": "some message",
-                  "refunds": {
-                      "amount_refunded": {
-                          "amount": "100",
-                          "asset": "USD"
-                      },
-                      "amount_fee": {
-                          "amount": "0",
-                          "asset": "USD"
-                      },
-                      "payments": [
-                          {
-                              "id": "refund-payment-id",
-                              "id_type": "external",
-                              "amount": {
-                                  "amount": "100",
-                                  "asset": "USD"
-                              },
-                              "fee": {
-                                  "amount": "0",
-                                  "asset": "USD"
-                              }
-                          }
-                      ]
-                  },
-                  "required_info_message": "some info message",
-                  "required_info_updates": ["first_name", "last_name"]
-              }
-          ]
-      }
-    """
-      .trimIndent()
-
-  val depositTxnJson =
-    """
-      {
-          "status": "incomplete",
-          "kind": "deposit",
-          "type": "bank_account",
-          "requestAssetCode": "USDC",
-          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountExpected": "100",
-          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
-      }
-    """
-      .trimIndent()
-
-  val depositTxnEventJson =
-    """
-      {
-          "type": "transaction_created",
-          "sep": "6",
-          "transaction": {
-              "sep": "6",
-              "kind": "deposit",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
-          }
-      }
-    """
-      .trimIndent()
-
-  val withdrawResJson =
-    """
-      {
-          "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "memo_type": "hash"
-      }
-    """
-      .trimIndent()
-
-  val withdrawTxnJson =
-    """
-      {
-          "status": "incomplete",
-          "kind": "withdrawal",
-          "type": "bank_account",
-          "requestAssetCode": "USDC",
-          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountExpected": "100",
-          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "memoType": "hash",
-          "refundMemo": "some text",
-          "refundMemoType": "text"
-      }
-    """
-      .trimIndent()
-
-  val withdrawTxnEventJson =
-    """
-      {
-          "type": "transaction_created",
-          "sep": "6",
-          "transaction": {
-              "sep": "6",
-              "kind": "withdrawal",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "destination_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text"
-          }
-      }
-    """
-      .trimIndent()
-
-  val withdrawExchangeTxnJson =
-    """
-      {
-          "status": "incomplete",
-          "kind": "withdrawal-exchange",
-          "type": "bank_account",
-          "requestAssetCode": "USDC",
-          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountIn": "100",
-          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountOut": "98",
-          "amountOutAsset": "iso4217:USD",
-          "amountFee": "2",
-          "amountFeeAsset": "iso4217:USD",
-          "amountExpected": "100",
-          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
-          "quoteId": "test-quote-id",
-          "refundMemo": "some text",
-          "refundMemoType": "text"
-      }
-    """
-      .trimIndent()
-
-  val withdrawExchangeTxnEventJson =
-    """
-      {
-          "type": "transaction_created",
-          "sep": "6",
-          "transaction": {
-              "sep": "6",
-              "kind": "withdrawal-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "iso4217:USD"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "iso4217:USD"
-              },
-              "quote_id": "test-quote-id",
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text"
-          }
-      }
-    """
-      .trimIndent()
-
-  val withdrawExchangeTxnWithoutQuoteJson =
-    """
-      {
-          "status": "incomplete",
-          "kind": "withdrawal-exchange",
-          "type": "bank_account",
-          "requestAssetCode": "USDC",
-          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountIn": "100",
-          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountOut": "98",
-          "amountOutAsset": "iso4217:USD",
-          "amountFee": "2",
-          "amountFeeAsset": "iso4217:USD",
-          "amountExpected": "100",
-          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
-          "refundMemo": "some text",
-          "refundMemoType": "text"
-      }
-    """
-      .trimIndent()
-
-  val withdrawExchangeTxnWithoutQuoteEventJson =
-    """
-      {
-          "type": "transaction_created",
-          "sep": "6",
-          "transaction": {
-              "sep": "6",
-              "kind": "withdrawal-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "iso4217:USD"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "iso4217:USD"
-              },
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text"
-          }
-      }
-    """
-      .trimIndent()
+  private val asset = assetService.getAsset(TEST_ASSET)
 
   @Test
   fun `test INFO response`() {
     val infoResponse = sep6Service.info
-    assertEquals(gson.fromJson(infoJson, InfoResponse::class.java), infoResponse)
+    assertEquals(
+      gson.fromJson(Sep6ServiceTestData.infoJson, InfoResponse::class.java),
+      infoResponse
+    )
   }
 
   @Test
@@ -436,16 +96,76 @@ class Sep6ServiceTest {
         .build()
     val response = sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
 
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.deposit.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.deposit.minAmount,
+        asset.deposit.maxAmount,
+      )
+    }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
 
-    JSONAssert.assertEquals(depositTxnJson, gson.toJson(slotTxn.captured), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.depositTxnJson,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
-      depositTxnEventJson,
+      Sep6ServiceTestData.depositTxnEventJson,
+      gson.toJson(slotEvent.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotEvent.captured.id.isNotEmpty())
+    assert(slotEvent.captured.transaction.id.isNotEmpty())
+    assertNotNull(slotEvent.captured.transaction.startedAt)
+
+    // Verify response
+    assertEquals(slotTxn.captured.id, response.id)
+  }
+
+  @Test
+  fun `test deposit without amount or type`() {
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    val request = StartDepositRequest.builder().assetCode(TEST_ASSET).account(TEST_ACCOUNT).build()
+    val response = sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+
+    // Verify effects
+    verify(exactly = 1) { txnStore.save(any()) }
+    verify(exactly = 1) { eventSession.publish(any()) }
+
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.depositTxnJsonWithoutAmountOrType,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotTxn.captured.id.isNotEmpty())
+    assertNotNull(slotTxn.captured.startedAt)
+
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.depositTxnEventWithoutAmountOrTypeJson,
       gson.toJson(slotEvent.captured),
       JSONCompareMode.LENIENT
     )
@@ -459,17 +179,90 @@ class Sep6ServiceTest {
 
   @Test
   fun `test deposit with unsupported asset`() {
+    val unsupportedAsset = "??"
     val request =
       StartDepositRequest.builder()
-        .assetCode("??")
+        .assetCode(unsupportedAsset)
         .account(TEST_ACCOUNT)
         .type("bank_account")
         .amount("100")
         .build()
+    every { requestValidator.getDepositAsset(unsupportedAsset) } throws
+      SepValidationException("unsupported asset")
 
     assertThrows<SepValidationException> {
       sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(unsupportedAsset) }
+
+    // Verify effects
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test deposit with unsupported type`() {
+    val unsupportedType = "??"
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(TEST_ACCOUNT)
+        .type(unsupportedType)
+        .amount("100")
+        .build()
+    every { requestValidator.validateTypes(unsupportedType, TEST_ASSET, any()) } throws
+      SepValidationException("unsupported type")
+
+    assertThrows<SepValidationException> {
+      sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes(unsupportedType, TEST_ASSET, asset.deposit.methods)
+    }
+
+    // Verify effects
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test deposit with bad amount`() {
+    val badAmount = "0"
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(TEST_ACCOUNT)
+        .type("bank_account")
+        .amount(badAmount)
+        .build()
+    every { requestValidator.validateAmount(badAmount, TEST_ASSET, any(), any(), any()) } throws
+      SepValidationException("bad amount")
+
+    assertThrows<SepValidationException> {
+      sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", TEST_ASSET, asset.deposit.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        badAmount,
+        TEST_ASSET,
+        asset.significantDecimals,
+        asset.deposit.minAmount,
+        asset.deposit.maxAmount,
+      )
+    }
+
+    // Verify effects
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }
@@ -488,8 +281,24 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount("100")
         .build()
+
     assertThrows<java.lang.RuntimeException> {
       sep6Service.deposit(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.deposit.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.deposit.minAmount,
+        asset.deposit.maxAmount,
+      )
     }
 
     // Verify effects
@@ -516,18 +325,37 @@ class Sep6ServiceTest {
 
     val response = sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
 
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
+    }
+
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
 
-    JSONAssert.assertEquals(withdrawTxnJson, gson.toJson(slotTxn.captured), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawTxnJson,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
     assert(slotTxn.captured.id.isNotEmpty())
     assert(slotTxn.captured.memo.isNotEmpty())
     assertEquals(slotTxn.captured.memoType, "hash")
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
-      withdrawTxnEventJson,
+      Sep6ServiceTestData.withdrawTxnEventJson,
       gson.toJson(slotEvent.captured),
       JSONCompareMode.LENIENT
     )
@@ -540,50 +368,154 @@ class Sep6ServiceTest {
     // Verify response
     assertEquals(slotTxn.captured.id, response.id)
     assertEquals(slotTxn.captured.memo, response.memo)
-    JSONAssert.assertEquals(withdrawResJson, gson.toJson(response), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
+  }
+
+  @Test
+  fun `test withdraw without amount or type`() {
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    val request =
+      StartWithdrawRequest.builder()
+        .assetCode(TEST_ASSET)
+        .refundMemo("some text")
+        .refundMemoType("text")
+        .build()
+    val response = sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+
+    // Verify effects
+    verify(exactly = 1) { txnStore.save(any()) }
+    verify(exactly = 1) { eventSession.publish(any()) }
+
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawTxnWithoutAmountOrTypeJson,
+      gson.toJson(slotTxn.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotTxn.captured.id.isNotEmpty())
+    assert(slotTxn.captured.memo.isNotEmpty())
+    assertEquals(slotTxn.captured.memoType, "hash")
+    assertNotNull(slotTxn.captured.startedAt)
+
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawTxnEventWithoutAmountOrTypeJson,
+      gson.toJson(slotEvent.captured),
+      JSONCompareMode.LENIENT
+    )
+    assert(slotEvent.captured.id.isNotEmpty())
+    assert(slotEvent.captured.transaction.id.isNotEmpty())
+    assert(slotEvent.captured.transaction.memo.isNotEmpty())
+    assertEquals(slotEvent.captured.transaction.memoType, "hash")
+    assertNotNull(slotEvent.captured.transaction.startedAt)
+
+    // Verify response
+    assertEquals(slotTxn.captured.id, response.id)
+    assertEquals(slotTxn.captured.memo, response.memo)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
   }
 
   @Test
   fun `test withdraw with unsupported asset`() {
+    val unsupportedAsset = "??"
     val request =
-      StartWithdrawRequest.builder().assetCode("??").type("bank_account").amount("100").build()
+      StartWithdrawRequest.builder()
+        .assetCode(unsupportedAsset)
+        .type("bank_account")
+        .amount("100")
+        .build()
+    every { requestValidator.getWithdrawAsset(unsupportedAsset) } throws
+      SepValidationException("unsupported asset")
 
     assertThrows<SepValidationException> {
       sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(unsupportedAsset) }
+
+    // Verify effects
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }
 
   @Test
   fun `test withdraw with unsupported type`() {
+    val unsupportedType = "??"
     val request =
       StartWithdrawRequest.builder()
         .assetCode(TEST_ASSET)
-        .type("unsupported_Type")
+        .type(unsupportedType)
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+    every { requestValidator.validateTypes(unsupportedType, TEST_ASSET, any()) } throws
+      SepValidationException("unsupported type")
 
     assertThrows<SepValidationException> {
       sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes(unsupportedType, asset.code, asset.withdraw.methods)
+    }
+
+    // Verify effects
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }
 
-  @ValueSource(strings = ["0", "-1", "0.0", "0.0000000001"])
-  @ParameterizedTest
-  fun `test withdraw with bad amount`(amount: String) {
+  @Test
+  fun `test withdraw with bad amount`() {
+    val badAmount = "0"
     val request =
       StartWithdrawRequest.builder()
         .assetCode(TEST_ASSET)
         .type("bank_account")
-        .amount(amount)
+        .amount(badAmount)
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+    every { requestValidator.validateAmount(badAmount, TEST_ASSET, any(), any(), any()) } throws
+      SepValidationException("bad amount")
 
     assertThrows<SepValidationException> {
       sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        badAmount,
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
+    }
+
+    // Verify effects
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }
@@ -601,8 +533,26 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+
     assertThrows<java.lang.RuntimeException> {
       sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
     }
 
     // Verify effects
@@ -641,8 +591,25 @@ class Sep6ServiceTest {
         .refundMemo("some text")
         .refundMemoType("text")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
 
     val response = sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) {
@@ -652,7 +619,7 @@ class Sep6ServiceTest {
     verify(exactly = 1) { eventSession.publish(any()) }
 
     JSONAssert.assertEquals(
-      withdrawExchangeTxnJson,
+      Sep6ServiceTestData.withdrawExchangeTxnJson,
       gson.toJson(slotTxn.captured),
       JSONCompareMode.LENIENT
     )
@@ -662,7 +629,7 @@ class Sep6ServiceTest {
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
-      withdrawExchangeTxnEventJson,
+      Sep6ServiceTestData.withdrawExchangeTxnEventJson,
       gson.toJson(slotEvent.captured),
       JSONCompareMode.LENIENT
     )
@@ -675,7 +642,11 @@ class Sep6ServiceTest {
     // Verify response
     assertEquals(slotTxn.captured.id, response.id)
     assertEquals(slotTxn.captured.memo, response.memo)
-    JSONAssert.assertEquals(withdrawResJson, gson.toJson(response), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
   }
 
   @Test
@@ -708,8 +679,25 @@ class Sep6ServiceTest {
         .refundMemo("some text")
         .refundMemoType("text")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
 
     val response = sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { exchangeAmountsCalculator.calculate(any(), any(), "100", TEST_ACCOUNT) }
@@ -717,7 +705,7 @@ class Sep6ServiceTest {
     verify(exactly = 1) { eventSession.publish(any()) }
 
     JSONAssert.assertEquals(
-      withdrawExchangeTxnWithoutQuoteJson,
+      Sep6ServiceTestData.withdrawExchangeTxnWithoutQuoteJson,
       gson.toJson(slotTxn.captured),
       JSONCompareMode.LENIENT
     )
@@ -727,7 +715,7 @@ class Sep6ServiceTest {
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
-      withdrawExchangeTxnWithoutQuoteEventJson,
+      Sep6ServiceTestData.withdrawExchangeTxnWithoutQuoteEventJson,
       gson.toJson(slotEvent.captured),
       JSONCompareMode.LENIENT
     )
@@ -740,22 +728,34 @@ class Sep6ServiceTest {
     // Verify response
     assertEquals(slotTxn.captured.id, response.id)
     assertEquals(slotTxn.captured.memo, response.memo)
-    JSONAssert.assertEquals(withdrawResJson, gson.toJson(response), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(
+      Sep6ServiceTestData.withdrawResJson,
+      gson.toJson(response),
+      JSONCompareMode.LENIENT
+    )
   }
 
   @Test
   fun `test withdraw-exchange with unsupported source asset`() {
+    val unsupportedAsset = "??"
     val request =
       StartWithdrawExchangeRequest.builder()
-        .sourceAsset("???")
+        .sourceAsset(unsupportedAsset)
         .destinationAsset("iso4217:USD")
         .type("bank_account")
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(unsupportedAsset) } throws
+      SepValidationException("unsupported asset")
 
     assertThrows<SepValidationException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(unsupportedAsset) }
+
+    // Verify effects
     verify { exchangeAmountsCalculator wasNot Called }
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
@@ -763,13 +763,16 @@ class Sep6ServiceTest {
 
   @Test
   fun `test withdraw-exchange with unsupported destination asset`() {
+    val unsupportedAsset = "??"
     val request =
       StartWithdrawExchangeRequest.builder()
         .sourceAsset(TEST_ASSET)
-        .destinationAsset("USD")
+        .destinationAsset(unsupportedAsset)
         .type("bank_account")
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
 
     assertThrows<SepValidationException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
@@ -781,36 +784,70 @@ class Sep6ServiceTest {
 
   @Test
   fun `test withdraw-exchange with unsupported type`() {
+    val unsupportedType = "??"
     val request =
       StartWithdrawExchangeRequest.builder()
         .sourceAsset(TEST_ASSET)
         .destinationAsset("iso4217:USD")
-        .type("unsupported_Type")
+        .type(unsupportedType)
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+    every { requestValidator.validateTypes(unsupportedType, TEST_ASSET, any()) } throws
+      SepValidationException("unsupported type")
 
     assertThrows<SepValidationException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes(unsupportedType, asset.code, asset.withdraw.methods)
+    }
+
+    // Verify effects
     verify { exchangeAmountsCalculator wasNot Called }
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }
 
-  @ValueSource(strings = ["0", "-1", "0.0", "0.0000000001"])
-  @ParameterizedTest
-  fun `test withdraw-exchange with bad amount`(amount: String) {
+  @Test
+  fun `test withdraw-exchange with bad amount`() {
+    val badAmount = "??"
     val request =
       StartWithdrawExchangeRequest.builder()
         .sourceAsset(TEST_ASSET)
         .destinationAsset("iso4217:USD")
         .type("bank_account")
-        .amount(amount)
+        .amount(badAmount)
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+    every { requestValidator.validateAmount(badAmount, TEST_ASSET, any(), any(), any()) } throws
+      SepValidationException("bad amount")
 
     assertThrows<SepValidationException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
     }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        badAmount,
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
+    }
+
+    // Verify effects
     verify { exchangeAmountsCalculator wasNot Called }
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
@@ -830,8 +867,26 @@ class Sep6ServiceTest {
         .type("bank_account")
         .amount("100")
         .build()
+    every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns
+      assetService.getAsset(TEST_ASSET)
+
     assertThrows<java.lang.RuntimeException> {
       sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    }
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) {
+      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+    }
+    verify(exactly = 1) {
+      requestValidator.validateAmount(
+        "100",
+        asset.code,
+        asset.significantDecimals,
+        asset.withdraw.minAmount,
+        asset.withdraw.maxAmount,
+      )
     }
 
     // Verify effects
@@ -987,7 +1042,7 @@ class Sep6ServiceTest {
 
     verify(exactly = 1) { txnStore.findTransactions(TEST_ACCOUNT, null, request) }
 
-    JSONAssert.assertEquals(transactionsJson, gson.toJson(response), true)
+    JSONAssert.assertEquals(Sep6ServiceTestData.transactionsJson, gson.toJson(response), true)
   }
 
   private fun createDepositTxn(

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -1,0 +1,416 @@
+package org.stellar.anchor.sep6
+
+class Sep6ServiceTestData {
+  companion object {
+    val infoJson =
+      """
+      {
+          "deposit": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "fields": {
+                      "type": {
+                          "description": "type of deposit to make",
+                          "choices": [
+                              "SEPA",
+                              "SWIFT"
+                          ],
+                          "optional": false
+                      }
+                  }
+              }
+          },
+          "deposit-exchange": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "fields": {
+                      "type": {
+                          "description": "type of deposit to make",
+                          "choices": [
+                              "SEPA",
+                              "SWIFT"
+                          ],
+                          "optional": false
+                      }
+                  }
+              }
+          },
+          "withdraw": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "types": {
+                      "cash": {
+                          "fields": {}
+                      },
+                      "bank_account": {
+                          "fields": {}
+                      }
+                  }
+              }
+          },
+          "withdraw-exchange": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "types": {
+                      "cash": {
+                          "fields": {}
+                      },
+                      "bank_account": {
+                          "fields": {}
+                      }
+                  }
+              }
+          },
+          "fee": {
+              "enabled": false,
+              "description": "Fee endpoint is not supported."
+          },
+          "transactions": {
+              "enabled": true,
+              "authentication_required": true
+          },
+          "transaction": {
+              "enabled": true,
+              "authentication_required": true
+          },
+          "features": {
+              "account_creation": false,
+              "claimable_balances": false
+          }
+      }
+    """
+        .trimIndent()
+
+    val transactionsJson =
+      """
+      {
+          "transactions": [
+              {
+                  "id": "2cb630d3-030b-4a0e-9d9d-f26b1df25d12",
+                  "kind": "deposit",
+                  "status": "complete",
+                  "status_eta": 5,
+                  "more_info_url": "https://example.com/more_info",
+                  "amount_in": "100",
+                  "amount_in_asset": "USD",
+                  "amount_out": "98",
+                  "amount_out_asset": "stellar:USDC:GABCD",
+                  "amount_fee": "2",
+                  "from": "GABCD",
+                  "to": "GABCD",
+                  "deposit_memo": "some memo",
+                  "deposit_memo_type": "text",
+                  "started_at": "2023-08-01T16:53:20Z",
+                  "updated_at": "2023-08-01T16:53:20Z",
+                  "completed_at": "2023-08-01T16:53:20Z",
+                  "stellar_transaction_id": "stellar-id",
+                  "external_transaction_id": "external-id",
+                  "message": "some message",
+                  "refunds": {
+                      "amount_refunded": {
+                          "amount": "100",
+                          "asset": "USD"
+                      },
+                      "amount_fee": {
+                          "amount": "0",
+                          "asset": "USD"
+                      },
+                      "payments": [
+                          {
+                              "id": "refund-payment-id",
+                              "id_type": "external",
+                              "amount": {
+                                  "amount": "100",
+                                  "asset": "USD"
+                              },
+                              "fee": {
+                                  "amount": "0",
+                                  "asset": "USD"
+                              }
+                          }
+                      ]
+                  },
+                  "required_info_message": "some info message",
+                  "required_info_updates": ["first_name", "last_name"]
+              }
+          ]
+      }
+    """
+        .trimIndent()
+
+    val depositTxnJson =
+      """
+      {
+          "status": "incomplete",
+          "kind": "deposit",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+      }
+    """
+        .trimIndent()
+
+    val depositTxnEventJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "deposit",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          }
+      }
+    """
+        .trimIndent()
+
+    val depositTxnJsonWithoutAmountOrType =
+      """
+      {
+          "status": "incomplete",
+          "kind": "deposit",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+      }
+    """
+        .trimIndent()
+
+    val depositTxnEventWithoutAmountOrTypeJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "deposit",
+              "status": "incomplete",
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          }
+      }
+    """
+        .trimIndent()
+
+    val withdrawResJson =
+      """
+      {
+          "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "memo_type": "hash"
+      }
+    """
+        .trimIndent()
+
+    val withdrawTxnJson =
+      """
+      {
+          "status": "incomplete",
+          "kind": "withdrawal",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "memoType": "hash",
+          "refundMemo": "some text",
+          "refundMemoType": "text"
+      }
+    """
+        .trimIndent()
+
+    val withdrawTxnEventJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "withdrawal",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "destination_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+              "memo_type": "hash",
+              "refund_memo": "some text",
+              "refund_memo_type": "text"
+          }
+      }
+    """
+        .trimIndent()
+
+    val withdrawTxnWithoutAmountOrTypeJson =
+      """
+      {
+          "status": "incomplete",
+          "kind": "withdrawal",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "toAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "memoType": "hash",
+          "refundMemo": "some text",
+          "refundMemoType": "text"
+      }
+    """
+        .trimIndent()
+
+    val withdrawTxnEventWithoutAmountOrTypeJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "withdrawal",
+              "status": "incomplete",
+              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "destination_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+              "memo_type": "hash",
+              "refund_memo": "some text",
+              "refund_memo_type": "text"
+          }
+      }
+    """
+        .trimIndent()
+
+    val withdrawExchangeTxnJson =
+      """
+      {
+          "status": "incomplete",
+          "kind": "withdrawal-exchange",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountIn": "100",
+          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOut": "98",
+          "amountOutAsset": "iso4217:USD",
+          "amountFee": "2",
+          "amountFeeAsset": "iso4217:USD",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "memoType": "hash",
+          "quoteId": "test-quote-id",
+          "refundMemo": "some text",
+          "refundMemoType": "text"
+      }
+    """
+        .trimIndent()
+
+    val withdrawExchangeTxnEventJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "withdrawal-exchange",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_in": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_out": {
+                  "amount": "98",
+                  "asset": "iso4217:USD"
+              },
+              "amount_fee": {
+                  "amount": "2",
+                  "asset": "iso4217:USD"
+              },
+              "quote_id": "test-quote-id",
+              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "memo_type": "hash",
+              "refund_memo": "some text",
+              "refund_memo_type": "text"
+          }
+      }
+    """
+        .trimIndent()
+
+    val withdrawExchangeTxnWithoutQuoteJson =
+      """
+      {
+          "status": "incomplete",
+          "kind": "withdrawal-exchange",
+          "type": "bank_account",
+          "requestAssetCode": "USDC",
+          "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountIn": "100",
+          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOut": "98",
+          "amountOutAsset": "iso4217:USD",
+          "amountFee": "2",
+          "amountFeeAsset": "iso4217:USD",
+          "amountExpected": "100",
+          "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+          "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "memoType": "hash",
+          "refundMemo": "some text",
+          "refundMemoType": "text"
+      }
+    """
+        .trimIndent()
+
+    val withdrawExchangeTxnWithoutQuoteEventJson =
+      """
+      {
+          "type": "transaction_created",
+          "sep": "6",
+          "transaction": {
+              "sep": "6",
+              "kind": "withdrawal-exchange",
+              "status": "incomplete",
+              "amount_expected": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_in": {
+                  "amount": "100",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+              },
+              "amount_out": {
+                  "amount": "98",
+                  "asset": "iso4217:USD"
+              },
+              "amount_fee": {
+                  "amount": "2",
+                  "asset": "iso4217:USD"
+              },
+              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "memo_type": "hash",
+              "refund_memo": "some text",
+              "refund_memo_type": "text"
+          }
+      }
+    """
+        .trimIndent()
+  }
+}

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
@@ -59,8 +59,8 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
         mapOf(
           "asset_code" to USDC.code,
           "account" to keypair.address,
-          "amount" to "0.01",
-          "type" to "bank_account"
+          "amount" to "1",
+          "type" to "SWIFT"
         )
       )
     waitStatus(deposit.id, "pending_customer_info_update", sep6Client)
@@ -102,7 +102,7 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
 
     val withdraw =
       sep6Client.withdraw(
-        mapOf("asset_code" to USDC.code, "amount" to "0.01", "type" to "bank_account")
+        mapOf("asset_code" to USDC.code, "amount" to "1", "type" to "bank_account")
       )
     waitStatus(withdraw.id, "pending_customer_info_update", sep6Client)
 
@@ -123,7 +123,7 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
       wallet
         .stellar()
         .transaction(keypair, memo = Pair(MemoType.HASH, withdraw.memo))
-        .transfer(withdraw.accountId, USDC, "0.01")
+        .transfer(withdraw.accountId, USDC, "1")
         .build()
     transfer.sign(keypair)
     wallet.stellar().submitTransaction(transfer)

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -121,8 +121,8 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
       mapOf(
         "asset_code" to "USDC",
         "account" to CLIENT_WALLET_ACCOUNT,
-        "amount" to "0.01",
-        "type" to "bank_account"
+        "amount" to "1",
+        "type" to "SWIFT"
       )
     val response = sep6Client.deposit(request)
     Log.info("GET /deposit response: $response")
@@ -137,7 +137,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
   }
 
   private fun `test sep6 withdraw`() {
-    val request = mapOf("asset_code" to "USDC", "type" to "bank_account", "amount" to "0.01")
+    val request = mapOf("asset_code" to "USDC", "type" to "bank_account", "amount" to "1")
     val response = sep6Client.withdraw(request)
     Log.info("GET /withdraw response: $response")
     assert(!response.id.isNullOrEmpty())

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -36,6 +36,7 @@ import org.stellar.anchor.sep31.Sep31TransactionStore;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
 import org.stellar.anchor.sep38.Sep38Service;
 import org.stellar.anchor.sep6.ExchangeAmountsCalculator;
+import org.stellar.anchor.sep6.RequestValidator;
 import org.stellar.anchor.sep6.Sep6Service;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
 
@@ -123,10 +124,16 @@ public class SepBeans {
       EventService eventService,
       FeeIntegration feeIntegration,
       Sep38QuoteStore sep38QuoteStore) {
+    RequestValidator requestValidator = new RequestValidator(assetService);
     ExchangeAmountsCalculator exchangeAmountsCalculator =
         new ExchangeAmountsCalculator(feeIntegration, sep38QuoteStore, assetService);
     return new Sep6Service(
-        sep6Config, assetService, txnStore, exchangeAmountsCalculator, eventService);
+        sep6Config,
+        assetService,
+        requestValidator,
+        txnStore,
+        exchangeAmountsCalculator,
+        eventService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -137,6 +137,7 @@ public class Sep6Controller {
   public GetTransactionsResponse getTransactions(
       HttpServletRequest request,
       @RequestParam(value = "asset_code") String assetCode,
+      @RequestParam(value = "account") String account,
       @RequestParam(required = false, value = "kind") String kind,
       @RequestParam(required = false, value = "limit") Integer limit,
       @RequestParam(required = false, value = "paging_id") String pagingId,
@@ -155,6 +156,7 @@ public class Sep6Controller {
     GetTransactionsRequest getTransactionsRequest =
         GetTransactionsRequest.builder()
             .assetCode(assetCode)
+            .account(account)
             .kind(kind)
             .limit(limit)
             .pagingId(pagingId)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -43,11 +43,11 @@ public class Sep6Controller {
       @RequestParam(value = "memo_type", required = false) String memoType,
       @RequestParam(value = "memo", required = false) String memo,
       @RequestParam(value = "email_address", required = false) String emailAddress,
-      @RequestParam(value = "type") String type,
+      @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "wallet_name", required = false) String walletName,
       @RequestParam(value = "wallet_url", required = false) String walletUrl,
       @RequestParam(value = "lang", required = false) String lang,
-      @RequestParam(value = "amount") String amount,
+      @RequestParam(value = "amount", required = false) String amount,
       @RequestParam(value = "country_code", required = false) String countryCode,
       @RequestParam(value = "claimable_balances_supported", required = false)
           Boolean claimableBalancesSupported)
@@ -79,8 +79,8 @@ public class Sep6Controller {
   public StartWithdrawResponse withdraw(
       HttpServletRequest request,
       @RequestParam(value = "asset_code") String assetCode,
-      @RequestParam(value = "type") String type,
-      @RequestParam(value = "amount") String amount,
+      @RequestParam(value = "type", required = false) String type,
+      @RequestParam(value = "amount", required = false) String amount,
       @RequestParam(value = "country_code", required = false) String countryCode,
       @RequestParam(value = "refundMemo", required = false) String refundMemo,
       @RequestParam(value = "refundMemoType", required = false) String refundMemoType)


### PR DESCRIPTION
### Description

This change:
- Adds additional validation to SEP-6 deposit
- Adds `minAmount` and `maxAmount` validation to all operations
- Makes `type` and `amount` optional in `deposit` and `withdraw`
- Refactors the validation into its own class

### Context

During the testing of `stellar-anchor-tests`, it was discovered that `type` and `amount` are optional parameters for the `deposit` and `withdraw` endpoints. `Sep6Service` had a lot of code duplication so I decided to refactor the validation into its own class.

### Testing

- `./gradlew test`
- `stellar-anchor-tests`

### Known limitations

N/A

