### PR TITLE
[ANCHOR-353] SEP-6: Verify SEP-12 status before deposit/withdraw proceeds

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.stellar.anchor.api.event.AnchorEvent;
+import org.stellar.anchor.api.platform.CustomerUpdatedResponse;
 import org.stellar.anchor.api.platform.GetQuoteResponse;
 import org.stellar.anchor.api.platform.GetTransactionResponse;
 
@@ -13,6 +14,7 @@ import org.stellar.anchor.api.platform.GetTransactionResponse;
 public class SendEventRequestPayload {
   GetTransactionResponse transaction;
   GetQuoteResponse quote;
+  CustomerUpdatedResponse customer;
 
   /**
    * Creates a SendEventRequestPayload from an AnchorEvent.
@@ -23,6 +25,8 @@ public class SendEventRequestPayload {
   public static SendEventRequestPayload from(AnchorEvent event) {
     SendEventRequestPayload payload = new SendEventRequestPayload();
     switch (event.getType()) {
+      case CUSTOMER_UPDATED:
+        payload.setCustomer(event.getCustomer());
       case QUOTE_CREATED:
         payload.setQuote(event.getQuote());
       case TRANSACTION_CREATED:

--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/SepCustomerInfoNeededException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/SepCustomerInfoNeededException.java
@@ -1,0 +1,12 @@
+package org.stellar.anchor.api.exception;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Thrown when a customer's info is needed to complete a request. */
+@RequiredArgsConstructor
+@Getter
+public class SepCustomerInfoNeededException extends AnchorException {
+  private final List<String> fields;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/CustomerInfoNeededResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/CustomerInfoNeededResponse.java
@@ -1,0 +1,12 @@
+package org.stellar.anchor.api.sep;
+
+import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Data
+public class CustomerInfoNeededResponse {
+  private final String type = "non_interactive_customer_info_needed";
+  private final List<String> fields;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12Status.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12Status.java
@@ -13,10 +13,7 @@ public enum Sep12Status {
   PROCESSING("PROCESSING"),
 
   @SerializedName("REJECTED")
-  REJECTED("REJECTED"),
-
-  @SerializedName("VERIFICATION_REQUIRED")
-  VERIFICATION_REQUIRED("VERIFICATION_REQUIRED");
+  REJECTED("REJECTED");
 
   private final String name;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawExchangeRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawExchangeRequest.java
@@ -33,6 +33,9 @@ public class StartWithdrawExchangeRequest {
   @SerializedName("quote_id")
   String quoteId;
 
+  /** The account to withdraw from. */
+  String account;
+
   /** The amount of the source asset the user would like to withdraw. */
   @NonNull String amount;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
@@ -23,6 +23,9 @@ public class StartWithdrawRequest {
   /** Type of withdrawal. */
   String type;
 
+  /** The account to withdraw from. */
+  String account;
+
   /** The amount to withdraw. */
   String amount;
 

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -142,6 +142,8 @@ public class Sep6Service {
           asset.getWithdraw().getMinAmount(),
           asset.getWithdraw().getMaxAmount());
     }
+    String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
+    requestValidator.validateAccount(sourceAccount);
 
     String id = SepHelper.generateSepTransactionId();
 
@@ -160,7 +162,7 @@ public class Sep6Service {
             .sep10AccountMemo(token.getAccountMemo())
             .memo(generateMemo(id))
             .memoType(memoTypeAsString(MEMO_HASH))
-            .fromAccount(token.getAccount())
+            .fromAccount(sourceAccount)
             .withdrawAnchorAccount(asset.getDistributionAccount())
             .toAccount(asset.getDistributionAccount())
             .refundMemo(request.getRefundMemo())
@@ -210,6 +212,8 @@ public class Sep6Service {
         sellAsset.getSignificantDecimals(),
         sellAsset.getWithdraw().getMinAmount(),
         sellAsset.getWithdraw().getMaxAmount());
+    String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
+    requestValidator.validateAccount(sourceAccount);
 
     String id = SepHelper.generateSepTransactionId();
 
@@ -245,7 +249,7 @@ public class Sep6Service {
             .sep10AccountMemo(token.getAccountMemo())
             .memo(generateMemo(id))
             .memoType(memoTypeAsString(MEMO_HASH))
-            .fromAccount(token.getAccount())
+            .fromAccount(sourceAccount)
             .withdrawAnchorAccount(sellAsset.getDistributionAccount())
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import java.time.Instant
-import java.util.UUID
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -339,6 +339,7 @@ class Sep6ServiceTest {
         asset.withdraw.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -376,6 +377,32 @@ class Sep6ServiceTest {
   }
 
   @Test
+  fun `test withdraw from requested account`() {
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    val request =
+      StartWithdrawRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account("requested_account")
+        .refundMemo("some text")
+        .refundMemoType("text")
+        .build()
+    sep6Service.withdraw(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) { requestValidator.validateAccount("requested_account") }
+
+    // Verify effects
+    assertEquals("requested_account", slotTxn.captured.fromAccount)
+    assertEquals("requested_account", slotEvent.captured.transaction.sourceAccount)
+  }
+
+  @Test
   fun `test withdraw without amount or type`() {
     val slotTxn = slot<Sep6Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -393,6 +420,7 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -554,6 +582,7 @@ class Sep6ServiceTest {
         asset.withdraw.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -610,6 +639,7 @@ class Sep6ServiceTest {
         asset.withdraw.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) {
@@ -698,6 +728,7 @@ class Sep6ServiceTest {
         asset.withdraw.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { exchangeAmountsCalculator.calculate(any(), any(), "100", TEST_ACCOUNT) }
@@ -733,6 +764,38 @@ class Sep6ServiceTest {
       gson.toJson(response),
       JSONCompareMode.LENIENT
     )
+  }
+
+  @Test
+  fun `test withdraw-exchange from requested account`() {
+    val sourceAsset = TEST_ASSET
+    val destinationAsset = "iso4217:USD"
+
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val slotEvent = slot<AnchorEvent>()
+    every { eventSession.publish(capture(slotEvent)) } returns Unit
+
+    val request =
+      StartWithdrawExchangeRequest.builder()
+        .sourceAsset(sourceAsset)
+        .destinationAsset(destinationAsset)
+        .type("bank_account")
+        .amount("100")
+        .account("requested_account")
+        .refundMemo("some text")
+        .refundMemoType("text")
+        .build()
+    sep6Service.withdrawExchange(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+
+    // Verify validations
+    verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
+    verify(exactly = 1) { requestValidator.validateAccount("requested_account") }
+
+    // Verify effects
+    assertEquals("requested_account", slotTxn.captured.fromAccount)
+    assertEquals("requested_account", slotEvent.captured.transaction.sourceAccount)
   }
 
   @Test
@@ -888,6 +951,7 @@ class Sep6ServiceTest {
         asset.withdraw.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -363,6 +363,7 @@ class Sep6ServiceTest {
         asset.deposit.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) {
@@ -443,6 +444,7 @@ class Sep6ServiceTest {
         asset.deposit.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { exchangeAmountsCalculator.calculate(any(), any(), "100", TEST_ACCOUNT) }
@@ -629,6 +631,7 @@ class Sep6ServiceTest {
         asset.deposit.maxAmount,
       )
     }
+    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
@@ -52,7 +52,9 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    anchor.customer(token).add(mapOf("first_name" to "John", "last_name" to "Doe"))
+    anchor
+      .customer(token)
+      .add(mapOf("first_name" to "John", "last_name" to "Doe", "email_address" to "john@email.com"))
 
     val deposit =
       sep6Client.deposit(
@@ -98,7 +100,9 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    anchor.customer(token).add(mapOf("first_name" to "John", "last_name" to "Doe"))
+    anchor
+      .customer(token)
+      .add(mapOf("first_name" to "John", "last_name" to "Doe", "email_address" to "john@email.com"))
 
     val withdraw =
       sep6Client.withdraw(

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -2,14 +2,24 @@ package org.stellar.anchor.platform.test
 
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
 import org.stellar.anchor.platform.CLIENT_WALLET_ACCOUNT
+import org.stellar.anchor.platform.Sep12Client
 import org.stellar.anchor.platform.Sep6Client
 import org.stellar.anchor.platform.gson
 import org.stellar.anchor.util.Log
 import org.stellar.anchor.util.Sep1Helper.TomlContent
 
 class Sep6Tests(val toml: TomlContent, jwt: String) {
-  private val sep6Client = Sep6Client(toml.getString("TRANSFER_SERVER"), jwt)
+  private val sep6Client: Sep6Client
+  private val sep12Client: Sep12Client
+
+  init {
+    sep6Client = Sep6Client(toml.getString("TRANSFER_SERVER"), jwt)
+    sep12Client = Sep12Client(toml.getString("KYC_SERVER"), jwt)
+    // Create a customer before running any tests
+    putCustomer()
+  }
 
   private val expectedSep6Info =
     """
@@ -148,6 +158,16 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
       gson.toJson(savedWithdrawTxn),
       JSONCompareMode.LENIENT
     )
+  }
+
+  private fun putCustomer() {
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .firstName("John")
+        .lastName("Doe")
+        .emailAddress("john@email.com")
+        .build()
+    sep12Client.putCustomer(request)
   }
 
   fun testAll() {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -17,8 +17,6 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
   init {
     sep6Client = Sep6Client(toml.getString("TRANSFER_SERVER"), jwt)
     sep12Client = Sep12Client(toml.getString("KYC_SERVER"), jwt)
-    // Create a customer before running any tests
-    putCustomer()
   }
 
   private val expectedSep6Info =
@@ -172,6 +170,8 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
 
   fun testAll() {
     Log.info("Performing SEP6 tests")
+    // Create a customer before running any tests
+    putCustomer()
     `test Sep6 info endpoint`()
     `test sep6 deposit`()
     `test sep6 withdraw`()

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Event.kt
@@ -1,5 +1,6 @@
 package org.stellar.reference.data
 
+import org.stellar.anchor.api.platform.CustomerUpdatedResponse
 import org.stellar.anchor.api.platform.GetQuoteResponse
 import org.stellar.anchor.api.platform.GetTransactionResponse
 
@@ -10,7 +11,8 @@ data class SendEventRequest(
   val payload: SendEventRequestPayload
 )
 
-public data class SendEventRequestPayload(
-  val transaction: GetTransactionResponse,
-  val quote: GetQuoteResponse
+data class SendEventRequestPayload(
+  val transaction: GetTransactionResponse?,
+  val quote: GetQuoteResponse?,
+  val customer: CustomerUpdatedResponse?
 )

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventService.kt
@@ -26,7 +26,7 @@ class EventService {
   fun getEvents(txnId: String?): List<SendEventRequest> {
     if (txnId != null) {
       // filter events with txnId
-      return receivedEvents.filter { it.payload.transaction.id == txnId }
+      return receivedEvents.filter { it.payload.transaction?.id == txnId }
     }
     // return all events
     return receivedEvents

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -122,9 +122,10 @@ public class SepBeans {
       AssetService assetService,
       Sep6TransactionStore txnStore,
       EventService eventService,
+      CustomerIntegration customerIntegration,
       FeeIntegration feeIntegration,
       Sep38QuoteStore sep38QuoteStore) {
-    RequestValidator requestValidator = new RequestValidator(assetService);
+    RequestValidator requestValidator = new RequestValidator(assetService, customerIntegration);
     ExchangeAmountsCalculator exchangeAmountsCalculator =
         new ExchangeAmountsCalculator(feeIntegration, sep38QuoteStore, assetService);
     return new Sep6Service(

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.stellar.anchor.api.exception.*;
+import org.stellar.anchor.api.sep.CustomerInfoNeededResponse;
 import org.stellar.anchor.api.sep.SepExceptionResponse;
 
 public abstract class AbstractControllerExceptionHandler {
@@ -39,6 +40,12 @@ public abstract class AbstractControllerExceptionHandler {
   public SepExceptionResponse handleAuthError(SepException ex) {
     errorEx(ex);
     return new SepExceptionResponse(ex.getMessage());
+  }
+
+  @ExceptionHandler(SepCustomerInfoNeededException.class)
+  @ResponseStatus(value = HttpStatus.FORBIDDEN)
+  public CustomerInfoNeededResponse handle(SepCustomerInfoNeededException ex) {
+    return new CustomerInfoNeededResponse(ex.getFields());
   }
 
   @ExceptionHandler({SepNotFoundException.class, NotFoundException.class})


### PR DESCRIPTION
### Description

This adds a check to verify that a customer is SEP-12 accepted as part of the deposit/withdraw request validation. This also removes the `VERIFICATION_REQUIRED` status as it is not a valid SEP-12 customer info status.

### Context

This was caught by a `stellar-anchor-tests` test case.

### Testing

- `./gradlew test`
- `stellar-anchor-tests`

### Known limitations

N/A

