### PR TITLE
SEP-6: Show min/max amounts in the info response

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/InfoResponse.java
@@ -69,6 +69,14 @@ public class InfoResponse {
     @SerializedName("authentication_required")
     Boolean authenticationRequired;
 
+    /** The minimum amount that can be deposited. */
+    @SerializedName("min_amount")
+    Long minAmount;
+
+    /** The maximum amount that can be deposited. */
+    @SerializedName("max_amount")
+    Long maxAmount;
+
     /**
      * The fields required to initiate a deposit.
      *
@@ -92,6 +100,14 @@ public class InfoResponse {
      */
     @SerializedName("authentication_required")
     Boolean authenticationRequired;
+
+    /** The minimum amount that can be withdrawn. */
+    @SerializedName("min_amount")
+    Long minAmount;
+
+    /** The maximum amount that can be withdrawn. */
+    @SerializedName("max_amount")
+    Long maxAmount;
 
     /**
      * The types of withdrawal methods supported and their fields.

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -515,6 +515,8 @@ public class Sep6Service {
               DepositAssetResponse.builder()
                   .enabled(true)
                   .authenticationRequired(true)
+                  .minAmount(asset.getDeposit().getMinAmount())
+                  .maxAmount(asset.getDeposit().getMaxAmount())
                   .fields(ImmutableMap.of("type", type))
                   .build();
 
@@ -533,6 +535,8 @@ public class Sep6Service {
               WithdrawAssetResponse.builder()
                   .enabled(true)
                   .authenticationRequired(true)
+                  .minAmount(asset.getWithdraw().getMinAmount())
+                  .maxAmount(asset.getWithdraw().getMaxAmount())
                   .types(types)
                   .build();
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -71,7 +71,7 @@ class Sep6ServiceTest {
   private val asset = assetService.getAsset(TEST_ASSET)
 
   @Test
-  fun `test INFO response`() {
+  fun `test info response`() {
     val infoResponse = sep6Service.info
     assertEquals(
       gson.fromJson(Sep6ServiceTestData.infoJson, InfoResponse::class.java),

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -4,85 +4,93 @@ class Sep6ServiceTestData {
   companion object {
     val infoJson =
       """
-      {
-          "deposit": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
-              }
-          },
-          "deposit-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
-              }
-          },
-          "withdraw": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "withdraw-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "fee": {
-              "enabled": false,
-              "description": "Fee endpoint is not supported."
-          },
-          "transactions": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "transaction": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "features": {
-              "account_creation": false,
-              "claimable_balances": false
-          }
-      }
-    """
+        {
+            "deposit": {
+                "USDC": {
+                    "enabled": true,
+                    "authentication_required": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "fields": {
+                        "type": {
+                            "description": "type of deposit to make",
+                            "choices": [
+                                "SEPA",
+                                "SWIFT"
+                            ],
+                            "optional": false
+                        }
+                    }
+                }
+            },
+            "deposit-exchange": {
+                "USDC": {
+                    "enabled": true,
+                    "authentication_required": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "fields": {
+                        "type": {
+                            "description": "type of deposit to make",
+                            "choices": [
+                                "SEPA",
+                                "SWIFT"
+                            ],
+                            "optional": false
+                        }
+                    }
+                }
+            },
+            "withdraw": {
+                "USDC": {
+                    "enabled": true,
+                    "authentication_required": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "types": {
+                        "cash": {
+                            "fields": {}
+                        },
+                        "bank_account": {
+                            "fields": {}
+                        }
+                    }
+                }
+            },
+            "withdraw-exchange": {
+                "USDC": {
+                    "enabled": true,
+                    "authentication_required": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "types": {
+                        "cash": {
+                            "fields": {}
+                        },
+                        "bank_account": {
+                            "fields": {}
+                        }
+                    }
+                }
+            },
+            "fee": {
+                "enabled": false,
+                "description": "Fee endpoint is not supported."
+            },
+            "transactions": {
+                "enabled": true,
+                "authentication_required": true
+            },
+            "transaction": {
+                "enabled": true,
+                "authentication_required": true
+            },
+            "features": {
+                "account_creation": false,
+                "claimable_balances": false
+            }
+        }
+      """
         .trimIndent()
 
     val transactionsJson =

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -14,74 +14,86 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
   private val expectedSep6Info =
     """
       {
-        "deposit": {
-          "USDC": {
-            "enabled": true,
-            "authentication_required": true,
-            "fields": {
-              "type": {
-                "description": "type of deposit to make",
-                "choices": [
-                  "SEPA",
-                  "SWIFT"
-                ],
-                "optional": false
+          "deposit": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "min_amount": 1,
+                  "fields": {
+                      "type": {
+                          "description": "type of deposit to make",
+                          "choices": [
+                              "SEPA",
+                              "SWIFT"
+                          ],
+                          "optional": false
+                      }
+                  }
               }
-            }
-          }
-        },
-        "deposit-exchange": {
-          "USDC": {
-            "enabled": true,
-            "authentication_required": true,
-            "fields": {
-              "type": {
-                "description": "type of deposit to make",
-                "choices": [
-                  "SEPA",
-                  "SWIFT"
-                ],
-                "optional": false
+          },
+          "deposit-exchange": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "min_amount": 1,
+                  "fields": {
+                      "type": {
+                          "description": "type of deposit to make",
+                          "choices": [
+                              "SEPA",
+                              "SWIFT"
+                          ],
+                          "optional": false
+                      }
+                  }
               }
-            }
+          },
+          "withdraw": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "max_amount": 1000000,
+                  "types": {
+                      "cash": {
+                          "fields": {}
+                      },
+                      "bank_account": {
+                          "fields": {}
+                      }
+                  }
+              }
+          },
+          "withdraw-exchange": {
+              "USDC": {
+                  "enabled": true,
+                  "authentication_required": true,
+                  "max_amount": 1000000,
+                  "types": {
+                      "cash": {
+                          "fields": {}
+                      },
+                      "bank_account": {
+                          "fields": {}
+                      }
+                  }
+              }
+          },
+          "fee": {
+              "enabled": false,
+              "description": "Fee endpoint is not supported."
+          },
+          "transactions": {
+              "enabled": true,
+              "authentication_required": true
+          },
+          "transaction": {
+              "enabled": true,
+              "authentication_required": true
+          },
+          "features": {
+              "account_creation": false,
+              "claimable_balances": false
           }
-        },
-        "withdraw": {
-          "USDC": {
-            "enabled": true,
-            "authentication_required": true,
-            "types": {
-              "cash": {},
-              "bank_account": {}
-            }
-          }
-        },
-        "withdraw-exchange": {
-          "USDC": {
-            "enabled": true,
-            "authentication_required": true,
-            "types": {
-              "cash": {},
-              "bank_account": {}
-            }
-          }
-        },
-        "fee": {
-          "enabled": false,
-          "description": "Fee endpoint is not supported."
-        },
-        "transactions": {
-          "enabled": true,
-          "authentication_required": true
-        },
-        "transaction": {
-          "enabled": true,
-          "authentication_required": true
-        },
-        "features": {
-          "account_creation": false,
-          "claimable_balances": false
-        }
       }
     """
       .trimIndent()
@@ -113,7 +125,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
 
   private fun `test Sep6 info endpoint`() {
     val info = sep6Client.getInfo()
-    JSONAssert.assertEquals(expectedSep6Info, gson.toJson(info), JSONCompareMode.LENIENT)
+    JSONAssert.assertEquals(expectedSep6Info, gson.toJson(info), JSONCompareMode.STRICT)
   }
 
   private fun `test sep6 deposit`() {


### PR DESCRIPTION
### Description

Since we are validating min/max amounts, if set, these should be show in the GET /info response.

### Context

These are currently missing from the info response.

### Testing

- `./gradlew test`

### Known limitations

N/A

