### PR TITLE
SEP-6: Remove to account set by withdraw

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -247,7 +247,6 @@ public class Sep6Service {
             .memoType(memoTypeAsString(MEMO_HASH))
             .fromAccount(token.getAccount())
             .withdrawAnchorAccount(asset.getDistributionAccount())
-            .toAccount(asset.getDistributionAccount())
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType());
 

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
@@ -27,5 +27,6 @@ public interface Sep6TransactionStore {
 
   List<? extends Sep6Transaction> findTransactions(TransactionsParams params) throws SepException;
 
-  Sep6Transaction findOneByToAccountAndMemoAndStatus(String toAccount, String memo, String status);
+  Sep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      String toAccount, String memo, String status);
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
@@ -28,5 +28,5 @@ public interface Sep6TransactionStore {
   List<? extends Sep6Transaction> findTransactions(TransactionsParams params) throws SepException;
 
   Sep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String toAccount, String memo, String status);
+      String withdrawAnchorAccount, String memo, String status);
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -339,7 +339,6 @@ class Sep6ServiceTestData {
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text"
@@ -361,7 +360,6 @@ class Sep6ServiceTestData {
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "destination_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
               "memo_type": "hash",
               "refund_memo": "some text",
               "refund_memo_type": "text"
@@ -380,7 +378,6 @@ class Sep6ServiceTestData {
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text"
@@ -398,7 +395,6 @@ class Sep6ServiceTestData {
               "kind": "withdrawal",
               "status": "incomplete",
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "destination_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
               "memo_type": "hash",
               "refund_memo": "some text",
               "refund_memo_type": "text"

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -104,7 +104,6 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
               "kind": "withdrawal",
               "status": "incomplete",
               "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-              "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
               "withdraw_memo_type": "hash"
           }
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -20,8 +20,8 @@ public interface JdbcSep6TransactionRepo
 
   JdbcSep6Transaction findOneByExternalTransactionId(String externalTransactionId);
 
-  JdbcSep6Transaction findOneByToAccountAndMemoAndStatus(
-      String toAccount, String memo, String status);
+  JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      String withdrawAnchorAccount, String memo, String status);
 
   List<Sep6Transaction> findBySep10AccountAndRequestAssetCodeOrderByStartedAtDesc(
       String stellarAccount, String assetCode);

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
@@ -116,8 +116,9 @@ public class JdbcSep6TransactionStore implements Sep6TransactionStore {
   }
 
   @Override
-  public JdbcSep6Transaction findOneByToAccountAndMemoAndStatus(
-      String toAccount, String memo, String status) {
-    return transactionRepo.findOneByToAccountAndMemoAndStatus(toAccount, memo, status);
+  public JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      String withdrawAnchorAccount, String memo, String status) {
+    return transactionRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+        withdrawAnchorAccount, memo, status);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -121,7 +121,7 @@ public class PaymentOperationToEventListener implements PaymentListener {
     JdbcSep6Transaction sep6Txn;
     try {
       sep6Txn =
-          sep6TransactionStore.findOneByToAccountAndMemoAndStatus(
+          sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
               payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
     } catch (Exception ex) {
       errorEx(ex);

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -230,6 +230,8 @@ public class TransactionService {
       case "6":
         // TODO: this needs major refactoring
         JdbcSep6Transaction sep6Transaction = (JdbcSep6Transaction) txn;
+        sep6Transaction.setFromAccount(patch.getTransaction().getSourceAccount());
+        sep6Transaction.setToAccount(patch.getTransaction().getDestinationAccount());
         sep6Transaction.setRequiredInfoMessage(patch.getTransaction().getRequiredInfoMessage());
         sep6Transaction.setRequiredInfoUpdates(patch.getTransaction().getRequiredInfoUpdates());
         sep6Transaction.setRequiredCustomerInfoMessage(

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -230,8 +230,6 @@ public class TransactionService {
       case "6":
         // TODO: this needs major refactoring
         JdbcSep6Transaction sep6Transaction = (JdbcSep6Transaction) txn;
-        sep6Transaction.setFromAccount(patch.getTransaction().getSourceAccount());
-        sep6Transaction.setToAccount(patch.getTransaction().getDestinationAccount());
         sep6Transaction.setRequiredInfoMessage(patch.getTransaction().getRequiredInfoMessage());
         sep6Transaction.setRequiredInfoUpdates(patch.getTransaction().getRequiredInfoUpdates());
         sep6Transaction.setRequiredCustomerInfoMessage(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -99,8 +99,9 @@ class PaymentOperationToEventListenerTest {
     } returns null
     every { sep24TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
       null
-    every { sep6TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every {
+      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns null
     paymentOperationToEventListener.onReceived(payment)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(
@@ -439,8 +440,9 @@ class PaymentOperationToEventListenerTest {
     every {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(any(), any(), any())
     } returns null
-    every { sep6TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every {
+      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns null
 
     val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
     every {
@@ -556,7 +558,7 @@ class PaymentOperationToEventListenerTest {
 
     val sep6TxnCopy = gson.fromJson(gson.toJson(sep6Txn), JdbcSep6Transaction::class.java)
     every {
-      sep6TransactionStore.findOneByToAccountAndMemoAndStatus(
+      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         capture(slotMemo),
         capture(slotStatus)


### PR DESCRIPTION
### Description

Removes the `to` account set by the withdraw endpoint.

### Context

`to` is an optional field in the transactions object, and is meant to store the user's off-chain account. This is not known at the time of transaction creation.

### Testing

- `./gradlew test`

### Known limitations

N/A

