### PR TITLE
[ANCHOR-497]: Restructure Sep1Service functions for extensibility and customizability

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
@@ -14,7 +14,8 @@ public interface Sep1Config {
   enum TomlType {
     STRING,
     FILE,
-    URL;
+    URL,
+    ;
 
     public static TomlType fromString(String name) throws InvalidConfigException {
       if (StringHelper.isEmpty(name)) name = "";

--- a/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep1Config.java
@@ -14,8 +14,7 @@ public interface Sep1Config {
   enum TomlType {
     STRING,
     FILE,
-    URL,
-    ;
+    URL;
 
     public static TomlType fromString(String name) throws InvalidConfigException {
       if (StringHelper.isEmpty(name)) name = "";

--- a/core/src/main/java/org/stellar/anchor/sep1/ISep1Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/ISep1Service.java
@@ -1,0 +1,15 @@
+package org.stellar.anchor.sep1;
+
+import org.stellar.anchor.config.Sep1Config;
+
+public interface ISep1Service {
+  /**
+   * Read the stellar.toml content from Java resource. Override this method to read from a different
+   * source.
+   *
+   * @param sep1Config The Sep1 configuration.
+   * @return The stellar.toml content.
+   * @throws Exception
+   */
+  String readSep1Toml(Sep1Config sep1Config) throws Exception;
+}

--- a/core/src/main/java/org/stellar/anchor/sep1/ISep1Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/ISep1Service.java
@@ -2,6 +2,10 @@ package org.stellar.anchor.sep1;
 
 import org.stellar.anchor.config.Sep1Config;
 
+/**
+ * The interface for SEP-1 service. Use this interface to override the default implementation of the
+ * Sep1Service class.
+ */
 public interface ISep1Service {
   /**
    * Read the stellar.toml content from Java resource. Override this method to read from a different

--- a/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java
@@ -23,10 +23,8 @@ public class Sep1Service implements ISep1Service {
    * Construct the Sep1Service that reads the stellar.toml content from Java resource.
    *
    * @param sep1Config The Sep1 configuration.
-   * @throws IOException if the file cannot be read.
-   * @throws InvalidConfigException if invalid type is specified.
    */
-  public Sep1Service(Sep1Config sep1Config) throws IOException, InvalidConfigException {
+  public Sep1Service(Sep1Config sep1Config) {
     this.sep1Config = sep1Config;
     Log.info("Sep1Service initialized.");
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
@@ -4,14 +4,14 @@ package org.stellar.anchor.sep1
 
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import java.nio.file.Files
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.config.Sep1Config
 import org.stellar.anchor.config.Sep1Config.TomlType.*
-import org.stellar.anchor.util.NetUtil
 
 @Order(89)
 internal class Sep1ServiceTest {
@@ -19,50 +19,52 @@ internal class Sep1ServiceTest {
 
   @BeforeEach
   fun setUp() {
-    MockKAnnotations.init(this, relaxUnitFun = true)
+    MockKAnnotations.init(this)
   }
 
   @Test
-  fun `disabled Sep1Service should return null string as toml value`() {
+  fun `disabled Sep1Service should throw SepException when reading the toml value`() {
+    // Given
     every { sep1Config.isEnabled } returns false
+    // When
     val sep1Service = Sep1Service(sep1Config)
-    assertEquals(null, sep1Service.stellarToml)
+    // Then
+    assertThrows<SepException> { sep1Service.toml }
   }
 
   @Test
   fun `test string type`() {
+    // Given
     every { sep1Config.isEnabled } returns true
     every { sep1Config.type } returns STRING
     every { sep1Config.value } returns "toml content"
+    // When
     val sep1Service = Sep1Service(sep1Config)
-    assertEquals("toml content", sep1Service.stellarToml)
+    // Then
+    assertEquals("toml content", sep1Service.toml)
   }
 
   @Test
   fun `test file type`() {
-    mockkStatic(Files::class)
-    every { Files.readString(any()) } returns "toml content"
+    // Given
     every { sep1Config.isEnabled } returns true
     every { sep1Config.type } returns FILE
     every { sep1Config.value } returns "toml_file_path"
-
-    val sep1Service = Sep1Service(sep1Config)
-    assertEquals("toml content", sep1Service.stellarToml)
-
-    unmockkStatic(Files::class)
+    val sep1Service = spyk(Sep1Service(sep1Config))
+    every { sep1Service.readTomlFromFile(eq("toml_file_path")) } returns "toml content"
+    // When, Then
+    assertEquals("toml content", sep1Service.toml)
   }
 
   @Test
   fun `test url type`() {
-    mockkStatic(NetUtil::class)
-    every { NetUtil.fetch(any()) } returns "toml content"
+    // Given
     every { sep1Config.isEnabled } returns true
     every { sep1Config.type } returns URL
     every { sep1Config.value } returns "toml_file_path"
-
-    val sep1Service = Sep1Service(sep1Config)
-    assertEquals("toml content", sep1Service.stellarToml)
-
-    unmockkStatic(NetUtil::class)
+    val sep1Service = spyk(Sep1Service(sep1Config))
+    every { sep1Service.readTomlFromURL(eq("toml_file_path")) } returns "toml content"
+    // When, Then
+    assertEquals("toml content", sep1Service.toml)
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep1/Sep1ServiceTest.kt
@@ -33,6 +33,27 @@ internal class Sep1ServiceTest {
   }
 
   @Test
+  fun `test readSep1Toml failure should throw Exceptions`() {
+    // Given
+    every { sep1Config.isEnabled } returns true
+    every { sep1Config.value } returns "toml content"
+    val sep1Service = spyk(Sep1Service(sep1Config))
+    every { sep1Config.type } returns FILE
+    every { sep1Service.readTomlFromFile(any()) } throws Exception("readTomlFromFile failed")
+
+    // When, Then
+    var ex = assertThrows<SepException> { sep1Service.toml }
+    assertEquals("Unable to read SEP-1 value", ex.message)
+
+    // Given
+    every { sep1Service.readTomlFromURL(any()) } throws Exception("readTomlFromURL failed")
+    every { sep1Config.type } returns URL
+    // When, Then
+    ex = assertThrows<SepException> { sep1Service.toml }
+    assertEquals("Unable to read SEP-1 value", ex.message)
+  }
+
+  @Test
   fun `test string type`() {
     // Given
     every { sep1Config.isEnabled } returns true

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep1Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep1Controller.java
@@ -1,11 +1,11 @@
 package org.stellar.anchor.platform.controller.sep;
 
-import java.io.IOException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
+import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.exception.SepNotFoundException;
 import org.stellar.anchor.api.sep.SepExceptionResponse;
 import org.stellar.anchor.config.Sep1Config;
@@ -41,13 +41,13 @@ public class Sep1Controller {
   @RequestMapping(
       value = "/.well-known/stellar.toml",
       method = {RequestMethod.GET, RequestMethod.OPTIONS})
-  public ResponseEntity<String> getToml() throws IOException, SepNotFoundException {
+  public ResponseEntity<String> getToml() throws SepException {
     if (!sep1Config.isEnabled()) {
       throw new SepNotFoundException("Not Found");
     }
     HttpHeaders headers = new HttpHeaders();
     headers.set("content-type", "text/plain");
-    return ResponseEntity.ok().headers(headers).body(sep1Service.getStellarToml());
+    return ResponseEntity.ok().headers(headers).body(sep1Service.getToml());
   }
 
   @ExceptionHandler({SepNotFoundException.class})

--- a/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
@@ -56,14 +56,14 @@ class Sep1ServiceTest {
   fun `test Sep1Service reading toml from inline string`() {
     val config = PropertySep1Config(true, TomlConfig(STRING, stellarToml))
     sep1 = Sep1Service(config)
-    assertEquals(sep1.stellarToml, stellarToml)
+    assertEquals(sep1.toml, stellarToml)
   }
 
   @Test
   fun `test Sep1Service reading toml from file`() {
     val config = PropertySep1Config(true, TomlConfig(FILE, Sep1ConfigTest.getTestTomlAsFile()))
     sep1 = Sep1Service(config)
-    assertEquals(sep1.stellarToml, Files.readString(Path.of(Sep1ConfigTest.getTestTomlAsFile())))
+    assertEquals(sep1.toml, Files.readString(Path.of(Sep1ConfigTest.getTestTomlAsFile())))
   }
 
   @Test
@@ -74,7 +74,7 @@ class Sep1ServiceTest {
     mockServer.enqueue(MockResponse().setBody(stellarToml))
     val config = PropertySep1Config(true, TomlConfig(URL, mockAnchorUrl))
     sep1 = Sep1Service(config)
-    assertEquals(sep1.stellarToml, stellarToml)
+    assertEquals(sep1.toml, stellarToml)
   }
 
   // this test is not expected to raise an exception. given the re-direct to a malicious
@@ -105,7 +105,7 @@ class Sep1ServiceTest {
 
     val config = PropertySep1Config(true, TomlConfig(URL, mockAnchorUrl))
     val sep1 = Sep1Service(config)
-    assertEquals(sep1.getStellarToml(), metadata)
+    assertEquals(sep1.getToml(), metadata)
     mockServer.shutdown()
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/Sep1ServiceTest.kt
@@ -1,16 +1,15 @@
 package org.stellar.anchor
 
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.config.Sep1Config.TomlType.*
 import org.stellar.anchor.platform.config.PropertySep1Config
 import org.stellar.anchor.platform.config.PropertySep1Config.TomlConfig
@@ -119,10 +118,9 @@ class Sep1ServiceTest {
     mockServer.enqueue(MockResponse().setResponseCode(500))
 
     val config = PropertySep1Config(true, TomlConfig(URL, mockAnchorUrl))
-    val exception = assertThrows(IOException::class.java) { sep1 = Sep1Service(config) }
-    assertTrue(
-      exception.message?.contains("Unsuccessful response code: 500, message: Server Error") == true
-    )
+    val sep1Service = Sep1Service(config)
+    val exception = assertThrows(SepException::class.java) { sep1Service.toml }
+    assertEquals(exception.message, "Unable to read SEP-1 value")
     mockServer.shutdown()
   }
 }


### PR DESCRIPTION
### Description

- Restructure Sep1 service functions for extensibility and customizability.
- Replaced the static mocks with member functions of `Sep1Service`.

### Context

Core SDK release.

### Testing

- `./gradlew test`

### Known liimitation
The test coverage is at 85%. This is because [the `TomlType` check ](https://github.com/lijamie98/java-stellar-anchor-sdk/blob/feature/anchor-497-sep1-refactor-core/core/src/main/java/org/stellar/anchor/sep1/Sep1Service.java#L45-L47)was not able to be tested. 

Also avoiding the static functions mocking also reduces the coverage. 
