### PR TITLE
[Anchor-424] Publish event only when rpc api change txn state

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -150,7 +150,7 @@ public class SepBeans {
   Sep24Service sep24Service(
       AppConfig appConfig,
       Sep24Config sep24Config,
-      ClientsConfig clientsConfig,
+      PropertyClientsConfig clientsConfig,
       AssetService assetService,
       JwtService jwtService,
       Sep24TransactionStore sep24TransactionStore,


### PR DESCRIPTION
### Description

Publish event for RPC call only when transaction state changed.

### Context

This PR changed it to publish event only when transaction state got changed, this change aims to prevent potential infinite event loop between platform server and business server.

### Testing

- `./gradlew test`
- TODO: replace with any additional test steps

### Known limitations

TODO: describe any limitations or replace with N/A

