### PR TITLE
[Fix] SEP-6: Set customers field in platform transaction

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -116,13 +116,15 @@ public class RequestValidator {
   }
 
   /**
-   * Validates that the authenticated account has been KYC'ed by the anchor.
+   * Validates that the authenticated account has been KYC'ed by the anchor and returns its SEP-12
+   * customer ID.
    *
    * @param sep10Account the authenticated account
    * @param sep10AccountMemo the authenticated account memo
    * @throws AnchorException if the account has not been KYC'ed
+   * @return the SEP-12 customer ID if the account has been KYC'ed
    */
-  public void validateKyc(String sep10Account, String sep10AccountMemo) throws AnchorException {
+  public String validateKyc(String sep10Account, String sep10AccountMemo) throws AnchorException {
     GetCustomerRequest request =
         sep10AccountMemo != null
             ? GetCustomerRequest.builder()
@@ -151,5 +153,7 @@ public class RequestValidator {
         throw new ServerErrorException(
             String.format("unknown customer status: %s", response.getStatus()));
     }
+
+    return response.getId();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -76,7 +76,7 @@ public class Sep6Service {
           asset.getDeposit().getMaxAmount());
     }
     requestValidator.validateAccount(request.getAccount());
-    requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
+    String customerId = requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
 
     Memo memo = makeMemo(request.getMemo(), request.getMemoType());
     String id = SepHelper.generateSepTransactionId();
@@ -94,7 +94,8 @@ public class Sep6Service {
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
-            .toAccount(request.getAccount());
+            .toAccount(request.getAccount())
+            .customer(customerId);
 
     if (memo != null) {
       builder.memo(memo.toString());
@@ -143,7 +144,7 @@ public class Sep6Service {
         buyAsset.getDeposit().getMinAmount(),
         buyAsset.getDeposit().getMaxAmount());
     requestValidator.validateAccount(request.getAccount());
-    requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
+    String customerId = requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
 
     ExchangeAmountsCalculator.Amounts amounts;
     if (request.getQuoteId() != null) {
@@ -180,7 +181,8 @@ public class Sep6Service {
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
             .toAccount(request.getAccount())
-            .quoteId(request.getQuoteId());
+            .quoteId(request.getQuoteId())
+            .customer(customerId);
 
     if (memo != null) {
       builder.memo(memo.toString());
@@ -229,7 +231,7 @@ public class Sep6Service {
     }
     String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
     requestValidator.validateAccount(sourceAccount);
-    requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
+    String customerId = requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
 
     String id = SepHelper.generateSepTransactionId();
 
@@ -251,7 +253,8 @@ public class Sep6Service {
             .fromAccount(sourceAccount)
             .withdrawAnchorAccount(asset.getDistributionAccount())
             .refundMemo(request.getRefundMemo())
-            .refundMemoType(request.getRefundMemoType());
+            .refundMemoType(request.getRefundMemoType())
+            .customer(customerId);
 
     Sep6Transaction txn = builder.build();
     txnStore.save(txn);
@@ -299,7 +302,7 @@ public class Sep6Service {
         sellAsset.getWithdraw().getMaxAmount());
     String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
     requestValidator.validateAccount(sourceAccount);
-    requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
+    String customerId = requestValidator.validateKyc(token.getAccount(), token.getAccountMemo());
 
     String id = SepHelper.generateSepTransactionId();
 
@@ -339,7 +342,8 @@ public class Sep6Service {
             .withdrawAnchorAccount(sellAsset.getDistributionAccount())
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())
-            .quoteId(request.getQuoteId());
+            .quoteId(request.getQuoteId())
+            .customer(customerId);
 
     Sep6Transaction txn = builder.build();
     txnStore.save(txn);

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
@@ -362,6 +362,15 @@ public interface Sep6Transaction extends SepTransaction {
 
   void setInstructions(Map<String, InstructionField> instructions);
 
+  /**
+   * The SEP-12 customer ID of the user initiating the transaction.
+   *
+   * @return the customer ID.
+   */
+  String getCustomer();
+
+  void setCustomer(String customer);
+
   enum Kind {
     DEPOSIT("deposit"),
     WITHDRAWAL("withdrawal"),

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
@@ -199,6 +199,11 @@ public class Sep6TransactionBuilder {
     return this;
   }
 
+  public Sep6TransactionBuilder customer(String customer) {
+    txn.setCustomer(customer);
+    return this;
+  }
+
   public Sep6Transaction build() {
     return txn;
   }

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -11,9 +11,7 @@ import org.stellar.anchor.api.platform.GetTransactionResponse;
 import org.stellar.anchor.api.platform.PlatformTransactionData;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
-import org.stellar.anchor.api.shared.Amount;
-import org.stellar.anchor.api.shared.RefundPayment;
-import org.stellar.anchor.api.shared.Refunds;
+import org.stellar.anchor.api.shared.*;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.sep24.Sep24RefundPayment;
 import org.stellar.anchor.sep24.Sep24Refunds;
@@ -95,6 +93,7 @@ public class TransactionHelper {
     String amountOutAsset = makeAsset(txn.getAmountOutAsset(), assetService, txn);
     String amountFeeAsset = makeAsset(txn.getAmountFeeAsset(), assetService, txn);
     String amountExpectedAsset = makeAsset(null, assetService, txn);
+    StellarId customer = StellarId.builder().id(txn.getCustomer()).build();
 
     return GetTransactionResponse.builder()
         .id(txn.getId())
@@ -124,6 +123,7 @@ public class TransactionHelper {
         .requiredCustomerInfoMessage(txn.getRequiredCustomerInfoMessage())
         .requiredCustomerInfoUpdates(txn.getRequiredCustomerInfoUpdates())
         .instructions(txn.getInstructions())
+        .customers(Customers.builder().sender(customer).receiver(customer).build())
         .build();
   }
 

--- a/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
@@ -49,4 +49,5 @@ public class PojoSep6Transaction implements Sep6Transaction {
   String requiredCustomerInfoMessage;
   List<String> requiredCustomerInfoUpdates;
   Map<String, InstructionField> instructions;
+  String customer;
 }

--- a/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
@@ -4,6 +4,7 @@ class TestConstants {
   companion object {
     const val TEST_SIGNING_SEED = "SBVEOFAHGJCKGR4AAM7RTDRCP6RMYYV5YUV32ZK7ZD3VPDGGHYLXTZRZ"
     const val TEST_ACCOUNT = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+    const val TEST_CUSTOMER_ID = "test-customer-id"
     const val TEST_MEMO = "123"
     const val TEST_WEB_AUTH_DOMAIN = "test.stellar.org/auth"
     const val TEST_CLIENT_DOMAIN = "test.client.stellar.org"

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -163,6 +163,16 @@ class RequestValidatorTest {
   }
 
   @Test
+  fun `test validateKyc`() {
+    every {
+      customerIntegration.getCustomer(
+        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
+      )
+    } returns GetCustomerResponse.builder().id("123").status(Sep12Status.ACCEPTED.name).build()
+    assertEquals("123", requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO))
+  }
+
+  @Test
   fun `test validateKyc customerIntegration failure`() {
     every {
       customerIntegration.getCustomer(
@@ -228,7 +238,7 @@ class RequestValidatorTest {
   fun `test validateKyc without memo`() {
     every {
       customerIntegration.getCustomer(GetCustomerRequest.builder().account(TEST_ACCOUNT).build())
-    } returns GetCustomerResponse.builder().status(Sep12Status.ACCEPTED.name).build()
-    requestValidator.validateKyc(TEST_ACCOUNT, null)
+    } returns GetCustomerResponse.builder().id("123").status(Sep12Status.ACCEPTED.name).build()
+    assertEquals("123", requestValidator.validateKyc(TEST_ACCOUNT, null))
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -15,6 +15,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_SEP38_FORMAT
+import org.stellar.anchor.TestConstants.Companion.TEST_CUSTOMER_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
 import org.stellar.anchor.TestHelper
@@ -58,6 +59,7 @@ class Sep6ServiceTest {
     every { eventService.createSession(any(), any()) } returns eventSession
     every { requestValidator.getDepositAsset(TEST_ASSET) } returns asset
     every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns asset
+    every { requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO) } returns TEST_CUSTOMER_ID
     sep6Service =
       Sep6Service(
         sep6Config,

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -168,7 +168,8 @@ class Sep6ServiceTestData {
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -186,7 +187,11 @@ class Sep6ServiceTestData {
                   "amount": "100",
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -200,7 +205,8 @@ class Sep6ServiceTestData {
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -214,7 +220,11 @@ class Sep6ServiceTestData {
               "sep": "6",
               "kind": "deposit",
               "status": "incomplete",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -237,7 +247,8 @@ class Sep6ServiceTestData {
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "quoteId": "test-quote-id"
+          "quoteId": "test-quote-id",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -268,7 +279,11 @@ class Sep6ServiceTestData {
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "quote_id": "test-quote-id",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -290,7 +305,8 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -320,7 +336,11 @@ class Sep6ServiceTestData {
                   "amount": "2",
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -349,7 +369,8 @@ class Sep6ServiceTestData {
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text"
+          "refundMemoType": "text",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -370,7 +391,11 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text"
+              "refund_memo_type": "text",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -388,7 +413,8 @@ class Sep6ServiceTestData {
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text"
+          "refundMemoType": "text",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -405,7 +431,11 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text"
+              "refund_memo_type": "text",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -432,7 +462,8 @@ class Sep6ServiceTestData {
           "memoType": "hash",
           "quoteId": "test-quote-id",
           "refundMemo": "some text",
-          "refundMemoType": "text"
+          "refundMemoType": "text",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -466,7 +497,11 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text"
+              "refund_memo_type": "text",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """
@@ -492,7 +527,8 @@ class Sep6ServiceTestData {
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text"
+          "refundMemoType": "text",
+          "customer": "test-customer-id"
       }
     """
         .trimIndent()
@@ -525,7 +561,11 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text"
+              "refund_memo_type": "text",
+              "customers": {
+                  "sender": { "id": "test-customer-id" },
+                  "receiver": { "id": "test-customer-id" }
+              }
           }
       }
     """

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
@@ -141,4 +141,7 @@ public class JdbcSep6Transaction extends JdbcSepTransaction implements Sep6Trans
   @Column(name = "instructions")
   @Type(type = "json")
   Map<String, InstructionField> instructions;
+
+  @Column(name = "customer")
+  String customer;
 }

--- a/platform/src/main/resources/db/migration/V10__sep6_field_updates.sql
+++ b/platform/src/main/resources/db/migration/V10__sep6_field_updates.sql
@@ -1,6 +1,7 @@
 ALTER TABLE sep6_transaction ADD required_customer_info_message VARCHAR(255);
 ALTER TABLE sep6_transaction ADD required_customer_info_updates JSON;
 ALTER TABLE sep6_transaction ADD instructions JSON;
+ALTER TABLE sep6_transaction ADD customer VARCHAR(255);
 
 ALTER TABLE sep6_transaction DROP COLUMN required_info_updates;
 ALTER TABLE sep6_transaction ADD required_info_updates JSON;


### PR DESCRIPTION
### Description

This sets the `customers`(See `TransactionSEP31` [docs](https://developers.stellar.org/api/anchor-platform/resources/get-transaction)) field in the SEP-6 platform transaction.

### Context

When the business server receives a transaction event, it needs to verify if the customer has enough KYC information to proceed with the transaction. Currently, the platform transaction only has `source_account` and `destination_account` fields which is not enough to identify users using a custodial wallet.

### Testing

- `./gradlew test`

### Known limitations

This persists SEP-12 customer IDs in the SEP-6 transaction table. SEP-12 customers can be deleted at any time, therefore an anchor may lose the mapping from transactions to these customers. This should be fine though since transactions would likely not move back into `pending_customer_info_update` after accepting user funds and can be completed.