### PR TITLE
ANCHOR-511: Fix Missing asset in JWT

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
@@ -3,8 +3,10 @@ package org.stellar.anchor.sep24;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.Map;
+import org.stellar.anchor.api.sep.AssetInfo;
 
 public abstract class InteractiveUrlConstructor {
-  public abstract String construct(Sep24Transaction txn, Map<String, String> sep9Fields)
+  public abstract String construct(
+      Sep24Transaction txn, Map<String, String> sep9Fields, AssetInfo asset)
       throws URISyntaxException, MalformedURLException;
 }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -267,7 +267,7 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(txn, withdrawRequest),
+            interactiveUrlConstructor.construct(txn, withdrawRequest, asset),
             txn.getTransactionId());
 
     // increment counter
@@ -428,7 +428,7 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(txn, depositRequest),
+            interactiveUrlConstructor.construct(txn, depositRequest, asset),
             txn.getTransactionId());
     // increment counter
     sep24DepositCounter.increment();

--- a/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
@@ -51,28 +51,6 @@ public class AssetHelper {
   }
 
   /**
-   * Returns the asset id in the SEP-38 asset identification format, or null if the asset is not
-   * supported.
-   *
-   * @param assetCode The asset code
-   * @param assetIssuer The asset issuer
-   * @return The asset id in the SEP-38 asset identification format.
-   */
-  public static String getAssetId(String assetCode, String assetIssuer) {
-    if (isISO4217(assetCode, assetIssuer)) {
-      // fiat assets
-      return "iso4217:" + assetCode;
-    } else if (isNativeAsset(assetCode, assetIssuer)) {
-      return "stellar:native";
-    } else if (isNonNativeAsset(assetCode, assetIssuer)) {
-      return "stellar:" + assetCode + ":" + assetIssuer;
-    } else {
-      // not supported
-      return null;
-    }
-  }
-
-  /**
    * Returns the asset code from asset
    *
    * @param asset asset

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -98,7 +98,7 @@ internal class Sep24ServiceTest {
     jwtService = spyk(JwtService(secretConfig, custodySecretConfig))
     testInteractiveUrlJwt = createTestInteractiveJwt(TEST_ACCOUNT, null)
     val strToken = jwtService.encode(testInteractiveUrlJwt)
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     every { moreInfoUrlConstructor.construct(any()) } returns
       "${TEST_SEP24_MORE_INFO_URL}?lang=en&token=$strToken"
@@ -122,7 +122,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_ACCOUNT, null))
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -166,7 +166,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_ACCOUNT, TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -251,7 +251,7 @@ internal class Sep24ServiceTest {
   @ValueSource(strings = ["true", "false"])
   fun `test deposit`(claimableBalanceSupported: String) {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_ACCOUNT, null))
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -279,7 +279,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_ACCOUNT, TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -336,7 +336,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit to whitelisted account`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_ACCOUNT, null))
-    every { interactiveUrlConstructor.construct(any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null

--- a/core/src/test/kotlin/org/stellar/anchor/util/AssetHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/AssetHelperTest.kt
@@ -51,19 +51,4 @@ class AssetHelperTest {
   fun `test invalid stellar assets`(assetCode: String?, assetIssuer: String?) {
     assertFalse(AssetHelper.isNonNativeAsset(assetCode, assetIssuer))
   }
-  @ParameterizedTest
-  @CsvSource(
-    value =
-      [
-        "USDC,GDJJES5JOST5VTBLDVVQRAW26LZ5IIJJFVN5IJOMICM73HLGGB3G74SS,stellar:USDC:GDJJES5JOST5VTBLDVVQRAW26LZ5IIJJFVN5IJOMICM73HLGGB3G74SS",
-        "USDC,BAD_WALLET,",
-        "USD,,iso4217:USD",
-        "USD,BAD_WALLET,",
-        ",GDJJES5JOST5VTBLDVVQRAW26LZ5IIJJFVN5IJOMICM73HLGGB3G74SS,",
-        "native,,stellar:native"
-      ]
-  )
-  fun `test getAssetId`(assetCode: String?, assetIssuer: String?, assetId: String?) {
-    assertEquals(assetId, AssetHelper.getAssetId(assetCode, assetIssuer))
-  }
 }


### PR DESCRIPTION
### Description

- Fix bug of missing asset in JWT when no asset issuer is specified

### Context

- Instead of parsing asset again, pass asset info to interactive url constructor

### Testing

- `./gradlew test`
- Added test to reproduce this behavior

### Known limitations

N/A

