### PR TITLE
ANCHOR-385: Add ability to pass JVM flags to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends openjdk-11-jre
 
 COPY --from=build /code/service-runner/build/libs/anchor-platform-runner*.jar /app/anchor-platform-runner.jar
+COPY --from=build /code/scripts/docker-start.sh /app/start.sh
 
-ENTRYPOINT ["java", "-jar", "/app/anchor-platform-runner.jar"]
+ENTRYPOINT ["/bin/bash", "/app/start.sh"]

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -156,6 +156,7 @@ public class Sep24Service {
 
     // Verify that the asset code exists in our database, with withdraw enabled.
     AssetInfo asset = assetService.getAsset(assetCode, assetIssuer);
+    debugF("Asset: {}", asset);
     if (asset == null || !asset.getWithdraw().getEnabled() || !asset.getSep24Enabled()) {
       infoF("invalid operation for asset {}", assetCode);
       throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -94,6 +94,9 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
     UrlConstructorHelper.addTxnFields(data, txn, sep24Config.getInteractiveUrl().getTxnFields());
 
     token.claim("data", data);
+
+    debugF("Attaching data to the token: {}", data);
+
     return jwtService.encode(token);
   }
 

--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -1,0 +1,2 @@
+#!/user/bin/env bash
+java $JVM_FLAGS -jar /app/anchor-platform-runner.jar "$@"


### PR DESCRIPTION
### Description

Add ability to pass JVM flags to docker container

### Context

Currently, we can't pass flags to the java command running in the container 

### Testing

Manual testing: checked passing flags is working 

### Known limitations

N/A

