### PR TITLE
[ANCHOR-388] SEP-6: Implement RPC actions

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.api.rpc.method;
 
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,4 +11,11 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class RequestCustomerInfoUpdateRequest extends RpcMethodParamsRequest {}
+public class RequestCustomerInfoUpdateRequest extends RpcMethodParamsRequest {
+
+  @SerializedName("required_customer_info_message")
+  private String requiredCustomerInfoMessage;
+
+  @SerializedName("required_customer_info_updates")
+  private List<String> requiredCustomerInfoUpdates;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestOffchainFundsRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestOffchainFundsRequest.java
@@ -1,10 +1,12 @@
 package org.stellar.anchor.api.rpc.method;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
+import org.stellar.anchor.api.shared.InstructionField;
 
 @Data
 @SuperBuilder
@@ -23,4 +25,7 @@ public class RequestOffchainFundsRequest extends RpcMethodParamsRequest {
 
   @SerializedName("amount_expected")
   private AmountRequest amountExpected;
+
+  @SerializedName("instructions")
+  Map<String, InstructionField> instructions;
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -90,6 +90,14 @@ public class Sep6Service {
             .type(request.getType())
             .assetCode(request.getAssetCode())
             .assetIssuer(asset.getIssuer())
+            // NB: these are purposely set to incorrect values.
+            // amount_out and amount_fee assets cannot be determined when the
+            // platform creates the transaction, but the RPC API requires
+            // these to be set during a notify_amounts_updated call.
+            .amountOut(request.getAmount())
+            .amountOutAsset(asset.getSep38AssetName())
+            .amountFee("0")
+            .amountFeeAsset(asset.getSep38AssetName())
             .amountExpected(request.getAmount())
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
@@ -244,6 +252,16 @@ public class Sep6Service {
             .type(request.getType())
             .assetCode(request.getAssetCode())
             .assetIssuer(asset.getIssuer())
+            .amountIn(request.getAmount())
+            .amountInAsset(asset.getSep38AssetName())
+            // NB: these are purposely set to incorrect values.
+            // amount_out and amount_fee assets cannot be determined when the
+            // platform creates the transaction, but the RPC API requires
+            // these to be set during a notify_amounts_updated call.
+            .amountOut(request.getAmount())
+            .amountOutAsset(asset.getSep38AssetName())
+            .amountFee("0")
+            .amountFeeAsset(asset.getSep38AssetName())
             .amountExpected(request.getAmount())
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
@@ -104,6 +104,15 @@ public interface Sep6Transaction extends SepTransaction {
   void setCompletedAt(Instant completedAt);
 
   /**
+   * The date and time the user funds were received.
+   *
+   * @return the transfer received at timestamp.
+   */
+  Instant getTransferReceivedAt();
+
+  void setTransferReceivedAt(Instant transferReceivedAt);
+
+  /**
    * The deposit or withdrawal method used. E.g. <code>bank_account</code>, <code>cash</code>
    *
    * @return the deposit or withdraw method.

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -109,6 +109,7 @@ public class TransactionHelper {
         .startedAt(txn.getStartedAt())
         .updatedAt(txn.getUpdatedAt())
         .completedAt(txn.getCompletedAt())
+        .transferReceivedAt(txn.getTransferReceivedAt())
         .message(txn.getMessage())
         .refunds(txn.getRefunds())
         .stellarTransactions(txn.getStellarTransactions())

--- a/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
@@ -22,6 +22,7 @@ public class PojoSep6Transaction implements Sep6Transaction {
   Instant startedAt;
   Instant completedAt;
   Instant updatedAt;
+  Instant transferReceivedAt;
   String type;
   String requestAssetCode;
   String requestAssetIssuer;

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -160,79 +160,104 @@ class Sep6ServiceTestData {
 
     val depositTxnJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "deposit",
           "type": "bank_account",
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOut": "100",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "0",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "customer": "test-customer-id"
-      }
+        }
     """
         .trimIndent()
 
     val depositTxnEventJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "deposit",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "deposit",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_out": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "0",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val depositTxnJsonWithoutAmountOrType =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "deposit",
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "0",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "customer": "test-customer-id"
-      }
-    """
+        }
+
+      """
         .trimIndent()
 
     val depositTxnEventWithoutAmountOrTypeJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "deposit",
-              "status": "incomplete",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "deposit",
+            "status": "incomplete",
+            "amount_expected": {
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "0",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val depositExchangeTxnJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "deposit-exchange",
           "type": "SWIFT",
@@ -246,52 +271,50 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "quoteId": "test-quote-id",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val depositExchangeTxnEventJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "deposit-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "iso4217:USD"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "quote_id": "test-quote-id",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "deposit-exchange",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_in": { "amount": "100", "asset": "iso4217:USD" },
+            "amount_out": {
+              "amount": "98",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "2",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "quote_id": "test-quote-id",
+            "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val depositExchangeTxnWithoutQuoteJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "deposit-exchange",
           "type": "SWIFT",
@@ -305,45 +328,43 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val depositExchangeTxnEventWithoutQuoteJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "deposit-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "iso4217:USD"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "deposit-exchange",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_in": { "amount": "100", "asset": "iso4217:USD" },
+            "amount_out": {
+              "amount": "98",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "2",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawResJson =
@@ -357,93 +378,124 @@ class Sep6ServiceTestData {
 
     val withdrawTxnJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "withdrawal",
           "type": "bank_account",
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountIn": "100",
+          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOut": "100",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "0",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawTxnEventJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "withdrawal",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "withdrawal",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_in": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_out": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "0",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "memo_type": "hash",
+            "refund_memo": "some text",
+            "refund_memo_type": "text",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawTxnWithoutAmountOrTypeJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "withdrawal",
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "0",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawTxnEventWithoutAmountOrTypeJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "withdrawal",
-              "status": "incomplete",
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "withdrawal",
+            "status": "incomplete",
+            "amount_expected": {
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_fee": {
+              "amount": "0",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "memo_type": "hash",
+            "refund_memo": "some text",
+            "refund_memo_type": "text",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawExchangeTxnJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "withdrawal-exchange",
           "type": "bank_account",
@@ -457,6 +509,7 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "iso4217:USD",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
@@ -464,52 +517,46 @@ class Sep6ServiceTestData {
           "refundMemo": "some text",
           "refundMemoType": "text",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawExchangeTxnEventJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "withdrawal-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "iso4217:USD"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "iso4217:USD"
-              },
-              "quote_id": "test-quote-id",
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "withdrawal-exchange",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_in": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_out": { "amount": "98", "asset": "iso4217:USD" },
+            "amount_fee": { "amount": "2", "asset": "iso4217:USD" },
+            "quote_id": "test-quote-id",
+            "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "memo_type": "hash",
+            "refund_memo": "some text",
+            "refund_memo_type": "text",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawExchangeTxnWithoutQuoteJson =
       """
-      {
+        {
           "status": "incomplete",
           "kind": "withdrawal-exchange",
           "type": "bank_account",
@@ -523,52 +570,47 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "iso4217:USD",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+          "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text",
           "customer": "test-customer-id"
-      }
-    """
+        }
+      """
         .trimIndent()
 
     val withdrawExchangeTxnWithoutQuoteEventJson =
       """
-      {
+        {
           "type": "transaction_created",
           "sep": "6",
           "transaction": {
-              "sep": "6",
-              "kind": "withdrawal-exchange",
-              "status": "incomplete",
-              "amount_expected": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_in": {
-                  "amount": "100",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              },
-              "amount_out": {
-                  "amount": "98",
-                  "asset": "iso4217:USD"
-              },
-              "amount_fee": {
-                  "amount": "2",
-                  "asset": "iso4217:USD"
-              },
-              "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "memo_type": "hash",
-              "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+            "sep": "6",
+            "kind": "withdrawal-exchange",
+            "status": "incomplete",
+            "amount_expected": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_in": {
+              "amount": "100",
+              "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+            },
+            "amount_out": { "amount": "98", "asset": "iso4217:USD" },
+            "amount_fee": { "amount": "2", "asset": "iso4217:USD" },
+            "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
+            "memo_type": "hash",
+            "refund_memo": "some text",
+            "refund_memo_type": "text",
+            "customers": {
+              "sender": { "id": "test-customer-id" },
+              "receiver": { "id": "test-customer-id" }
+            }
           }
-      }
-    """
+        }
+      """
         .trimIndent()
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
@@ -336,6 +336,9 @@ class PlatformApiTests(config: TestConfig, toml: TomlContent, jwt: String) {
     val expectedResult = actionResponses.replace(TX_ID_KEY, txId).trimIndent()
     val actualResult = rpcActionResponses.body?.string()?.trimIndent()
 
+    println(expectedResult)
+    println(actualResult)
+
     JSONAssert.assertEquals(
       expectedResult,
       actualResult,

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiTests.kt
@@ -336,9 +336,6 @@ class PlatformApiTests(config: TestConfig, toml: TomlContent, jwt: String) {
     val expectedResult = actionResponses.replace(TX_ID_KEY, txId).trimIndent()
     val actualResult = rpcActionResponses.body?.string()?.trimIndent()
 
-    println(expectedResult)
-    println(actualResult)
-
     JSONAssert.assertEquals(
       expectedResult,
       actualResult,

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
@@ -118,7 +118,16 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
       )
     assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
 
-    val expectedStatuses = listOf(INCOMPLETE, PENDING_CUSTOMER_INFO_UPDATE, COMPLETED)
+    val expectedStatuses =
+      listOf(
+        INCOMPLETE,
+        PENDING_ANCHOR, // update amounts
+        PENDING_CUSTOMER_INFO_UPDATE, // request KYC
+        PENDING_USR_TRANSFER_START, // provide deposit instructions
+        PENDING_ANCHOR, // deposit into user wallet
+        PENDING_STELLAR,
+        COMPLETED
+      )
     assertAnchorReceivedStatuses(deposit.id, expectedStatuses)
     assertWalletReceivedStatuses(deposit.id, expectedStatuses)
   }
@@ -157,9 +166,11 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
     val expectedStatuses =
       listOf(
         INCOMPLETE,
-        PENDING_CUSTOMER_INFO_UPDATE,
-        PENDING_USR_TRANSFER_START,
-        PENDING_ANCHOR,
+        PENDING_ANCHOR, // update amounts
+        PENDING_CUSTOMER_INFO_UPDATE, // request KYC
+        PENDING_USR_TRANSFER_START, // wait for onchain user transfer
+        PENDING_ANCHOR, // funds available for pickup
+        PENDING_EXTERNAL,
         COMPLETED
       )
     assertAnchorReceivedStatuses(withdraw.id, expectedStatuses)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -1,6 +1,5 @@
 package org.stellar.reference.data
 
-import io.ktor.server.application.*
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -65,10 +64,11 @@ sealed class RpcActionParamsRequest {
 data class RequestOffchainFundsRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String,
-  @SerialName("amount_in") val amountIn: AmountAssetRequest,
-  @SerialName("amount_out") val amountOut: AmountAssetRequest,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest,
-  @SerialName("amount_expected") val amountExpected: AmountRequest? = null
+  @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
+  @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
+  @SerialName("amount_expected") val amountExpected: AmountRequest? = null,
+  @SerialName("instructions") val instructions: Map<String, InstructionField>? = null
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -82,10 +82,19 @@ data class RequestOnchainFundsRequest(
 ) : RpcActionParamsRequest()
 
 @Serializable
+data class RequestCustomerInfoUpdateHandler(
+  @SerialName("transaction_id") override val transactionId: String,
+  override val message: String?,
+  @SerialName("required_customer_info_message") val requiredCustomerInfoMessage: String? = null,
+  @SerialName("required_customer_info_updates")
+  val requiredCustomerInfoUpdates: List<String>? = null
+) : RpcActionParamsRequest()
+
+@Serializable
 data class NotifyOnchainFundsSentRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("stellar_transaction_id") val stellarTransactionId: String? = null
+  @SerialName("stellar_transaction_id") val stellarTransactionId: String
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -97,6 +106,28 @@ data class NotifyOffchainFundsReceivedRequest(
   @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
   @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
   @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null
+) : RpcActionParamsRequest()
+
+@Serializable
+data class NotifyOffchainFundsAvailableRequest(
+  @SerialName("transaction_id") override val transactionId: String,
+  override val message: String? = null,
+  @SerialName("external_transaction_id") val externalTransactionId: String? = null
+) : RpcActionParamsRequest()
+
+@Serializable
+data class NotifyOffchainFundsPendingRequest(
+  @SerialName("transaction_id") override val transactionId: String,
+  override val message: String? = null,
+  @SerialName("external_transaction_id") val externalTransactionId: String? = null
+) : RpcActionParamsRequest()
+
+@Serializable
+data class NotifyAmountsUpdatedRequest(
+  @SerialName("transaction_id") override val transactionId: String,
+  override val message: String? = null,
+  @SerialName("amount_out") val amountOut: AmountAssetRequest,
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -124,6 +155,8 @@ data class NotifyTransactionErrorRequest(
 @Serializable data class AmountRequest(val amount: String)
 
 @Serializable data class Amount(val amount: String? = null, val asset: String? = null)
+
+@Serializable data class InstructionField(val value: String, val description: String)
 
 class JwtToken(
   val transactionId: String,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/EventConsumerContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/EventConsumerContainer.kt
@@ -28,7 +28,8 @@ object EventConsumerContainer {
       config,
       ServiceContainer.horizon,
       ServiceContainer.platform,
-      ServiceContainer.customerService
+      ServiceContainer.customerService,
+      ServiceContainer.sepHelper
     )
   private val noOpEventProcessor = NoOpEventProcessor()
   private val processor = AnchorEventProcessor(sep6EventProcessor, noOpEventProcessor)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -1,20 +1,19 @@
 package org.stellar.reference.event.processor
 
 import java.time.Instant
+import java.util.*
 import kotlinx.coroutines.runBlocking
 import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.platform.*
+import org.stellar.anchor.api.platform.PatchTransactionsRequest
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind
-import org.stellar.anchor.api.sep.SepTransactionStatus
-import org.stellar.anchor.api.shared.Amount
-import org.stellar.anchor.api.shared.InstructionField
-import org.stellar.anchor.api.shared.StellarPayment
-import org.stellar.anchor.api.shared.StellarTransaction
+import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.reference.callbacks.customer.CustomerService
 import org.stellar.reference.client.PlatformClient
-import org.stellar.reference.data.Config
+import org.stellar.reference.data.*
 import org.stellar.reference.log
+import org.stellar.reference.service.SepHelper
 import org.stellar.sdk.*
 
 class Sep6EventProcessor(
@@ -22,6 +21,11 @@ class Sep6EventProcessor(
   private val server: Server,
   private val platformClient: PlatformClient,
   private val customerService: CustomerService,
+  private val sepHelper: SepHelper,
+  /** Map of transaction ID to Stellar transaction ID. */
+  private val onchainPayments: MutableMap<String, String> = mutableMapOf(),
+  /** Map of transaction ID to external transaction ID. */
+  private val offchainPayments: MutableMap<String, String> = mutableMapOf()
 ) : SepAnchorEventProcessor {
   companion object {
     val requiredKyc =
@@ -38,31 +42,7 @@ class Sep6EventProcessor(
   override fun onTransactionCreated(event: AnchorEvent) {
     when (val kind = event.transaction.kind) {
       Kind.DEPOSIT,
-      Kind.WITHDRAWAL -> {
-        if (event.transaction.status != SepTransactionStatus.INCOMPLETE) {
-          log.warn(
-            "Received $kind transaction created event with unsupported status: ${event.transaction.status}"
-          )
-          return
-        }
-        val missingFields = verifyKyc(event.transaction.customers.sender.id, kind)
-        val (status, requiredFields) =
-          if (missingFields.isEmpty()) {
-            SepTransactionStatus.PENDING_ANCHOR to null
-          } else {
-            SepTransactionStatus.PENDING_CUSTOMER_INFO_UPDATE to missingFields
-          }
-        runBlocking {
-          patchTransaction(
-            PlatformTransactionData.builder()
-              .id(event.transaction.id)
-              .status(status)
-              .updatedAt(Instant.now())
-              .requiredCustomerInfoUpdates(requiredFields)
-              .build()
-          )
-        }
-      }
+      Kind.WITHDRAWAL -> updateAmounts(event)
       else -> {
         log.warn("Received transaction created event with unsupported kind: $kind")
       }
@@ -86,35 +66,53 @@ class Sep6EventProcessor(
   private fun onDepositTransactionStatusChanged(event: AnchorEvent) {
     val transaction = event.transaction
     when (val status = transaction.status) {
-      SepTransactionStatus.PENDING_ANCHOR -> {
-        val missingFields = verifyKyc(event.transaction.customers.sender.id, Kind.DEPOSIT)
-        val (newStatus, requiredFields) =
-          if (missingFields.isEmpty()) {
-            SepTransactionStatus.COMPLETED to null
-          } else {
-            SepTransactionStatus.PENDING_CUSTOMER_INFO_UPDATE to missingFields
-          }
+      PENDING_ANCHOR -> {
+        if (verifyKyc(transaction.customers.sender.id, Kind.DEPOSIT).isNotEmpty()) {
+          requestKyc(event)
+          return
+        }
         runBlocking {
+          val keypair = KeyPair.fromSecretSeed(config.appSettings.secret)
+          val txnId =
+            submitStellarTransaction(
+              keypair.accountId,
+              transaction.destinationAccount,
+              Asset.create(transaction.amountExpected.asset.toAssetId()),
+              transaction.amountExpected.amount
+            )
+          onchainPayments[transaction.id] = txnId
+          // TODO: manually submit the transaction until custody service is implemented
           patchTransaction(
             PlatformTransactionData.builder()
-              .id(event.transaction.id)
-              .status(newStatus)
+              .id(transaction.id)
+              .status(PENDING_STELLAR)
               .updatedAt(Instant.now())
-              .requiredCustomerInfoUpdates(requiredFields)
-              .apply {
-                if (newStatus == SepTransactionStatus.COMPLETED) {
-                  completedAt(Instant.now())
-                  requiredInfoMessage(null)
-                  requiredInfoUpdates(null)
-                  requiredCustomerInfoMessage(null)
-                  requiredCustomerInfoUpdates(null)
-                }
-              }
               .build()
           )
         }
       }
-      SepTransactionStatus.COMPLETED -> {
+      PENDING_USR_TRANSFER_START ->
+        runBlocking {
+          sepHelper.rpcAction(
+            "notify_offchain_funds_received",
+            NotifyOffchainFundsReceivedRequest(
+              transactionId = transaction.id,
+              message = "Funds received from user",
+            )
+          )
+        }
+      PENDING_STELLAR ->
+        runBlocking {
+          sepHelper.rpcAction(
+            "notify_onchain_funds_sent",
+            NotifyOnchainFundsSentRequest(
+              transactionId = transaction.id,
+              message = "Funds sent to user",
+              stellarTransactionId = onchainPayments[transaction.id]!!
+            )
+          )
+        }
+      COMPLETED -> {
         log.info("Transaction ${transaction.id} completed")
       }
       else -> {
@@ -126,21 +124,46 @@ class Sep6EventProcessor(
   private fun onWithdrawTransactionStatusChanged(event: AnchorEvent) {
     val transaction = event.transaction
     when (val status = transaction.status) {
-      // The transaction only moves into this state after the user has submitted funds to the
-      // Anchor.
-      SepTransactionStatus.PENDING_ANCHOR -> {
+      PENDING_ANCHOR -> {
+        if (verifyKyc(transaction.customers.sender.id, Kind.WITHDRAWAL).isNotEmpty()) {
+          requestKyc(event)
+          return
+        }
         runBlocking {
-          patchTransaction(
-            PlatformTransactionData.builder()
-              .id(transaction.id)
-              .status(SepTransactionStatus.COMPLETED)
-              .updatedAt(Instant.now())
-              .completedAt(Instant.now())
-              .build()
-          )
+          if (offchainPayments[transaction.id] == null) {
+            val externalTxnId = UUID.randomUUID()
+            offchainPayments[transaction.id] = externalTxnId.toString()
+            sepHelper.rpcAction(
+              "notify_offchain_funds_pending",
+              NotifyOffchainFundsPendingRequest(
+                transactionId = transaction.id,
+                message = "Funds sent to user",
+                externalTransactionId = externalTxnId.toString()
+              )
+            )
+          } else {
+            sepHelper.rpcAction(
+              "notify_offchain_funds_available",
+              NotifyOffchainFundsAvailableRequest(
+                transactionId = transaction.id,
+                message = "Funds available for withdrawal",
+                externalTransactionId = offchainPayments[transaction.id]!!
+              )
+            )
+          }
         }
       }
-      SepTransactionStatus.COMPLETED -> {
+      PENDING_EXTERNAL ->
+        runBlocking {
+          sepHelper.rpcAction(
+            "notify_offchain_funds_sent",
+            NotifyOffchainFundsSentRequest(
+              transactionId = transaction.id,
+              message = "Funds sent to user",
+            )
+          )
+        }
+      COMPLETED -> {
         log.info("Transaction ${transaction.id} completed")
       }
       else -> {
@@ -157,15 +180,77 @@ class Sep6EventProcessor(
               .sep(TransactionsSeps.SEP_6)
               .orderBy(TransactionsOrderBy.CREATED_AT)
               .order(TransactionsOrder.ASC)
-              .statuses(listOf(SepTransactionStatus.PENDING_CUSTOMER_INFO_UPDATE))
+              .statuses(listOf(PENDING_CUSTOMER_INFO_UPDATE))
               .build()
           )
           .records
       }
       .forEach { transaction ->
         when (transaction.kind) {
-          Kind.DEPOSIT -> handleDepositTransaction(transaction)
-          Kind.WITHDRAWAL -> handleWithdrawTransaction(transaction)
+          Kind.DEPOSIT -> {
+            if (verifyKyc(transaction.customers.sender.id, Kind.DEPOSIT).isNotEmpty()) {
+              return
+            }
+            runBlocking {
+              sepHelper.rpcAction(
+                "request_offchain_funds",
+                RequestOffchainFundsRequest(
+                  transactionId = transaction.id,
+                  message = "Please deposit the amount to the following bank account",
+                  amountIn =
+                    AmountAssetRequest(
+                      asset = "iso4217:USD",
+                      amount = transaction.amountExpected.amount
+                    ),
+                  amountOut =
+                    AmountAssetRequest(
+                      asset = transaction.amountOut.asset,
+                      amount = transaction.amountOut.amount
+                    ),
+                  amountFee = AmountAssetRequest(asset = "iso4217:USD", amount = "0"),
+                  instructions =
+                    mapOf(
+                      "organization.bank_number" to
+                        InstructionField(
+                          value = "121122676",
+                          description = "US Bank routing number"
+                        ),
+                      "organization.bank_account_number" to
+                        InstructionField(
+                          value = "13719713158835300",
+                          description = "US Bank account number"
+                        ),
+                    )
+                )
+              )
+            }
+          }
+          Kind.WITHDRAWAL -> {
+            if (verifyKyc(transaction.customers.sender.id, Kind.WITHDRAWAL).isNotEmpty()) {
+              return
+            }
+            runBlocking {
+              sepHelper.rpcAction(
+                "request_onchain_funds",
+                RequestOnchainFundsRequest(
+                  transactionId = transaction.id,
+                  message = "Please deposit the amount to the following address",
+                  amountIn =
+                    AmountAssetRequest(
+                      asset = transaction.amountExpected.asset,
+                      amount = transaction.amountExpected.amount
+                    ),
+                  amountOut =
+                    AmountAssetRequest(
+                      asset = "iso4217:USD",
+                      amount = transaction.amountExpected.amount
+                    ),
+                  amountFee =
+                    AmountAssetRequest(asset = transaction.amountExpected.asset, amount = "0")
+                )
+              )
+            }
+          }
           else -> {
             log.warn(
               "Received transaction created event with unsupported kind: ${transaction.kind}"
@@ -175,67 +260,47 @@ class Sep6EventProcessor(
       }
   }
 
-  private fun handleDepositTransaction(transaction: GetTransactionResponse) {
-    if (verifyKyc(transaction.customers.sender.id, Kind.DEPOSIT).isNotEmpty()) {
-      return
-    }
+  private fun verifyKyc(customerId: String, kind: Kind): List<String> {
+    val customer = customerService.getCustomer(GetCustomerRequest.builder().id(customerId).build())
+    val providedFields = customer.providedFields.keys
+    return requiredKyc
+      .plus(if (kind == Kind.DEPOSIT) depositRequiredKyc else withdrawRequiredKyc)
+      .filter { !providedFields.contains(it) }
+  }
 
-    val keypair = KeyPair.fromSecretSeed(config.appSettings.secret)
-    val assetCode = transaction.amountExpected.asset.toAssetId()
-
-    val asset = Asset.create(assetCode)
-    val amount = transaction.amountExpected.amount
-    val destination = transaction.destinationAccount
-
-    val stellarTxn = submitStellarTransaction(keypair.accountId, destination, asset, amount)
+  private fun updateAmounts(event: AnchorEvent) {
+    val asset =
+      when (event.transaction.kind) {
+        Kind.DEPOSIT -> event.transaction.amountExpected.asset
+        Kind.WITHDRAWAL -> "iso4217:USD"
+        else -> throw RuntimeException("Unsupported kind: ${event.transaction.kind}")
+      }
     runBlocking {
-      patchTransaction(
-        PlatformTransactionData.builder()
-          .id(transaction.id)
-          .status(SepTransactionStatus.COMPLETED)
-          .updatedAt(Instant.now())
-          .completedAt(Instant.now())
-          .requiredInfoMessage(null)
-          .requiredInfoUpdates(null)
-          .requiredCustomerInfoMessage(null)
-          .requiredCustomerInfoUpdates(null)
-          .instructions(
-            mapOf(
-              "organization.bank_number" to
-                InstructionField.builder()
-                  .value("121122676")
-                  .description("US Bank routing number")
-                  .build(),
-              "organization.bank_account_number" to
-                InstructionField.builder()
-                  .value("13719713158835300")
-                  .description("US Bank account number")
-                  .build(),
-            )
-          )
-          .stellarTransactions(listOf(stellarTxn))
-          .build()
+      sepHelper.rpcAction(
+        "notify_amounts_updated",
+        NotifyAmountsUpdatedRequest(
+          transactionId = event.transaction.id,
+          amountOut = AmountAssetRequest(asset, amount = event.transaction.amountExpected.amount),
+          amountFee = AmountAssetRequest(asset, amount = "0")
+        )
       )
     }
   }
 
-  private fun handleWithdrawTransaction(transaction: GetTransactionResponse) {
-    if (verifyKyc(transaction.customers.sender.id, Kind.WITHDRAWAL).isNotEmpty()) {
-      return
-    }
-
+  private fun requestKyc(event: AnchorEvent) {
+    val kind = event.transaction.kind
+    val missingFields = verifyKyc(event.transaction.customers.sender.id, kind)
     runBlocking {
-      patchTransaction(
-        PlatformTransactionData.builder()
-          .id(transaction.id)
-          .status(SepTransactionStatus.PENDING_USR_TRANSFER_START)
-          .updatedAt(Instant.now())
-          .requiredInfoMessage(null)
-          .requiredInfoUpdates(null)
-          .requiredCustomerInfoUpdates(null)
-          .requiredCustomerInfoUpdates(null)
-          .build()
-      )
+      if (missingFields.isNotEmpty()) {
+        sepHelper.rpcAction(
+          "request_customer_info_update",
+          RequestCustomerInfoUpdateHandler(
+            transactionId = event.transaction.id,
+            message = "Please update your info",
+            requiredCustomerInfoUpdates = missingFields
+          )
+        )
+      }
     }
   }
 
@@ -248,20 +313,12 @@ class Sep6EventProcessor(
     }
   }
 
-  private fun verifyKyc(customerId: String, kind: Kind): List<String> {
-    val customer = customerService.getCustomer(GetCustomerRequest.builder().id(customerId).build())
-    val providedFields = customer.providedFields.keys
-    return requiredKyc
-      .plus(if (kind == Kind.DEPOSIT) depositRequiredKyc else withdrawRequiredKyc)
-      .filter { !providedFields.contains(it) }
-  }
-
   private fun submitStellarTransaction(
     source: String,
     destination: String,
     asset: Asset,
     amount: String
-  ): StellarTransaction {
+  ): String {
     // TODO: use Kotlin wallet SDK
     val account = server.accounts().account(source)
     val transaction =
@@ -275,17 +332,8 @@ class Sep6EventProcessor(
     if (!txnResponse.isSuccess) {
       throw RuntimeException("Error submitting transaction: ${txnResponse.extras.resultCodes}")
     }
-    val txHash = txnResponse.hash
-    val operationId = server.operations().forTransaction(txHash).execute().records.firstOrNull()?.id
-    val stellarPayment =
-      StellarPayment(
-        operationId.toString(),
-        Amount(amount, asset.toString()),
-        StellarPayment.Type.PAYMENT,
-        source,
-        destination
-      )
-    return StellarTransaction.builder().id(txHash).payments(listOf(stellarPayment)).build()
+
+    return txnResponse.hash
   }
 
   private suspend fun patchTransaction(data: PlatformTransactionData) {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -39,6 +39,7 @@ import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24DepositInfoGenerator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 @Configuration
 public class RpcActionBeans {
@@ -50,6 +51,7 @@ public class RpcActionBeans {
 
   @Bean
   DoStellarPaymentHandler doStellarPaymentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -61,6 +63,7 @@ public class RpcActionBeans {
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     return new DoStellarPaymentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -75,6 +78,7 @@ public class RpcActionBeans {
 
   @Bean
   DoStellarRefundHandler doStellarRefundHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -84,6 +88,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new DoStellarRefundHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -96,6 +101,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyAmountsUpdatedHandler notifyAmountsUpdatedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -103,11 +109,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyAmountsUpdatedHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyInteractiveFlowCompletedHandler notifyInteractiveFlowCompletedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -115,11 +128,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyInteractiveFlowCompletedHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyOffchainFundsAvailableHandler notifyOffchainFundsAvailableHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -127,11 +147,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOffchainFundsAvailableHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyOffchainFundsPendingHandler notifyOffchainFundsPendingHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -139,11 +166,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOffchainFundsPendingHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyOffchainFundsReceivedHandler notifyOffchainFundsReceivedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -153,6 +187,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOffchainFundsReceivedHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -165,6 +200,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyOffchainFundsSentHandler notifyOffchainFundsSentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -172,11 +208,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOffchainFundsSentHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyOnchainFundsReceivedHandler notifyOnchainFundsReceivedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -185,6 +228,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOnchainFundsReceivedHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -196,6 +240,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyOnchainFundsSentHandler notifyOnchainFundsSentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -204,6 +249,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyOnchainFundsSentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -215,6 +261,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyRefundPendingHandler notifyRefundPendingHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -222,11 +269,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyRefundPendingHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyRefundSentHandler notifyRefundSentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -234,11 +288,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyRefundSentHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyTransactionErrorHandler notifyTransactionErrorHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -247,6 +308,7 @@ public class RpcActionBeans {
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     return new NotifyTransactionErrorHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -258,6 +320,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyTransactionExpiredHandler notifyTransactionExpiredHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -266,6 +329,7 @@ public class RpcActionBeans {
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     return new NotifyTransactionExpiredHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -277,6 +341,7 @@ public class RpcActionBeans {
 
   @Bean
   NotifyTransactionRecoveryHandler notifyTransactionRecoveryHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -284,11 +349,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyTransactionRecoveryHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyTrustSetHandler notifyTrustSetHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -298,6 +370,7 @@ public class RpcActionBeans {
       PropertyCustodyConfig custodyConfig,
       CustodyService custodyService) {
     return new NotifyTrustSetHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -310,6 +383,7 @@ public class RpcActionBeans {
 
   @Bean
   RequestCustomerInfoUpdateHandler requestCustomerInfoUpdateHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -317,11 +391,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new RequestCustomerInfoUpdateHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   NotifyCustomerInfoUpdatedHandler notifyCustomerInfoUpdatedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -329,11 +410,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new NotifyCustomerInfoUpdatedHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   RequestOffchainFundsHandler requestOffchainFundsHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -341,11 +429,18 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new RequestOffchainFundsHandler(
-        txn24Store, txn31Store, requestValidator, assetService, eventService, metricsService);
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean
   RequestOnchainFundsHandler requestOnchainFundsHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -356,6 +451,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new RequestOnchainFundsHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -369,6 +465,7 @@ public class RpcActionBeans {
 
   @Bean
   RequestTrustlineHandler requestTrustHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -377,6 +474,7 @@ public class RpcActionBeans {
       EventService eventService,
       MetricsService metricsService) {
     return new RequestTrustlineHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarPaymentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarPaymentHandler.java
@@ -33,6 +33,7 @@ import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRequest> {
 
@@ -42,6 +43,7 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
   private final Horizon horizon;
 
   public DoStellarPaymentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -53,6 +55,7 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarRefundHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarRefundHandler.java
@@ -39,6 +39,7 @@ import org.stellar.anchor.sep24.Sep24Refunds;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31Refunds;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequest> {
 
@@ -46,6 +47,7 @@ public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequ
   private final CustodyConfig custodyConfig;
 
   public DoStellarRefundHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -55,6 +57,7 @@ public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequ
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
@@ -21,11 +21,13 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyCustomerInfoUpdatedHandler
     extends RpcMethodHandler<NotifyCustomerInfoUpdatedRequest> {
 
   public NotifyCustomerInfoUpdatedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -33,6 +35,7 @@ public class NotifyCustomerInfoUpdatedHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyInteractiveFlowCompletedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyInteractiveFlowCompletedHandler.java
@@ -25,11 +25,13 @@ import org.stellar.anchor.platform.utils.AssetValidationUtils;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyInteractiveFlowCompletedHandler
     extends RpcMethodHandler<NotifyInteractiveFlowCompletedRequest> {
 
   public NotifyInteractiveFlowCompletedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -37,6 +39,7 @@ public class NotifyInteractiveFlowCompletedHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
@@ -2,12 +2,14 @@ package org.stellar.anchor.platform.rpc;
 
 import static java.util.Collections.emptySet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL_EXCHANGE;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_AVAILABLE;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_COMPLETE;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind;
@@ -65,7 +67,8 @@ public class NotifyOffchainFundsAvailableHandler
     switch (Sep.from(txn.getProtocol())) {
       case SEP_6:
         JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
-        if (WITHDRAWAL == Kind.from(txn6.getKind()) && areFundsReceived(txn6)) {
+        if (ImmutableSet.of(WITHDRAWAL, WITHDRAWAL_EXCHANGE).contains(Kind.from(txn6.getKind()))
+            && areFundsReceived(txn6)) {
           return Set.of(PENDING_ANCHOR);
         }
         break;

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.rpc;
 import static java.util.Collections.emptySet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_AVAILABLE;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_COMPLETE;
@@ -18,15 +19,18 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyOffchainFundsAvailableHandler
     extends RpcMethodHandler<NotifyOffchainFundsAvailableRequest> {
 
   public NotifyOffchainFundsAvailableHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -34,6 +38,7 @@ public class NotifyOffchainFundsAvailableHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -57,13 +62,21 @@ public class NotifyOffchainFundsAvailableHandler
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (SEP_24 == Sep.from(txn.getProtocol())) {
-      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-      if (WITHDRAWAL == Kind.from(txn24.getKind())) {
-        if (areFundsReceived(txn24)) {
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (WITHDRAWAL == Kind.from(txn6.getKind()) && areFundsReceived(txn6)) {
           return Set.of(PENDING_ANCHOR);
         }
-      }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (WITHDRAWAL == Kind.from(txn24.getKind()) && areFundsReceived(txn24)) {
+          return Set.of(PENDING_ANCHOR);
+        }
+        break;
+      default:
+        break;
     }
     return emptySet();
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandler.java
@@ -1,11 +1,11 @@
 package org.stellar.anchor.platform.rpc;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL_EXCHANGE;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_PENDING;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_EXTERNAL;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
@@ -18,15 +18,18 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyOffchainFundsPendingHandler
     extends RpcMethodHandler<NotifyOffchainFundsPendingRequest> {
 
   public NotifyOffchainFundsPendingHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -34,6 +37,7 @@ public class NotifyOffchainFundsPendingHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -59,12 +63,17 @@ public class NotifyOffchainFundsPendingHandler
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     Set<SepTransactionStatus> supportedStatuses = new HashSet<>();
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (ImmutableSet.of(WITHDRAWAL, WITHDRAWAL_EXCHANGE).contains(Kind.from((txn6).getKind()))
+            && areFundsReceived(txn6)) {
+          supportedStatuses.add(PENDING_ANCHOR);
+        }
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-        if (WITHDRAWAL == Kind.from(txn24.getKind())) {
-          if (areFundsReceived(txn)) {
-            return Set.of(PENDING_ANCHOR);
-          }
+        if (WITHDRAWAL == Kind.from(txn24.getKind()) && areFundsReceived(txn24)) {
+          return Set.of(PENDING_ANCHOR);
         }
         break;
       case SEP_31:

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
@@ -1,12 +1,15 @@
 package org.stellar.anchor.platform.rpc;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT_EXCHANGE;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_RECEIVED;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_EXTERNAL;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_START;
 
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,11 +29,13 @@ import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.utils.AssetValidationUtils;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyOffchainFundsReceivedHandler
     extends RpcMethodHandler<NotifyOffchainFundsReceivedRequest> {
@@ -39,6 +44,7 @@ public class NotifyOffchainFundsReceivedHandler
   private final CustodyConfig custodyConfig;
 
   public NotifyOffchainFundsReceivedHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -48,6 +54,7 @@ public class NotifyOffchainFundsReceivedHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -122,14 +129,27 @@ public class NotifyOffchainFundsReceivedHandler
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     Set<SepTransactionStatus> supportedStatuses = new HashSet<>();
-    if (SEP_24 == Sep.from(txn.getProtocol())) {
-      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-      if (DEPOSIT == Kind.from(txn24.getKind())) {
-        supportedStatuses.add(PENDING_USR_TRANSFER_START);
-        if (areFundsReceived(txn24)) {
-          supportedStatuses.add(PENDING_EXTERNAL);
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
+          supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          if (areFundsReceived(txn6)) {
+            supportedStatuses.add(PENDING_EXTERNAL);
+          }
         }
-      }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (DEPOSIT == Kind.from(txn24.getKind())) {
+          supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          if (areFundsReceived(txn24)) {
+            supportedStatuses.add(PENDING_EXTERNAL);
+          }
+        }
+        break;
+      default:
+        break;
     }
     return supportedStatuses;
   }
@@ -157,9 +177,12 @@ public class NotifyOffchainFundsReceivedHandler
       txn.setAmountFee(request.getAmountFee().getAmount());
     }
 
-    JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-    if (custodyConfig.isCustodyIntegrationEnabled()) {
-      custodyService.createTransaction(txn24);
+    // TODO: add support for SEP-6
+    if (SEP_24 == Sep.from(txn.getProtocol())) {
+      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+      if (custodyConfig.isCustodyIntegrationEnabled()) {
+        custodyService.createTransaction(txn24);
+      }
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandler.java
@@ -1,7 +1,9 @@
 package org.stellar.anchor.platform.rpc;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT_EXCHANGE;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_SENT;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.COMPLETED;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
@@ -10,6 +12,7 @@ import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_COMPLETE;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_START;
 
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -23,15 +26,18 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyOffchainFundsSentHandler
     extends RpcMethodHandler<NotifyOffchainFundsSentRequest> {
 
   public NotifyOffchainFundsSentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -39,6 +45,7 @@ public class NotifyOffchainFundsSentHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -58,6 +65,21 @@ public class NotifyOffchainFundsSentHandler
       JdbcSepTransaction txn, NotifyOffchainFundsSentRequest request)
       throws InvalidRequestException {
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        switch (Kind.from(txn6.getKind())) {
+          case DEPOSIT:
+          case DEPOSIT_EXCHANGE:
+            return PENDING_EXTERNAL;
+          case WITHDRAWAL:
+          case WITHDRAWAL_EXCHANGE:
+            return COMPLETED;
+          default:
+            throw new InvalidRequestException(
+                String.format(
+                    "Kind[%s] is not supported for protocol[%s] and action[%s]",
+                    txn6.getKind(), txn6.getProtocol(), getRpcMethod()));
+        }
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         switch (Kind.from(txn24.getKind())) {
@@ -85,6 +107,23 @@ public class NotifyOffchainFundsSentHandler
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     Set<SepTransactionStatus> supportedStatuses = new HashSet<>();
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        switch (Kind.from(txn6.getKind())) {
+          case DEPOSIT:
+          case DEPOSIT_EXCHANGE:
+            supportedStatuses.add(PENDING_USR_TRANSFER_START);
+            break;
+          case WITHDRAWAL:
+          case WITHDRAWAL_EXCHANGE:
+            if (areFundsReceived(txn6)) {
+              supportedStatuses.add(PENDING_ANCHOR);
+            }
+            supportedStatuses.add(PENDING_USR_TRANSFER_COMPLETE);
+            supportedStatuses.add(PENDING_EXTERNAL);
+            break;
+        }
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         switch (Kind.from(txn24.getKind())) {
@@ -113,15 +152,27 @@ public class NotifyOffchainFundsSentHandler
       JdbcSepTransaction txn, NotifyOffchainFundsSentRequest request) {
     if (request.getExternalTransactionId() != null) {
       txn.setExternalTransactionId(request.getExternalTransactionId());
-      if (SEP_24 == Sep.from(txn.getProtocol())) {
-        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-        if (DEPOSIT == Kind.from(txn24.getKind())) {
-          if (request.getFundsSentAt() != null) {
-            txn24.setTransferReceivedAt(request.getFundsSentAt());
-          } else {
-            txn24.setTransferReceivedAt(Instant.now());
+      switch (Sep.from(txn.getProtocol())) {
+        case SEP_6:
+          JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+          if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
+            if (request.getFundsSentAt() != null) {
+              txn6.setTransferReceivedAt(request.getFundsSentAt());
+            } else {
+              txn6.setTransferReceivedAt(Instant.now());
+            }
           }
-        }
+          break;
+        case SEP_24:
+          JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+          if (DEPOSIT == Kind.from(txn24.getKind())) {
+            if (request.getFundsSentAt() != null) {
+              txn24.setTransferReceivedAt(request.getFundsSentAt());
+            } else {
+              txn24.setTransferReceivedAt(Instant.now());
+            }
+          }
+          break;
       }
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandler.java
@@ -36,10 +36,12 @@ import org.stellar.anchor.sep24.Sep24RefundPayment;
 import org.stellar.anchor.sep24.Sep24Refunds;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyRefundPendingHandler extends RpcMethodHandler<NotifyRefundPendingRequest> {
 
   public NotifyRefundPendingHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -47,6 +49,7 @@ public class NotifyRefundPendingHandler extends RpcMethodHandler<NotifyRefundPen
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundSentHandler.java
@@ -43,10 +43,12 @@ import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.RefundPayment;
 import org.stellar.anchor.sep31.Sep31Refunds;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyRefundSentHandler extends RpcMethodHandler<NotifyRefundSentRequest> {
 
   public NotifyRefundSentHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -54,6 +56,7 @@ public class NotifyRefundSentHandler extends RpcMethodHandler<NotifyRefundSentRe
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandler.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_TRANSACTION_ERROR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.ERROR;
 
@@ -21,12 +22,14 @@ import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyTransactionErrorHandler extends RpcMethodHandler<NotifyTransactionErrorRequest> {
 
   private final JdbcTransactionPendingTrustRepo transactionPendingTrustRepo;
 
   public NotifyTransactionErrorHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -35,6 +38,7 @@ public class NotifyTransactionErrorHandler extends RpcMethodHandler<NotifyTransa
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -58,7 +62,7 @@ public class NotifyTransactionErrorHandler extends RpcMethodHandler<NotifyTransa
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (Set.of(SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
+    if (Set.of(SEP_6, SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
       return Arrays.stream(SepTransactionStatus.values())
           .filter(s -> !isErrorStatus(s) && !isFinalStatus(s))
           .collect(toSet());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandler.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_TRANSACTION_EXPIRED;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.EXPIRED;
 
@@ -21,6 +22,7 @@ import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyTransactionExpiredHandler
     extends RpcMethodHandler<NotifyTransactionExpiredRequest> {
@@ -28,6 +30,7 @@ public class NotifyTransactionExpiredHandler
   private final JdbcTransactionPendingTrustRepo transactionPendingTrustRepo;
 
   public NotifyTransactionExpiredHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -36,6 +39,7 @@ public class NotifyTransactionExpiredHandler
       MetricsService metricsService,
       JdbcTransactionPendingTrustRepo transactionPendingTrustRepo) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -59,7 +63,7 @@ public class NotifyTransactionExpiredHandler
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (Set.of(SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
+    if (Set.of(SEP_6, SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
       if (!areFundsReceived(txn)) {
         return Arrays.stream(SepTransactionStatus.values())
             .filter(s -> !isErrorStatus(s) && !isFinalStatus(s))

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandler.java
@@ -1,8 +1,7 @@
 package org.stellar.anchor.platform.rpc;
 
 import static java.util.Collections.emptySet;
-import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
-import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_TRANSACTION_RECOVERY;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.ERROR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.EXPIRED;
@@ -23,11 +22,13 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyTransactionRecoveryHandler
     extends RpcMethodHandler<NotifyTransactionRecoveryRequest> {
 
   public NotifyTransactionRecoveryHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -35,6 +36,7 @@ public class NotifyTransactionRecoveryHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -54,6 +56,7 @@ public class NotifyTransactionRecoveryHandler
       JdbcSepTransaction txn, NotifyTransactionRecoveryRequest request)
       throws InvalidRequestException {
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
       case SEP_24:
         return PENDING_ANCHOR;
       case SEP_31:
@@ -68,7 +71,7 @@ public class NotifyTransactionRecoveryHandler
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (Set.of(SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
+    if (Set.of(SEP_6, SEP_24, SEP_31).contains(Sep.from(txn.getProtocol()))) {
       if (areFundsReceived(txn)) {
         return Set.of(ERROR, EXPIRED);
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTrustSetHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTrustSetHandler.java
@@ -28,6 +28,7 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class NotifyTrustSetHandler extends RpcMethodHandler<NotifyTrustSetRequest> {
 
@@ -35,6 +36,7 @@ public class NotifyTrustSetHandler extends RpcMethodHandler<NotifyTrustSetReques
   private final CustodyService custodyService;
 
   public NotifyTrustSetHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -44,6 +46,7 @@ public class NotifyTrustSetHandler extends RpcMethodHandler<NotifyTrustSetReques
       PropertyCustodyConfig custodyConfig,
       CustodyService custodyService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandler.java
@@ -2,9 +2,9 @@ package org.stellar.anchor.platform.rpc;
 
 import static java.util.Collections.emptySet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.REQUEST_CUSTOMER_INFO_UPDATE;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_CUSTOMER_INFO_UPDATE;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
 import java.util.Set;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -21,11 +21,14 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6Transaction;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class RequestCustomerInfoUpdateHandler
     extends RpcMethodHandler<RequestCustomerInfoUpdateRequest> {
 
   public RequestCustomerInfoUpdateHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -33,6 +36,7 @@ public class RequestCustomerInfoUpdateHandler
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -61,13 +65,29 @@ public class RequestCustomerInfoUpdateHandler
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (SEP_31 == Sep.from(txn.getProtocol())) {
-      return Set.of(PENDING_RECEIVER);
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        return Set.of(INCOMPLETE, PENDING_ANCHOR, PENDING_CUSTOMER_INFO_UPDATE);
+      case SEP_31:
+        return Set.of(PENDING_RECEIVER);
+      default:
+        return emptySet();
     }
-    return emptySet();
   }
 
   @Override
   protected void updateTransactionWithRpcRequest(
-      JdbcSepTransaction txn, RequestCustomerInfoUpdateRequest request) {}
+      JdbcSepTransaction txn, RequestCustomerInfoUpdateRequest request) {
+    if (Sep.from(txn.getProtocol()) == SEP_6) {
+      Sep6Transaction txn6 = (Sep6Transaction) txn;
+
+      if (request.getRequiredCustomerInfoMessage() != null) {
+        txn6.setRequiredCustomerInfoMessage(request.getRequiredCustomerInfoMessage());
+      }
+
+      if (request.getRequiredCustomerInfoUpdates() != null) {
+        txn6.setRequiredCustomerInfoUpdates(request.getRequiredCustomerInfoUpdates());
+      }
+    }
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
@@ -1,12 +1,13 @@
 package org.stellar.anchor.platform.rpc;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT_EXCHANGE;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.REQUEST_OFFCHAIN_FUNDS;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.INCOMPLETE;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_START;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -22,15 +23,18 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.utils.AssetValidationUtils;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchainFundsRequest> {
 
   public RequestOffchainFundsHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -38,6 +42,7 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
       EventService eventService,
       MetricsService metricsService) {
     super(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -116,14 +121,28 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     Set<SepTransactionStatus> supportedStatuses = new HashSet<>();
-    if (SEP_24 == Sep.from(txn.getProtocol())) {
-      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-      if (DEPOSIT == Kind.from(txn24.getKind())) {
-        supportedStatuses.add(INCOMPLETE);
-        if (!areFundsReceived(txn24)) {
-          supportedStatuses.add(PENDING_ANCHOR);
+    switch (Sep.from((txn.getProtocol()))) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
+          supportedStatuses.add(INCOMPLETE);
+          if (!areFundsReceived(txn6)) {
+            supportedStatuses.add(PENDING_ANCHOR);
+            supportedStatuses.add(PENDING_CUSTOMER_INFO_UPDATE);
+          }
         }
-      }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (DEPOSIT == Kind.from(txn24.getKind())) {
+          supportedStatuses.add(INCOMPLETE);
+          if (!areFundsReceived(txn24)) {
+            supportedStatuses.add(PENDING_ANCHOR);
+          }
+        }
+        break;
+      default:
+        break;
     }
     return supportedStatuses;
   }
@@ -143,12 +162,28 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
       txn.setAmountFee(request.getAmountFee().getAmount());
       txn.setAmountFeeAsset(request.getAmountFee().getAsset());
     }
-
-    JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-    if (request.getAmountExpected() != null) {
-      txn24.setAmountExpected(request.getAmountExpected().getAmount());
-    } else if (request.getAmountIn() != null) {
-      txn24.setAmountExpected(request.getAmountIn().getAmount());
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (request.getAmountExpected() != null) {
+          txn6.setAmountExpected(request.getAmountExpected().getAmount());
+        } else if (request.getAmountIn() != null) {
+          txn6.setAmountExpected(request.getAmountIn().getAmount());
+        }
+        if (request.getInstructions() != null) {
+          txn6.setInstructions(request.getInstructions());
+        }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (request.getAmountExpected() != null) {
+          txn24.setAmountExpected(request.getAmountExpected().getAmount());
+        } else if (request.getAmountIn() != null) {
+          txn24.setAmountExpected(request.getAmountIn().getAmount());
+        }
+        break;
+      default:
+        break;
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcMethodHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcMethodHandler.java
@@ -15,7 +15,6 @@ import com.google.gson.Gson;
 import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.transaction.annotation.Transactional;
 import org.stellar.anchor.api.event.AnchorEvent;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -32,17 +31,21 @@ import org.stellar.anchor.event.EventService.Session;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
 import org.stellar.anchor.platform.data.JdbcSep31Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
+import org.stellar.anchor.sep24.Sep24Transaction;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31Transaction;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
 import org.stellar.anchor.util.GsonUtils;
 
 public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
 
   private static final Gson gson = GsonUtils.getInstance();
 
+  protected final Sep6TransactionStore txn6Store;
   protected final Sep24TransactionStore txn24Store;
   protected final Sep31TransactionStore txn31Store;
   protected final AssetService assetService;
@@ -52,6 +55,7 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
   private final Session eventSession;
 
   public RpcMethodHandler(
+      Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,
       Sep31TransactionStore txn31Store,
       RequestValidator requestValidator,
@@ -59,6 +63,7 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
       EventService eventService,
       MetricsService metricsService,
       Class<T> requestType) {
+    this.txn6Store = txn6Store;
     this.txn24Store = txn24Store;
     this.txn31Store = txn31Store;
     this.requestValidator = requestValidator;
@@ -68,7 +73,6 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
   }
 
-  @Transactional
   public GetTransactionResponse handle(Object requestParams) throws AnchorException {
     T request = gson.fromJson(gson.toJson(requestParams), requestType);
     JdbcSepTransaction txn = getTransaction(request.getTransactionId());
@@ -81,6 +85,9 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
     if (!getSupportedStatuses(txn).contains(SepTransactionStatus.from(txn.getStatus()))) {
       String kind;
       switch (Sep.from(txn.getProtocol())) {
+        case SEP_6:
+          kind = ((JdbcSep6Transaction) txn).getKind();
+          break;
         case SEP_24:
           JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
           kind = txn24.getKind();
@@ -127,7 +134,11 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
     if (txn31 != null) {
       return (JdbcSep31Transaction) txn31;
     }
-    return (JdbcSep24Transaction) txn24Store.findByTransactionId(transactionId);
+    Sep24Transaction txn24 = txn24Store.findByTransactionId(transactionId);
+    if (txn24 != null) {
+      return (JdbcSep24Transaction) txn24;
+    }
+    return (JdbcSep6Transaction) txn6Store.findByTransactionId(transactionId);
   }
 
   protected void validate(JdbcSepTransaction txn, T request)
@@ -157,6 +168,15 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
     }
 
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (request.getMessage() != null) {
+          txn6.setMessage(request.getMessage());
+        } else if (shouldClearMessageStatus) {
+          txn6.setMessage(null);
+        }
+        txn6Store.save(txn6);
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         if (request.getMessage() != null) {
@@ -194,6 +214,9 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
 
   private void updateMetrics(JdbcSepTransaction txn) {
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        metricsService.counter(PLATFORM_RPC_TRANSACTION, SEP, TV_SEP6).increment();
+        break;
       case SEP_24:
         metricsService.counter(PLATFORM_RPC_TRANSACTION, SEP, TV_SEP24).increment();
         break;

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/PaymentsUtil.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/PaymentsUtil.java
@@ -2,10 +2,11 @@ package org.stellar.anchor.platform.utils;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static org.stellar.anchor.platform.service.PaymentOperationToEventListener.parsePaymentTime;
 import static org.stellar.anchor.util.Log.error;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,6 +19,7 @@ import org.stellar.anchor.platform.data.JdbcSep24Transaction;
 import org.stellar.anchor.platform.data.JdbcSep31Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.observer.ObservedPayment;
+import org.stellar.anchor.util.Log;
 import org.stellar.sdk.responses.operations.OperationResponse;
 import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse;
 import org.stellar.sdk.responses.operations.PaymentOperationResponse;
@@ -107,5 +109,15 @@ public class PaymentsUtil {
         .filter(Objects::nonNull)
         .sorted(comparing(ObservedPayment::getCreatedAt))
         .collect(toList());
+  }
+
+  private static Instant parsePaymentTime(String paymentTimeStr) {
+    try {
+      return DateTimeFormatter.ISO_INSTANT.parse(paymentTimeStr, Instant::from);
+    } catch (DateTimeParseException | NullPointerException ex) {
+      Log.errorF("Error parsing paymentTimeStr {}.", paymentTimeStr);
+      ex.printStackTrace();
+      return null;
+    }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarPaymentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarPaymentHandlerTest.kt
@@ -37,6 +37,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class DoStellarPaymentHandlerTest {
@@ -48,6 +49,8 @@ class DoStellarPaymentHandlerTest {
     private const val AMOUNT_OUT_ASSET = "testAmountOutAsset"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -82,6 +85,7 @@ class DoStellarPaymentHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       DoStellarPaymentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
@@ -50,6 +50,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class DoStellarRefundHandlerTest {
@@ -65,6 +66,8 @@ class DoStellarRefundHandlerTest {
     private const val MEMO_TYPE = "text"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -95,6 +98,7 @@ class DoStellarRefundHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       DoStellarRefundHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedTest.kt
@@ -55,7 +55,6 @@ class NotifyAmountsUpdatedTest {
       "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -366,7 +365,6 @@ class NotifyAmountsUpdatedTest {
     txn6.amountOut = "1.8"
     txn6.amountFeeAsset = STELLAR_USDC
     txn6.amountFee = "0.2"
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -395,7 +393,6 @@ class NotifyAmountsUpdatedTest {
     expectedSep6Txn.amountOut = "0.9"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.amountFee = "0.1"
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -411,8 +408,7 @@ class NotifyAmountsUpdatedTest {
     expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyInteractiveFlowCompletedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyInteractiveFlowCompletedHandlerTest.kt
@@ -38,6 +38,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyInteractiveFlowCompletedHandlerTest {
@@ -51,6 +52,8 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -77,6 +80,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       NotifyInteractiveFlowCompletedHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -94,6 +98,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     txn24.status = INCOMPLETE.toString()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -104,6 +109,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -116,6 +122,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.status = PENDING_ANCHOR.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -125,6 +132,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -136,6 +144,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val txn24 = JdbcSep24Transaction()
     txn24.status = INCOMPLETE.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -144,6 +153,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -166,6 +176,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -177,6 +188,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -249,6 +261,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -260,6 +273,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -332,6 +346,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     txn24.requestAssetCode = FIAT_USD_CODE
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -355,6 +370,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     ex = assertThrows { handler.handle(request) }
     assertEquals("amount_expected.amount should be positive", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -376,6 +392,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     txn24.requestAssetCode = FIAT_USD_CODE
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -395,6 +412,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     assertEquals("amount_fee.asset should be non-stellar asset", ex.message)
     request.amountFee.asset = FIAT_USD
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -416,6 +434,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     txn24.requestAssetCode = FIAT_USD_CODE
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -435,6 +454,7 @@ class NotifyInteractiveFlowCompletedHandlerTest {
     assertEquals("amount_fee.asset should be stellar asset", ex.message)
     request.amountFee.asset = STELLAR_USDC
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandlerTest.kt
@@ -480,6 +480,7 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedResponse.status = PENDING_USR_TRANSFER_COMPLETE
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
@@ -555,6 +556,7 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = PENDING_USR_TRANSFER_COMPLETE
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandlerTest.kt
@@ -48,7 +48,6 @@ class NotifyOffchainFundsAvailableHandlerTest {
     private const val TX_ID = "testId"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -440,7 +439,6 @@ class NotifyOffchainFundsAvailableHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -466,7 +464,6 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -482,8 +479,7 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -518,7 +514,6 @@ class NotifyOffchainFundsAvailableHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -543,7 +538,6 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedSep6Txn.status = PENDING_USR_TRANSFER_COMPLETE.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -558,8 +552,7 @@ class NotifyOffchainFundsAvailableHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
@@ -558,6 +558,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
@@ -633,6 +634,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedResponse.kind = Kind.from(kind)
     expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
@@ -48,7 +48,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     private const val TX_ID = "testId"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -436,7 +435,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn6.status = PENDING_TRUST.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = Instant.now()
-    txn6.customer = CUSTOMER_ID
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
@@ -462,7 +460,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = Instant.now()
-    txn6.customer = CUSTOMER_ID
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
@@ -487,7 +484,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
-    txn6.customer = CUSTOMER_ID
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
@@ -518,7 +514,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -544,7 +539,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -560,8 +554,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -596,7 +589,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -621,7 +613,6 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedSep6Txn.status = PENDING_EXTERNAL.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -636,8 +627,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsPendingHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -16,6 +18,7 @@ import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyOffchainFundsPendingRequest
@@ -30,10 +33,12 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyOffchainFundsPendingHandlerTest {
@@ -43,7 +48,10 @@ class NotifyOffchainFundsPendingHandlerTest {
     private const val TX_ID = "testId"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -69,6 +77,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyOffchainFundsPendingHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -79,7 +88,7 @@ class NotifyOffchainFundsPendingHandlerTest {
   }
 
   @Test
-  fun test_handle_sep24_unsupportedProtocol() {
+  fun test_handle_unsupportedProtocol() {
     val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_ANCHOR.toString()
@@ -87,6 +96,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -97,6 +107,7 @@ class NotifyOffchainFundsPendingHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -110,6 +121,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn24.kind = WITHDRAWAL.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -119,6 +131,7 @@ class NotifyOffchainFundsPendingHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -132,6 +145,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -141,6 +155,7 @@ class NotifyOffchainFundsPendingHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -153,6 +168,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.kind = WITHDRAWAL.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -162,6 +178,7 @@ class NotifyOffchainFundsPendingHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -175,6 +192,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     txn24.kind = WITHDRAWAL.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -183,6 +201,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -203,6 +222,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -214,6 +234,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -263,6 +284,76 @@ class NotifyOffchainFundsPendingHandlerTest {
   }
 
   @Test
+  fun test_handle_ok_sep24_deposit_withoutExternalTxId() {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = transferReceivedAt
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep24") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep24Txn = JdbcSep24Transaction()
+    expectedSep24Txn.kind = WITHDRAWAL.kind
+    expectedSep24Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedSep24Txn.transferReceivedAt = transferReceivedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep24Txn),
+      gson.toJson(sep24TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_24
+    expectedResponse.kind = WITHDRAWAL
+    expectedResponse.status = PENDING_EXTERNAL
+    expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_24.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @Test
   fun test_handle_ok_sep31_deposit_withExternalTxId() {
     val request =
       NotifyOffchainFundsPendingRequest.builder()
@@ -274,6 +365,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
@@ -285,6 +377,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -335,49 +428,139 @@ class NotifyOffchainFundsPendingHandlerTest {
     assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
   }
 
-  @Test
-  fun test_handle_ok_sep24_deposit_withoutExternalTxId() {
-    val transferReceivedAt = Instant.now()
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
     val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.transferReceivedAt = transferReceivedAt
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+    txn6.customer = CUSTOMER_ID
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_pending] is not supported. Status[pending_trust], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+    txn6.customer = CUSTOMER_ID
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_pending] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_transferNotReceived(kind: String) {
+    val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.customer = CUSTOMER_ID
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_pending] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_deposit_withExternalTxId(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOffchainFundsPendingRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
     every { eventSession.publish(capture(anchorEventCapture)) } just Runs
-    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep24") } returns
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
       sepTransactionCounter
 
     val startDate = Instant.now()
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
-    val expectedSep24Txn = JdbcSep24Transaction()
-    expectedSep24Txn.kind = WITHDRAWAL.kind
-    expectedSep24Txn.status = PENDING_EXTERNAL.toString()
-    expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
-    expectedSep24Txn.transferReceivedAt = transferReceivedAt
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
-      gson.toJson(expectedSep24Txn),
-      gson.toJson(sep24TxnCapture.captured),
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
       JSONCompareMode.STRICT
     )
 
     val expectedResponse = GetTransactionResponse()
-    expectedResponse.sep = SEP_24
-    expectedResponse.kind = WITHDRAWAL
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
     expectedResponse.status = PENDING_EXTERNAL
-    expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -388,7 +571,7 @@ class NotifyOffchainFundsPendingHandlerTest {
     val expectedEvent =
       AnchorEvent.builder()
         .id(anchorEventCapture.captured.id)
-        .sep(SEP_24.sep.toString())
+        .sep(SEP_6.sep.toString())
         .type(TRANSACTION_STATUS_CHANGED)
         .transaction(expectedResponse)
         .build()
@@ -399,7 +582,82 @@ class NotifyOffchainFundsPendingHandlerTest {
       JSONCompareMode.STRICT
     )
 
-    assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
-    assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_deposit_withoutExternalTxId(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyOffchainFundsPendingRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
+    expectedResponse.status = PENDING_EXTERNAL
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
@@ -58,7 +58,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     private const val FIAT_USD_CODE = "USD"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTMOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -638,7 +637,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = INCOMPLETE.toString()
     txn6.kind = kind
-    txn6.customer = CUSTMOMER_ID
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
@@ -700,7 +698,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn6.amountInAsset = FIAT_USD
     txn6.amountOutAsset = STELLAR_USDC
     txn6.amountFeeAsset = STELLAR_USDC
-    txn6.customer = CUSTMOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -734,7 +731,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedSep6Txn.amountOutAsset = STELLAR_USDC
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
-    expectedSep6Txn.customer = CUSTMOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -753,8 +749,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
-    expectedResponse.customers =
-      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -793,7 +788,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
     txn6.amountInAsset = FIAT_USD
-    txn6.customer = CUSTMOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -822,7 +816,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
     expectedSep6Txn.amountIn = "1"
     expectedSep6Txn.amountInAsset = FIAT_USD
-    expectedSep6Txn.customer = CUSTMOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -838,8 +831,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
-    expectedResponse.customers =
-      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -877,7 +869,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
-    txn6.customer = CUSTMOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -906,7 +897,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
     expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
-    expectedSep6Txn.customer = CUSTMOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -922,8 +912,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
-    expectedResponse.customers =
-      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -959,7 +948,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
-    txn6.customer = CUSTMOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -985,7 +973,6 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
     expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
-    expectedSep6Txn.customer = CUSTMOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1000,8 +987,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
-    expectedResponse.customers =
-      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -17,14 +19,16 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.AmountRequest
 import org.stellar.anchor.api.rpc.method.NotifyOffchainFundsReceivedRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.config.CustodyConfig
@@ -34,11 +38,13 @@ import org.stellar.anchor.event.EventService.EventQueue.TRANSACTION
 import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24Transaction
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyOffchainFundsReceivedHandlerTest {
@@ -52,7 +58,10 @@ class NotifyOffchainFundsReceivedHandlerTest {
     private const val FIAT_USD_CODE = "USD"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTMOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -83,6 +92,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       NotifyOffchainFundsReceivedHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -102,6 +112,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn24.status = PENDING_USR_TRANSFER_START.toString()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -112,70 +123,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedStatus() {
-    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_offchain_funds_received] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedKind() {
-    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_offchain_funds_received] is not supported. Status[pending_user_transfer_start], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_transferReceived() {
-    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_EXTERNAL.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_offchain_funds_received] is not supported. Status[pending_external], kind[withdrawal], protocol[24], funds received[true]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -189,6 +137,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -197,13 +146,158 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok_withAmountsAndExternalTxIdAndFundsReceivedAt() {
+  fun test_handle_notAllAmounts() {
+    val request =
+      NotifyOffchainFundsReceivedRequest.builder()
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("1"))
+        .transactionId(TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = DEPOSIT.kind
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(
+      "Invalid amounts combination provided: all, none or only amount_in should be set",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidAmounts() {
+    val request =
+      NotifyOffchainFundsReceivedRequest.builder()
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("1"))
+        .amountFee(AmountRequest("1"))
+        .transactionId(TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.requestAssetCode = FIAT_USD_CODE
+    txn24.amountInAsset = FIAT_USD
+    txn24.amountOutAsset = STELLAR_USDC
+    txn24.amountFeeAsset = STELLAR_USDC
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    request.amountIn.amount = "-1"
+    var ex = assertThrows<BadRequestException> { handler.handle(request) }
+    assertEquals("amount_in.amount should be positive", ex.message)
+    request.amountIn.amount = "1"
+
+    request.amountOut.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_out.amount should be positive", ex.message)
+    request.amountOut.amount = "1"
+
+    request.amountFee.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_fee.amount should be non-negative", ex.message)
+    request.amountFee.amount = "1"
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_received] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedKind() {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_received] is not supported. Status[pending_user_transfer_start], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_transferReceived() {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_EXTERNAL.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_received] is not supported. Status[pending_external], kind[withdrawal], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok_withAmountsAndExternalTxIdAndFundsReceivedAt() {
     val transferReceivedAt = Instant.now()
     val request =
       NotifyOffchainFundsReceivedRequest.builder()
@@ -224,6 +318,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -236,6 +331,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { custodyService.createTransaction(ofType(Sep24Transaction::class)) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
@@ -296,7 +392,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_onlyWithAmountIn() {
+  fun test_handle_sep24_ok_onlyWithAmountIn() {
     val request =
       NotifyOffchainFundsReceivedRequest.builder()
         .transactionId(TX_ID)
@@ -310,6 +406,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -322,6 +419,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { custodyService.createTransaction(ofType(Sep24Transaction::class)) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
@@ -374,7 +472,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_withExternalTxIdAndWithoutFundsReceivedAt_custodyIntegrationEnabled() {
+  fun test_handle_sep24_ok_withExternalTxIdAndWithoutFundsReceivedAt_custodyIntegrationEnabled() {
     val request =
       NotifyOffchainFundsReceivedRequest.builder()
         .transactionId(TX_ID)
@@ -388,6 +486,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val sep24CustodyTxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -401,6 +500,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -460,7 +560,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_withoutAmountAndExternalTxIdAndFundsReceivedAt() {
+  fun test_handle_sep24_ok_withoutAmountAndExternalTxIdAndFundsReceivedAt() {
     val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_USR_TRANSFER_START.toString()
@@ -469,6 +569,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -480,6 +581,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -529,73 +631,397 @@ class NotifyOffchainFundsReceivedHandlerTest {
     assertTrue(sep24TxnCapture.captured.transferReceivedAt <= endDate)
   }
 
-  @Test
-  fun test_handle_notAllAmounts() {
-    val request =
-      NotifyOffchainFundsReceivedRequest.builder()
-        .amountIn(AmountRequest("1"))
-        .amountOut(AmountRequest("1"))
-        .transactionId(TX_ID)
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = DEPOSIT.kind
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+    txn6.customer = CUSTMOMER_ID
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
     assertEquals(
-      "Invalid amounts combination provided: all, none or only amount_in should be set",
+      "RPC method[notify_offchain_funds_received] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
-  @Test
-  fun test_handle_invalidAmounts() {
-    val request =
-      NotifyOffchainFundsReceivedRequest.builder()
-        .amountIn(AmountRequest("1"))
-        .amountOut(AmountRequest("1"))
-        .amountFee(AmountRequest("1"))
-        .transactionId(TX_ID)
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.requestAssetCode = FIAT_USD_CODE
-    txn24.amountInAsset = FIAT_USD
-    txn24.amountOutAsset = STELLAR_USDC
-    txn24.amountFeeAsset = STELLAR_USDC
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    request.amountIn.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_in.amount should be positive", ex.message)
-    request.amountIn.amount = "1"
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_received] is not supported. Status[pending_user_transfer_start], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
 
-    request.amountOut.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
-    request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_fee.amount should be non-negative", ex.message)
-    request.amountFee.amount = "1"
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withAmountsAndExternalTxIdAndFundsReceivedAt(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOffchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("0.9"))
+        .amountFee(AmountRequest("0.1"))
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .fundsReceivedAt(transferReceivedAt)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = FIAT_USD
+    txn6.amountOutAsset = STELLAR_USDC
+    txn6.amountFeeAsset = STELLAR_USDC
+    txn6.customer = CUSTMOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
+    expectedSep6Txn.customer = CUSTMOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.customers =
+      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_onlyWithAmountIn(kind: String) {
+    val request =
+      NotifyOffchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountRequest("1"))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = FIAT_USD
+    txn6.customer = CUSTMOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.customer = CUSTMOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.customers =
+      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withExternalTxIdAndWithoutFundsReceivedAt(kind: String) {
+    val request =
+      NotifyOffchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.customer = CUSTMOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.customer = CUSTMOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.customers =
+      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withoutAmountAndExternalTxIdAndFundsReceivedAt(kind: String) {
+    val request = NotifyOffchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.customer = CUSTMOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
+    expectedSep6Txn.customer = CUSTMOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.customers =
+      Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandlerTest.kt
@@ -748,6 +748,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
@@ -834,6 +835,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.kind = Kind.from(kind)
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.customers =
@@ -918,6 +920,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.customers =
       Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))
@@ -995,6 +998,7 @@ class NotifyOffchainFundsReceivedHandlerTest {
     expectedResponse.kind = Kind.from(kind)
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.customers =
       Customers(StellarId(CUSTMOMER_ID, null), StellarId(CUSTMOMER_ID, null))

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
@@ -48,7 +48,6 @@ class NotifyOffchainFundsSentHandlerTest {
     private const val TX_ID = "testId"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -700,7 +699,6 @@ class NotifyOffchainFundsSentHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -726,7 +724,6 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -742,8 +739,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -780,7 +776,6 @@ class NotifyOffchainFundsSentHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -806,7 +801,6 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
     expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -822,8 +816,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -858,7 +851,6 @@ class NotifyOffchainFundsSentHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -883,7 +875,6 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedSep6Txn.status = PENDING_EXTERNAL.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -897,8 +888,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -938,7 +928,6 @@ class NotifyOffchainFundsSentHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -965,7 +954,6 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
     expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -982,8 +970,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -1020,7 +1007,6 @@ class NotifyOffchainFundsSentHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -1046,7 +1032,6 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1062,8 +1047,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
@@ -740,6 +740,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
@@ -819,6 +820,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.status = PENDING_EXTERNAL
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
@@ -977,6 +979,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.status = COMPLETED
     expectedResponse.externalTransactionId = EXTERNAL_TX_ID
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =
@@ -1056,6 +1059,7 @@ class NotifyOffchainFundsSentHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = COMPLETED
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.customers =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOffchainFundsSentHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -16,6 +18,7 @@ import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyOffchainFundsSentRequest
@@ -30,10 +33,12 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyOffchainFundsSentHandlerTest {
@@ -43,7 +48,10 @@ class NotifyOffchainFundsSentHandlerTest {
     private const val TX_ID = "testId"
     private const val EXTERNAL_TX_ID = "testExternalTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -69,6 +77,7 @@ class NotifyOffchainFundsSentHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyOffchainFundsSentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -79,13 +88,14 @@ class NotifyOffchainFundsSentHandlerTest {
   }
 
   @Test
-  fun test_handle_sep24_unsupportedProtocol() {
+  fun test_handle_unsupportedProtocol() {
     val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = INCOMPLETE.toString()
     txn24.kind = DEPOSIT.kind
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -95,6 +105,29 @@ class NotifyOffchainFundsSentHandlerTest {
       "RPC method[notify_offchain_funds_sent] is not supported. Status[incomplete], kind[null], protocol[38], funds received[false]",
       ex.message
     )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidRequest() {
+    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { requestValidator.validate(request) } throws
+      InvalidParamsException(VALIDATION_ERROR_MESSAGE)
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
@@ -108,6 +141,7 @@ class NotifyOffchainFundsSentHandlerTest {
     txn24.status = PENDING_EXTERNAL.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -117,6 +151,7 @@ class NotifyOffchainFundsSentHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -129,6 +164,7 @@ class NotifyOffchainFundsSentHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.kind = WITHDRAWAL.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -138,27 +174,7 @@ class NotifyOffchainFundsSentHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_sep24_invalidRequest() {
-    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { requestValidator.validate(request) } throws
-      InvalidParamsException(VALIDATION_ERROR_MESSAGE)
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -179,6 +195,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -190,6 +207,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -239,88 +257,6 @@ class NotifyOffchainFundsSentHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_sep31_deposit_withExternalTxIdAndDate() {
-    val transferReceivedAt = Instant.now()
-    val request =
-      NotifyOffchainFundsSentRequest.builder()
-        .transactionId(TX_ID)
-        .externalTransactionId(EXTERNAL_TX_ID)
-        .fundsSentAt(transferReceivedAt.minusSeconds(100))
-        .build()
-    val txn31 = JdbcSep31Transaction()
-    txn31.status = PENDING_RECEIVER.toString()
-    txn31.transferReceivedAt = transferReceivedAt
-    val sep31TxnCapture = slot<JdbcSep31Transaction>()
-    val anchorEventCapture = slot<AnchorEvent>()
-
-    every { txn24Store.findByTransactionId(any()) } returns null
-    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
-    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
-    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
-    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
-      sepTransactionCounter
-
-    val startDate = Instant.now()
-    val response = handler.handle(request)
-    val endDate = Instant.now()
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 1) { sepTransactionCounter.increment() }
-
-    val expectedSep31Txn = JdbcSep31Transaction()
-    expectedSep31Txn.status = COMPLETED.toString()
-    expectedSep31Txn.updatedAt = sep31TxnCapture.captured.updatedAt
-    expectedSep31Txn.externalTransactionId = EXTERNAL_TX_ID
-    expectedSep31Txn.transferReceivedAt = transferReceivedAt
-    expectedSep31Txn.completedAt = sep31TxnCapture.captured.completedAt
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedSep31Txn),
-      gson.toJson(sep31TxnCapture.captured),
-      JSONCompareMode.STRICT
-    )
-
-    val expectedResponse = GetTransactionResponse()
-    expectedResponse.sep = SEP_31
-    expectedResponse.kind = RECEIVE
-    expectedResponse.status = COMPLETED
-    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
-    expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
-    expectedResponse.completedAt = sep31TxnCapture.captured.completedAt
-    expectedResponse.amountIn = Amount()
-    expectedResponse.amountOut = Amount()
-    expectedResponse.amountFee = Amount()
-    expectedResponse.amountExpected = Amount()
-    expectedResponse.customers = Customers(StellarId(), StellarId())
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedResponse),
-      gson.toJson(response),
-      JSONCompareMode.STRICT
-    )
-
-    val expectedEvent =
-      AnchorEvent.builder()
-        .id(anchorEventCapture.captured.id)
-        .sep(SEP_31.sep.toString())
-        .type(AnchorEvent.Type.TRANSACTION_STATUS_CHANGED)
-        .transaction(expectedResponse)
-        .build()
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedEvent),
-      gson.toJson(anchorEventCapture.captured),
-      JSONCompareMode.STRICT
-    )
-
-    assertTrue(sep31TxnCapture.captured.updatedAt >= startDate)
-    assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
-    assertTrue(sep31TxnCapture.captured.completedAt >= startDate)
-    assertTrue(sep31TxnCapture.captured.completedAt <= endDate)
-  }
-
-  @Test
   fun test_handle_ok_sep24_deposit_withExternalTxIdAndWithoutDate() {
     val request =
       NotifyOffchainFundsSentRequest.builder()
@@ -333,6 +269,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -344,6 +281,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -403,6 +341,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -414,6 +353,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -476,6 +416,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -487,6 +428,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -550,6 +492,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -561,6 +504,7 @@ class NotifyOffchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -609,5 +553,537 @@ class NotifyOffchainFundsSentHandlerTest {
     assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
     assertTrue(sep24TxnCapture.captured.completedAt >= startDate)
     assertTrue(sep24TxnCapture.captured.completedAt <= endDate)
+  }
+
+  @Test
+  fun test_handle_ok_sep31_deposit_withExternalTxIdAndDate() {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOffchainFundsSentRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .fundsSentAt(transferReceivedAt.minusSeconds(100))
+        .build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = PENDING_RECEIVER.toString()
+    txn31.transferReceivedAt = transferReceivedAt
+    val sep31TxnCapture = slot<JdbcSep31Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep31Txn = JdbcSep31Transaction()
+    expectedSep31Txn.status = COMPLETED.toString()
+    expectedSep31Txn.updatedAt = sep31TxnCapture.captured.updatedAt
+    expectedSep31Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep31Txn.transferReceivedAt = transferReceivedAt
+    expectedSep31Txn.completedAt = sep31TxnCapture.captured.completedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep31Txn),
+      gson.toJson(sep31TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_31
+    expectedResponse.kind = RECEIVE
+    expectedResponse.status = COMPLETED
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
+    expectedResponse.completedAt = sep31TxnCapture.captured.completedAt
+    expectedResponse.amountIn = Amount()
+    expectedResponse.amountOut = Amount()
+    expectedResponse.amountFee = Amount()
+    expectedResponse.amountExpected = Amount()
+    expectedResponse.customers = Customers(StellarId(), StellarId())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_31.sep.toString())
+        .type(AnchorEvent.Type.TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep31TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep31TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep31TxnCapture.captured.completedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange", "withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_sent] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_withdrawal_transferNotReceived(kind: String) {
+    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_offchain_funds_sent] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_deposit_withExternalTxIdAndDate(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOffchainFundsSentRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .fundsSentAt(transferReceivedAt)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_EXTERNAL
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_deposit_withExternalTxIdAndWithoutDate(kind: String) {
+    val request =
+      NotifyOffchainFundsSentRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_EXTERNAL
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.transferReceivedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_deposit_withoutExternalTxIdAndDate(kind: String) {
+    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_EXTERNAL.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = sep6TxnCapture.captured.transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_EXTERNAL
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_withdrawal_withExternalTxIdAndDate(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOffchainFundsSentRequest.builder()
+        .transactionId(TX_ID)
+        .externalTransactionId(EXTERNAL_TX_ID)
+        .fundsSentAt(transferReceivedAt.minusSeconds(100))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = COMPLETED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
+    expectedSep6Txn.externalTransactionId = EXTERNAL_TX_ID
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = COMPLETED
+    expectedResponse.externalTransactionId = EXTERNAL_TX_ID
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.completedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_withdrawal_withoutExternalTxId(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyOffchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = COMPLETED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = COMPLETED
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.completedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -795,6 +795,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
@@ -894,6 +895,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.stellarTransactions = stellarTransactions
@@ -987,6 +989,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.stellarTransactions = stellarTransactions
     expectedResponse.customers =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -63,7 +63,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     private const val STELLAR_TX_ID = "stellarTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
     private const val STELLAR_PAYMENT_DATE = "2023-05-10T10:18:20Z"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -738,7 +737,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     txn6.amountInAsset = FIAT_USD
     txn6.amountOutAsset = STELLAR_USDC
     txn6.amountFeeAsset = STELLAR_USDC
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -782,7 +780,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
     expectedSep6Txn.stellarTransactions = stellarTransactions
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -801,8 +798,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.stellarTransactions = stellarTransactions
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -842,7 +838,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
     txn6.amountInAsset = FIAT_USD
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -882,7 +877,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedSep6Txn.amountInAsset = FIAT_USD
     expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
     expectedSep6Txn.stellarTransactions = stellarTransactions
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -899,8 +893,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.amountIn = Amount("1", FIAT_USD)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.stellarTransactions = stellarTransactions
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -938,7 +931,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -976,7 +968,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
     expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
     expectedSep6Txn.stellarTransactions = stellarTransactions
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -992,8 +983,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
     expectedResponse.amountExpected = Amount(null, FIAT_USD)
     expectedResponse.stellarTransactions = stellarTransactions
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -11,6 +11,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -20,6 +22,7 @@ import org.stellar.anchor.api.exception.rpc.InternalErrorException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.AmountRequest
@@ -38,10 +41,12 @@ import org.stellar.anchor.horizon.Horizon
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.sdk.responses.operations.OperationResponse
 import org.stellar.sdk.responses.operations.PaymentOperationResponse
@@ -58,7 +63,10 @@ class NotifyOnchainFundsReceivedHandlerTest {
     private const val STELLAR_TX_ID = "stellarTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
     private const val STELLAR_PAYMENT_DATE = "2023-05-10T10:18:20Z"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -87,6 +95,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       NotifyOnchainFundsReceivedHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -98,13 +107,14 @@ class NotifyOnchainFundsReceivedHandlerTest {
   }
 
   @Test
-  fun test_handle_sep24_unsupportedProtocol() {
+  fun test_handle_unsupportedProtocol() {
     val request = NotifyOnchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_USR_TRANSFER_START.toString()
     txn24.kind = WITHDRAWAL.kind
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -115,6 +125,104 @@ class NotifyOnchainFundsReceivedHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidRequest() {
+    val request = NotifyOnchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { requestValidator.validate(request) } throws
+      InvalidParamsException(VALIDATION_ERROR_MESSAGE)
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_notAllAmounts() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("1"))
+        .transactionId(TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = WITHDRAWAL.kind
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(
+      "Invalid amounts combination provided: all, none or only amount_in should be set",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidAmounts() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("1"))
+        .amountFee(AmountRequest("1"))
+        .transactionId(TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.requestAssetCode = FIAT_USD_CODE
+    txn24.amountInAsset = FIAT_USD
+    txn24.amountOutAsset = STELLAR_USDC
+    txn24.amountFeeAsset = STELLAR_USDC
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    request.amountIn.amount = "-1"
+    var ex = assertThrows<BadRequestException> { handler.handle(request) }
+    assertEquals("amount_in.amount should be positive", ex.message)
+    request.amountIn.amount = "1"
+
+    request.amountOut.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_out.amount should be positive", ex.message)
+    request.amountOut.amount = "1"
+
+    request.amountFee.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_fee.amount should be non-negative", ex.message)
+    request.amountFee.amount = "1"
+
+    request.amountIn.amount = "0"
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -127,6 +235,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     txn24.status = INCOMPLETE.toString()
     txn24.kind = WITHDRAWAL.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -136,6 +245,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -148,6 +258,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     txn24.status = PENDING_USR_TRANSFER_START.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -157,27 +268,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_sep24_invalidRequest() {
-    val request = NotifyOnchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { requestValidator.validate(request) } throws
-      InvalidParamsException(VALIDATION_ERROR_MESSAGE)
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -212,6 +303,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val stellarTransactions: List<StellarTransaction> =
       gson.fromJson(stellarTransactions, stellarTransactionsToken)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -224,6 +316,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -308,6 +401,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val stellarTransactions: List<StellarTransaction> =
       gson.fromJson(stellarTransactions, stellarTransactionsToken)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -320,6 +414,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -396,6 +491,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val stellarTransactions: List<StellarTransaction> =
       gson.fromJson(stellarTransactions, stellarTransactionsToken)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -408,6 +504,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -459,6 +556,35 @@ class NotifyOnchainFundsReceivedHandlerTest {
   }
 
   @Test
+  fun test_handle_ok_sep24_withoutAmounts_invalidStellarTransaction() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.requestAssetCode = FIAT_USD_CODE
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(any()) } throws
+      IOException("Invalid stellar transaction")
+
+    val ex = assertThrows<InternalErrorException> { handler.handle(request) }
+    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
   fun test_handle_ok_sep31_withoutAmounts() {
     val request =
       NotifyOnchainFundsReceivedRequest.builder()
@@ -479,6 +605,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val stellarTransactions: List<StellarTransaction> =
       gson.fromJson(stellarTransactions, stellarTransactionsToken)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
@@ -491,6 +618,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -544,56 +672,375 @@ class NotifyOnchainFundsReceivedHandlerTest {
     assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
   }
 
-  @Test
-  fun test_handle_ok_sep24_withoutAmounts_invalidStellarTransaction() {
+  @CsvSource(value = ["deposit", "deposit-exchange", "withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyOnchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_received] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = NotifyOnchainFundsReceivedRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_received] is not supported. Status[pending_user_transfer_start], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_withAmounts(kind: String) {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountRequest("1"))
+        .amountOut(AmountRequest("0.9"))
+        .amountFee(AmountRequest("0.1"))
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = FIAT_USD
+    txn6.amountOutAsset = STELLAR_USDC
+    txn6.amountFeeAsset = STELLAR_USDC
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    val operationRecordsTypeToken =
+      object : TypeToken<ArrayList<PaymentOperationResponse>>() {}.type
+    val operationRecords: ArrayList<OperationResponse> =
+      gson.fromJson(paymentOperationRecord, operationRecordsTypeToken)
+
+    val stellarTransactionsToken = object : TypeToken<List<StellarTransaction>>() {}.type
+    val stellarTransactions: List<StellarTransaction> =
+      gson.fromJson(stellarTransactions, stellarTransactionsToken)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(STELLAR_TX_ID) } returns operationRecords
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
+    expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
+    expectedSep6Txn.stellarTransactions = stellarTransactions
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.stellarTransactions = stellarTransactions
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_onlyWithAmountIn(kind: String) {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountRequest("1"))
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = FIAT_USD
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    val operationRecordsTypeToken =
+      object : TypeToken<ArrayList<PaymentOperationResponse>>() {}.type
+    val operationRecords: ArrayList<OperationResponse> =
+      gson.fromJson(paymentOperationRecord, operationRecordsTypeToken)
+
+    val stellarTransactionsToken = object : TypeToken<List<StellarTransaction>>() {}.type
+    val stellarTransactions: List<StellarTransaction> =
+      gson.fromJson(stellarTransactions, stellarTransactionsToken)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(STELLAR_TX_ID) } returns operationRecords
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
+    expectedSep6Txn.stellarTransactions = stellarTransactions
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.stellarTransactions = stellarTransactions
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_withoutAmounts(kind: String) {
     val request =
       NotifyOnchainFundsReceivedRequest.builder()
         .transactionId(TX_ID)
         .stellarTransactionId(STELLAR_TX_ID)
         .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.requestAssetCode = FIAT_USD_CODE
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    val operationRecordsTypeToken =
+      object : TypeToken<ArrayList<PaymentOperationResponse>>() {}.type
+    val operationRecords: ArrayList<OperationResponse> =
+      gson.fromJson(paymentOperationRecord, operationRecordsTypeToken)
+
+    val stellarTransactionsToken = object : TypeToken<List<StellarTransaction>>() {}.type
+    val stellarTransactions: List<StellarTransaction> =
+      gson.fromJson(stellarTransactions, stellarTransactionsToken)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(STELLAR_TX_ID) } returns operationRecords
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
+    expectedSep6Txn.stellarTransactions = stellarTransactions
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.stellarTransactions = stellarTransactions
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_withoutAmounts_invalidStellarTransaction(kind: String) {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
     every { horizon.getStellarTxnOperations(any()) } throws
       IOException("Invalid stellar transaction")
 
     val ex = assertThrows<InternalErrorException> { handler.handle(request) }
     assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_sep24_notAllAmounts() {
-    val request =
-      NotifyOnchainFundsReceivedRequest.builder()
-        .amountIn(AmountRequest("1"))
-        .amountOut(AmountRequest("1"))
-        .transactionId(TX_ID)
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = WITHDRAWAL.kind
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals(
-      "Invalid amounts combination provided: all, none or only amount_in should be set",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -702,48 +1149,6 @@ class NotifyOnchainFundsReceivedHandlerTest {
   }
 ]  
 """
-
-  @Test
-  fun test_handle_sep24_invalidAmounts() {
-    val request =
-      NotifyOnchainFundsReceivedRequest.builder()
-        .amountIn(AmountRequest("1"))
-        .amountOut(AmountRequest("1"))
-        .amountFee(AmountRequest("1"))
-        .transactionId(TX_ID)
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_USR_TRANSFER_START.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.requestAssetCode = FIAT_USD_CODE
-    txn24.amountInAsset = FIAT_USD
-    txn24.amountOutAsset = STELLAR_USDC
-    txn24.amountFeeAsset = STELLAR_USDC
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    request.amountIn.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_in.amount should be positive", ex.message)
-    request.amountIn.amount = "1"
-
-    request.amountOut.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
-    request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_fee.amount should be non-negative", ex.message)
-    request.amountFee.amount = "1"
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
 
   private val stellarTransactions =
     """

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
@@ -11,6 +11,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -19,12 +21,15 @@ import org.stellar.anchor.api.exception.rpc.InternalErrorException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
-import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyOnchainFundsSentRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.api.shared.StellarTransaction
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.event.EventService
@@ -33,10 +38,12 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.horizon.Horizon
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.sdk.responses.operations.OperationResponse
 import org.stellar.sdk.responses.operations.PaymentOperationResponse
@@ -48,7 +55,10 @@ class NotifyOnchainFundsSentHandlerTest {
     private const val TX_ID = "testId"
     private const val STELLAR_TX_ID = "stellarTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -76,6 +86,7 @@ class NotifyOnchainFundsSentHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyOnchainFundsSentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -93,6 +104,7 @@ class NotifyOnchainFundsSentHandlerTest {
     txn24.status = PENDING_STELLAR.toString()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -103,69 +115,7 @@ class NotifyOnchainFundsSentHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedStatus() {
-    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_onchain_funds_sent] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedKind() {
-    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_STELLAR.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_stellar], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_transferNotReceived() {
-    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_anchor], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -180,6 +130,7 @@ class NotifyOnchainFundsSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = transferReceivedAt
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -188,13 +139,113 @@ class NotifyOnchainFundsSentHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok() {
+  fun test_handle_invalidStellarTransaction() {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyOnchainFundsSentRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = transferReceivedAt
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(any()) } throws
+      IOException("Invalid stellar transaction")
+
+    val ex = assertThrows<InternalErrorException> { handler.handle(request) }
+    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedKind() {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_STELLAR.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_stellar], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_transferNotReceived() {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_anchor], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok() {
     val transferReceivedAt = Instant.now()
     val request =
       NotifyOnchainFundsSentRequest.builder()
@@ -217,6 +268,7 @@ class NotifyOnchainFundsSentHandlerTest {
     val stellarTransactions: List<StellarTransaction> =
       gson.fromJson(stellarTransactions, stellarTransactionsToken)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -229,6 +281,7 @@ class NotifyOnchainFundsSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -282,32 +335,172 @@ class NotifyOnchainFundsSentHandlerTest {
     assertTrue(sep24TxnCapture.captured.completedAt <= endDate)
   }
 
-  @Test
-  fun test_handle_invalidStellarTransaction() {
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_STELLAR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_stellar], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_transferNotReceived(kind: String) {
+    val request = NotifyOnchainFundsSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_onchain_funds_sent] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok(kind: String) {
     val transferReceivedAt = Instant.now()
     val request =
       NotifyOnchainFundsSentRequest.builder()
         .transactionId(TX_ID)
         .stellarTransactionId(STELLAR_TX_ID)
         .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = transferReceivedAt
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    val operationRecordsTypeToken =
+      object : TypeToken<ArrayList<PaymentOperationResponse>>() {}.type
+    val operationRecords: ArrayList<OperationResponse> =
+      gson.fromJson(paymentOperationRecord, operationRecordsTypeToken)
+
+    val stellarTransactionsToken = object : TypeToken<List<StellarTransaction>>() {}.type
+    val stellarTransactions: List<StellarTransaction> =
+      gson.fromJson(stellarTransactions, stellarTransactionsToken)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-    every { horizon.getStellarTxnOperations(any()) } throws
-      IOException("Invalid stellar transaction")
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { horizon.getStellarTxnOperations(STELLAR_TX_ID) } returns operationRecords
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
 
-    val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
 
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = COMPLETED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
+    expectedSep6Txn.stellarTransactions = stellarTransactions
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = COMPLETED
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.stellarTransactions = stellarTransactions
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.completedAt <= endDate)
   }
 
   private val paymentOperationRecord =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
@@ -471,6 +471,7 @@ class NotifyOnchainFundsSentHandlerTest {
     expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
     expectedResponse.status = COMPLETED
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.stellarTransactions = stellarTransactions

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
@@ -55,7 +55,6 @@ class NotifyOnchainFundsSentHandlerTest {
     private const val TX_ID = "testId"
     private const val STELLAR_TX_ID = "stellarTxId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -420,7 +419,6 @@ class NotifyOnchainFundsSentHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -458,7 +456,6 @@ class NotifyOnchainFundsSentHandlerTest {
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
     expectedSep6Txn.stellarTransactionId = STELLAR_TX_ID
     expectedSep6Txn.stellarTransactions = stellarTransactions
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -475,8 +472,7 @@ class NotifyOnchainFundsSentHandlerTest {
     expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.stellarTransactions = stellarTransactions
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandlerTest.kt
@@ -40,6 +40,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyRefundPendingHandlerTest {
@@ -52,6 +53,8 @@ class NotifyRefundPendingHandlerTest {
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -78,6 +81,7 @@ class NotifyRefundPendingHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       NotifyRefundPendingHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
@@ -19,26 +19,19 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
-import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.RECEIVE
-import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.AmountAssetRequest
 import org.stellar.anchor.api.rpc.method.NotifyRefundSentRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
-import org.stellar.anchor.api.shared.Amount
-import org.stellar.anchor.api.shared.Customers
-import org.stellar.anchor.api.shared.RefundPayment
-import org.stellar.anchor.api.shared.Refunds
-import org.stellar.anchor.api.shared.StellarId
+import org.stellar.anchor.api.shared.*
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.event.EventService.EventQueue.TRANSACTION
 import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
+import org.stellar.anchor.platform.data.*
 import org.stellar.anchor.platform.data.JdbcSep24RefundPayment
 import org.stellar.anchor.platform.data.JdbcSep24Refunds
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
@@ -49,6 +42,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyRefundSentHandlerTest {
@@ -61,6 +55,8 @@ class NotifyRefundSentHandlerTest {
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -87,6 +83,7 @@ class NotifyRefundSentHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       NotifyRefundSentHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandlerTest.kt
@@ -47,7 +47,6 @@ class NotifyTransactionErrorHandlerTest {
     private const val TX_ID = "testId"
     private const val TX_MESSAGE = "testMessage"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -352,7 +351,6 @@ class NotifyTransactionErrorHandlerTest {
     txn6.id = TX_ID
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = DEPOSIT.kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -381,7 +379,6 @@ class NotifyTransactionErrorHandlerTest {
     expectedSep6Txn.status = ERROR.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.message = TX_MESSAGE
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -397,8 +394,7 @@ class NotifyTransactionErrorHandlerTest {
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.message = TX_MESSAGE
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
@@ -18,8 +18,7 @@ import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyTransactionExpiredRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
@@ -32,11 +31,13 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyTransactionExpiredHandlerTest {
@@ -46,7 +47,10 @@ class NotifyTransactionExpiredHandlerTest {
     private const val TX_ID = "testId"
     private const val TX_MESSAGE = "testMessage"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -75,6 +79,7 @@ class NotifyTransactionExpiredHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyTransactionExpiredHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -92,6 +97,7 @@ class NotifyTransactionExpiredHandlerTest {
     txn24.status = ERROR.toString()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -102,6 +108,7 @@ class NotifyTransactionExpiredHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -113,6 +120,7 @@ class NotifyTransactionExpiredHandlerTest {
     val txn24 = JdbcSep24Transaction()
     txn24.status = EXPIRED.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -122,6 +130,7 @@ class NotifyTransactionExpiredHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -133,6 +142,7 @@ class NotifyTransactionExpiredHandlerTest {
     val txn24 = JdbcSep24Transaction()
     txn24.status = COMPLETED.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -142,6 +152,7 @@ class NotifyTransactionExpiredHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -153,12 +164,14 @@ class NotifyTransactionExpiredHandlerTest {
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_ANCHOR.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("message is required", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -172,6 +185,7 @@ class NotifyTransactionExpiredHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -181,6 +195,7 @@ class NotifyTransactionExpiredHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -193,6 +208,7 @@ class NotifyTransactionExpiredHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -201,6 +217,7 @@ class NotifyTransactionExpiredHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -217,6 +234,7 @@ class NotifyTransactionExpiredHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -230,6 +248,7 @@ class NotifyTransactionExpiredHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { transactionPendingTrustRepo.deleteById(TX_ID) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
@@ -289,6 +308,7 @@ class NotifyTransactionExpiredHandlerTest {
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
@@ -298,6 +318,7 @@ class NotifyTransactionExpiredHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
 
     val expectedSep31Txn = JdbcSep31Transaction()
@@ -345,5 +366,85 @@ class NotifyTransactionExpiredHandlerTest {
 
     assertTrue(expectedSep31Txn.updatedAt >= startDate)
     assertTrue(expectedSep31Txn.updatedAt <= endDate)
+  }
+
+  @Test
+  fun test_handle_ok_sep6() {
+    val request =
+      NotifyTransactionExpiredRequest.builder().transactionId(TX_ID).message(TX_MESSAGE).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.id = TX_ID
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = DEPOSIT.kind
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { transactionPendingTrustRepo.deleteById(TX_ID) } just Runs
+    every { transactionPendingTrustRepo.existsById(TX_ID) } returns true
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { transactionPendingTrustRepo.deleteById(TX_ID) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.id = TX_ID
+    expectedSep6Txn.kind = DEPOSIT.kind
+    expectedSep6Txn.status = EXPIRED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.message = TX_MESSAGE
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.id = TX_ID
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = DEPOSIT
+    expectedResponse.status = EXPIRED
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.message = TX_MESSAGE
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
@@ -47,7 +47,6 @@ class NotifyTransactionExpiredHandlerTest {
     private const val TX_ID = "testId"
     private const val TX_MESSAGE = "testMessage"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -376,7 +375,6 @@ class NotifyTransactionExpiredHandlerTest {
     txn6.id = TX_ID
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = DEPOSIT.kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -405,7 +403,6 @@ class NotifyTransactionExpiredHandlerTest {
     expectedSep6Txn.status = EXPIRED.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.message = TX_MESSAGE
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -421,8 +418,7 @@ class NotifyTransactionExpiredHandlerTest {
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.message = TX_MESSAGE
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
@@ -46,7 +46,6 @@ class NotifyTransactionRecoveryHandlerTest {
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
     private const val TX_MESSAGE = "testMessage"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -313,7 +312,6 @@ class NotifyTransactionRecoveryHandlerTest {
     txn6.kind = DEPOSIT.kind
     txn6.message = TX_MESSAGE
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -338,7 +336,6 @@ class NotifyTransactionRecoveryHandlerTest {
     expectedSep6Txn.status = PENDING_ANCHOR.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -353,8 +350,7 @@ class NotifyTransactionRecoveryHandlerTest {
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
@@ -352,6 +352,7 @@ class NotifyTransactionRecoveryHandlerTest {
     expectedResponse.status = PENDING_ANCHOR
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
@@ -18,13 +18,9 @@ import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyTransactionRecoveryRequest
-import org.stellar.anchor.api.sep.SepTransactionStatus.ERROR
-import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR
-import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER
+import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.api.shared.Customers
 import org.stellar.anchor.api.shared.StellarId
@@ -35,10 +31,12 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyTransactionRecoveryHandlerTest {
@@ -48,7 +46,10 @@ class NotifyTransactionRecoveryHandlerTest {
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
     private const val TX_MESSAGE = "testMessage"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -74,6 +75,7 @@ class NotifyTransactionRecoveryHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyTransactionRecoveryHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -91,6 +93,7 @@ class NotifyTransactionRecoveryHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -101,6 +104,7 @@ class NotifyTransactionRecoveryHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -113,6 +117,7 @@ class NotifyTransactionRecoveryHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -122,6 +127,7 @@ class NotifyTransactionRecoveryHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -133,6 +139,7 @@ class NotifyTransactionRecoveryHandlerTest {
     val txn24 = JdbcSep24Transaction()
     txn24.status = ERROR.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -142,6 +149,7 @@ class NotifyTransactionRecoveryHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -155,6 +163,7 @@ class NotifyTransactionRecoveryHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -163,6 +172,7 @@ class NotifyTransactionRecoveryHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -180,6 +190,7 @@ class NotifyTransactionRecoveryHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -191,6 +202,7 @@ class NotifyTransactionRecoveryHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -247,6 +259,7 @@ class NotifyTransactionRecoveryHandlerTest {
     txn31.requiredInfoMessage = TX_MESSAGE
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
@@ -255,6 +268,7 @@ class NotifyTransactionRecoveryHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
 
     val expectedSep31Txn = JdbcSep31Transaction()
@@ -288,5 +302,80 @@ class NotifyTransactionRecoveryHandlerTest {
 
     assertTrue(sep31TxnCapture.captured.updatedAt >= startDate)
     assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @Test
+  fun test_handle_ok_sep6() {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyTransactionRecoveryRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = ERROR.toString()
+    txn6.kind = DEPOSIT.kind
+    txn6.message = TX_MESSAGE
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = DEPOSIT.kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = DEPOSIT
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTrustSetHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTrustSetHandlerTest.kt
@@ -35,6 +35,7 @@ import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTIO
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class NotifyTrustSetHandlerTest {
@@ -44,6 +45,8 @@ class NotifyTrustSetHandlerTest {
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -73,6 +76,7 @@ class NotifyTrustSetHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       NotifyTrustSetHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandlerTest.kt
@@ -46,7 +46,6 @@ class RequestCustomerInfoUpdateHandlerTest {
     private val gson = GsonUtils.getInstance()
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -274,7 +273,6 @@ class RequestCustomerInfoUpdateHandlerTest {
     val txn6 = JdbcSep6Transaction()
     txn6.status = status
     txn6.kind = kind
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -297,7 +295,6 @@ class RequestCustomerInfoUpdateHandlerTest {
     expectedSep6Txn.kind = kind
     expectedSep6Txn.status = PENDING_CUSTOMER_INFO_UPDATE.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
     expectedSep6Txn.requiredCustomerInfoUpdates =
       listOf("email_address", "family_name", "given_name")
 
@@ -313,8 +310,7 @@ class RequestCustomerInfoUpdateHandlerTest {
     expectedResponse.status = PENDING_CUSTOMER_INFO_UPDATE
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.requiredCustomerInfoUpdates =
       listOf("email_address", "family_name", "given_name")
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -17,15 +19,18 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.AmountAssetRequest
 import org.stellar.anchor.api.rpc.method.AmountRequest
 import org.stellar.anchor.api.rpc.method.RequestOffchainFundsRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.InstructionField
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.event.EventService
@@ -33,10 +38,12 @@ import org.stellar.anchor.event.EventService.EventQueue.TRANSACTION
 import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class RequestOffchainFundsHandlerTest {
@@ -49,7 +56,10 @@ class RequestOffchainFundsHandlerTest {
       "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -76,6 +86,7 @@ class RequestOffchainFundsHandlerTest {
     this.assetService = DefaultAssetService.fromJsonResource("test_assets.json")
     this.handler =
       RequestOffchainFundsHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -93,6 +104,7 @@ class RequestOffchainFundsHandlerTest {
     txn24.kind = DEPOSIT.kind
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -103,6 +115,7 @@ class RequestOffchainFundsHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -115,6 +128,7 @@ class RequestOffchainFundsHandlerTest {
     txn24.status = PENDING_EXTERNAL.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -124,49 +138,7 @@ class RequestOffchainFundsHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_transferReceived() {
-    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[request_offchain_funds] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[true]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedKind() {
-    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[request_offchain_funds] is not supported. Status[incomplete], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -179,6 +151,7 @@ class RequestOffchainFundsHandlerTest {
     txn24.status = INCOMPLETE.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -187,13 +160,250 @@ class RequestOffchainFundsHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok_withExpectedAmount() {
+  fun test_handle_withoutAmounts_amountsAbsent() {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("amount_in is required", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_withoutAmounts_amount_out_absent() {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.amountIn = "1"
+    txn24.amountInAsset = FIAT_USD
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("amount_out is required", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_withoutAmounts_amount_fee_absent() {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.amountIn = "1"
+    txn24.amountInAsset = FIAT_USD
+    txn24.amountOut = "0.9"
+    txn24.amountOutAsset = STELLAR_USDC
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("amount_fee is required", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_notAllAmounts() {
+    val request =
+      RequestOffchainFundsRequest.builder()
+        .amountIn(AmountAssetRequest("1", FIAT_USD))
+        .amountOut(AmountAssetRequest("1", FIAT_USD))
+        .transactionId(TX_ID)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(
+      "All or none of the amount_in, amount_out, and amount_fee should be set",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidAmounts() {
+    val request =
+      RequestOffchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", FIAT_USD))
+        .amountOut(AmountAssetRequest("1", STELLAR_USDC))
+        .amountFee(AmountAssetRequest("1", FIAT_USD))
+        .amountExpected(AmountRequest("1"))
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.requestAssetCode = FIAT_USD_CODE
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    request.amountIn.amount = "-1"
+    var ex = assertThrows<BadRequestException> { handler.handle(request) }
+    assertEquals("amount_in.amount should be positive", ex.message)
+    request.amountIn.amount = "1"
+
+    request.amountOut.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_out.amount should be positive", ex.message)
+    request.amountOut.amount = "1"
+
+    request.amountFee.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_fee.amount should be non-negative", ex.message)
+    request.amountFee.amount = "1"
+
+    request.amountExpected.amount = "-1"
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_expected.amount should be positive", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_invalidAssets() {
+    val request =
+      RequestOffchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", FIAT_USD))
+        .amountOut(AmountAssetRequest("1", STELLAR_USDC))
+        .amountFee(AmountAssetRequest("1", FIAT_USD))
+        .amountExpected(AmountRequest("1"))
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.requestAssetCode = FIAT_USD_CODE
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    request.amountIn.asset = STELLAR_USDC
+    var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("amount_in.asset should be non-stellar asset", ex.message)
+    request.amountIn.asset = FIAT_USD
+
+    request.amountOut.asset = FIAT_USD
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_out.asset should be stellar asset", ex.message)
+    request.amountOut.asset = STELLAR_USDC
+
+    request.amountFee.asset = STELLAR_USDC
+    ex = assertThrows { handler.handle(request) }
+    assertEquals("amount_fee.asset should be non-stellar asset", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_transferReceived() {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_offchain_funds] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedKind() {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_offchain_funds] is not supported. Status[incomplete], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok_withExpectedAmount() {
     val request =
       RequestOffchainFundsRequest.builder()
         .transactionId(TX_ID)
@@ -209,6 +419,7 @@ class RequestOffchainFundsHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -220,6 +431,7 @@ class RequestOffchainFundsHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -277,7 +489,7 @@ class RequestOffchainFundsHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_withoutAmountExpected() {
+  fun test_handle_sep24_ok_withoutAmountExpected() {
     val request =
       RequestOffchainFundsRequest.builder()
         .transactionId(TX_ID)
@@ -303,6 +515,7 @@ class RequestOffchainFundsHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -360,7 +573,7 @@ class RequestOffchainFundsHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_withoutAmounts_amountsPresent() {
+  fun test_handle_sep24_ok_withoutAmounts_amountsPresent() {
     val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = INCOMPLETE.toString()
@@ -376,6 +589,7 @@ class RequestOffchainFundsHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -387,6 +601,7 @@ class RequestOffchainFundsHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -444,179 +659,363 @@ class RequestOffchainFundsHandlerTest {
   }
 
   @Test
-  fun test_handle_withoutAmounts_amountsAbsent() {
+  fun test_handle_sep6_transferReceived() {
     val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = DEPOSIT.kind
+    txn6.transferReceivedAt = Instant.now()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(any()) } returns txn6
+    every { txn24Store.findByTransactionId(TX_ID) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("amount_in is required", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_withoutAmounts_amount_out_absent() {
-    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.amountIn = "1"
-    txn24.amountInAsset = FIAT_USD
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("amount_out is required", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_withoutAmounts_amount_fee_absent() {
-    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.amountIn = "1"
-    txn24.amountInAsset = FIAT_USD
-    txn24.amountOut = "0.9"
-    txn24.amountOutAsset = STELLAR_USDC
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("amount_fee is required", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_notAllAmounts() {
-    val request =
-      RequestOffchainFundsRequest.builder()
-        .amountIn(AmountAssetRequest("1", FIAT_USD))
-        .amountOut(AmountAssetRequest("1", FIAT_USD))
-        .transactionId(TX_ID)
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
     assertEquals(
-      "All or none of the amount_in, amount_out, and amount_fee should be set",
+      "RPC method[request_offchain_funds] is not supported. Status[pending_anchor], kind[deposit], protocol[6], funds received[true]",
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
-  @Test
-  fun test_handle_invalidAmounts() {
-    val request =
-      RequestOffchainFundsRequest.builder()
-        .transactionId(TX_ID)
-        .amountIn(AmountAssetRequest("1", FIAT_USD))
-        .amountOut(AmountAssetRequest("1", STELLAR_USDC))
-        .amountFee(AmountAssetRequest("1", FIAT_USD))
-        .amountExpected(AmountRequest("1"))
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.requestAssetCode = FIAT_USD_CODE
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = RequestOffchainFundsRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    request.amountIn.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_in.amount should be positive", ex.message)
-    request.amountIn.amount = "1"
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_offchain_funds] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
 
-    request.amountOut.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
-    request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_fee.amount should be non-negative", ex.message)
-    request.amountFee.amount = "1"
-
-    request.amountExpected.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_expected.amount should be positive", ex.message)
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
-  @Test
-  fun test_handle_invalidAssets() {
+  @CsvSource(
+    value =
+      [
+        "deposit, incomplete",
+        "deposit, pending_anchor",
+        "deposit, pending_customer_info_update",
+        "deposit-exchange, incomplete",
+        "deposit-exchange, pending_anchor",
+        "deposit-exchange, pending_customer_info_update"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withExpectedAmount(kind: String, status: String) {
     val request =
       RequestOffchainFundsRequest.builder()
         .transactionId(TX_ID)
         .amountIn(AmountAssetRequest("1", FIAT_USD))
-        .amountOut(AmountAssetRequest("1", STELLAR_USDC))
-        .amountFee(AmountAssetRequest("1", FIAT_USD))
+        .amountOut(AmountAssetRequest("0.9", STELLAR_USDC))
+        .amountFee(AmountAssetRequest("0.1", FIAT_USD))
         .amountExpected(AmountRequest("1"))
+        .instructions(mapOf("first_name" to InstructionField.builder().build()))
         .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.requestAssetCode = FIAT_USD_CODE
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = status
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
 
-    request.amountIn.asset = STELLAR_USDC
-    var ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("amount_in.asset should be non-stellar asset", ex.message)
-    request.amountIn.asset = FIAT_USD
-
-    request.amountOut.asset = FIAT_USD
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.asset should be stellar asset", ex.message)
-    request.amountOut.asset = STELLAR_USDC
-
-    request.amountFee.asset = STELLAR_USDC
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_fee.asset should be non-stellar asset", ex.message)
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
 
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.amountExpected = "1"
+    expectedSep6Txn.customer = CUSTOMER_ID
+    expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_USR_TRANSFER_START
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.amountExpected = Amount("1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, incomplete",
+        "deposit, pending_anchor",
+        "deposit, pending_customer_info_update",
+        "deposit-exchange, incomplete",
+        "deposit-exchange, pending_anchor",
+        "deposit-exchange, pending_customer_info_update"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withoutAmountExpected(kind: String, status: String) {
+    val request =
+      RequestOffchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", FIAT_USD))
+        .amountOut(AmountAssetRequest("0.9", STELLAR_USDC))
+        .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+        .instructions(mapOf("first_name" to InstructionField.builder().build()))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = status
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.amountExpected = "1"
+    expectedSep6Txn.customer = CUSTOMER_ID
+    expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_USR_TRANSFER_START
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.amountExpected = Amount("1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, incomplete",
+        "deposit, pending_anchor",
+        "deposit, pending_customer_info_update",
+        "deposit-exchange, incomplete",
+        "deposit-exchange, pending_anchor",
+        "deposit-exchange, pending_customer_info_update"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withoutAmounts_amountsPresent(kind: String, status: String) {
+    val request =
+      RequestOffchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .instructions(mapOf("first_name" to InstructionField.builder().build()))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = status
+    txn6.kind = kind
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "1"
+    txn6.amountInAsset = FIAT_USD
+    txn6.amountOut = "0.9"
+    txn6.amountOutAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = STELLAR_USDC
+    txn6.amountExpected = "1"
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = FIAT_USD
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
+    expectedSep6Txn.amountExpected = "1"
+    expectedSep6Txn.customer = CUSTOMER_ID
+    expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_USR_TRANSFER_START
+    expectedResponse.amountIn = Amount("1", FIAT_USD)
+    expectedResponse.amountOut = Amount("0.9", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
+    expectedResponse.amountExpected = Amount("1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
@@ -56,7 +56,6 @@ class RequestOffchainFundsHandlerTest {
       "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
     private const val FIAT_USD_CODE = "USD"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -732,7 +731,6 @@ class RequestOffchainFundsHandlerTest {
     txn6.status = status
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -764,7 +762,6 @@ class RequestOffchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = FIAT_USD
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.customer = CUSTOMER_ID
     expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(
@@ -782,8 +779,7 @@ class RequestOffchainFundsHandlerTest {
     expectedResponse.amountFee = Amount("0.1", FIAT_USD)
     expectedResponse.amountExpected = Amount("1", FIAT_USD)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(
@@ -835,7 +831,6 @@ class RequestOffchainFundsHandlerTest {
     txn6.status = status
     txn6.kind = kind
     txn6.requestAssetCode = FIAT_USD_CODE
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -866,7 +861,6 @@ class RequestOffchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = FIAT_USD
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.customer = CUSTOMER_ID
     expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(
@@ -884,8 +878,7 @@ class RequestOffchainFundsHandlerTest {
     expectedResponse.amountFee = Amount("0.1", FIAT_USD)
     expectedResponse.amountExpected = Amount("1", FIAT_USD)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(
@@ -941,7 +934,6 @@ class RequestOffchainFundsHandlerTest {
     txn6.amountFee = "0.1"
     txn6.amountFeeAsset = STELLAR_USDC
     txn6.amountExpected = "1"
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -973,7 +965,6 @@ class RequestOffchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.customer = CUSTOMER_ID
     expectedSep6Txn.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(
@@ -991,8 +982,7 @@ class RequestOffchainFundsHandlerTest {
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.amountExpected = Amount("1", FIAT_USD)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.instructions = mapOf("first_name" to InstructionField.builder().build())
 
     JSONAssert.assertEquals(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -73,7 +73,6 @@ class RequestOnchainFundsHandlerTest {
     private const val DESTINATION_ACCOUNT = "testDestinationAccount"
     private const val DESTINATION_ACCOUNT_2 = "testDestinationAccount2"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -1221,7 +1220,6 @@ class RequestOnchainFundsHandlerTest {
     txn6.kind = kind
     txn6.requestAssetCode = STELLAR_USDC_CODE
     txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -1259,7 +1257,6 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
     expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1279,8 +1276,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -1324,7 +1320,6 @@ class RequestOnchainFundsHandlerTest {
     txn6.kind = kind
     txn6.requestAssetCode = STELLAR_USDC_CODE
     txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -1361,7 +1356,6 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
     expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1381,8 +1375,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),
@@ -1430,7 +1423,6 @@ class RequestOnchainFundsHandlerTest {
     txn6.amountFee = "0.1"
     txn6.amountFeeAsset = STELLAR_USDC
     txn6.amountExpected = "1"
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -1468,7 +1460,6 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
     expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1488,8 +1479,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
@@ -48,7 +48,6 @@ class RequestTrustlineHandlerTest {
     private val gson = GsonUtils.getInstance()
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
-    private const val CUSTOMER_ID = "testCustomerId"
   }
 
   @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
@@ -364,7 +363,6 @@ class RequestTrustlineHandlerTest {
     txn6.status = PENDING_ANCHOR.toString()
     txn6.kind = kind
     txn6.transferReceivedAt = transferReceivedAt
-    txn6.customer = CUSTOMER_ID
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -390,7 +388,6 @@ class RequestTrustlineHandlerTest {
     expectedSep6Txn.status = PENDING_TRUST.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedSep6Txn.transferReceivedAt = transferReceivedAt
-    expectedSep6Txn.customer = CUSTOMER_ID
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -405,8 +402,7 @@ class RequestTrustlineHandlerTest {
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.customers =
-      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
@@ -404,6 +404,7 @@ class RequestTrustlineHandlerTest {
     expectedResponse.status = PENDING_TRUST
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
     expectedResponse.customers =
       Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestTrustlineHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -16,13 +18,15 @@ import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.RequestTrustRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR
 import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_TRUST
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.config.CustodyConfig
 import org.stellar.anchor.event.EventService
@@ -30,10 +34,12 @@ import org.stellar.anchor.event.EventService.EventQueue.TRANSACTION
 import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
 class RequestTrustlineHandlerTest {
@@ -42,7 +48,10 @@ class RequestTrustlineHandlerTest {
     private val gson = GsonUtils.getInstance()
     private const val TX_ID = "testId"
     private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+    private const val CUSTOMER_ID = "testCustomerId"
   }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
@@ -70,6 +79,7 @@ class RequestTrustlineHandlerTest {
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     this.handler =
       RequestTrustlineHandler(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -89,6 +99,7 @@ class RequestTrustlineHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -99,35 +110,14 @@ class RequestTrustlineHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_unsupportedStatus() {
-    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_TRUST.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[request_trust] is not supported. Status[pending_trust], kind[deposit], protocol[24], funds received[true]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_handle_custodyIntegrationEnabled() {
+  fun test_handle_custodyIntegrationEnabled() {
     val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_ANCHOR.toString()
@@ -135,34 +125,14 @@ class RequestTrustlineHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
     val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
     assertEquals("RPC method[request_trust] requires disabled custody integration", ex.message)
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_transferNotReceived() {
-    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-    every { custodyConfig.isCustodyIntegrationEnabled } returns false
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[request_trust] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -176,6 +146,7 @@ class RequestTrustlineHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -184,13 +155,62 @@ class RequestTrustlineHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok() {
+  fun test_handle_sep24_transferNotReceived() {
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_trust] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_TRUST.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_trust] is not supported. Status[pending_trust], kind[deposit], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok() {
     val transferReceivedAt = Instant.now()
     val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
@@ -200,6 +220,7 @@ class RequestTrustlineHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -212,6 +233,7 @@ class RequestTrustlineHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -256,5 +278,156 @@ class RequestTrustlineHandlerTest {
 
     assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
     assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_transferNotReceived(kind: String) {
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_trust] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_trust] is not supported. Status[pending_trust], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[request_trust] is not supported. Status[pending_trust], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = RequestTrustRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.customer = CUSTOMER_ID
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(AnchorMetrics.PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_TRUST.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.customer = CUSTOMER_ID
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_TRUST
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers =
+      Customers(StellarId(CUSTOMER_ID, null), StellarId(CUSTOMER_ID, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RpcMethodHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RpcMethodHandlerTest.kt
@@ -1,7 +1,9 @@
 package org.stellar.anchor.platform.rpc
 
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -23,11 +25,13 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
 
 class RpcMethodHandlerTest {
 
   // test implementation
   class RpcMethodHandlerTestImpl(
+    txn6Store: Sep6TransactionStore,
     txn24Store: Sep24TransactionStore,
     txn31Store: Sep31TransactionStore,
     requestValidator: RequestValidator,
@@ -36,6 +40,7 @@ class RpcMethodHandlerTest {
     metricsService: MetricsService
   ) :
     RpcMethodHandler<NotifyInteractiveFlowCompletedRequest>(
+      txn6Store,
       txn24Store,
       txn31Store,
       requestValidator,
@@ -69,6 +74,8 @@ class RpcMethodHandlerTest {
     private const val TX_ID = "testId"
   }
 
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
+
   @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
 
   @MockK(relaxed = true) private lateinit var txn31Store: Sep31TransactionStore
@@ -88,6 +95,7 @@ class RpcMethodHandlerTest {
     MockKAnnotations.init(this, relaxUnitFun = true)
     this.handler =
       RpcMethodHandlerTestImpl(
+        txn6Store,
         txn24Store,
         txn31Store,
         requestValidator,
@@ -103,12 +111,14 @@ class RpcMethodHandlerTest {
     val tnx24 = JdbcSep24Transaction()
     tnx24.status = INCOMPLETE.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
 
     val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
     assertEquals("Transaction with id[testId] is not found", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -12,14 +12,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.stellar.anchor.api.exception.SepException
-import org.stellar.anchor.api.platform.PatchTransactionsRequest
-import org.stellar.anchor.api.platform.PatchTransactionsResponse
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.sep.SepTransactionStatus
-import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.api.shared.StellarId
-import org.stellar.anchor.api.shared.StellarPayment
-import org.stellar.anchor.api.shared.StellarTransaction
 import org.stellar.anchor.apiclient.PlatformApiClient
 import org.stellar.anchor.platform.config.RpcConfig
 import org.stellar.anchor.platform.data.*
@@ -487,7 +482,7 @@ class PaymentOperationToEventListenerTest {
     val transferReceivedAtStr = DateTimeFormatter.ISO_INSTANT.format(transferReceivedAt)
     val asset = createAsset(assetType, assetCode, assetIssuer)
 
-    val payment =
+    val p =
       ObservedPayment.builder()
         .transactionHash("1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30")
         .transactionMemo("39623738663066612d393366392d343139382d386439332d6537366664303834")
@@ -510,21 +505,23 @@ class PaymentOperationToEventListenerTest {
 
     val slotMemo = slot<String>()
     val slotStatus = slot<String>()
-    val sep6Txn = JdbcSep24Transaction()
-    sep6Txn.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
-    sep6Txn.requestAssetCode = assetCode
-    sep6Txn.requestAssetIssuer = assetIssuer
-    sep6Txn.amountExpected = "10.0000000"
-    sep6Txn.memo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ"
-    sep6Txn.memoType = "hash"
+    val sep6TxMock = JdbcSep6Transaction()
+    sep6TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
+    sep6TxMock.requestAssetCode = assetCode
+    sep6TxMock.requestAssetIssuer = assetIssuer
+    sep6TxMock.amountExpected = "10.0000000"
+    sep6TxMock.memo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ"
+    sep6TxMock.memoType = "hash"
+    sep6TxMock.kind = PlatformTransactionData.Kind.WITHDRAWAL.kind
 
+    // TODO: this shouldn't be necessary
     every {
       sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(any(), any(), any())
     } returns null
     every { sep24TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
       null
 
-    val sep6TxnCopy = gson.fromJson(gson.toJson(sep6Txn), JdbcSep6Transaction::class.java)
+    val sep6TxnCopy = gson.fromJson(gson.toJson(sep6TxMock), JdbcSep6Transaction::class.java)
     every {
       sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
@@ -533,35 +530,22 @@ class PaymentOperationToEventListenerTest {
       )
     } returns sep6TxnCopy
 
-    val patchTxnRequestSlot = slot<PatchTransactionsRequest>()
-    every { platformApiClient.patchTransaction(capture(patchTxnRequestSlot)) } answers
-      {
-        PatchTransactionsResponse(emptyList())
-      }
+    val txnIdCapture = slot<String>()
+    val stellarTxnIdCapture = slot<String>()
+    val amountCapture = slot<String>()
+    val messageCapture = slot<String>()
 
-    val stellarTransaction =
-      StellarTransaction.builder()
-        .id("1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30")
-        .memo("OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ")
-        .memoType("hash")
-        .createdAt(transferReceivedAt)
-        .envelope(
-          "AAAAAgAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAAAB9AAAACwAAAABAAAAAEAAAAAAAAAAAAAAABiMbeEAAAAAAAAABQAAAAAAAAAAAAAAADcXPrnCDi+IDcGSvu/HjP779qjBv6K9Sie8i3WDySaIgAAAAA8M2CAAAAAAAAAAAAAAAAAJXdMB+xylKwEPk1tOLU82vnDM0u15RsK6/HCKsY1O3MAAAAAPDNggAAAAAAAAAAAAAAAALn+JaJ9iXEcrPeRFqEMGo6WWFeOwW15H/vvCOuMqCsSAAAAADwzYIAAAAAAAAAAAAAAAADbWpHlX0LQjIjY0x8jWkclnQDK8jFmqhzCmB+1EusXwAAAAAA8M2CAAAAAAAAAAAAAAAAAmy3UTqTnhNzIg8TjCYiRh9l07ls0Hi5FTqelhfZ4KqAAAAAAPDNggAAAAAAAAAAAAAAAAIwiZIIbYJn7MbHrrM+Pg85c6Lcn0ZGLb8NIiXLEIPTnAAAAADwzYIAAAAAAAAAAAAAAAAAYEjPKA/6lDpr/w1Cfif2hK4GHeNODhw0kk4kgLrmPrQAAAAA8M2CAAAAAAAAAAAAAAAAASMrE32C3vL39cj84pIg2mt6OkeWBz5OSZn0eypcjS4IAAAAAPDNggAAAAAAAAAAAAAAAAIuxsI+2mSeh3RkrkcpQ8bMqE7nXUmdvgwyJS/dBThIPAAAAADwzYIAAAAAAAAAAAAAAAACuZxdjR/GXaymdc9y5WFzz2A8Yk5hhgzBZsQ9R0/BmZwAAAAA8M2CAAAAAAAAAAAAAAAAAAtWBvyq0ToNovhQHSLeQYu7UzuqbVrm0i3d1TjRm7WEAAAAAPDNggAAAAAAAAAAAAAAAANtrzNON0u1IEGKmVsm80/Av+BKip0ioeS/4E+Ejs9YPAAAAADwzYIAAAAAAAAAAAAAAAAD+ejNcgNcKjR/ihUx1ikhdz5zmhzvRET3LGd7oOiBlTwAAAAA8M2CAAAAAAAAAAAAAAAAASXG3P6KJjS6e0dzirbso8vRvZKo6zETUsEv7OSP8XekAAAAAPDNggAAAAAAAAAAAAAAAAC5orVpxxvGEB8ISTho2YdOPZJrd7UBj1Bt8TOjLOiEKAAAAADwzYIAAAAAAAAAAAAAAAAAOQR7AqdGyIIMuFLw9JQWtHqsUJD94kHum7SJS9PXkOwAAAAA8M2CAAAAAAAAAAAAAAAAAIosijRx7xSP/+GA6eAjGeV9wJtKDySP+OJr90euE1yQAAAAAPDNggAAAAAAAAAAAAAAAAKlHXWQvwNPeT4Pp1oJDiOpcKwS3d9sho+ha+6pyFwFqAAAAADwzYIAAAAAAAAAAAAAAAABjCjnoL8+FEP0LByZA9PfMLwU1uAX4Cb13rVs83e1UZAAAAAA8M2CAAAAAAAAAAAAAAAAAokhNCZNGq9uAkfKTNoNGr5XmmMoY5poQEmp8OVbit7IAAAAAPDNggAAAAAAAAAABhlbgnAAAAEBa9csgF5/0wxrYM6oVsbM4Yd+/3uVIplS6iLmPOS4xf8oLQLtjKKKIIKmg9Gc/yYm3icZyU7icy9hGjcujenMN"
-        )
-        .payments(
-          listOf(
-            StellarPayment.builder()
-              .id("755914248193")
-              .paymentType(StellarPayment.Type.PAYMENT)
-              .sourceAccount("GAJKV32ZXP5QLYHPCMLTV5QCMNJR3W6ZKFP6HMDN67EM2ULDHHDGEZYO")
-              .destinationAccount("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364")
-              .amount(Amount("10.0000000", asset.toString()))
-              .build()
-          )
-        )
-        .build()
+    every { rpcConfig.customMessages.incomingPaymentReceived } returns "payment received"
+    every {
+      platformApiClient.notifyOnchainFundsReceived(
+        capture(txnIdCapture),
+        capture(stellarTxnIdCapture),
+        capture(amountCapture),
+        capture(messageCapture)
+      )
+    } just Runs
 
-    paymentOperationToEventListener.onReceived(payment)
+    paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
@@ -570,16 +554,10 @@ class PaymentOperationToEventListenerTest {
       )
     }
 
-    val capturedRequest = patchTxnRequestSlot.captured.records[0]
-    assertEquals(
-      SepTransactionStatus.PENDING_ANCHOR.status.toString(),
-      capturedRequest.transaction.status.toString()
-    )
-    assertEquals(stellarTransaction.id, capturedRequest.transaction.stellarTransactions[0].id)
-    assertEquals(transferReceivedAt, capturedRequest.transaction.transferReceivedAt)
-    assertEquals(transferReceivedAt, capturedRequest.transaction.updatedAt)
-    assertEquals(listOf(stellarTransaction), capturedRequest.transaction.stellarTransactions)
-    assertEquals(sep6Txn.id, capturedRequest.transaction.id)
+    assertEquals(sep6TxMock.id, txnIdCapture.captured)
+    assertEquals(p.transactionHash, stellarTxnIdCapture.captured)
+    assertEquals(p.amount, amountCapture.captured)
+    assertEquals("payment received", messageCapture.captured)
   }
 
   private fun createAsset(assetType: String, assetCode: String, assetIssuer: String?): Asset {


### PR DESCRIPTION
### Description

This updates the RPC actions for SEP-6 and updates the reference server implementation to use them. This PR is quite large as it updates the unit tests for most of the RPC actions but, implementation-wise, not much has changed. It might helpful to start by reviewing the `Sep6End2EndTest`  to get a sense of what changed with this PR.

### Context

SEP-6 should support RPC API.

### Testing

- `./gradlew test`

### Known limitations

- Platform API integration tests do not test the new flow but are covered by the SEP-6 e2e tests.
- Refunds and custody service integration have not been implemented.

Both of these will be addressed by ANCHOR-508

