### PR TITLE
[ANCHOR-518] Add @LockAndMockStatic and @LockStatic annotations

### DIFF
--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -22,8 +22,8 @@ class AuthHelperTest {
   @ParameterizedTest
   @EnumSource(AuthType::class)
   fun `test AuthHeader creation based on the AuthType`(authType: AuthType) {
-    val calendarSingleton = mockk<Calendar>(relaxed = true)
     lockAndMockStatic(Calendar::class) {
+      val calendarSingleton = mockk<Calendar>(relaxed = true)
       // Mock calendar to guarantee the jwt token format
       when (authType) {
         JWT -> {

--- a/core/src/test/kotlin/org/stellar/anchor/util/LogTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/LogTest.kt
@@ -8,14 +8,17 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
+import org.stellar.anchor.LockAndMockStatic
+import org.stellar.anchor.LockAndMockTest
 import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.PII
-import org.stellar.anchor.lockAndMockStatic
 import org.stellar.anchor.util.Log.shorter
 import org.stellar.sdk.Network.TESTNET
 
 @Disabled
+@ExtendWith(LockAndMockTest::class)
 internal class LogTest {
   @MockK(relaxed = true) private lateinit var logger: Logger
 
@@ -40,48 +43,46 @@ internal class LogTest {
   val wantTestPIIJson = """{"fieldNoPII":"no secret"}"""
 
   @Test
+  @LockAndMockStatic([Log::class])
   fun `test log messages`() {
-    lockAndMockStatic(Log::class) {
-      every { Log.getLogger() } returns logger
+    every { Log.getLogger() } returns logger
 
-      Log.error("Hello")
-      verify { logger.error("Hello") }
+    Log.error("Hello")
+    verify { logger.error("Hello") }
 
-      Log.warn("Hello")
-      verify { logger.warn("Hello") }
+    Log.warn("Hello")
+    verify { logger.warn("Hello") }
 
-      Log.info("Hello")
-      verify { logger.info("Hello") }
+    Log.info("Hello")
+    verify { logger.info("Hello") }
 
-      Log.debug("Hello")
-      verify { logger.debug("Hello") }
+    Log.debug("Hello")
+    verify { logger.debug("Hello") }
 
-      Log.trace("Hello")
-      verify { logger.trace("Hello") }
-    }
+    Log.trace("Hello")
+    verify { logger.trace("Hello") }
   }
 
   @Test
+  @LockAndMockStatic([Log::class])
   fun `test log messages with JSON format`() {
-    lockAndMockStatic(Log::class) {
-      every { Log.getLogger() } returns logger
-      val detail = TestBeanPII()
+    every { Log.getLogger() } returns logger
+    val detail = TestBeanPII()
 
-      Log.error("Hello", detail)
-      verify { logger.error("Hello$wantTestPIIJson") }
+    Log.error("Hello", detail)
+    verify { logger.error("Hello$wantTestPIIJson") }
 
-      Log.warn("Hello", detail)
-      verify { logger.warn("Hello$wantTestPIIJson") }
+    Log.warn("Hello", detail)
+    verify { logger.warn("Hello$wantTestPIIJson") }
 
-      Log.info("Hello", detail)
-      verify { logger.info("Hello$wantTestPIIJson") }
+    Log.info("Hello", detail)
+    verify { logger.info("Hello$wantTestPIIJson") }
 
-      Log.debug("Hello", detail)
-      verify { logger.debug("Hello$wantTestPIIJson") }
+    Log.debug("Hello", detail)
+    verify { logger.debug("Hello$wantTestPIIJson") }
 
-      Log.trace("Hello", detail)
-      verify { logger.trace("Hello$wantTestPIIJson") }
-    }
+    Log.trace("Hello", detail)
+    verify { logger.trace("Hello$wantTestPIIJson") }
   }
 
   @Suppress("unused")
@@ -104,21 +105,20 @@ internal class LogTest {
   }
 
   @Test
+  @LockAndMockStatic([Log::class])
   fun `test errorEx`() {
-    lockAndMockStatic(Log::class) {
-      every { logger.error(any()) } answers {}
+    every { logger.error(any()) } answers {}
 
-      every { Log.getLogger() } returns logger
-      Log.errorEx(Exception("mock exception"))
-      verify(exactly = 1) { logger.error(ofType(String::class)) }
+    every { Log.getLogger() } returns logger
+    Log.errorEx(Exception("mock exception"))
+    verify(exactly = 1) { logger.error(ofType(String::class)) }
 
-      val slot = slot<String>()
-      every { logger.error(capture(slot)) } answers {}
+    val slot = slot<String>()
+    every { logger.error(capture(slot)) } answers {}
 
-      Log.errorEx("Hello", Exception("mock exception"))
-      assertTrue(slot.captured.contains("Hello"))
-      assertTrue(slot.captured.contains("mock exception"))
-    }
+    Log.errorEx("Hello", Exception("mock exception"))
+    assertTrue(slot.captured.contains("Hello"))
+    assertTrue(slot.captured.contains("mock exception"))
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/NetUtilTest.kt
@@ -12,14 +12,17 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.stellar.anchor.lockAndMockStatic
+import org.stellar.anchor.LockAndMockStatic
+import org.stellar.anchor.LockAndMockTest
 import org.stellar.anchor.util.NetUtil.*
 
 @Order(100)
+@ExtendWith(LockAndMockTest::class)
 internal class NetUtilTest {
   @MockK private lateinit var mockCall: okhttp3.Call
 
@@ -33,45 +36,42 @@ internal class NetUtilTest {
   }
 
   @Test
+  @LockAndMockStatic([NetUtil::class])
   fun `test fetch successful response`() {
-    lockAndMockStatic(NetUtil::class) {
-      every { getCall(any()) } returns mockCall
-      every { mockCall.execute() } returns mockResponse
-      every { mockResponse.isSuccessful } returns true
-      every { mockResponse.body } returns mockResponseBody
-      every { mockResponseBody.string() } returns "result"
+    every { getCall(any()) } returns mockCall
+    every { mockCall.execute() } returns mockResponse
+    every { mockResponse.isSuccessful } returns true
+    every { mockResponse.body } returns mockResponseBody
+    every { mockResponseBody.string() } returns "result"
 
-      val result = fetch("http://hello")
-      assertEquals("result", result)
+    val result = fetch("http://hello")
+    assertEquals("result", result)
 
-      verify {
-        getCall(any())
-        mockCall.execute()
-      }
+    verify {
+      getCall(any())
+      mockCall.execute()
     }
   }
 
   @Test
+  @LockAndMockStatic([NetUtil::class])
   fun `test fetch unsuccessful response`() {
-    lockAndMockStatic(NetUtil::class) {
-      every { getCall(any()) } returns mockCall
-      every { mockCall.execute() } returns mockResponse
-      every { mockResponse.isSuccessful } returns false
+    every { getCall(any()) } returns mockCall
+    every { mockCall.execute() } returns mockResponse
+    every { mockResponse.isSuccessful } returns false
 
-      assertThrows(IOException::class.java) { NetUtil.fetch("http://hello") }
-    }
+    assertThrows(IOException::class.java) { NetUtil.fetch("http://hello") }
   }
 
   @Test
+  @LockAndMockStatic([NetUtil::class])
   fun `test fetch null response body`() {
-    lockAndMockStatic(NetUtil::class) {
-      every { getCall(any()) } returns mockCall
-      every { mockCall.execute() } returns mockResponse
-      every { mockResponse.isSuccessful } returns true
-      every { mockResponse.body } returns null
+    every { getCall(any()) } returns mockCall
+    every { mockCall.execute() } returns mockResponse
+    every { mockResponse.isSuccessful } returns true
+    every { mockResponse.body } returns null
 
-      assertThrows(IOException::class.java) { NetUtil.fetch("http://hello") }
-    }
+    assertThrows(IOException::class.java) { NetUtil.fetch("http://hello") }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -4,14 +4,17 @@ import io.mockk.*
 import java.util.*
 import kotlin.test.assertEquals
 import okhttp3.Request
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.stellar.anchor.LockAndMockStatic
+import org.stellar.anchor.LockAndMockTest
 import org.stellar.anchor.auth.*
 import org.stellar.anchor.auth.ApiAuthJwt.PlatformAuthJwt
 import org.stellar.anchor.auth.AuthType.*
 import org.stellar.anchor.auth.JwtService
-import org.stellar.anchor.lockAndMockStatic
 
+@ExtendWith(LockAndMockTest::class)
 class PlatformIntegrationHelperTest {
   companion object {
     const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
@@ -20,60 +23,57 @@ class PlatformIntegrationHelperTest {
 
   @ParameterizedTest
   @EnumSource(AuthType::class)
+  @LockAndMockStatic([Calendar::class])
   fun test_getRequestBuilder(authType: AuthType) {
-    lockAndMockStatic(Calendar::class) {
-      when (authType) {
-        JWT -> {
-          // Mock calendar to guarantee the jwt token format
-          val calendarSingleton = Calendar.getInstance()
-          val currentTimeMilliseconds = calendarSingleton.timeInMillis
-          mockkObject(calendarSingleton)
-          every { calendarSingleton.timeInMillis } returns currentTimeMilliseconds
-          every { calendarSingleton.timeInMillis = any() } answers { callOriginal() }
-          every { Calendar.getInstance() } returns calendarSingleton
+    when (authType) {
+      JWT -> {
+        // Mock calendar to guarantee the jwt token format
+        val calendarSingleton = Calendar.getInstance()
+        val currentTimeMilliseconds = calendarSingleton.timeInMillis
+        mockkObject(calendarSingleton)
+        every { calendarSingleton.timeInMillis } returns currentTimeMilliseconds
+        every { calendarSingleton.timeInMillis = any() } answers { callOriginal() }
+        every { Calendar.getInstance() } returns calendarSingleton
 
-          // mock jwt token based on the mocked calendar
-          val wantJwtToken =
-            PlatformAuthJwt(
-              currentTimeMilliseconds / 1000L,
-              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
-            )
+        // mock jwt token based on the mocked calendar
+        val wantJwtToken =
+          PlatformAuthJwt(
+            currentTimeMilliseconds / 1000L,
+            (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+          )
 
-          val jwtService = JwtService(null, null, null, "secret", "secret", "secret")
-          val authHelper = AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS)
+        val jwtService = JwtService(null, null, null, "secret", "secret", "secret")
+        val authHelper = AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS)
 
-          val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-          val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          val wantRequestBuilder: Request.Builder =
-            Request.Builder()
-              .header("Content-Type", "application/json")
-              .header("Authorization", "Bearer ${jwtService.encode(wantJwtToken)}")
-          val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          assertEquals(wantRequest.headers, gotRequest.headers)
-        }
-        API_KEY -> {
-          val authHelper = AuthHelper.forApiKey("secret")
-          val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-          val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          val wantRequestBuilder: Request.Builder =
-            Request.Builder()
-              .header("Content-Type", "application/json")
-              .header("X-Api-Key", "secret")
-          val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          assertEquals(wantRequest.headers, gotRequest.headers)
-        }
-        NONE -> {
-          val authHelper = AuthHelper.forNone()
-          val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
-          val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          val wantRequestBuilder: Request.Builder =
-            Request.Builder().header("Content-Type", "application/json")
-          val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
-          assertEquals(wantRequest.headers, gotRequest.headers)
-        }
-        else -> {
-          throw Exception("Unsupported new AuthType!!!")
-        }
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder()
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer ${jwtService.encode(wantJwtToken)}")
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      API_KEY -> {
+        val authHelper = AuthHelper.forApiKey("secret")
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder().header("Content-Type", "application/json").header("X-Api-Key", "secret")
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      NONE -> {
+        val authHelper = AuthHelper.forNone()
+        val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
+        val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        val wantRequestBuilder: Request.Builder =
+          Request.Builder().header("Content-Type", "application/json")
+        val wantRequest = wantRequestBuilder.url(TEST_HOME_DOMAIN).get().build()
+        assertEquals(wantRequest.headers, gotRequest.headers)
+      }
+      else -> {
+        throw Exception("Unsupported new AuthType!!!")
       }
     }
   }

--- a/test-lib/src/main/kotlin/org/stellar/anchor/LockAndMockExtension.kt
+++ b/test-lib/src/main/kotlin/org/stellar/anchor/LockAndMockExtension.kt
@@ -1,0 +1,65 @@
+package org.stellar.anchor
+
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.reflect.KClass
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class LockAndMockTest : BeforeTestExecutionCallback, AfterTestExecutionCallback {
+  private val mutexThreadLocal = ThreadLocal<TestMutex>()
+
+  override fun beforeTestExecution(context: ExtensionContext?) {
+    val annotation = getAnnotation(context)
+    if (annotation is LockAndMockStatic) {
+      val mutex = TestMutex(*annotation.classes)
+      mutex.lock()
+      mutexThreadLocal.set(mutex)
+      for (clz in annotation.classes) {
+        mockkStatic(clz)
+      }
+    } else if (annotation is LockStatic) {
+      val mutex = TestMutex(*annotation.classes)
+      mutex.lock()
+      mutexThreadLocal.set(mutex)
+    }
+  }
+
+  override fun afterTestExecution(context: ExtensionContext?) {
+    val annotation = getAnnotation(context)
+    if (annotation is LockAndMockStatic) {
+      for (clz in annotation.classes) {
+        unmockkStatic(clz)
+      }
+      mutexThreadLocal.get()?.unlock()
+      mutexThreadLocal.remove()
+    } else if (annotation is LockStatic) {
+      mutexThreadLocal.get()?.unlock()
+      mutexThreadLocal.remove()
+    }
+  }
+
+  private fun getAnnotation(context: ExtensionContext?): Annotation? {
+    return context?.requiredTestMethod?.annotations?.find {
+      it is LockAndMockStatic || it is LockStatic
+    }
+  }
+  //
+  //  private fun getLockAndMockStaticAnnotation(context: ExtensionContext?): LockAndMockStatic? {
+  //    return context?.requiredTestMethod?.annotations?.find { it is LockAndMockStatic }
+  //      as LockAndMockStatic?
+  //  }
+  //
+  //  private fun getLockStaticAnnotation(context: ExtensionContext?): LockStatic? {
+  //    return context?.requiredTestMethod?.annotations?.find { it is LockStatic } as LockStatic?
+  //  }
+}
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LockAndMockStatic(val classes: Array<KClass<*>>)
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LockStatic(val classes: Array<KClass<*>>)

--- a/test-lib/src/main/kotlin/org/stellar/anchor/LockAndMockExtension.kt
+++ b/test-lib/src/main/kotlin/org/stellar/anchor/LockAndMockExtension.kt
@@ -10,6 +10,10 @@ import org.junit.jupiter.api.extension.ExtensionContext
 class LockAndMockTest : BeforeTestExecutionCallback, AfterTestExecutionCallback {
   private val mutexThreadLocal = ThreadLocal<TestMutex>()
 
+  /**
+   * Lock the classes and optionally mock the static methods of the classes before the test method
+   * call.
+   */
   override fun beforeTestExecution(context: ExtensionContext?) {
     val annotation = getAnnotation(context)
     if (annotation is LockAndMockStatic) {
@@ -26,6 +30,10 @@ class LockAndMockTest : BeforeTestExecutionCallback, AfterTestExecutionCallback 
     }
   }
 
+  /**
+   * Unlock the classes and optionally unmock the static methods of the classes after the test
+   * method call.
+   */
   override fun afterTestExecution(context: ExtensionContext?) {
     val annotation = getAnnotation(context)
     if (annotation is LockAndMockStatic) {
@@ -45,21 +53,33 @@ class LockAndMockTest : BeforeTestExecutionCallback, AfterTestExecutionCallback 
       it is LockAndMockStatic || it is LockStatic
     }
   }
-  //
-  //  private fun getLockAndMockStaticAnnotation(context: ExtensionContext?): LockAndMockStatic? {
-  //    return context?.requiredTestMethod?.annotations?.find { it is LockAndMockStatic }
-  //      as LockAndMockStatic?
-  //  }
-  //
-  //  private fun getLockStaticAnnotation(context: ExtensionContext?): LockStatic? {
-  //    return context?.requiredTestMethod?.annotations?.find { it is LockStatic } as LockStatic?
-  //  }
 }
 
+/**
+ * The annotated method will lock the classes and mock the static methods of the classes in the
+ * array.
+ *
+ * In order to use this annotation, the JUnit test class must be extended with the [LockAndMockTest]
+ * extension.
+ *
+ * For example:
+ * ```
+ * @ExtendWith(LockAndMockTest::class) class MyTest {}
+ * ```
+ */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class LockAndMockStatic(val classes: Array<KClass<*>>)
 
+/**
+ * The annotated method will lock the classes in the array. In order to use this annotation, the
+ * JUnit test class must be extended with the [LockAndMockTest] extension.
+ *
+ * For example:
+ * ```
+ * @ExtendWith(LockAndMockTest::class) class MyTest {}
+ * ```
+ */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class LockStatic(val classes: Array<KClass<*>>)

--- a/test-lib/src/main/kotlin/org/stellar/anchor/TestMutex.kt
+++ b/test-lib/src/main/kotlin/org/stellar/anchor/TestMutex.kt
@@ -5,7 +5,7 @@ import io.mockk.unmockkStatic
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.reflect.KClass
 
-private class TestMutex(vararg clzs: KClass<*>) {
+class TestMutex(vararg clzs: KClass<*>) {
   companion object {
     val knownClasses = mutableMapOf<KClass<*>, ReentrantLock>()
   }
@@ -13,6 +13,15 @@ private class TestMutex(vararg clzs: KClass<*>) {
   private val classes = clzs.sortedBy { it.qualifiedName }
 
   fun withLock(action: () -> Unit) {
+    try {
+      lock()
+      action()
+    } finally {
+      unlock()
+    }
+  }
+
+  fun lock() {
     for (clazz in classes) {
       var lock: ReentrantLock?
       synchronized(knownClasses) {
@@ -23,19 +32,15 @@ private class TestMutex(vararg clzs: KClass<*>) {
         }
       }
       lock!!.lock()
-      println("Locked ${clazz.qualifiedName} ${knownClasses[clazz]}")
     }
-    try {
-      action()
-    } finally {
-      for (clazz in classes.asReversed()) {
-        knownClasses[clazz]!!.unlock()
-        println("Unlocked ${clazz.qualifiedName} ${knownClasses[clazz]}")
-      }
+  }
+
+  fun unlock() {
+    for (clazz in classes.asReversed()) {
+      knownClasses[clazz]!!.unlock()
     }
   }
 }
-
 /**
  * Obtain locks of the clzs in order and execute the action.
  *
@@ -61,3 +66,67 @@ fun lockAndMockStatic(vararg clzs: KClass<*>, action: () -> Unit) {
     }
   }
 }
+
+// package org.stellar.anchor
+//
+// import io.mockk.mockkStatic
+// import io.mockk.unmockkStatic
+// import java.util.concurrent.locks.ReentrantLock
+// import kotlin.reflect.KClass
+//
+// private class TestMutex(vararg clzs: KClass<*>) {
+//  companion object {
+//    val knownClasses = mutableMapOf<KClass<*>, ReentrantLock>()
+//  }
+//
+//  private val classes = clzs.sortedBy { it.qualifiedName }
+//
+//  fun withLock(action: () -> Unit) {
+//    for (clazz in classes) {
+//      var lock: ReentrantLock?
+//      synchronized(knownClasses) {
+//        lock = knownClasses[clazz]
+//        if (lock == null) {
+//          lock = ReentrantLock()
+//          knownClasses[clazz] = lock!!
+//        }
+//      }
+//      lock!!.lock()
+//      println("Locked ${clazz.qualifiedName} ${knownClasses[clazz]}")
+//    }
+//    try {
+//      action()
+//    } finally {
+//      for (clazz in classes.asReversed()) {
+//        knownClasses[clazz]!!.unlock()
+//        println("Unlocked ${clazz.qualifiedName} ${knownClasses[clazz]}")
+//      }
+//    }
+//  }
+// }
+//
+/// **
+// * Obtain locks of the clzs in order and execute the action.
+// *
+// * @param clzs the Kotlin classes to lock
+// * @param action the action to execute
+// */
+// fun withLock(vararg clzs: KClass<*>, action: () -> Unit) {
+//  TestMutex(*clzs).withLock { action() }
+// }
+//
+// fun lockAndMockStatic(vararg clzs: KClass<*>, action: () -> Unit) {
+//  // Lock all the classes in order
+//  withLock(*clzs) {
+//    // static mocks
+//    for (kclz in clzs) {
+//      mockkStatic(kclz)
+//    }
+//    // call action
+//    action()
+//    // static unmocks
+//    for (kclz in clzs) {
+//      unmockkStatic(kclz)
+//    }
+//  }
+// }

--- a/test-lib/src/main/kotlin/org/stellar/anchor/TestMutex.kt
+++ b/test-lib/src/main/kotlin/org/stellar/anchor/TestMutex.kt
@@ -7,9 +7,12 @@ import kotlin.reflect.KClass
 
 class TestMutex(vararg clzs: KClass<*>) {
   companion object {
+    // A map of known classes to their locks
     val knownClasses = mutableMapOf<KClass<*>, ReentrantLock>()
   }
 
+  // The classes to lock. The classes must always be locked by the same order otherwise it will be
+  // vulnerable to deadlocks.
   private val classes = clzs.sortedBy { it.qualifiedName }
 
   fun withLock(action: () -> Unit) {
@@ -23,15 +26,15 @@ class TestMutex(vararg clzs: KClass<*>) {
 
   fun lock() {
     for (clazz in classes) {
-      var lock: ReentrantLock?
+      var rlock: ReentrantLock?
       synchronized(knownClasses) {
-        lock = knownClasses[clazz]
-        if (lock == null) {
-          lock = ReentrantLock()
-          knownClasses[clazz] = lock!!
+        rlock = knownClasses[clazz]
+        if (rlock == null) {
+          rlock = ReentrantLock()
+          knownClasses[clazz] = rlock!!
         }
       }
-      lock!!.lock()
+      rlock!!.lock()
     }
   }
 
@@ -51,6 +54,12 @@ fun withLock(vararg clzs: KClass<*>, action: () -> Unit) {
   TestMutex(*clzs).withLock { action() }
 }
 
+/**
+ * Locks the clzs in order, mocks the static methods of the clzs, executes the action, and unmocks.
+ *
+ * @param clzs the Kotlin classes to lock and mock
+ * @param action the action to execute
+ */
 fun lockAndMockStatic(vararg clzs: KClass<*>, action: () -> Unit) {
   // Lock all the classes in order
   withLock(*clzs) {
@@ -66,67 +75,3 @@ fun lockAndMockStatic(vararg clzs: KClass<*>, action: () -> Unit) {
     }
   }
 }
-
-// package org.stellar.anchor
-//
-// import io.mockk.mockkStatic
-// import io.mockk.unmockkStatic
-// import java.util.concurrent.locks.ReentrantLock
-// import kotlin.reflect.KClass
-//
-// private class TestMutex(vararg clzs: KClass<*>) {
-//  companion object {
-//    val knownClasses = mutableMapOf<KClass<*>, ReentrantLock>()
-//  }
-//
-//  private val classes = clzs.sortedBy { it.qualifiedName }
-//
-//  fun withLock(action: () -> Unit) {
-//    for (clazz in classes) {
-//      var lock: ReentrantLock?
-//      synchronized(knownClasses) {
-//        lock = knownClasses[clazz]
-//        if (lock == null) {
-//          lock = ReentrantLock()
-//          knownClasses[clazz] = lock!!
-//        }
-//      }
-//      lock!!.lock()
-//      println("Locked ${clazz.qualifiedName} ${knownClasses[clazz]}")
-//    }
-//    try {
-//      action()
-//    } finally {
-//      for (clazz in classes.asReversed()) {
-//        knownClasses[clazz]!!.unlock()
-//        println("Unlocked ${clazz.qualifiedName} ${knownClasses[clazz]}")
-//      }
-//    }
-//  }
-// }
-//
-/// **
-// * Obtain locks of the clzs in order and execute the action.
-// *
-// * @param clzs the Kotlin classes to lock
-// * @param action the action to execute
-// */
-// fun withLock(vararg clzs: KClass<*>, action: () -> Unit) {
-//  TestMutex(*clzs).withLock { action() }
-// }
-//
-// fun lockAndMockStatic(vararg clzs: KClass<*>, action: () -> Unit) {
-//  // Lock all the classes in order
-//  withLock(*clzs) {
-//    // static mocks
-//    for (kclz in clzs) {
-//      mockkStatic(kclz)
-//    }
-//    // call action
-//    action()
-//    // static unmocks
-//    for (kclz in clzs) {
-//      unmockkStatic(kclz)
-//    }
-//  }
-// }


### PR DESCRIPTION
### Description

Add @LockAndMockStatic and @LockStatic annotations. Instead of 
```kotlin
class MyTest {
  @LockAndMockStatic([NetUtil::class]) 
  fun myTest(){
    lockAndMockStatic() {
      // my tests here
   }
  }
}
```
the test method can be annotated with `@LockAndMockStatic`

```kotlin
@ExtendWith(LockAndMockTest::class) 
class MyTest {
  @LockAndMockStatic([NetUtil::class]) 
  fun myTest(){
  }
}
```

### Context

To simplify the `lockAndMock` function.

### Testing

- `./gradlew test`
