### PR TITLE
[ANCHOR- 474]  Update SEP10.home_domain to accommodate multi-tenancy

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
@@ -16,7 +16,7 @@ public interface Sep10Config {
    * The `web_auth_domain` property of <a
    * href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response">SEP-10</a>.
    * If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the first value
-   * of `home_domains`. `web_auth_domain` value must be equal to the host of the SEP server.
+   * of `home_domains`. The `web_auth_domain` value must equal to the host of the SEP server.
    *
    * @return the web auth domain.
    */

--- a/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
@@ -15,23 +15,20 @@ public interface Sep10Config {
   /**
    * The `web_auth_domain` property of <a
    * href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response">SEP-10</a>.
-   * If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of
-   * the value of the `home_domain`. `web_auth_domain` value must be equal to the host of the SEP
-   * server.
+   * If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the first value
+   * of `home_domains`. `web_auth_domain` value must be equal to the host of the SEP server.
    *
    * @return the web auth domain.
    */
   String getWebAuthDomain();
 
   /**
-   * The `home_domain` property of <a
+   * The `home_domains` property of <a
    * href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request">SEP-10</a>.
-   * `home_domain` value must be equal to the host of the toml file. If sep1 is enabled, toml file
-   * will be hosted on the SEP server.
    *
-   * @return the home domain.
+   * @return the list of home domains.
    */
-  String getHomeDomain();
+  List<String> getHomeDomains();
 
   /**
    * Set the authentication challenge transaction timeout in seconds. An expired signed transaction

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -116,7 +116,7 @@ public class Sep10Service implements ISep10Service {
       throw new SepValidationException("Invalid challenge transaction.");
     }
 
-    if (!Objects.equals(sep10Config.getHomeDomain(), homeDomain)) {
+    if ((!sep10Config.getHomeDomains().contains(homeDomain))) {
       throw new SepValidationException(format("Invalid home_domain. %s", homeDomain));
     }
 
@@ -257,10 +257,11 @@ public class Sep10Service implements ISep10Service {
 
   void validateHomeDomain(ChallengeRequest request) throws SepValidationException {
     String homeDomain = request.getHomeDomain();
+    String defaultHomeDomain = sep10Config.getHomeDomains().get(0);
     if (homeDomain == null) {
-      debugF("home_domain is not specified. Will use the default: {}", sep10Config.getHomeDomain());
-      request.setHomeDomain(sep10Config.getHomeDomain());
-    } else if (!homeDomain.equalsIgnoreCase(sep10Config.getHomeDomain())) {
+      debugF("home_domain is not specified. Will use the default: {}", defaultHomeDomain);
+      request.setHomeDomain(defaultHomeDomain);
+    } else if (!sep10Config.getHomeDomains().contains(homeDomain)) {
       infoF("Bad home_domain: {}", homeDomain);
       throw new SepValidationException(format("home_domain [%s] is not supported.", homeDomain));
     }
@@ -295,7 +296,7 @@ public class Sep10Service implements ISep10Service {
             request.getTransaction(),
             serverAccountId,
             new Network(appConfig.getStellarNetworkPassphrase()),
-            sep10Config.getHomeDomain(),
+            sep10Config.getHomeDomains().toArray(new String[0]),
             sep10Config.getWebAuthDomain(),
             threshold,
             signers);
@@ -349,7 +350,7 @@ public class Sep10Service implements ISep10Service {
               request.getTransaction(),
               serverAccountId,
               new Network(appConfig.getStellarNetworkPassphrase()),
-              sep10Config.getHomeDomain(),
+              sep10Config.getHomeDomains().toArray(new String[0]),
               sep10Config.getWebAuthDomain(),
               signers);
 
@@ -395,7 +396,7 @@ public class Sep10Service implements ISep10Service {
                 transaction,
                 serverAccountId,
                 new Network(appConfig.getStellarNetworkPassphrase()),
-                sep10Config.getHomeDomain(),
+                sep10Config.getHomeDomains().toArray(new String[0]),
                 sep10Config.getWebAuthDomain());
 
     debugF(
@@ -461,35 +462,35 @@ class Sep10ChallengeWrapper {
       String challengeXdr,
       String serverAccountId,
       Network network,
-      String domainName,
+      String[] domainNames,
       String webAuthDomain)
       throws InvalidSep10ChallengeException, IOException {
     return Sep10Challenge.readChallengeTransaction(
-        challengeXdr, serverAccountId, network, domainName, webAuthDomain);
+        challengeXdr, serverAccountId, network, domainNames, webAuthDomain);
   }
 
   public synchronized void verifyChallengeTransactionSigners(
       String challengeXdr,
       String serverAccountId,
       Network network,
-      String domainName,
+      String[] domainNames,
       String webAuthDomain,
       Set<String> signers)
       throws InvalidSep10ChallengeException, IOException {
     Sep10Challenge.verifyChallengeTransactionSigners(
-        challengeXdr, serverAccountId, network, domainName, webAuthDomain, signers);
+        challengeXdr, serverAccountId, network, domainNames, webAuthDomain, signers);
   }
 
   public synchronized void verifyChallengeTransactionThreshold(
       String challengeXdr,
       String serverAccountId,
       Network network,
-      String domainName,
+      String[] domainNames,
       String webAuthDomain,
       int threshold,
       Set<Sep10Challenge.Signer> signers)
       throws InvalidSep10ChallengeException, IOException {
     Sep10Challenge.verifyChallengeTransactionThreshold(
-        challengeXdr, serverAccountId, network, domainName, webAuthDomain, threshold, signers);
+        challengeXdr, serverAccountId, network, domainNames, webAuthDomain, threshold, signers);
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -106,7 +106,7 @@ internal class Sep10ServiceTest {
     every { sep10Config.webAuthDomain } returns TEST_WEB_AUTH_DOMAIN
     every { sep10Config.authTimeout } returns 900
     every { sep10Config.jwtTimeout } returns 900
-    every { sep10Config.homeDomain } returns TEST_HOME_DOMAIN
+    every { sep10Config.homeDomains } returns listOf(TEST_HOME_DOMAIN)
 
     every { appConfig.stellarNetworkPassphrase } returns TESTNET.networkPassphrase
 

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -54,6 +54,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
     if (homeDomains == null || homeDomains.isEmpty()) {
       homeDomains = List.of(homeDomain);
     }
+    // If webAuthDomain is not specified and there is 1 and only 1 domain in the home_domains
     if (isEmpty(webAuthDomain) && homeDomains.size() == 1) {
       webAuthDomain = homeDomains.get(0);
     }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -315,12 +315,20 @@ sep10:
   enabled: false
   #
   # The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
-  # If the `web_auth_domain` is not specified, the `web_auth_domain` will be set to the domain of the value of the `home_domain`.
-  # `web_auth_domain` value must equal to the host of the SEP server.
+  # `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if
+  #   1) the `home_domain` is in use,
+  #   2) or the `home_domains` is in use and has only one value
+  # `web_auth_domain` is required if
+  #   1) the `home_domains` is in use has more than one value
   web_auth_domain:
   # The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
   # `home_domain` value must be equal to the host of the toml file. If sep1 is enabled, toml file will be hosted on the SEP server.
+  # This property cannot coexist with `home_domains` and is going to be deprecated. Please use `home_domains` instead.
   home_domain: localhost:8080
+  # The `home_domains` property of SEP-10. This is a list of domains that the client can use to authenticate.
+  # https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
+  # This property cannot coexist with `home_domain`. Please also set web_auth_domain if you have more than one home domain in this list.
+  home_domains:
   # Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing
   # a domain in the challenge transaction request and signing the challenge with the ``SIGNING_KEY`` on that domain's
   # SEP-1 stellar.toml. See the SEP-10 section `Verifying Client Application Identity` for more information

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -315,10 +315,10 @@ sep10:
   enabled: false
   #
   # The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
-  # `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if
+  # The `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if
   #   1) the `home_domain` is in use,
   #   2) or the `home_domains` is in use and has only one value
-  # `web_auth_domain` is required if
+  # The `web_auth_domain` is required if
   #   1) the `home_domains` is in use has more than one value
   web_auth_domain:
   # The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
@@ -328,6 +328,9 @@ sep10:
   # The `home_domains` property of SEP-10. This is a list of domains that the client can use to authenticate.
   # https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
   # This property cannot coexist with `home_domain`. Please also set web_auth_domain if you have more than one home domain in this list.
+  # The following lists are examples:
+  # Ex: home_domains: [ap.stellar.org, sdp.stellar.org]
+  # Ex: home_domains: ap.stellar.org, sdp.stellar.org
   home_domains:
   # Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing
   # a domain in the challenge transaction request and signing the challenge with the ``SIGNING_KEY`` on that domain's

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -74,6 +74,7 @@ sep10.client_allow_list:
 sep10.client_attribution_required:
 sep10.enabled:
 sep10.home_domain:
+sep10.home_domains:
 sep10.jwt_timeout:
 sep10.known_custodial_account_required:
 sep10.web_auth_domain:


### PR DESCRIPTION
### Description

Add `home_domains` to SEP-10 to take a list of domains,
Rename `Sep10Config::getHomeDomain()` to  `Sep10Config::getHomeDomains()` to always return a list of available domains
`home_domain` and `home_domains` cannot coexist in Sep10Config, this is comment in default-value.yml, also enforced in validation rules
`web_auth_domain` will be required if there are more than 1 home domain specified in `home_domains`

### Context

The SDP multi-tenant integration will rely on multiple toml files, so we’ll need the Anchor Platform to accommodate that by allowing multiple home_domains to be configured, in the format of a comma-separated list of domains.


### Testing

- `./gradlew test`

