### PR TITLE
[Fix] SEP-6: Add `type` to platform transaction

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -30,6 +30,8 @@ public class PlatformTransactionData {
   Kind kind;
   SepTransactionStatus status;
 
+  String type;
+
   @SerializedName("amount_expected")
   Amount amountExpected;
 

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -100,6 +100,7 @@ public class TransactionHelper {
         .sep(PlatformTransactionData.Sep.SEP_6)
         .kind(PlatformTransactionData.Kind.from(txn.getKind()))
         .status(SepTransactionStatus.from(txn.getStatus()))
+        .type(txn.getType())
         .amountExpected(new Amount(txn.getAmountExpected(), amountExpectedAsset))
         .amountIn(Amount.create(txn.getAmountIn(), amountInAsset))
         .amountOut(Amount.create(txn.getAmountOut(), amountOutAsset))


### PR DESCRIPTION
### Description

This commit adds the `type` field to the SEP-6 platform transaction.

### Context

The `type` determines which fields need to be collected for KYC.

### Testing

- `./gradlew test`

### Known limitations

N/A

