### PR TITLE
[Fix] SEP-6: Add `min_amount` and `max_amount` to response

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositResponse.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.api.sep.sep6;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
 
@@ -23,4 +24,12 @@ public class StartDepositResponse {
 
   /** The anchor's ID for this deposit. */
   String id;
+
+  /** The minimum amount that can be deposited. */
+  @SerializedName("min_amount")
+  String minAmount;
+
+  /** The maximum amount that can be deposited. */
+  @SerializedName("max_amount")
+  String maxAmount;
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawResponse.java
@@ -27,4 +27,12 @@ public class StartWithdrawResponse {
 
   /** The anchor's ID for this withdrawal. */
   String id;
+
+  /** The minimum amount that can be withdrawn. */
+  @SerializedName("min_amount")
+  String minAmount;
+
+  /** The maximum amount that can be withdrawn. */
+  @SerializedName("max_amount")
+  String maxAmount;
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -113,9 +113,14 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
+    Long minAmount = asset.getDeposit().getMinAmount();
+    Long maxAmount = asset.getDeposit().getMaxAmount();
+
     return StartDepositResponse.builder()
         .how("Check the transaction for more information about how to deposit.")
         .id(txn.getId())
+        .minAmount(minAmount != null ? minAmount.toString() : null)
+        .maxAmount(maxAmount != null ? maxAmount.toString() : null)
         .build();
   }
 
@@ -200,9 +205,14 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
+    Long minAmount = buyAsset.getDeposit().getMinAmount();
+    Long maxAmount = buyAsset.getDeposit().getMaxAmount();
+
     return StartDepositResponse.builder()
         .how("Check the transaction for more information about how to deposit.")
         .id(id)
+        .minAmount(minAmount != null ? minAmount.toString() : null)
+        .maxAmount(maxAmount != null ? maxAmount.toString() : null)
         .build();
   }
 
@@ -267,11 +277,16 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
+    Long minAmount = asset.getWithdraw().getMinAmount();
+    Long maxAmount = asset.getWithdraw().getMaxAmount();
+
     return StartWithdrawResponse.builder()
         .accountId(asset.getDistributionAccount())
         .id(txn.getId())
         .memo(txn.getMemo())
         .memoType(memoTypeAsString(MEMO_HASH))
+        .minAmount(minAmount != null ? minAmount.toString() : null)
+        .maxAmount(maxAmount != null ? maxAmount.toString() : null)
         .build();
   }
 
@@ -356,11 +371,16 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
+    Long minAmount = sellAsset.getWithdraw().getMinAmount();
+    Long maxAmount = sellAsset.getWithdraw().getMaxAmount();
+
     return StartWithdrawResponse.builder()
         .accountId(sellAsset.getDistributionAccount())
         .id(txn.getId())
         .memo(txn.getMemo())
         .memoType(memoTypeAsString(MEMO_HASH))
+        .minAmount(minAmount != null ? minAmount.toString() : null)
+        .maxAmount(maxAmount != null ? maxAmount.toString() : null)
         .build();
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -153,9 +153,11 @@ class Sep6ServiceTestData {
     val depositResJson =
       """
       {
-          "how": "Check the transaction for more information about how to deposit."
+          "how": "Check the transaction for more information about how to deposit.",
+          "min_amount": "1",
+          "max_amount": "10000"
       }
-    """
+      """
         .trimIndent()
 
     val depositTxnJson =
@@ -350,7 +352,9 @@ class Sep6ServiceTestData {
       """
       {
           "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "memo_type": "hash"
+          "memo_type": "hash",
+          "min_amount": "1",
+          "max_amount": "10000"
       }
     """
         .trimIndent()


### PR DESCRIPTION
### Description

This adds the missing `min_amount` and `max_amount` to the transaction initiation responses.

### Context

These fields were missing from the response.

### Testing

- `./gradlew test`

### Known limitations

N/A

