### PR TITLE
[Fix] Fix test failures due to static mock race

### DIFF
--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -82,8 +82,8 @@ class ClientStatusCallbackHandlerTest {
       )
   }
 
-  @LockAndMockStatic([Sep24Helper::class, Sep6TransactionUtils::class])
   @Test
+  @LockAndMockStatic([Sep24Helper::class, Sep6TransactionUtils::class])
   fun `test verify request signature`() {
     // header example: "X-Stellar-Signature": "t=....., s=......"
     // Get the signature from request


### PR DESCRIPTION
### Description

This fixes two test concurrency bugs due to static mocking.

1. `Sep10ServiceTest`:  the verify sees two calls to `Sep10Challenge#newChallenge`. My guess is that the `LockAndMockStatic` annotation does not know about `ParameterizedTest`s.
2. `Sep24ServiceTest`: the mock of `KeyPair` in `Sep10ServiceTest` to throw an exception causes the `Sep24Service` to throw it as well.

These two issues were only observed in the `sep-6` branch despite it using static mocks or touching existing tests.

### Context

Fixes test stability in `sep-6` branch.

### Testing

- Ran `./gradlew test` a few times

### Documentation

N/A

### Known limitations

This is only a temporary fix as it does not prevent us from writing similar tests in the future.

