### PR TITLE
[ANCHOR-522] Fix `SimpleMoreInfoUrlConstructorTest` calendar skew

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -1,10 +1,12 @@
 package org.stellar.anchor.auth;
 
+import static java.util.Date.*;
+
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.impl.DefaultJwsHeader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
+import java.time.Instant;
 import java.util.Map;
 import lombok.Getter;
 import org.apache.commons.codec.binary.Base64;
@@ -57,19 +59,15 @@ public class JwtService {
   }
 
   public String encode(Sep10Jwt token) {
-    Calendar calIat = Calendar.getInstance();
-    calIat.setTimeInMillis(1000L * token.getIat());
-
-    Calendar calExp = Calendar.getInstance();
-    calExp.setTimeInMillis(1000L * token.getExp());
-
+    Instant timeExp = Instant.ofEpochSecond(token.getExp());
+    Instant timeIat = Instant.ofEpochSecond(token.getIat());
     JwtBuilder builder =
         Jwts.builder()
             .setId(token.getJti())
             .setIssuer(token.getIss())
             .setSubject(token.getSub())
-            .setIssuedAt(calIat.getTime())
-            .setExpiration(calExp.getTime())
+            .setIssuedAt(from(timeIat))
+            .setExpiration(from(timeExp))
             .setSubject(token.getSub());
 
     if (token.getClientDomain() != null) {
@@ -88,12 +86,11 @@ public class JwtService {
       throw new InvalidConfigException(
           "Please provide the secret before encoding JWT for Sep24 interactive url");
     }
-    Calendar calExp = Calendar.getInstance();
-    calExp.setTimeInMillis(1000L * token.getExp());
+    Instant timeExp = Instant.ofEpochSecond(token.getExp());
     JwtBuilder builder =
         Jwts.builder()
             .setId(token.getJti())
-            .setExpiration(calExp.getTime())
+            .setExpiration(from(timeExp))
             .setSubject(token.getSub());
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
@@ -107,12 +104,11 @@ public class JwtService {
       throw new InvalidConfigException(
           "Please provide the secret before encoding JWT for more_info_url");
     }
-    Calendar calExp = Calendar.getInstance();
-    calExp.setTimeInMillis(1000L * token.getExp());
+    Instant timeExp = Instant.ofEpochSecond(token.getExp());
     JwtBuilder builder =
         Jwts.builder()
             .setId(token.getJti())
-            .setExpiration(calExp.getTime())
+            .setExpiration(from(timeExp))
             .setSubject(token.getSub());
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
@@ -139,11 +135,9 @@ public class JwtService {
           "Please provide the secret before encoding JWT for API Authentication");
     }
 
-    Calendar calNow = Calendar.getInstance();
-    Calendar calExp = Calendar.getInstance();
-    calExp.setTimeInMillis(1000L * token.getExp());
-    JwtBuilder builder =
-        Jwts.builder().setIssuedAt(calNow.getTime()).setExpiration(calExp.getTime());
+    Instant timeExp = Instant.ofEpochSecond(token.getExp());
+    Instant timeIat = Instant.ofEpochSecond(token.getIat());
+    JwtBuilder builder = Jwts.builder().setIssuedAt(from(timeIat)).setExpiration(from(timeExp));
 
     return builder.signWith(SignatureAlgorithm.HS256, secret).compact();
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.api.parallel.ExecutionMode.*
 import org.springframework.web.util.UriComponentsBuilder
 import org.stellar.anchor.LockStatic
@@ -25,6 +27,7 @@ import org.stellar.anchor.platform.config.PropertySep24Config
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.util.GsonUtils
 
+@Execution(ExecutionMode.SAME_THREAD)
 class SimpleMoreInfoUrlConstructorTest {
   companion object {
     private val gson = GsonUtils.getInstance()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructorTest.kt
@@ -4,12 +4,15 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import java.time.Instant
+import java.util.Calendar
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.ExecutionMode.*
 import org.springframework.web.util.UriComponentsBuilder
+import org.stellar.anchor.LockStatic
 import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.Sep24MoreInfoUrlJwt
@@ -71,6 +74,7 @@ class SimpleMoreInfoUrlConstructorTest {
   }
 
   @Test
+  @LockStatic([Calendar::class])
   fun `test correct config`() {
     val config =
       gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
@@ -90,6 +94,7 @@ class SimpleMoreInfoUrlConstructorTest {
   }
 
   @Test
+  @LockStatic([Calendar::class])
   fun `test unknown client domain`() {
     val config =
       gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
@@ -99,7 +104,6 @@ class SimpleMoreInfoUrlConstructorTest {
     txn.sep10AccountMemo = null
 
     val url = constructor.construct(txn)
-
     val params = UriComponentsBuilder.fromUriString(url).build().queryParams
     val cipher = params["token"]!![0]
 
@@ -112,6 +116,7 @@ class SimpleMoreInfoUrlConstructorTest {
   }
 
   @Test
+  @LockStatic([Calendar::class])
   fun `test custodial wallet`() {
     val config =
       gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)
@@ -134,6 +139,7 @@ class SimpleMoreInfoUrlConstructorTest {
   }
 
   @Test
+  @LockStatic([Calendar::class])
   fun `test non-custodial wallet with missing client domain`() {
     val config =
       gson.fromJson(SIMPLE_CONFIG_JSON, PropertySep24Config.MoreInfoUrlConfig::class.java)


### PR DESCRIPTION
### Description

Fix `SimpleMoreInfoUrlConstructorTest` calendar skew

### Context

The tests in `SimpleMoreInfoUrlConstructorTest` calls Calendar which may be statically mocked by other concurrent tests. Add `@LockStatic` to avoid the conflict. 

### Testing

- `./gradlew test`

