### PR TITLE
[ANCHOR-515] SEP-6: Remove KYC verification

### DIFF
--- a/.github/workflows/sub_gradle_test_and_build.yml
+++ b/.github/workflows/sub_gradle_test_and_build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Prepare Stellar Validation Tests
       - name: Pull Stellar Validation Tests Docker Image
-        run: docker pull stellar/anchor-tests:v0.6.6 &
+        run: docker pull stellar/anchor-tests:v0.6.7 &
 
       # Set up JDK 11
       - name: Set up JDK 11
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.6 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
+          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.7 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
   analyze:
     name: CodeQL Analysis

--- a/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarId.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/shared/StellarId.java
@@ -10,6 +10,7 @@ import lombok.Data;
 public class StellarId {
   String id;
   String account;
+  String memo;
 
   public StellarId() {}
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -184,6 +184,7 @@ public class Sep31Service {
     StellarId creatorStellarId =
         StellarId.builder()
             .account(Objects.requireNonNullElse(sep10Jwt.getMuxedAccount(), sep10Jwt.getAccount()))
+            .memo(sep10Jwt.getAccountMemo())
             .build();
 
     Amount fee = Context.get().getFee();

--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.stellar.anchor.api.callback.CustomerIntegration;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.asset.AssetService;
@@ -14,7 +13,6 @@ import org.stellar.sdk.KeyPair;
 @RequiredArgsConstructor
 public class RequestValidator {
   @NonNull private final AssetService assetService;
-  @NonNull private final CustomerIntegration customerIntegration;
 
   /**
    * Validates that the requested asset is valid and enabled for deposit.

--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -1,13 +1,10 @@
 package org.stellar.anchor.sep6;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.stellar.anchor.api.callback.CustomerIntegration;
-import org.stellar.anchor.api.callback.GetCustomerRequest;
-import org.stellar.anchor.api.callback.GetCustomerResponse;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.asset.AssetService;
@@ -113,47 +110,5 @@ public class RequestValidator {
     } catch (RuntimeException ex) {
       throw new SepValidationException(String.format("invalid account %s", account));
     }
-  }
-
-  /**
-   * Validates that the authenticated account has been KYC'ed by the anchor and returns its SEP-12
-   * customer ID.
-   *
-   * @param sep10Account the authenticated account
-   * @param sep10AccountMemo the authenticated account memo
-   * @throws AnchorException if the account has not been KYC'ed
-   * @return the SEP-12 customer ID if the account has been KYC'ed
-   */
-  public String validateKyc(String sep10Account, String sep10AccountMemo) throws AnchorException {
-    GetCustomerRequest request =
-        sep10AccountMemo != null
-            ? GetCustomerRequest.builder()
-                .account(sep10Account)
-                .memo(sep10AccountMemo)
-                .memoType("id")
-                .build()
-            : GetCustomerRequest.builder().account(sep10Account).build();
-    GetCustomerResponse response = customerIntegration.getCustomer(request);
-
-    if (response == null || response.getStatus() == null) {
-      throw new ServerErrorException("unable to get required fields for customer") {};
-    }
-
-    switch (response.getStatus()) {
-      case "NEEDS_INFO":
-        throw new SepCustomerInfoNeededException(new ArrayList<>(response.getFields().keySet()));
-      case "PROCESSING":
-        throw new SepNotAuthorizedException("customer is being reviewed by anchor");
-      case "REJECTED":
-        throw new SepNotAuthorizedException("customer rejected by anchor");
-      case "ACCEPTED":
-        // do nothing
-        break;
-      default:
-        throw new ServerErrorException(
-            String.format("unknown customer status: %s", response.getStatus()));
-    }
-
-    return response.getId();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -150,7 +150,7 @@ public class Sep6Service {
           exchangeAmountsCalculator.calculateFromQuote(
               request.getQuoteId(), sellAsset, request.getAmount());
     } else {
-      // If a quote is no provided set, amounts to 0.
+      // If a quote is not provided, set the fee and out amounts to 0.
       // The business server should use the notify_amounts_updated RPC to update the amounts.
       amounts =
           Amounts.builder()
@@ -314,7 +314,7 @@ public class Sep6Service {
           exchangeAmountsCalculator.calculateFromQuote(
               request.getQuoteId(), sellAsset, request.getAmount());
     } else {
-      // If a quote is no provided set, amounts to 0.
+      // If a quote is not provided, set the fee and out amounts to 0.
       // The business server should use the notify_amounts_updated RPC to update the amounts.
       amounts =
           Amounts.builder()

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
@@ -362,15 +362,6 @@ public interface Sep6Transaction extends SepTransaction {
 
   void setInstructions(Map<String, InstructionField> instructions);
 
-  /**
-   * The SEP-12 customer ID of the user initiating the transaction.
-   *
-   * @return the customer ID.
-   */
-  String getCustomer();
-
-  void setCustomer(String customer);
-
   enum Kind {
     DEPOSIT("deposit"),
     WITHDRAWAL("withdrawal"),

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
@@ -199,11 +199,6 @@ public class Sep6TransactionBuilder {
     return this;
   }
 
-  public Sep6TransactionBuilder customer(String customer) {
-    txn.setCustomer(customer);
-    return this;
-  }
-
   public Sep6Transaction build() {
     return txn;
   }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
@@ -62,7 +62,7 @@ public class Sep6TransactionUtils {
             .requiredCustomerInfoUpdates(txn.getRequiredCustomerInfoUpdates())
             .instructions(txn.getInstructions());
 
-    if (Sep6Transaction.Kind.valueOf(txn.getKind().toUpperCase()).isDeposit()) {
+    if (Sep6Transaction.Kind.valueOf(txn.getKind().toUpperCase().replace("-", "_")).isDeposit()) {
       return builder.depositMemo(txn.getMemo()).depositMemoType(txn.getMemoType()).build();
     } else {
       return builder

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -93,7 +93,8 @@ public class TransactionHelper {
     String amountOutAsset = makeAsset(txn.getAmountOutAsset(), assetService, txn);
     String amountFeeAsset = makeAsset(txn.getAmountFeeAsset(), assetService, txn);
     String amountExpectedAsset = makeAsset(null, assetService, txn);
-    StellarId customer = StellarId.builder().id(txn.getCustomer()).build();
+    StellarId customer =
+        StellarId.builder().account(txn.getSep10Account()).memo(txn.getSep10AccountMemo()).build();
 
     return GetTransactionResponse.builder()
         .id(txn.getId())

--- a/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
@@ -49,5 +49,4 @@ public class PojoSep6Transaction implements Sep6Transaction {
   String requiredCustomerInfoMessage;
   List<String> requiredCustomerInfoUpdates;
   Map<String, InstructionField> instructions;
-  String customer;
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -840,7 +840,8 @@ class Sep31ServiceTest {
       "receiverId":"137938d4-43a7-4252-a452-842adcee474c",
       "senderId":"d2bd1412-e2f6-4047-ad70-a1a2f133b25c",
       "creator": {
-        "account": "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
+        "account": "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2",
+        "memo": "123456"
       }
     }"""
         .trimMargin()

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -124,7 +124,7 @@ class Sep31TransactionTest {
         .clientDomain("test.com")
         .senderId("6c1770b0-0ea4-11ed-861d-0242ac120002")
         .receiverId("31212353-f265-4dba-9eb4-0bbeda3ba7f2")
-        .creator(StellarId("141ee445-f32c-4c38-9d25-f4475d6c5558", null))
+        .creator(StellarId("141ee445-f32c-4c38-9d25-f4475d6c5558", null, null))
         .build()
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -2,7 +2,6 @@ package org.stellar.anchor.sep6
 
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -10,17 +9,12 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
-import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.api.callback.CustomerIntegration
 import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.callback.GetCustomerResponse
-import org.stellar.anchor.api.exception.SepCustomerInfoNeededException
-import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.exception.SepValidationException
-import org.stellar.anchor.api.exception.ServerErrorException
 import org.stellar.anchor.api.sep.AssetInfo
 import org.stellar.anchor.api.sep.sep12.Sep12Status
-import org.stellar.anchor.api.shared.CustomerField
 import org.stellar.anchor.asset.AssetService
 
 class RequestValidatorTest {
@@ -160,85 +154,5 @@ class RequestValidatorTest {
     assertThrows<SepValidationException> { requestValidator.validateAccount("??") }
 
     verify { customerIntegration wasNot called }
-  }
-
-  @Test
-  fun `test validateKyc`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } returns GetCustomerResponse.builder().id("123").status(Sep12Status.ACCEPTED.name).build()
-    assertEquals("123", requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO))
-  }
-
-  @Test
-  fun `test validateKyc customerIntegration failure`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } throws RuntimeException("test")
-    assertThrows<RuntimeException> { requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO) }
-  }
-
-  @Test
-  fun `test validateKyc with needs info customer`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } returns
-      GetCustomerResponse.builder()
-        .status(Sep12Status.NEEDS_INFO.name)
-        .fields(mapOf("first_name" to CustomerField.builder().build()))
-        .build()
-    val ex =
-      assertThrows<SepCustomerInfoNeededException> {
-        requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO)
-      }
-    assertEquals(listOf("first_name"), ex.fields)
-  }
-
-  @Test
-  fun `test validateKyc with processing customer`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } returns GetCustomerResponse.builder().status(Sep12Status.PROCESSING.name).build()
-    assertThrows<SepNotAuthorizedException> {
-      requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO)
-    }
-  }
-
-  @Test
-  fun `test validateKyc with rejected customer`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } returns GetCustomerResponse.builder().status(Sep12Status.REJECTED.name).build()
-    assertThrows<SepNotAuthorizedException> {
-      requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO)
-    }
-  }
-
-  @Test
-  fun `test validateKyc with unknown status customer`() {
-    every {
-      customerIntegration.getCustomer(
-        GetCustomerRequest.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).memoType("id").build()
-      )
-    } returns GetCustomerResponse.builder().status("??").build()
-    assertThrows<ServerErrorException> { requestValidator.validateKyc(TEST_ACCOUNT, TEST_MEMO) }
-  }
-
-  @Test
-  fun `test validateKyc without memo`() {
-    every {
-      customerIntegration.getCustomer(GetCustomerRequest.builder().account(TEST_ACCOUNT).build())
-    } returns GetCustomerResponse.builder().id("123").status(Sep12Status.ACCEPTED.name).build()
-    assertEquals("123", requestValidator.validateKyc(TEST_ACCOUNT, null))
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -9,24 +9,19 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
-import org.stellar.anchor.api.callback.CustomerIntegration
-import org.stellar.anchor.api.callback.GetCustomerRequest
-import org.stellar.anchor.api.callback.GetCustomerResponse
 import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.api.sep.AssetInfo
-import org.stellar.anchor.api.sep.sep12.Sep12Status
 import org.stellar.anchor.asset.AssetService
 
 class RequestValidatorTest {
   @MockK(relaxed = true) lateinit var assetService: AssetService
-  @MockK(relaxed = true) lateinit var customerIntegration: CustomerIntegration
 
   private lateinit var requestValidator: RequestValidator
 
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
-    requestValidator = RequestValidator(assetService, customerIntegration)
+    requestValidator = RequestValidator(assetService)
   }
 
   @Test
@@ -143,16 +138,11 @@ class RequestValidatorTest {
 
   @Test
   fun `test validateAccount`() {
-    every {
-      customerIntegration.getCustomer(GetCustomerRequest.builder().account(TEST_ACCOUNT).build())
-    } returns GetCustomerResponse.builder().status(Sep12Status.ACCEPTED.name).build()
     requestValidator.validateAccount(TEST_ACCOUNT)
   }
 
   @Test
   fun `test validateAccount with invalid account`() {
     assertThrows<SepValidationException> { requestValidator.validateAccount("??") }
-
-    verify { customerIntegration wasNot called }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -15,12 +15,9 @@ import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_SEP38_FORMAT
-import org.stellar.anchor.TestConstants.Companion.TEST_CUSTOMER_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
 import org.stellar.anchor.TestHelper
-import org.stellar.anchor.api.callback.CustomerIntegration
-import org.stellar.anchor.api.callback.GetCustomerResponse
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
@@ -45,7 +42,6 @@ class Sep6ServiceTest {
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
 
   @MockK(relaxed = true) lateinit var sep6Config: Sep6Config
-  @MockK(relaxed = true) lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) lateinit var requestValidator: RequestValidator
   @MockK(relaxed = true) lateinit var txnStore: Sep6TransactionStore
   @MockK(relaxed = true) lateinit var exchangeAmountsCalculator: ExchangeAmountsCalculator
@@ -61,15 +57,12 @@ class Sep6ServiceTest {
     every { sep6Config.features.isClaimableBalances } returns false
     every { txnStore.newInstance() } returns PojoSep6Transaction()
     every { eventService.createSession(any(), any()) } returns eventSession
-    every { customerIntegration.getCustomer(any()) } returns
-      GetCustomerResponse.builder().id(TEST_CUSTOMER_ID).status("ACCEPTED").build()
     every { requestValidator.getDepositAsset(TEST_ASSET) } returns asset
     every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns asset
     sep6Service =
       Sep6Service(
         sep6Config,
         assetService,
-        customerIntegration,
         requestValidator,
         txnStore,
         exchangeAmountsCalculator,

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -168,8 +168,7 @@ class Sep6ServiceTestData {
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "customer": "test-customer-id"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
       }
     """
         .trimIndent()
@@ -187,11 +186,7 @@ class Sep6ServiceTestData {
                   "amount": "100",
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
           }
       }
     """
@@ -205,8 +200,7 @@ class Sep6ServiceTestData {
           "requestAssetCode": "USDC",
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "customer": "test-customer-id"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
       }
     """
         .trimIndent()
@@ -220,11 +214,7 @@ class Sep6ServiceTestData {
               "sep": "6",
               "kind": "deposit",
               "status": "incomplete",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
           }
       }
     """
@@ -247,8 +237,7 @@ class Sep6ServiceTestData {
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "quoteId": "test-quote-id",
-          "customer": "test-customer-id"
+          "quoteId": "test-quote-id"
       }
     """
         .trimIndent()
@@ -279,11 +268,7 @@ class Sep6ServiceTestData {
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "quote_id": "test-quote-id",
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
           }
       }
     """
@@ -299,14 +284,13 @@ class Sep6ServiceTestData {
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountIn": "100",
           "amountInAsset": "iso4217:USD",
-          "amountOut": "98",
+          "amountOut": "0",
           "amountOutAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountFee": "2",
-          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amountFee": "0",
+          "amountFeeAsset": "iso4217:USD",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "customer": "test-customer-id"
+          "toAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
       }
     """
         .trimIndent()
@@ -329,18 +313,14 @@ class Sep6ServiceTestData {
                   "asset": "iso4217:USD"
               },
               "amount_out": {
-                  "amount": "98",
+                  "amount": "0",
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "amount_fee": {
-                  "amount": "2",
-                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+                  "amount": "0",
+                  "asset": "iso4217:USD"
               },
-              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "destination_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
           }
       }
     """
@@ -369,8 +349,7 @@ class Sep6ServiceTestData {
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text",
-          "customer": "test-customer-id"
+          "refundMemoType": "text"
       }
     """
         .trimIndent()
@@ -391,11 +370,7 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "refund_memo_type": "text"
           }
       }
     """
@@ -413,8 +388,7 @@ class Sep6ServiceTestData {
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text",
-          "customer": "test-customer-id"
+          "refundMemoType": "text"
       }
     """
         .trimIndent()
@@ -431,11 +405,7 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "refund_memo_type": "text"
           }
       }
     """
@@ -462,8 +432,7 @@ class Sep6ServiceTestData {
           "memoType": "hash",
           "quoteId": "test-quote-id",
           "refundMemo": "some text",
-          "refundMemoType": "text",
-          "customer": "test-customer-id"
+          "refundMemoType": "text"
       }
     """
         .trimIndent()
@@ -497,11 +466,7 @@ class Sep6ServiceTestData {
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "refund_memo_type": "text"
           }
       }
     """
@@ -517,18 +482,17 @@ class Sep6ServiceTestData {
           "requestAssetIssuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountIn": "100",
           "amountInAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amountOut": "98",
+          "amountOut": "0",
           "amountOutAsset": "iso4217:USD",
-          "amountFee": "2",
-          "amountFeeAsset": "iso4217:USD",
+          "amountFee": "0",
+          "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "memoType": "hash",
           "refundMemo": "some text",
-          "refundMemoType": "text",
-          "customer": "test-customer-id"
+          "refundMemoType": "text"
       }
     """
         .trimIndent()
@@ -551,21 +515,17 @@ class Sep6ServiceTestData {
                   "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "amount_out": {
-                  "amount": "98",
+                  "amount": "0",
                   "asset": "iso4217:USD"
               },
               "amount_fee": {
-                  "amount": "2",
-                  "asset": "iso4217:USD"
+                  "amount": "0",
+                  "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
               },
               "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
               "memo_type": "hash",
               "refund_memo": "some text",
-              "refund_memo_type": "text",
-              "customers": {
-                  "sender": { "id": "test-customer-id" },
-                  "receiver": { "id": "test-customer-id" }
-              }
+              "refund_memo_type": "text"
           }
       }
     """

--- a/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep6Client.kt
+++ b/integration-tests/src/main/kotlin/org/stellar/anchor/platform/Sep6Client.kt
@@ -4,26 +4,23 @@ import org.stellar.anchor.api.sep.sep6.GetTransactionResponse
 import org.stellar.anchor.api.sep.sep6.InfoResponse
 import org.stellar.anchor.api.sep.sep6.StartDepositResponse
 import org.stellar.anchor.api.sep.sep6.StartWithdrawResponse
-import org.stellar.anchor.util.Log
 
 class Sep6Client(private val endpoint: String, private val jwt: String) : SepClient() {
   fun getInfo(): InfoResponse {
-    Log.info("SEP6 $endpoint/info")
     val responseBody = httpGet("$endpoint/info")
     return gson.fromJson(responseBody, InfoResponse::class.java)
   }
 
-  fun deposit(request: Map<String, String>): StartDepositResponse {
-    val baseUrl = "$endpoint/deposit?"
+  fun deposit(request: Map<String, String>, exchange: Boolean = false): StartDepositResponse {
+    val baseUrl = if (exchange) "$endpoint/deposit-exchange?" else "$endpoint/deposit?"
     val url = request.entries.fold(baseUrl) { acc, entry -> "$acc${entry.key}=${entry.value}&" }
 
-    Log.info("SEP6 $url")
     val responseBody = httpGet(url, jwt)
     return gson.fromJson(responseBody, StartDepositResponse::class.java)
   }
 
-  fun withdraw(request: Map<String, String>): StartWithdrawResponse {
-    val baseUrl = "$endpoint/withdraw?"
+  fun withdraw(request: Map<String, String>, exchange: Boolean = false): StartWithdrawResponse {
+    val baseUrl = if (exchange) "$endpoint/withdraw-exchange?" else "$endpoint/withdraw?"
     val url = request.entries.fold(baseUrl) { acc, entry -> "$acc${entry.key}=${entry.value}&" }
 
     val responseBody = httpGet(url, jwt)
@@ -34,7 +31,6 @@ class Sep6Client(private val endpoint: String, private val jwt: String) : SepCli
     val baseUrl = "$endpoint/transaction?"
     val url = request.entries.fold(baseUrl) { acc, entry -> "$acc${entry.key}=${entry.value}&" }
 
-    Log.info("SEP6 $url")
     val responseBody = httpGet(url, jwt)
     return gson.fromJson(responseBody, GetTransactionResponse::class.java)
   }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -2,9 +2,9 @@ package org.stellar.anchor.platform.test
 
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
-import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
+import org.stellar.anchor.api.sep.sep38.Sep38Context
 import org.stellar.anchor.platform.CLIENT_WALLET_ACCOUNT
-import org.stellar.anchor.platform.Sep12Client
+import org.stellar.anchor.platform.Sep38Client
 import org.stellar.anchor.platform.Sep6Client
 import org.stellar.anchor.platform.gson
 import org.stellar.anchor.util.Log
@@ -12,11 +12,11 @@ import org.stellar.anchor.util.Sep1Helper.TomlContent
 
 class Sep6Tests(val toml: TomlContent, jwt: String) {
   private val sep6Client: Sep6Client
-  private val sep12Client: Sep12Client
+  private val sep38Client: Sep38Client
 
   init {
     sep6Client = Sep6Client(toml.getString("TRANSFER_SERVER"), jwt)
-    sep12Client = Sep12Client(toml.getString("KYC_SERVER"), jwt)
+    sep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), jwt)
   }
 
   private val expectedSep6Info =
@@ -117,6 +117,42 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
   """
       .trimIndent()
 
+  private val expectedSep6DepositExchangeResponse =
+    """
+      {
+        "transaction": {
+          "kind": "deposit-exchange",
+          "status": "incomplete",
+          "amount_in": "1",
+          "amount_in_asset": "iso4217:USD",
+          "amount_out": "0",
+          "amount_out_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amount_fee": "0",
+          "amount_fee_asset": "iso4217:USD",
+          "to": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
+        }
+      }
+    """
+      .trimIndent()
+
+  private val expectedSep6DepositExchangeWithQuoteResponse =
+    """
+      {
+        "transaction": {
+          "kind": "deposit-exchange",
+          "status": "incomplete",
+          "amount_in": "10",
+          "amount_in_asset": "iso4217:USD",
+          "amount_out": "8.8235",
+          "amount_out_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amount_fee": "1.00",
+          "amount_fee_asset": "iso4217:USD",
+          "to": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
+        }
+      }
+    """
+      .trimIndent()
+
   private val expectedSep6WithdrawResponse =
     """
       {
@@ -126,6 +162,46 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
               "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "withdraw_memo_type": "hash"
           }
+      }
+    """
+      .trimIndent()
+
+  private val expectedSep6WithdrawExchangeResponse =
+    """
+      {
+        "transaction": {
+          "kind": "withdrawal-exchange",
+          "status": "incomplete",
+          "amount_in": "1",
+          "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amount_out": "0",
+          "amount_out_asset": "iso4217:USD",
+          "amount_fee": "0",
+          "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+          "withdraw_memo_type": "hash"
+        }
+      }
+    """
+      .trimIndent()
+
+  private val expectedSep6WithdrawExchangeWithQuoteResponse =
+    """
+      {
+        "transaction": {
+          "kind": "withdrawal-exchange",
+          "status": "incomplete",
+          "amount_in": "10",
+          "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "amount_out": "8.5714",
+          "amount_out_asset": "iso4217:USD",
+          "amount_fee": "1.00",
+          "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
+          "withdraw_memo_type": "hash"
+        }
       }
     """
       .trimIndent()
@@ -155,6 +231,57 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
     )
   }
 
+  private fun `test sep6 deposit-exchange without quote`() {
+    val request =
+      mapOf(
+        "destination_asset" to "USDC",
+        "source_asset" to "iso4217:USD",
+        "amount" to "1",
+        "account" to CLIENT_WALLET_ACCOUNT,
+        "type" to "SWIFT"
+      )
+
+    val response = sep6Client.deposit(request, exchange = true)
+    Log.info("GET /deposit-exchange response: $response")
+    assert(!response.id.isNullOrEmpty())
+
+    val savedDepositTxn = sep6Client.getTransaction(mapOf("id" to response.id!!))
+    JSONAssert.assertEquals(
+      expectedSep6DepositExchangeResponse,
+      gson.toJson(savedDepositTxn),
+      JSONCompareMode.LENIENT
+    )
+  }
+
+  private fun `test sep6 deposit-exchange with quote`() {
+    val quoteId =
+      postQuote(
+        "iso4217:USD",
+        "10",
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+      )
+    val request =
+      mapOf(
+        "destination_asset" to "USDC",
+        "source_asset" to "iso4217:USD",
+        "amount" to "10",
+        "account" to CLIENT_WALLET_ACCOUNT,
+        "type" to "SWIFT",
+        "quote_id" to quoteId
+      )
+
+    val response = sep6Client.deposit(request, exchange = true)
+    Log.info("GET /deposit-exchange response: $response")
+    assert(!response.id.isNullOrEmpty())
+
+    val savedDepositTxn = sep6Client.getTransaction(mapOf("id" to response.id!!))
+    JSONAssert.assertEquals(
+      expectedSep6DepositExchangeWithQuoteResponse,
+      gson.toJson(savedDepositTxn),
+      JSONCompareMode.LENIENT
+    )
+  }
+
   private fun `test sep6 withdraw`() {
     val request = mapOf("asset_code" to "USDC", "type" to "bank_account", "amount" to "1")
     val response = sep6Client.withdraw(request)
@@ -169,22 +296,67 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
     )
   }
 
-  private fun putCustomer() {
+  private fun `test sep6 withdraw-exchange without quote`() {
     val request =
-      Sep12PutCustomerRequest.builder()
-        .firstName("John")
-        .lastName("Doe")
-        .emailAddress("john@email.com")
-        .build()
-    sep12Client.putCustomer(request)
+      mapOf(
+        "destination_asset" to "iso4217:USD",
+        "source_asset" to "USDC",
+        "amount" to "1",
+        "type" to "bank_account"
+      )
+
+    val response = sep6Client.withdraw(request, exchange = true)
+    Log.info("GET /withdraw-exchange response: $response")
+    assert(!response.id.isNullOrEmpty())
+
+    val savedDepositTxn = sep6Client.getTransaction(mapOf("id" to response.id!!))
+    JSONAssert.assertEquals(
+      expectedSep6WithdrawExchangeResponse,
+      gson.toJson(savedDepositTxn),
+      JSONCompareMode.LENIENT
+    )
+  }
+
+  private fun `test sep6 withdraw-exchange with quote`() {
+    val quoteId =
+      postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "iso4217:USD"
+      )
+    val request =
+      mapOf(
+        "destination_asset" to "iso4217:USD",
+        "source_asset" to "USDC",
+        "amount" to "10",
+        "type" to "bank_account",
+        "quote_id" to quoteId
+      )
+
+    val response = sep6Client.withdraw(request, exchange = true)
+    Log.info("GET /withdraw-exchange response: $response")
+    assert(!response.id.isNullOrEmpty())
+
+    val savedDepositTxn = sep6Client.getTransaction(mapOf("id" to response.id!!))
+    JSONAssert.assertEquals(
+      expectedSep6WithdrawExchangeWithQuoteResponse,
+      gson.toJson(savedDepositTxn),
+      JSONCompareMode.LENIENT
+    )
+  }
+
+  private fun postQuote(sellAsset: String, sellAmount: String, buyAsset: String): String {
+    return sep38Client.postQuote(sellAsset, sellAmount, buyAsset, Sep38Context.SEP6).id
   }
 
   fun testAll() {
     Log.info("Performing SEP6 tests")
-    // Create a customer before running any tests
-    putCustomer()
     `test Sep6 info endpoint`()
     `test sep6 deposit`()
+    `test sep6 deposit-exchange without quote`()
+    `test sep6 deposit-exchange with quote`()
     `test sep6 withdraw`()
+    `test sep6 withdraw-exchange without quote`()
+    `test sep6 withdraw-exchange with quote`()
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -137,20 +137,19 @@ public class SepBeans {
   @Bean
   @ConditionalOnAllSepsEnabled(seps = {"sep6"})
   Sep6Service sep6Service(
-      ClientFinder clientFinder,
       Sep6Config sep6Config,
       AssetService assetService,
+      CustomerIntegration customerIntegration,
       Sep6TransactionStore txnStore,
       EventService eventService,
-      CustomerIntegration customerIntegration,
-      FeeIntegration feeIntegration,
       Sep38QuoteStore sep38QuoteStore) {
     RequestValidator requestValidator = new RequestValidator(assetService, customerIntegration);
     ExchangeAmountsCalculator exchangeAmountsCalculator =
-        new ExchangeAmountsCalculator(clientFinder, feeIntegration, sep38QuoteStore, assetService);
+        new ExchangeAmountsCalculator(sep38QuoteStore);
     return new Sep6Service(
         sep6Config,
         assetService,
+        customerIntegration,
         requestValidator,
         txnStore,
         exchangeAmountsCalculator,

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -139,17 +139,15 @@ public class SepBeans {
   Sep6Service sep6Service(
       Sep6Config sep6Config,
       AssetService assetService,
-      CustomerIntegration customerIntegration,
       Sep6TransactionStore txnStore,
       EventService eventService,
       Sep38QuoteStore sep38QuoteStore) {
-    RequestValidator requestValidator = new RequestValidator(assetService, customerIntegration);
+    RequestValidator requestValidator = new RequestValidator(assetService);
     ExchangeAmountsCalculator exchangeAmountsCalculator =
         new ExchangeAmountsCalculator(sep38QuoteStore);
     return new Sep6Service(
         sep6Config,
         assetService,
-        customerIntegration,
         requestValidator,
         txnStore,
         exchangeAmountsCalculator,

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
@@ -141,7 +141,4 @@ public class JdbcSep6Transaction extends JdbcSepTransaction implements Sep6Trans
   @Column(name = "instructions")
   @Type(type = "json")
   Map<String, InstructionField> instructions;
-
-  @Column(name = "customer")
-  String customer;
 }

--- a/platform/src/main/resources/db/migration/V10__sep6_field_updates.sql
+++ b/platform/src/main/resources/db/migration/V10__sep6_field_updates.sql
@@ -1,7 +1,6 @@
 ALTER TABLE sep6_transaction ADD required_customer_info_message VARCHAR(255);
 ALTER TABLE sep6_transaction ADD required_customer_info_updates JSON;
 ALTER TABLE sep6_transaction ADD instructions JSON;
-ALTER TABLE sep6_transaction ADD customer VARCHAR(255);
 
 ALTER TABLE sep6_transaction DROP COLUMN required_info_updates;
 ALTER TABLE sep6_transaction ADD required_info_updates JSON;

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
@@ -465,7 +465,7 @@ class DoStellarRefundHandlerTest {
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.customers = Customers(StellarId(null, null), StellarId(null, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
@@ -1017,7 +1017,7 @@ class NotifyRefundSentHandlerTest {
     expectedResponse.amountFee = Amount("0", STELLAR_USDC)
     expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.customers = Customers(StellarId(null, null), StellarId(null, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     val refundPayment = RefundPayment()
     refundPayment.amount = Amount("1", txn31.amountInAsset)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionErrorHandlerTest.kt
@@ -300,7 +300,7 @@ class NotifyTransactionErrorHandlerTest {
     expectedResponse.amountFee = Amount(null, null)
     expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedResponse.message = TX_MESSAGE
-    expectedResponse.customers = Customers(StellarId(null, null), StellarId(null, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionExpiredHandlerTest.kt
@@ -321,7 +321,7 @@ class NotifyTransactionExpiredHandlerTest {
     expectedResponse.amountFee = Amount(null, null)
     expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedResponse.message = TX_MESSAGE
-    expectedResponse.customers = Customers(StellarId(null, null), StellarId(null, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionRecoveryHandlerTest.kt
@@ -18,13 +18,9 @@ import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyTransactionRecoveryRequest
-import org.stellar.anchor.api.sep.SepTransactionStatus.ERROR
-import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR
-import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER
+import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.api.shared.Customers
 import org.stellar.anchor.api.shared.StellarId
@@ -278,7 +274,7 @@ class NotifyTransactionRecoveryHandlerTest {
     expectedResponse.amountFee = Amount(null, null)
     expectedResponse.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedResponse.transferReceivedAt = transferReceivedAt
-    expectedResponse.customers = Customers(StellarId(null, null), StellarId(null, null))
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),


### PR DESCRIPTION
### Description

This removes KYC verification from the SEP-6 transaction initiation. Now that KYC is removed, the customer may not be known to the Anchor at the time of transaction initiation so the `customer` field cannot be set. To allow Anchors to associate SEP transactions with a customer, the SEP-10 account memo is now added as a field to the `StellarId` object. 

This means for the exchange endpoints, the platform can no longer make a request to the Fee integration as it requires setting SEP-12 sender and receiver fields. Business servers are expected to update the amounts asynchronously like they already do for regular fees.

### Context

KYC verification is done "interactively" in SEP-6.

### Testing

- `./gradlew test`

### Documentation

Stellar docs need to be updated so that the `StellarId` object includes an optional `memo` field

### Known limitations

N/A

