### PR TITLE
[ANCHOR-476] add withdraw_anchor_account to PATCH /transactions

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -83,6 +83,9 @@ public class PlatformTransactionData {
   @SerializedName("refund_memo_type")
   String refundMemoType;
 
+  @SerializedName("withdraw_anchor_account")
+  String withdrawAnchorAccount;
+
   Customers customers;
   StellarId creator;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -250,17 +250,6 @@ public class TransactionService {
       case "24":
         JdbcSep24Transaction sep24Txn = (JdbcSep24Transaction) txn;
 
-        // add a memo for the transaction if the transaction is ready for user to send funds
-        if (sep24Txn.getMemo() == null
-            && Kind.WITHDRAWAL.getKind().equals(sep24Txn.getKind())
-            && sep24Txn.getStatus().equals(PENDING_USR_TRANSFER_START.toString())) {
-          SepDepositInfo sep24DepositInfo = sep24DepositInfoGenerator.generate(sep24Txn);
-          sep24Txn.setToAccount(sep24DepositInfo.getStellarAddress());
-          sep24Txn.setWithdrawAnchorAccount(sep24DepositInfo.getStellarAddress());
-          sep24Txn.setMemo(sep24DepositInfo.getMemo());
-          sep24Txn.setMemoType(sep24DepositInfo.getMemoType());
-        }
-
         if (custodyConfig.isCustodyIntegrationEnabled()
             && !lastStatus.equals(sep24Txn.getStatus())
             && ((Kind.DEPOSIT.getKind().equals(sep24Txn.getKind())
@@ -343,7 +332,17 @@ public class TransactionService {
           txnUpdated = updateField(patch, sep24Txn, "memoType", txnUpdated);
         }
 
+        // add a memo for the transaction if the transaction is ready for user to send funds
+        if (sep24Txn.getMemo() == null
+            && Kind.WITHDRAWAL.getKind().equals(sep24Txn.getKind())
+            && sep24Txn.getStatus().equals(PENDING_USR_TRANSFER_START.toString())) {
+          SepDepositInfo sep24DepositInfo = sep24DepositInfoGenerator.generate(sep24Txn);
+          sep24Txn.setMemo(sep24DepositInfo.getMemo());
+          sep24Txn.setMemoType(sep24DepositInfo.getMemoType());
+        }
+
         txnUpdated = updateField(patch, sep24Txn, "message", txnUpdated);
+        txnUpdated = updateField(patch, sep24Txn, "withdrawAnchorAccount", txnUpdated);
 
         // update refunds
         if (patch.getRefunds() != null) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
@@ -44,7 +44,7 @@ class TransactionServiceTest {
     private const val fiatUSD = "iso4217:USD"
     private const val stellarUSDC =
       "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
-    private const val TEST_ACCOUNT = "GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"
+    private const val TEST_DEST_ACCOUNT = "testWithdrawAnchorAccount"
     private const val TEST_MEMO = "test memo"
     private const val TEST_TXN_ID = "a4baff5f-778c-43d6-bbef-3e9fb41d096e"
     private val gson = GsonUtils.getInstance()
@@ -327,11 +327,13 @@ class TransactionServiceTest {
     val tx = JdbcSep24Transaction()
     tx.status = SepTransactionStatus.INCOMPLETE.toString()
     tx.kind = "withdrawal"
+    tx.withdrawAnchorAccount = null
     val data = PlatformTransactionData()
     data.id = txId
     data.memo = "12345"
     data.memoType = "id"
     data.status = SepTransactionStatus.PENDING_USR_TRANSFER_START
+    data.withdrawAnchorAccount = TEST_DEST_ACCOUNT
     val request =
       PatchTransactionsRequest.builder().records(listOf(PatchTransactionRequest(data))).build()
 
@@ -344,6 +346,7 @@ class TransactionServiceTest {
     verify(exactly = 1) { custodyService.createTransaction(ofType(Sep24Transaction::class)) }
     verify(exactly = 1) { sep24TransactionStore.save(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
+    assertEquals(TEST_DEST_ACCOUNT, tx.withdrawAnchorAccount)
   }
 
   @Test


### PR DESCRIPTION
### Description

 add `withdraw_anchor_account` to `PATCH /transactions` to support setting destination accounts for withdrawals dynamically

### Context

Today, the Anchor Platform sets `withdraw_anchor_account` to the value of the asset’s distribution account set in the config when the transaction is created.

Per partner request, support setting `withdraw_anchor_account` via `PATCH /transactions` – the address set can be different from the configured distribution account for the asset

### Testing

- `./gradlew test`
- Added test case to verify `withdraw_anchor_account` is updated via patch /transaction

