### PR TITLE
[ANCHOR-508] SEP-6: Custody integration

### DIFF
--- a/.github/workflows/sub_gradle_test_and_build.yml
+++ b/.github/workflows/sub_gradle_test_and_build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Prepare Stellar Validation Tests
       - name: Pull Stellar Validation Tests Docker Image
-        run: docker pull stellar/anchor-tests:v0.6.8 &
+        run: docker pull stellar/anchor-tests:v0.6.9 &
 
       # Set up JDK 11
       - name: Set up JDK 11
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.8 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
+          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.9 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
       - name: Upload Artifacts
         if: always()

--- a/.github/workflows/sub_gradle_test_and_build.yml
+++ b/.github/workflows/sub_gradle_test_and_build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Prepare Stellar Validation Tests
       - name: Pull Stellar Validation Tests Docker Image
-        run: docker pull stellar/anchor-tests:v0.6.7 &
+        run: docker pull stellar/anchor-tests:v0.6.8 &
 
       # Set up JDK 11
       - name: Set up JDK 11
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.7 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
+          docker run --network host -v ${GITHUB_WORKSPACE}/platform/src/test/resources://config stellar/anchor-tests:v0.6.8 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
       - name: Upload Artifacts
         if: always()

--- a/core/src/main/java/org/stellar/anchor/config/Sep6Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep6Config.java
@@ -11,6 +11,8 @@ public interface Sep6Config {
 
   Features getFeatures();
 
+  DepositInfoGeneratorType getDepositInfoGeneratorType();
+
   @Getter
   @Setter
   @AllArgsConstructor
@@ -21,5 +23,11 @@ public interface Sep6Config {
 
     @SerializedName("claimable_balances")
     boolean claimableBalances;
+  }
+
+  enum DepositInfoGeneratorType {
+    SELF,
+    CUSTODY,
+    NONE
   }
 }

--- a/core/src/main/java/org/stellar/anchor/custody/CustodyService.java
+++ b/core/src/main/java/org/stellar/anchor/custody/CustodyService.java
@@ -5,8 +5,17 @@ import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.rpc.method.DoStellarRefundRequest;
 import org.stellar.anchor.sep24.Sep24Transaction;
 import org.stellar.anchor.sep31.Sep31Transaction;
+import org.stellar.anchor.sep6.Sep6Transaction;
 
 public interface CustodyService {
+
+  /**
+   * Create custody transaction for SEP6 transaction
+   *
+   * @param txn SEP6 transaction
+   * @throws AnchorException if error happens
+   */
+  void createTransaction(Sep6Transaction txn) throws AnchorException;
 
   /**
    * Create custody transaction for SEP24 transaction

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6DepositInfoGenerator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6DepositInfoGenerator.java
@@ -1,0 +1,16 @@
+package org.stellar.anchor.sep6;
+
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.shared.SepDepositInfo;
+
+public interface Sep6DepositInfoGenerator {
+
+  /**
+   * Gets the deposit info based on the input parameter.
+   *
+   * @param txn the original SEP-6 transaction the deposit info will be used for.
+   * @return a SepDepositInfo instance containing the destination address, memo and memoType.
+   * @throws AnchorException if the deposit info cannot be generated
+   */
+  SepDepositInfo generate(Sep6Transaction txn) throws AnchorException;
+}

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -268,7 +268,6 @@ public class Sep6Service {
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
-            .withdrawAnchorAccount(asset.getDistributionAccount())
             .fromAccount(sourceAccount)
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType());
@@ -284,10 +283,7 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
-    return StartWithdrawResponse.builder()
-        .accountId(asset.getDistributionAccount())
-        .id(txn.getId())
-        .build();
+    return StartWithdrawResponse.builder().id(txn.getId()).build();
   }
 
   public StartWithdrawResponse withdrawExchange(
@@ -358,7 +354,6 @@ public class Sep6Service {
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
-            .withdrawAnchorAccount(sellAsset.getDistributionAccount())
             .fromAccount(sourceAccount)
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())
@@ -375,10 +370,7 @@ public class Sep6Service {
             .transaction(TransactionHelper.toGetTransactionResponse(txn, assetService))
             .build());
 
-    return StartWithdrawResponse.builder()
-        .accountId(sellAsset.getDistributionAccount())
-        .id(txn.getId())
-        .build();
+    return StartWithdrawResponse.builder().id(txn.getId()).build();
   }
 
   public GetTransactionsResponse findTransactions(Sep10Jwt token, GetTransactionsRequest request)

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -1,7 +1,6 @@
 package org.stellar.anchor.sep6;
 
 import static org.stellar.anchor.util.MemoHelper.*;
-import static org.stellar.sdk.xdr.MemoType.MEMO_HASH;
 
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
@@ -190,7 +189,6 @@ public class Sep6Service {
             .amountFee(amounts.getAmountFee())
             .amountFeeAsset(amounts.getAmountFeeAsset())
             .amountExpected(request.getAmount())
-            .amountExpected(request.getAmount())
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
@@ -270,10 +268,8 @@ public class Sep6Service {
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
-            .memo(generateMemo(id))
-            .memoType(memoTypeAsString(MEMO_HASH))
-            .fromAccount(sourceAccount)
             .withdrawAnchorAccount(asset.getDistributionAccount())
+            .fromAccount(sourceAccount)
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType());
 
@@ -291,8 +287,6 @@ public class Sep6Service {
     return StartWithdrawResponse.builder()
         .accountId(asset.getDistributionAccount())
         .id(txn.getId())
-        .memo(txn.getMemo())
-        .memoType(memoTypeAsString(MEMO_HASH))
         .build();
   }
 
@@ -364,10 +358,8 @@ public class Sep6Service {
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
             .sep10AccountMemo(token.getAccountMemo())
-            .memo(generateMemo(id))
-            .memoType(memoTypeAsString(MEMO_HASH))
-            .fromAccount(sourceAccount)
             .withdrawAnchorAccount(sellAsset.getDistributionAccount())
+            .fromAccount(sourceAccount)
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())
             .quoteId(request.getQuoteId());
@@ -386,8 +378,6 @@ public class Sep6Service {
     return StartWithdrawResponse.builder()
         .accountId(sellAsset.getDistributionAccount())
         .id(txn.getId())
-        .memo(txn.getMemo())
-        .memoType(memoTypeAsString(MEMO_HASH))
         .build();
   }
 

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -6,7 +6,6 @@ import static org.stellar.sdk.xdr.MemoType.*;
 import java.util.Base64;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.StringUtils;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.exception.SepValidationException;
 import org.stellar.sdk.*;
@@ -125,11 +124,5 @@ public class MemoHelper {
         String memoTypeStr = memoTypeAsString(memo);
         throw new SepException("Unsupported value: " + memoTypeStr);
     }
-  }
-
-  public static String generateMemo(String transactionId) {
-    String memo = StringUtils.truncate(transactionId, 32);
-    memo = StringUtils.leftPad(memo, 32, "0");
-    return new String(Base64.getEncoder().encode(memo.getBytes()));
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -657,8 +657,6 @@ class Sep6ServiceTest {
       JSONCompareMode.LENIENT
     )
     assert(slotTxn.captured.id.isNotEmpty())
-    assert(slotTxn.captured.memo.isNotEmpty())
-    assertEquals(slotTxn.captured.memoType, "hash")
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
@@ -668,8 +666,6 @@ class Sep6ServiceTest {
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
-    assert(slotEvent.captured.transaction.memo.isNotEmpty())
-    assertEquals(slotEvent.captured.transaction.memoType, "hash")
     assertNotNull(slotEvent.captured.transaction.startedAt)
 
     // Verify response
@@ -738,8 +734,6 @@ class Sep6ServiceTest {
       JSONCompareMode.LENIENT
     )
     assert(slotTxn.captured.id.isNotEmpty())
-    assert(slotTxn.captured.memo.isNotEmpty())
-    assertEquals(slotTxn.captured.memoType, "hash")
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
@@ -749,8 +743,6 @@ class Sep6ServiceTest {
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
-    assert(slotEvent.captured.transaction.memo.isNotEmpty())
-    assertEquals(slotEvent.captured.transaction.memoType, "hash")
     assertNotNull(slotEvent.captured.transaction.startedAt)
 
     // Verify response
@@ -945,8 +937,6 @@ class Sep6ServiceTest {
       JSONCompareMode.LENIENT
     )
     assert(slotTxn.captured.id.isNotEmpty())
-    assert(slotTxn.captured.memo.isNotEmpty())
-    assertEquals(slotTxn.captured.memoType, "hash")
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
@@ -956,8 +946,6 @@ class Sep6ServiceTest {
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
-    assert(slotEvent.captured.transaction.memo.isNotEmpty())
-    assertEquals(slotEvent.captured.transaction.memoType, "hash")
     assertNotNull(slotEvent.captured.transaction.startedAt)
 
     // Verify response
@@ -1018,8 +1006,6 @@ class Sep6ServiceTest {
       JSONCompareMode.LENIENT
     )
     assert(slotTxn.captured.id.isNotEmpty())
-    assert(slotTxn.captured.memo.isNotEmpty())
-    assertEquals(slotTxn.captured.memoType, "hash")
     assertNotNull(slotTxn.captured.startedAt)
 
     JSONAssert.assertEquals(
@@ -1029,8 +1015,6 @@ class Sep6ServiceTest {
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
-    assert(slotEvent.captured.transaction.memo.isNotEmpty())
-    assertEquals(slotEvent.captured.transaction.memoType, "hash")
     assertNotNull(slotEvent.captured.transaction.startedAt)
 
     // Verify response

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -388,7 +388,6 @@ class Sep6ServiceTestData {
     val withdrawResJson =
       """
       {
-          "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I"
       }
       """
         .trimIndent()
@@ -410,7 +409,6 @@ class Sep6ServiceTestData {
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "sep10AccountMemo": "123",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "refundMemo": "some text",
           "refundMemoType": "text"
@@ -474,7 +472,6 @@ class Sep6ServiceTestData {
           "amountFeeAsset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "sep10AccountMemo": "123",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "refundMemo": "some text",
           "refundMemoType": "text"
@@ -533,7 +530,6 @@ class Sep6ServiceTestData {
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "sep10AccountMemo": "123",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "quoteId": "test-quote-id",
           "refundMemo": "some text",
@@ -597,7 +593,6 @@ class Sep6ServiceTestData {
           "amountExpected": "100",
           "sep10Account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "sep10AccountMemo": "123",
-          "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
           "refundMemo": "some text",
           "refundMemoType": "text"

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -388,10 +388,9 @@ class Sep6ServiceTestData {
     val withdrawResJson =
       """
       {
-          "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-          "memo_type": "hash"
+          "account_id": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I"
       }
-    """
+      """
         .trimIndent()
 
     val withdrawTxnJson =
@@ -413,7 +412,6 @@ class Sep6ServiceTestData {
           "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text"
         }
@@ -446,7 +444,6 @@ class Sep6ServiceTestData {
               "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
             },
             "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-            "memo_type": "hash",
             "refund_memo": "some text",
             "refund_memo_type": "text",
             "customers": {
@@ -479,7 +476,6 @@ class Sep6ServiceTestData {
           "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text"
         }
@@ -503,7 +499,6 @@ class Sep6ServiceTestData {
               "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
             },
             "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-            "memo_type": "hash",
             "refund_memo": "some text",
             "refund_memo_type": "text",
             "customers": {
@@ -540,7 +535,6 @@ class Sep6ServiceTestData {
           "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
           "quoteId": "test-quote-id",
           "refundMemo": "some text",
           "refundMemoType": "text"
@@ -569,7 +563,6 @@ class Sep6ServiceTestData {
             "amount_fee": { "amount": "2", "asset": "iso4217:USD" },
             "quote_id": "test-quote-id",
             "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-            "memo_type": "hash",
             "refund_memo": "some text",
             "refund_memo_type": "text",
             "customers": {
@@ -606,7 +599,6 @@ class Sep6ServiceTestData {
           "sep10AccountMemo": "123",
           "withdrawAnchorAccount": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
           "fromAccount": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-          "memoType": "hash",
           "refundMemo": "some text",
           "refundMemoType": "text"
         }
@@ -637,7 +629,6 @@ class Sep6ServiceTestData {
               "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
             },
             "source_account": "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-            "memo_type": "hash",
             "refund_memo": "some text",
             "refund_memo_type": "text",
             "customers": {

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformCustodyEnd2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformCustodyEnd2EndTest.kt
@@ -28,4 +28,12 @@ class AnchorPlatformCustodyEnd2EndTest :
   fun runSep24Test() {
     singleton.sep24CustodyE2eTests.testAll()
   }
+
+  @Test
+  @Order(11)
+  fun runSep6Test() {
+    // The SEP-6 reference server implementation only implements RPC, so technically this test
+    // should be in the RPC test suite.
+    singleton.sep6E2eTests.testAll()
+  }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformEnd2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/AnchorPlatformEnd2EndTest.kt
@@ -31,6 +31,8 @@ class AnchorPlatformEnd2EndTest : AbstractIntegrationTest(TestConfig(testProfile
   @Test
   @Order(2)
   fun runSep6Test() {
+    // The SEP-6 reference server implementation only implements RPC, so technically this test
+    // should be in the RPC test suite.
     singleton.sep6E2eTests.testAll()
   }
 }

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiCustodyTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/PlatformApiCustodyTests.kt
@@ -62,6 +62,14 @@ class PlatformApiCustodyTests(config: TestConfig, toml: Sep1Helper.TomlContent, 
     `SEP-31 refunded do_stellar_refund`()
   }
 
+  private fun `SEP-6 deposit complete full`() {
+    // TODO(philip): add this after custody changes are merged
+  }
+
+  private fun `SEP-6 withdraw full refund`() {
+    // TODO(philip): add this after custody changes are merged
+  }
+
   /**
    * 1. incomplete -> notify_interactive_flow_complete
    * 2. pending_anchor -> request_offchain_funds
@@ -70,7 +78,7 @@ class PlatformApiCustodyTests(config: TestConfig, toml: Sep1Helper.TomlContent, 
    * 5. completed
    */
   private fun `SEP-24 deposit complete full`() {
-    `test deposit flow`(
+    `test SEP-24 deposit flow`(
       SEP_24_DEPOSIT_COMPLETE_FULL_FLOW_ACTION_REQUESTS,
       SEP_24_DEPOSIT_COMPLETE_FULL_FLOW_ACTION_RESPONSES
     )
@@ -85,7 +93,7 @@ class PlatformApiCustodyTests(config: TestConfig, toml: Sep1Helper.TomlContent, 
    * 6. refunded
    */
   private fun `SEP-24 withdraw full refund`() {
-    `test withdraw flow`(
+    `test SEP-24 withdraw flow`(
       SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_REQUESTS,
       SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES
     )
@@ -104,7 +112,7 @@ class PlatformApiCustodyTests(config: TestConfig, toml: Sep1Helper.TomlContent, 
     )
   }
 
-  private fun `test deposit flow`(actionRequests: String, actionResponse: String) {
+  private fun `test SEP-24 deposit flow`(actionRequests: String, actionResponse: String) {
     val depositRequest = gson.fromJson(SEP_24_DEPOSIT_FLOW_REQUEST, HashMap::class.java)
     val depositResponse = sep24Client.deposit(depositRequest as HashMap<String, String>)
     `test flow`(depositResponse.id, actionRequests, actionResponse)
@@ -136,7 +144,7 @@ class PlatformApiCustodyTests(config: TestConfig, toml: Sep1Helper.TomlContent, 
     `test flow`(receiveResponse.id, updatedActionRequests, updatedActionResponses)
   }
 
-  private fun `test withdraw flow`(actionRequests: String, actionResponse: String) {
+  private fun `test SEP-24 withdraw flow`(actionRequests: String, actionResponse: String) {
     val withdrawRequest = gson.fromJson(SEP_24_WITHDRAW_FLOW_REQUEST, HashMap::class.java)
     val withdrawResponse = sep24Client.withdraw(withdrawRequest as HashMap<String, String>)
     `test flow`(withdrawResponse.id, actionRequests, actionResponse)

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
@@ -153,15 +153,14 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
     anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! })
     waitStatus(withdraw.id, PENDING_USR_TRANSFER_START, sep6Client)
 
-    val withdrawMemo =
-      sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction.withdrawMemo
+    val withdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction
 
     // Transfer the withdrawal amount to the Anchor
     val transfer =
       wallet
         .stellar()
-        .transaction(keypair, memo = Pair(MemoType.HASH, withdrawMemo))
-        .transfer(withdraw.accountId, USDC, "1")
+        .transaction(keypair, memo = Pair(MemoType.HASH, withdrawTxn.withdrawMemo))
+        .transfer(withdrawTxn.withdrawAnchorAccount, USDC, "1")
         .build()
     transfer.sign(keypair)
     wallet.stellar().submitTransaction(transfer)

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6End2EndTest.kt
@@ -15,6 +15,7 @@ import org.stellar.anchor.api.shared.InstructionField
 import org.stellar.anchor.platform.CLIENT_WALLET_SECRET
 import org.stellar.anchor.platform.Sep6Client
 import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.GsonUtils
 import org.stellar.anchor.util.Log
 import org.stellar.reference.client.AnchorReferenceServerClient
 import org.stellar.reference.wallet.WalletServerClient
@@ -152,11 +153,14 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
     anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! })
     waitStatus(withdraw.id, PENDING_USR_TRANSFER_START, sep6Client)
 
+    val withdrawMemo =
+      sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction.withdrawMemo
+
     // Transfer the withdrawal amount to the Anchor
     val transfer =
       wallet
         .stellar()
-        .transaction(keypair, memo = Pair(MemoType.HASH, withdraw.memo))
+        .transaction(keypair, memo = Pair(MemoType.HASH, withdrawMemo))
         .transfer(withdraw.accountId, USDC, "1")
         .build()
     transfer.sign(keypair)
@@ -206,6 +210,7 @@ class Sep6End2EndTest(val config: TestConfig, val jwt: String) {
       if (expectedStatus.status != transaction.transaction.status) {
         Log.info("Transaction status: ${transaction.transaction.status}")
       } else {
+        Log.info("${GsonUtils.getInstance().toJson(transaction)}")
         Log.info(
           "Transaction status ${transaction.transaction.status} matched expected status $expectedStatus"
         )

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -159,8 +159,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
           "transaction": {
               "kind": "withdrawal",
               "status": "incomplete",
-              "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-              "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+              "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
           }
       }
     """
@@ -178,8 +177,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
           "amount_out_asset": "iso4217:USD",
           "amount_fee": "0",
           "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
         }
       }
     """
@@ -197,8 +195,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
           "amount_out_asset": "iso4217:USD",
           "amount_fee": "1.00",
           "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+          "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
         }
       }
     """

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep6Tests.kt
@@ -160,7 +160,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
               "kind": "withdrawal",
               "status": "incomplete",
               "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-              "withdraw_memo_type": "hash"
+              "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
           }
       }
     """
@@ -179,8 +179,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
           "amount_fee": "0",
           "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "withdraw_memo_type": "hash"
+          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
         }
       }
     """
@@ -199,8 +198,7 @@ class Sep6Tests(val toml: TomlContent, jwt: String) {
           "amount_fee": "1.00",
           "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "withdraw_memo_type": "hash"
+          "withdraw_anchor_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
         }
       }
     """

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -39,6 +39,7 @@ import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24DepositInfoGenerator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 @Configuration
@@ -447,6 +448,7 @@ public class RpcActionBeans {
       AssetService assetService,
       CustodyService custodyService,
       CustodyConfig custodyConfig,
+      Sep6DepositInfoGenerator sep6DepositInfoGenerator,
       Sep24DepositInfoGenerator sep24DepositInfoGenerator,
       EventService eventService,
       MetricsService metricsService) {
@@ -458,6 +460,7 @@ public class RpcActionBeans {
         assetService,
         custodyService,
         custodyConfig,
+        sep6DepositInfoGenerator,
         sep24DepositInfoGenerator,
         eventService,
         metricsService);

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -59,12 +59,6 @@ public class SepBeans {
   }
 
   @Bean
-  @ConfigurationProperties(prefix = "sep6")
-  Sep6Config sep6Config() {
-    return new PropertySep6Config();
-  }
-
-  @Bean
   @ConfigurationProperties(prefix = "sep10")
   Sep10Config sep10Config(
       AppConfig appConfig, SecretConfig secretConfig, PropertyClientsConfig clientsConfig) {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -9,16 +9,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.stellar.anchor.api.exception.NotSupportedException;
 import org.stellar.anchor.auth.JwtService;
-import org.stellar.anchor.config.AppConfig;
-import org.stellar.anchor.config.CustodyConfig;
-import org.stellar.anchor.config.CustodySecretConfig;
-import org.stellar.anchor.config.SecretConfig;
+import org.stellar.anchor.config.*;
 import org.stellar.anchor.healthcheck.HealthCheckable;
 import org.stellar.anchor.horizon.Horizon;
-import org.stellar.anchor.platform.config.PropertyAppConfig;
-import org.stellar.anchor.platform.config.PropertyClientsConfig;
-import org.stellar.anchor.platform.config.PropertySecretConfig;
-import org.stellar.anchor.platform.config.PropertySep24Config;
+import org.stellar.anchor.platform.config.*;
 import org.stellar.anchor.platform.service.HealthCheckService;
 import org.stellar.anchor.platform.service.SimpleMoreInfoUrlConstructor;
 import org.stellar.anchor.platform.validator.RequestValidator;
@@ -55,6 +49,12 @@ public class UtilityBeans {
   @ConfigurationProperties(prefix = "sep24")
   PropertySep24Config sep24Config(SecretConfig secretConfig, CustodyConfig custodyConfig) {
     return new PropertySep24Config(secretConfig, custodyConfig);
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "sep6")
+  PropertySep6Config sep6Config(CustodyConfig custodyConfig) {
+    return new PropertySep6Config(custodyConfig);
   }
 
   /**********************************

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarPaymentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarPaymentHandler.java
@@ -2,12 +2,15 @@ package org.stellar.anchor.platform.rpc;
 
 import static java.util.Collections.emptySet;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT_EXCHANGE;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.DO_STELLAR_PAYMENT;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_STELLAR;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_TRUST;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Set;
@@ -26,10 +29,7 @@ import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.metrics.MetricsService;
-import org.stellar.anchor.platform.data.JdbcSep24Transaction;
-import org.stellar.anchor.platform.data.JdbcSepTransaction;
-import org.stellar.anchor.platform.data.JdbcTransactionPendingTrust;
-import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
+import org.stellar.anchor.platform.data.*;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
@@ -76,7 +76,7 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
 
     if (!custodyConfig.isCustodyIntegrationEnabled()) {
       throw new InvalidRequestException(
-          String.format("RPC method[%s] requires disabled custody integration", getRpcMethod()));
+          String.format("RPC method[%s] requires enabled custody integration", getRpcMethod()));
     }
   }
 
@@ -88,14 +88,25 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
   @Override
   protected SepTransactionStatus getNextStatus(
       JdbcSepTransaction txn, DoStellarPaymentRequest request) {
-    JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
 
-    boolean trustlineConfigured;
+    boolean trustlineConfigured = false;
     try {
-      trustlineConfigured =
-          horizon.isTrustlineConfigured(txn24.getToAccount(), txn24.getAmountOutAsset());
+      switch (Sep.from(txn.getProtocol())) {
+        case SEP_6:
+          JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+          trustlineConfigured =
+              horizon.isTrustlineConfigured(txn6.getToAccount(), txn6.getAmountOutAsset());
+          break;
+        case SEP_24:
+          JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+          trustlineConfigured =
+              horizon.isTrustlineConfigured(txn24.getToAccount(), txn24.getAmountOutAsset());
+          break;
+        default:
+          break;
+      }
     } catch (IOException ex) {
-      trustlineConfigured = false;
+      // assume trustline is not configured
     }
 
     if (trustlineConfigured) {
@@ -107,13 +118,25 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
 
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
-    if (SEP_24 == Sep.from(txn.getProtocol())) {
-      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-      if (DEPOSIT == Kind.from(txn24.getKind())) {
-        if (areFundsReceived(txn24)) {
-          return Set.of(PENDING_ANCHOR);
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
+          if (areFundsReceived(txn6)) {
+            return Set.of(PENDING_ANCHOR);
+          }
         }
-      }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (DEPOSIT == Kind.from(txn24.getKind())) {
+          if (areFundsReceived(txn24)) {
+            return Set.of(PENDING_ANCHOR);
+          }
+        }
+        break;
+      default:
+        break;
     }
     return emptySet();
   }
@@ -121,26 +144,54 @@ public class DoStellarPaymentHandler extends RpcMethodHandler<DoStellarPaymentRe
   @Override
   protected void updateTransactionWithRpcRequest(
       JdbcSepTransaction txn, DoStellarPaymentRequest request) throws AnchorException {
-    JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-
     boolean trustlineConfigured;
-    try {
-      trustlineConfigured =
-          horizon.isTrustlineConfigured(txn24.getToAccount(), txn24.getAmountOutAsset());
-    } catch (IOException ex) {
-      trustlineConfigured = false;
-    }
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
 
-    if (trustlineConfigured) {
-      custodyService.createTransactionPayment(txn24.getId(), null);
-    } else {
-      transactionPendingTrustRepo.save(
-          JdbcTransactionPendingTrust.builder()
-              .id(txn24.getId())
-              .createdAt(Instant.now())
-              .asset(txn24.getAmountOutAsset())
-              .account(txn24.getToAccount())
-              .build());
+        try {
+          trustlineConfigured =
+              horizon.isTrustlineConfigured(txn6.getToAccount(), txn6.getAmountOutAsset());
+        } catch (IOException ex) {
+          trustlineConfigured = false;
+        }
+
+        if (trustlineConfigured) {
+          custodyService.createTransactionPayment(txn6.getId(), null);
+        } else {
+          transactionPendingTrustRepo.save(
+              JdbcTransactionPendingTrust.builder()
+                  .id(txn6.getId())
+                  .createdAt(Instant.now())
+                  .asset(txn6.getAmountOutAsset())
+                  .account(txn6.getToAccount())
+                  .build());
+        }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+
+        try {
+          trustlineConfigured =
+              horizon.isTrustlineConfigured(txn24.getToAccount(), txn24.getAmountOutAsset());
+        } catch (IOException ex) {
+          trustlineConfigured = false;
+        }
+
+        if (trustlineConfigured) {
+          custodyService.createTransactionPayment(txn24.getId(), null);
+        } else {
+          transactionPendingTrustRepo.save(
+              JdbcTransactionPendingTrust.builder()
+                  .id(txn24.getId())
+                  .createdAt(Instant.now())
+                  .asset(txn24.getAmountOutAsset())
+                  .account(txn24.getToAccount())
+                  .build());
+        }
+        break;
+      default:
+        break;
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarRefundHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/DoStellarRefundHandler.java
@@ -1,8 +1,7 @@
 package org.stellar.anchor.platform.rpc;
 
 import static java.util.Collections.emptySet;
-import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.RECEIVE;
-import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.DO_STELLAR_REFUND;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
@@ -12,6 +11,7 @@ import static org.stellar.anchor.util.AssetHelper.getAssetCode;
 import static org.stellar.anchor.util.MathHelper.decimal;
 import static org.stellar.anchor.util.MathHelper.sum;
 
+import com.google.common.collect.ImmutableSet;
 import java.math.BigDecimal;
 import java.util.Set;
 import org.stellar.anchor.api.exception.AnchorException;
@@ -25,6 +25,7 @@ import org.stellar.anchor.api.rpc.method.DoStellarRefundRequest;
 import org.stellar.anchor.api.rpc.method.RpcMethod;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
+import org.stellar.anchor.api.shared.Refunds;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.config.CustodyConfig;
 import org.stellar.anchor.custody.CustodyService;
@@ -32,6 +33,7 @@ import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
 import org.stellar.anchor.platform.data.JdbcSep31Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.utils.AssetValidationUtils;
 import org.stellar.anchor.platform.validator.RequestValidator;
@@ -120,6 +122,16 @@ public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequ
 
     BigDecimal totalRefunded;
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        Refunds refunds = txn6.getRefunds();
+        if (refunds == null || refunds.getPayments() == null) {
+          totalRefunded = sum(assetInfo, amount, amountFee);
+        } else {
+          totalRefunded =
+              sum(assetInfo, refunds.getAmountRefunded().getAmount(), amount, amountFee);
+        }
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         Sep24Refunds sep24Refunds = txn24.getRefunds();
@@ -160,6 +172,14 @@ public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequ
   @Override
   protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (ImmutableSet.of(WITHDRAWAL, WITHDRAWAL_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
+          if (areFundsReceived(txn6)) {
+            return Set.of(PENDING_ANCHOR);
+          }
+        }
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         if (WITHDRAWAL == Kind.from(txn24.getKind())) {
@@ -179,6 +199,11 @@ public class DoStellarRefundHandler extends RpcMethodHandler<DoStellarRefundRequ
   protected void updateTransactionWithRpcRequest(
       JdbcSepTransaction txn, DoStellarRefundRequest request) throws AnchorException {
     switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        custodyService.createTransactionRefund(
+            request, txn6.getRefundMemo(), txn6.getRefundMemoType());
+        break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         custodyService.createTransactionRefund(

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
@@ -177,12 +177,21 @@ public class NotifyOffchainFundsReceivedHandler
       txn.setAmountFee(request.getAmountFee().getAmount());
     }
 
-    // TODO: add support for SEP-6
-    if (SEP_24 == Sep.from(txn.getProtocol())) {
-      JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
-      if (custodyConfig.isCustodyIntegrationEnabled()) {
-        custodyService.createTransaction(txn24);
-      }
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (custodyConfig.isCustodyIntegrationEnabled()) {
+          custodyService.createTransaction(txn6);
+        }
+        break;
+      case SEP_24:
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (custodyConfig.isCustodyIntegrationEnabled()) {
+          custodyService.createTransaction(txn24);
+        }
+        break;
+      default:
+        break;
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/CustodyServiceImpl.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/CustodyServiceImpl.java
@@ -20,6 +20,7 @@ import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.platform.apiclient.CustodyApiClient;
 import org.stellar.anchor.sep24.Sep24Transaction;
 import org.stellar.anchor.sep31.Sep31Transaction;
+import org.stellar.anchor.sep6.Sep6Transaction;
 
 public class CustodyServiceImpl implements CustodyService {
 
@@ -27,6 +28,11 @@ public class CustodyServiceImpl implements CustodyService {
 
   public CustodyServiceImpl(Optional<CustodyApiClient> custodyApiClient) {
     this.custodyApiClient = custodyApiClient;
+  }
+
+  @Override
+  public void createTransaction(Sep6Transaction txn) throws AnchorException {
+    create(toCustodyTransaction(txn));
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoCustodyGenerator.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoCustodyGenerator.java
@@ -1,0 +1,23 @@
+package org.stellar.anchor.platform.service;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.stellar.anchor.api.custody.GenerateDepositAddressResponse;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.shared.SepDepositInfo;
+import org.stellar.anchor.platform.apiclient.CustodyApiClient;
+import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
+import org.stellar.anchor.sep6.Sep6Transaction;
+
+@RequiredArgsConstructor
+public class Sep6DepositInfoCustodyGenerator implements Sep6DepositInfoGenerator {
+  @NonNull private final CustodyApiClient custodyApiClient;
+
+  @Override
+  public SepDepositInfo generate(Sep6Transaction txn) throws AnchorException {
+    GenerateDepositAddressResponse depositAddress =
+        custodyApiClient.generateDepositAddress(txn.getAmountInAsset());
+    return new SepDepositInfo(
+        depositAddress.getAddress(), depositAddress.getMemo(), depositAddress.getMemoType());
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoNoneGenerator.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoNoneGenerator.java
@@ -1,0 +1,14 @@
+package org.stellar.anchor.platform.service;
+
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.BadRequestException;
+import org.stellar.anchor.api.shared.SepDepositInfo;
+import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
+import org.stellar.anchor.sep6.Sep6Transaction;
+
+public class Sep6DepositInfoNoneGenerator implements Sep6DepositInfoGenerator {
+  @Override
+  public SepDepositInfo generate(Sep6Transaction txn) throws AnchorException {
+    throw new BadRequestException("SEP-6 deposit info generation is disabled");
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoSelfGenerator.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep6DepositInfoSelfGenerator.java
@@ -1,0 +1,32 @@
+package org.stellar.anchor.platform.service;
+
+import static org.stellar.anchor.util.MemoHelper.memoTypeAsString;
+import static org.stellar.sdk.xdr.MemoType.MEMO_HASH;
+
+import java.util.Base64;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.sep.AssetInfo;
+import org.stellar.anchor.api.shared.SepDepositInfo;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
+import org.stellar.anchor.sep6.Sep6Transaction;
+
+@RequiredArgsConstructor
+public class Sep6DepositInfoSelfGenerator implements Sep6DepositInfoGenerator {
+  @NonNull private final AssetService assetService;
+
+  @Override
+  public SepDepositInfo generate(Sep6Transaction txn) throws AnchorException {
+    AssetInfo assetInfo =
+        assetService.getAsset(txn.getRequestAssetCode(), txn.getRequestAssetIssuer());
+
+    String memo = StringUtils.truncate(txn.getId(), 32);
+    memo = StringUtils.leftPad(memo, 32, '0');
+    memo = new String(Base64.getEncoder().encode(memo.getBytes()));
+    return new SepDepositInfo(
+        assetInfo.getDistributionAccount(), memo, memoTypeAsString(MEMO_HASH));
+  }
+}

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -301,6 +301,16 @@ sep6:
   features:
     account_creation: false
     claimable_balances: false
+  ## @param: deposit_info_generator_type
+  ## @default: self
+  ## Used to choose how the SEP-6 deposit information will be generated, which includes the
+  ##     deposit address, memo and memo type.
+  ## @supported_values:
+  ##     self: the memo and memo type are generated in the local code, and the distribution account is used for the deposit address.
+  ##     custody: the memo and memo type are generated through Custody API, for example Fireblocks, as well as the deposit address.
+  ##     none: deposit address, memo and memo type should be provided by the business in PATCH/RPC request.
+  #
+  deposit_info_generator_type: self
 
 ######################
 # SEP-10 Configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -94,6 +94,7 @@ sep31.enabled:
 sep31.payment_type:
 sep38.enabled:
 sep38.sep10_enforced:
+sep6.deposit_info_generator_type:
 sep6.enabled:
 sep6.features.account_creation:
 sep6.features.claimable_balances:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep6ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep6ConfigTest.kt
@@ -1,21 +1,33 @@
 package org.stellar.anchor.platform.config
 
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.validation.BindException
 import org.springframework.validation.Errors
+import org.stellar.anchor.config.CustodyConfig
 import org.stellar.anchor.config.Sep6Config
 
 class Sep6ConfigTest {
+  @MockK(relaxed = true) lateinit var custodyConfig: CustodyConfig
   lateinit var config: PropertySep6Config
   lateinit var errors: Errors
 
   @BeforeEach
   fun setUp() {
-    config = PropertySep6Config()
-    config.enabled = true
-    config.features = Sep6Config.Features(false, false)
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    config =
+      PropertySep6Config(custodyConfig).apply {
+        enabled = true
+        features = Sep6Config.Features(false, false)
+        depositInfoGeneratorType = Sep6Config.DepositInfoGeneratorType.CUSTODY
+      }
     errors = BindException(config, "config")
   }
 
@@ -57,5 +69,23 @@ class Sep6ConfigTest {
     config.features = Sep6Config.Features(false, true)
     config.validate(config, errors)
     Assertions.assertEquals("sep6-features-claimable-balances-invalid", errors.allErrors[0].code)
+  }
+
+  @CsvSource(value = ["NONE", "SELF"])
+  @ParameterizedTest
+  fun `test validation rejecting custody enabled and non-custodial deposit info generator`(
+    type: String
+  ) {
+    config.depositInfoGeneratorType = Sep6Config.DepositInfoGeneratorType.valueOf(type)
+    config.validate(config, errors)
+    Assertions.assertEquals("sep6-deposit-info-generator-type", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test validation rejecting custody disabled and custodial deposit generator`() {
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    config.depositInfoGeneratorType = Sep6Config.DepositInfoGeneratorType.CUSTODY
+    config.validate(config, errors)
+    Assertions.assertEquals("sep6-deposit-info-generator-type", errors.allErrors[0].code)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarPaymentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarPaymentHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -16,12 +18,14 @@ import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.DoStellarPaymentRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.config.CustodyConfig
 import org.stellar.anchor.custody.CustodyService
@@ -31,6 +35,7 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.horizon.Horizon
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrust
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
@@ -108,6 +113,7 @@ class DoStellarPaymentHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -119,71 +125,7 @@ class DoStellarPaymentHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedStatus() {
-    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_TRUST.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { custodyConfig.isCustodyIntegrationEnabled } returns true
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[do_stellar_payment] is not supported. Status[pending_trust], kind[deposit], protocol[24], funds received[true]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_handle_custodyIntegrationDisabled() {
-    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { custodyConfig.isCustodyIntegrationEnabled } returns false
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals("RPC method[do_stellar_payment] requires disabled custody integration", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_transferNotReceived() {
-    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { custodyConfig.isCustodyIntegrationEnabled } returns true
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[do_stellar_payment] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -197,6 +139,7 @@ class DoStellarPaymentHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -205,13 +148,85 @@ class DoStellarPaymentHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok_trustlineConfigured() {
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_TRUST.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_payment] is not supported. Status[pending_trust], kind[deposit], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_custodyIntegrationDisabled() {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals("RPC method[do_stellar_payment] requires enabled custody integration", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_transferNotReceived() {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_payment] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok_trustlineConfigured() {
     val transferReceivedAt = Instant.now()
     val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
@@ -224,6 +239,7 @@ class DoStellarPaymentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -237,6 +253,7 @@ class DoStellarPaymentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { transactionPendingTrustRepo.save(any()) }
     verify(exactly = 1) { custodyService.createTransactionPayment(TX_ID, null) }
@@ -291,7 +308,7 @@ class DoStellarPaymentHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_trustlineNotConfigured() {
+  fun test_handle_sep24_ok_trustlineNotConfigured() {
     val transferReceivedAt = Instant.now()
     val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
@@ -305,12 +322,14 @@ class DoStellarPaymentHandlerTest {
     val txnPendingTrustCapture = slot<JdbcTransactionPendingTrust>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
     every { horizon.isTrustlineConfigured(TO_ACCOUNT, AMOUNT_OUT_ASSET) } returns false
-    every { transactionPendingTrustRepo.save(capture(txnPendingTrustCapture)) } returns null
+    every { transactionPendingTrustRepo.save(capture(txnPendingTrustCapture)) } returns
+      JdbcTransactionPendingTrust()
     every { eventSession.publish(capture(anchorEventCapture)) } just Runs
     every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep24") } returns
       sepTransactionCounter
@@ -319,6 +338,7 @@ class DoStellarPaymentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { custodyService.createTransactionPayment(any(), any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
@@ -381,6 +401,266 @@ class DoStellarPaymentHandlerTest {
 
     assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
     assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(txnPendingTrustCapture.captured.createdAt >= startDate)
+    assertTrue(txnPendingTrustCapture.captured.createdAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_payment] is not supported. Status[pending_trust], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_custodyIntegrationDisabled(kind: String) {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals("RPC method[do_stellar_payment] requires enabled custody integration", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_transferNotReceived(kind: String) {
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(TX_ID) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_payment] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_trustlineConfigured(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.id = TX_ID
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.toAccount = TO_ACCOUNT
+    txn6.amountOutAsset = AMOUNT_OUT_ASSET
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { horizon.isTrustlineConfigured(TO_ACCOUNT, AMOUNT_OUT_ASSET) } returns true
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { transactionPendingTrustRepo.save(any()) }
+    verify(exactly = 1) { custodyService.createTransactionPayment(TX_ID, null) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.id = TX_ID
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_STELLAR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.toAccount = TO_ACCOUNT
+    expectedSep6Txn.amountOutAsset = AMOUNT_OUT_ASSET
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.id = TX_ID
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_STELLAR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.destinationAccount = TO_ACCOUNT
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_trustlineNotConfigured(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = DoStellarPaymentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.id = TX_ID
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.toAccount = TO_ACCOUNT
+    txn6.amountOutAsset = AMOUNT_OUT_ASSET
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val txnPendingTrustCapture = slot<JdbcTransactionPendingTrust>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { horizon.isTrustlineConfigured(TO_ACCOUNT, AMOUNT_OUT_ASSET) } returns false
+    every { transactionPendingTrustRepo.save(capture(txnPendingTrustCapture)) } returns
+      JdbcTransactionPendingTrust()
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { custodyService.createTransactionPayment(any(), any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.id = TX_ID
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_TRUST.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    expectedSep6Txn.toAccount = TO_ACCOUNT
+    expectedSep6Txn.amountOutAsset = AMOUNT_OUT_ASSET
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.id = TX_ID
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_TRUST
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.destinationAccount = TO_ACCOUNT
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedTxnPendingTrust = JdbcTransactionPendingTrust()
+    expectedTxnPendingTrust.id = TX_ID
+    expectedTxnPendingTrust.asset = AMOUNT_OUT_ASSET
+    expectedTxnPendingTrust.account = TO_ACCOUNT
+    expectedTxnPendingTrust.createdAt = txnPendingTrustCapture.captured.createdAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedTxnPendingTrust),
+      gson.toJson(txnPendingTrustCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
     assertTrue(txnPendingTrustCapture.captured.createdAt >= startDate)
     assertTrue(txnPendingTrustCapture.captured.createdAt <= endDate)
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -17,12 +19,14 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.RECEIVE
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_31
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6
 import org.stellar.anchor.api.rpc.method.AmountAssetRequest
 import org.stellar.anchor.api.rpc.method.DoStellarRefundRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus
@@ -31,6 +35,8 @@ import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR
 import org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER
 import org.stellar.anchor.api.shared.Amount
 import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.RefundPayment
+import org.stellar.anchor.api.shared.Refunds
 import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
@@ -46,6 +52,7 @@ import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep31RefundPayment
 import org.stellar.anchor.platform.data.JdbcSep31Refunds
 import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
@@ -117,6 +124,7 @@ class DoStellarRefundHandlerTest {
     txn24.status = PENDING_ANCHOR.toString()
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -127,48 +135,7 @@ class DoStellarRefundHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedKind() {
-    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = DEPOSIT.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedStatus() {
-    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = INCOMPLETE.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -182,6 +149,7 @@ class DoStellarRefundHandlerTest {
     txn24.transferReceivedAt = Instant.now()
     txn24.kind = WITHDRAWAL.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -190,30 +158,7 @@ class DoStellarRefundHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_disabledCustodyIntegration() {
-    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.requestAssetCode = FIAT_USD_CODE
-    txn24.amountOutAsset = STELLAR_USDC
-    txn24.amountFeeAsset = FIAT_USD
-    txn24.transferReceivedAt = Instant.now()
-    txn24.kind = WITHDRAWAL.kind
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("RPC method[do_stellar_refund] requires enabled custody integration", ex.message)
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -241,6 +186,7 @@ class DoStellarRefundHandlerTest {
     txn24.kind = WITHDRAWAL.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -255,6 +201,7 @@ class DoStellarRefundHandlerTest {
     ex = assertThrows { handler.handle(request) }
     assertEquals("refund.amountFee.amount should be non-negative", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -282,6 +229,7 @@ class DoStellarRefundHandlerTest {
     txn24.kind = WITHDRAWAL.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -299,13 +247,140 @@ class DoStellarRefundHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok_sep24() {
+  fun test_handle_sep24_unsupportedKind() {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = INCOMPLETE.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_disabledCustodyIntegration() {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.requestAssetCode = FIAT_USD_CODE
+    txn24.amountOutAsset = STELLAR_USDC
+    txn24.amountFeeAsset = FIAT_USD
+    txn24.transferReceivedAt = Instant.now()
+    txn24.kind = WITHDRAWAL.kind
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("RPC method[do_stellar_refund] requires enabled custody integration", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_sent_more_then_amount_in() {
+    val transferReceivedAt = Instant.now()
+    val request =
+      DoStellarRefundRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          DoStellarRefundRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
+            .build()
+        )
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = transferReceivedAt
+    txn24.requestAssetCode = FIAT_USD_CODE
+    txn24.amountInAsset = STELLAR_USDC
+    txn24.amountIn = "1.1"
+    txn24.amountOutAsset = FIAT_USD
+    txn24.amountOut = "1"
+    txn24.amountFeeAsset = STELLAR_USDC
+    txn24.amountFee = "0.1"
+    txn24.refundMemo = MEMO
+    txn24.refundMemoType = MEMO_TYPE
+
+    val payment = JdbcSep24RefundPayment()
+    payment.id = "1"
+    payment.amount = "0.1"
+    payment.fee = "0"
+    val refunds = JdbcSep24Refunds()
+    refunds.amountRefunded = "1"
+    refunds.amountFee = "0.1"
+    refunds.payments = listOf(payment)
+    txn24.refunds = refunds
+
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("Refund amount exceeds amount_in", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok() {
     val transferReceivedAt = Instant.now()
     val request =
       DoStellarRefundRequest.builder()
@@ -333,6 +408,7 @@ class DoStellarRefundHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -345,6 +421,7 @@ class DoStellarRefundHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -430,7 +507,8 @@ class DoStellarRefundHandlerTest {
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns null
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
@@ -496,58 +574,6 @@ class DoStellarRefundHandlerTest {
   }
 
   @Test
-  fun test_handle_sep24_sent_more_then_amount_in() {
-    val transferReceivedAt = Instant.now()
-    val request =
-      DoStellarRefundRequest.builder()
-        .transactionId(TX_ID)
-        .refund(
-          DoStellarRefundRequest.Refund.builder()
-            .amount(AmountAssetRequest("1", STELLAR_USDC))
-            .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
-            .build()
-        )
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = WITHDRAWAL.kind
-    txn24.transferReceivedAt = transferReceivedAt
-    txn24.requestAssetCode = FIAT_USD_CODE
-    txn24.amountInAsset = STELLAR_USDC
-    txn24.amountIn = "1.1"
-    txn24.amountOutAsset = FIAT_USD
-    txn24.amountOut = "1"
-    txn24.amountFeeAsset = STELLAR_USDC
-    txn24.amountFee = "0.1"
-    txn24.refundMemo = MEMO
-    txn24.refundMemoType = MEMO_TYPE
-
-    val payment = JdbcSep24RefundPayment()
-    payment.id = "1"
-    payment.amount = "0.1"
-    payment.fee = "0"
-    val refunds = JdbcSep24Refunds()
-    refunds.amountRefunded = "1"
-    refunds.amountFee = "0.1"
-    refunds.payments = listOf(payment)
-    txn24.refunds = refunds
-
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(TX_ID) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-    every { custodyConfig.isCustodyIntegrationEnabled } returns true
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("Refund amount exceeds amount_in", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
   fun test_handle_sep31_sent_more_then_amount_in() {
     val transferReceivedAt = Instant.now()
     val request =
@@ -571,7 +597,8 @@ class DoStellarRefundHandlerTest {
     txn31.amountFee = "0.1"
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns null
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
@@ -579,6 +606,7 @@ class DoStellarRefundHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("Refund amount exceeds amount_in", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -608,14 +636,16 @@ class DoStellarRefundHandlerTest {
     txn31.amountFee = "0.1"
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns null
-    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.findByTransactionId(any()) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
 
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("Refund amount is less than amount_in", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -654,7 +684,8 @@ class DoStellarRefundHandlerTest {
     txn31.refunds = refunds
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
 
-    every { txn24Store.findByTransactionId(TX_ID) } returns null
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(TX_ID) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
     every { custodyConfig.isCustodyIntegrationEnabled } returns true
@@ -665,8 +696,246 @@ class DoStellarRefundHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[do_stellar_refund] is not supported. Status[incomplete], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_disabledCustodyIntegration(kind: String) {
+    val request = DoStellarRefundRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountOutAsset = STELLAR_USDC
+    txn6.amountFeeAsset = FIAT_USD
+    txn6.transferReceivedAt = Instant.now()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("RPC method[do_stellar_refund] requires enabled custody integration", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_sent_more_then_amount_in(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      DoStellarRefundRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          DoStellarRefundRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountIn = "1.1"
+    txn6.amountOutAsset = FIAT_USD
+    txn6.amountOut = "1"
+    txn6.amountFeeAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.refundMemo = MEMO
+    txn6.refundMemoType = MEMO_TYPE
+
+    val payment = RefundPayment()
+    payment.id = "1"
+    payment.amount = Amount("0.1", STELLAR_USDC)
+    payment.fee = Amount("0", STELLAR_USDC)
+    val refunds = Refunds()
+    refunds.amountRefunded = Amount("1", STELLAR_USDC)
+    refunds.amountFee = Amount("0.1", STELLAR_USDC)
+    refunds.payments = arrayOf(payment)
+    txn6.refunds = refunds
+
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("Refund amount exceeds amount_in", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      DoStellarRefundRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          DoStellarRefundRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountIn = "1.1"
+    txn6.amountOutAsset = STELLAR_USDC
+    txn6.amountOut = "1"
+    txn6.amountFeeAsset = FIAT_USD
+    txn6.amountFee = "0.1"
+    txn6.refundMemo = MEMO
+    txn6.refundMemoType = MEMO_TYPE
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = SepTransactionStatus.PENDING_STELLAR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountIn = "1.1"
+    expectedSep6Txn.amountOutAsset = STELLAR_USDC
+    expectedSep6Txn.amountOut = "1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.refundMemo = MEMO
+    expectedSep6Txn.refundMemoType = MEMO_TYPE
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = SepTransactionStatus.PENDING_STELLAR
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("1.1", STELLAR_USDC)
+    expectedResponse.amountOut = Amount("1", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.refundMemo = MEMO
+    expectedResponse.refundMemoType = MEMO_TYPE
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTrustSetHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTrustSetHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
@@ -16,13 +18,15 @@ import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_24
-import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_38
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.NotifyTrustSetRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.custody.CustodyService
 import org.stellar.anchor.event.EventService
@@ -31,6 +35,7 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.config.PropertyCustodyConfig
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24TransactionStore
@@ -96,6 +101,7 @@ class NotifyTrustSetHandlerTest {
     txn24.kind = DEPOSIT.kind
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -106,48 +112,7 @@ class NotifyTrustSetHandlerTest {
       ex.message
     )
 
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedStatus() {
-    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
-      ex.message
-    )
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_unsupportedKind() {
-    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = WITHDRAWAL.kind
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-
-    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
-    assertEquals(
-      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[withdrawal], protocol[24], funds received[false]",
-      ex.message
-    )
-
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -160,6 +125,7 @@ class NotifyTrustSetHandlerTest {
     txn24.status = PENDING_TRUST.toString()
     txn24.kind = DEPOSIT.kind
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -168,19 +134,67 @@ class NotifyTrustSetHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals(VALIDATION_ERROR_MESSAGE, ex.message?.trimIndent())
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 
   @Test
-  fun test_handle_ok_custodyIntegrationDisabled() {
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedKind() {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[withdrawal], protocol[24], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok_custodyIntegrationDisabled() {
     val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_TRUST.toString()
     txn24.kind = DEPOSIT.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -192,6 +206,7 @@ class NotifyTrustSetHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -224,7 +239,7 @@ class NotifyTrustSetHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_custodyIntegrationEnabled_success() {
+  fun test_handle_sep24_ok_custodyIntegrationEnabled_success() {
     val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).success(true).build()
     val txn24 = JdbcSep24Transaction()
     txn24.id = TX_ID
@@ -232,6 +247,7 @@ class NotifyTrustSetHandlerTest {
     txn24.kind = DEPOSIT.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -244,6 +260,7 @@ class NotifyTrustSetHandlerTest {
     val endDate = Instant.now()
 
     verify(exactly = 1) { custodyService.createTransactionPayment(TX_ID, null) }
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -278,13 +295,14 @@ class NotifyTrustSetHandlerTest {
   }
 
   @Test
-  fun test_handle_ok_custodyIntegrationEnabled_fail() {
+  fun test_handle_sep24_ok_custodyIntegrationEnabled_fail() {
     val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).success(false).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_TRUST.toString()
     txn24.kind = DEPOSIT.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -297,6 +315,7 @@ class NotifyTrustSetHandlerTest {
     val endDate = Instant.now()
 
     verify(exactly = 0) { custodyService.createTransactionPayment(any(), any()) }
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -329,7 +348,7 @@ class NotifyTrustSetHandlerTest {
   }
 
   @Test
-  fun test_handle_ok() {
+  fun test_handle_sep24_ok() {
     val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
     val txn24 = JdbcSep24Transaction()
     txn24.status = PENDING_TRUST.toString()
@@ -337,6 +356,7 @@ class NotifyTrustSetHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -349,6 +369,7 @@ class NotifyTrustSetHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -392,5 +413,290 @@ class NotifyTrustSetHandlerTest {
 
     assertTrue(expectedSep24Txn.updatedAt >= startDate)
     assertTrue(expectedSep24Txn.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedKind(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_trust_set] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[false]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_custodyIntegrationDisabled(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_custodyIntegrationEnabled_success(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).success(true).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.id = TX_ID
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 1) { custodyService.createTransactionPayment(TX_ID, null) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.id = TX_ID
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_STELLAR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.id = TX_ID
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_STELLAR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(expectedSep6Txn.updatedAt >= startDate)
+    assertTrue(expectedSep6Txn.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_custodyIntegrationEnabled_fail(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).success(false).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { custodyService.createTransactionPayment(any(), any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(expectedSep6Txn.updatedAt >= startDate)
+    assertTrue(expectedSep6Txn.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok(kind: String) {
+    val request = NotifyTrustSetRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(expectedSep6Txn.updatedAt >= startDate)
+    assertTrue(expectedSep6Txn.updatedAt <= endDate)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -46,10 +46,13 @@ import org.stellar.anchor.platform.data.JdbcSep6Transaction
 import org.stellar.anchor.platform.service.AnchorMetrics
 import org.stellar.anchor.platform.service.Sep24DepositInfoNoneGenerator
 import org.stellar.anchor.platform.service.Sep24DepositInfoSelfGenerator
+import org.stellar.anchor.platform.service.Sep6DepositInfoNoneGenerator
+import org.stellar.anchor.platform.service.Sep6DepositInfoSelfGenerator
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24Transaction
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6Transaction
 import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
 
@@ -89,6 +92,8 @@ class RequestOnchainFundsHandlerTest {
 
   @MockK(relaxed = true) private lateinit var custodyService: CustodyService
 
+  @MockK(relaxed = true) private lateinit var sep6DepositInfoGenerator: Sep6DepositInfoNoneGenerator
+
   @MockK(relaxed = true)
   private lateinit var sep24DepositInfoGenerator: Sep24DepositInfoNoneGenerator
 
@@ -116,6 +121,7 @@ class RequestOnchainFundsHandlerTest {
         assetService,
         custodyService,
         custodyConfig,
+        sep6DepositInfoGenerator,
         sep24DepositInfoGenerator,
         eventService,
         metricsService
@@ -664,6 +670,7 @@ class RequestOnchainFundsHandlerTest {
         assetService,
         custodyService,
         custodyConfig,
+        sep6DepositInfoGenerator,
         sep24DepositInfoGenerator,
         eventService,
         metricsService
@@ -1092,6 +1099,7 @@ class RequestOnchainFundsHandlerTest {
         assetService,
         custodyService,
         custodyConfig,
+        sep6DepositInfoGenerator,
         sep24DepositInfoGenerator,
         eventService,
         metricsService
@@ -1221,12 +1229,16 @@ class RequestOnchainFundsHandlerTest {
     txn6.requestAssetCode = STELLAR_USDC_CODE
     txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val sep6CustodyTxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    every { custodyConfig.type } returns NONE
+    every { custodyService.createTransaction(capture(sep6CustodyTxnCapture)) } just Runs
     every { eventSession.publish(capture(anchorEventCapture)) } just Runs
     every { metricsService.counter(AnchorMetrics.PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
       sepTransactionCounter
@@ -1255,8 +1267,129 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountExpected = "1"
     expectedSep6Txn.memo = TEXT_MEMO
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
-    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6CustodyTxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_USR_TRANSFER_START
+    expectedResponse.amountIn = Amount("1", STELLAR_USDC)
+    expectedResponse.amountOut = Amount("0.9", FIAT_USD)
+    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
+    expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.memo = TEXT_MEMO
+    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_autogeneratedMemo(kind: String) {
+    val sep6DepositInfoGenerator: Sep6DepositInfoSelfGenerator = mockk()
+    this.handler =
+      RequestOnchainFundsHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        custodyService,
+        custodyConfig,
+        sep6DepositInfoGenerator,
+        sep24DepositInfoGenerator,
+        eventService,
+        metricsService
+      )
+
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("0.9", FIAT_USD))
+        .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
+        .amountExpected(AmountRequest("1"))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = STELLAR_USDC_CODE
+    txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val depositInfo = SepDepositInfo(DESTINATION_ACCOUNT_2, TEXT_MEMO_2, TEXT_MEMO_TYPE)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+    every { custodyConfig.type } returns NONE
+    every { sep6DepositInfoGenerator.generate(ofType(Sep6Transaction::class)) } returns depositInfo
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(AnchorMetrics.PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { custodyService.createTransaction(ofType(Sep6Transaction::class)) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = STELLAR_USDC_CODE
+    expectedSep6Txn.requestAssetIssuer = STELLAR_USDC_ISSUER
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = FIAT_USD
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
+    expectedSep6Txn.amountExpected = "1"
+    expectedSep6Txn.memo = TEXT_MEMO_2
+    expectedSep6Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT_2
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1273,9 +1406,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
+    expectedResponse.memo = TEXT_MEMO_2
     expectedResponse.memoType = TEXT_MEMO_TYPE
-    expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
@@ -1354,7 +1486,6 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountExpected = "1"
     expectedSep6Txn.memo = TEXT_MEMO
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
-    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -1374,7 +1505,6 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
-    expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
@@ -1458,7 +1588,6 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountExpected = "1"
     expectedSep6Txn.memo = TEXT_MEMO
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
-    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -1478,7 +1607,6 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
-    expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
@@ -1503,5 +1631,55 @@ class RequestOnchainFundsHandlerTest {
 
     assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
     assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_notNoneGenerator(kind: String) {
+    val sep6DepositInfoGenerator: Sep6DepositInfoSelfGenerator = mockk()
+    this.handler =
+      RequestOnchainFundsHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        custodyService,
+        custodyConfig,
+        sep6DepositInfoGenerator,
+        sep24DepositInfoGenerator,
+        eventService,
+        metricsService
+      )
+
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .memo(TEXT_MEMO)
+        .memoType(TEXT_MEMO_TYPE)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("1", FIAT_USD))
+        .amountFee(AmountAssetRequest("1", STELLAR_USDC))
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+    val sep6TxnCapture = slot<JdbcSep24Transaction>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep6TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(
+      "Anchor is not configured to accept memo, memo_type and destination_account",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep6DepositInfoCustodyGeneratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep6DepositInfoCustodyGeneratorTest.kt
@@ -1,0 +1,44 @@
+package org.stellar.anchor.platform.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.custody.GenerateDepositAddressResponse
+import org.stellar.anchor.api.shared.SepDepositInfo
+import org.stellar.anchor.platform.apiclient.CustodyApiClient
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
+
+class Sep6DepositInfoCustodyGeneratorTest {
+  companion object {
+    private const val ADDRESS = "testAccount"
+    private const val MEMO = "MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc="
+    private const val MEMO_TYPE = "hash"
+    private const val ASSET_ID = "USDC"
+  }
+
+  @MockK(relaxed = true) lateinit var custodyApiClient: CustodyApiClient
+
+  private lateinit var generator: Sep6DepositInfoCustodyGenerator
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    generator = Sep6DepositInfoCustodyGenerator(custodyApiClient)
+  }
+
+  @Test
+  fun test_sep6_custodyGenerator_success() {
+    val txn = JdbcSep6Transaction()
+    txn.amountInAsset = ASSET_ID
+
+    every { custodyApiClient.generateDepositAddress(ASSET_ID) } returns
+      GenerateDepositAddressResponse(ADDRESS, MEMO, MEMO_TYPE)
+
+    val result = generator.generate(txn)
+    val expected = SepDepositInfo(ADDRESS, MEMO, MEMO_TYPE)
+    assertEquals(expected, result)
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep6DepositInfoSelfGeneratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep6DepositInfoSelfGeneratorTest.kt
@@ -1,0 +1,49 @@
+package org.stellar.anchor.platform.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.sep.AssetInfo
+import org.stellar.anchor.api.shared.SepDepositInfo
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
+
+class Sep6DepositInfoSelfGeneratorTest {
+
+  companion object {
+    private val TXN_ID = "testId"
+    private const val ASSET_CODE = "USDC"
+    private const val ASSET_ISSUER = "testIssuer"
+    private const val DISTRIBUTION_ACCOUNT = "testAccount"
+  }
+
+  @MockK(relaxed = true) lateinit var assetService: AssetService
+
+  private lateinit var generator: Sep6DepositInfoSelfGenerator
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    val asset = mockk<AssetInfo>()
+    every { asset.distributionAccount } returns DISTRIBUTION_ACCOUNT
+    every { assetService.getAsset(ASSET_CODE, ASSET_ISSUER) } returns asset
+    generator = Sep6DepositInfoSelfGenerator(assetService)
+  }
+
+  @Test
+  fun test_sep6_custodyGenerator_success() {
+    val txn = JdbcSep6Transaction()
+    txn.id = TXN_ID
+    txn.requestAssetCode = ASSET_CODE
+    txn.requestAssetIssuer = ASSET_ISSUER
+
+    val result = generator.generate(txn)
+    val expected =
+      SepDepositInfo(DISTRIBUTION_ACCOUNT, "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDB0ZXN0SWQ=", "hash")
+    assertEquals(expected, result)
+  }
+}

--- a/service-runner/src/main/resources/profiles/default-custody-rpc/config.env
+++ b/service-runner/src/main/resources/profiles/default-custody-rpc/config.env
@@ -42,6 +42,7 @@ sep38.enabled=true
 sep24.enabled=true
 sep24.interactive_url.base_url=http://localhost:8091/sep24/interactive
 sep24.more_info_url.base_url=http://localhost:8091/sep24/transaction/more_info
+sep6.deposit_info_generator_type=custody
 sep24.deposit_info_generator_type=custody
 sep31.deposit_info_generator_type=custody
 custody.type=fireblocks

--- a/service-runner/src/main/resources/profiles/default-custody/config.env
+++ b/service-runner/src/main/resources/profiles/default-custody/config.env
@@ -42,6 +42,7 @@ sep38.enabled=true
 sep24.enabled=true
 sep24.interactive_url.base_url=http://localhost:8091/sep24/interactive
 sep24.more_info_url.base_url=http://localhost:8091/sep24/transaction/more_info
+sep6.deposit_info_generator_type=custody
 sep24.deposit_info_generator_type=custody
 sep31.deposit_info_generator_type=custody
 custody.type=fireblocks


### PR DESCRIPTION
### Description

This implements the custody service RPC actions. This includes payments as well as refunds.

### Context

SEP-6 will support custodians.

### Testing

- `./gradlew test`

### Documentation

- [stellar-docs](https://github.com/stellar/stellar-docs/pull/253)

### Known limitations

N/A

