### PR TITLE
[Fix] SEP-6: Shutdown the event consumer cleanly

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/ReferenceServer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/ReferenceServer.kt
@@ -1,14 +1,15 @@
 package org.stellar.reference
 
-import com.sksamuel.hoplite.*
 import io.ktor.server.netty.*
 import mu.KotlinLogging
 import org.stellar.reference.di.ConfigContainer
 import org.stellar.reference.di.EventConsumerContainer
 import org.stellar.reference.di.ReferenceServerContainer
+import org.stellar.reference.event.EventConsumer
 
 val log = KotlinLogging.logger {}
 lateinit var referenceKotlinServer: NettyApplicationEngine
+lateinit var eventConsumer: EventConsumer
 
 fun main(args: Array<String>) {
   startServer(null, args.getOrNull(0)?.toBooleanStrictOrNull() ?: true)
@@ -20,7 +21,7 @@ fun startServer(envMap: Map<String, String>?, wait: Boolean) {
 
   Thread {
       log.info("Starting event consumer")
-      EventConsumerContainer.eventConsumer.start()
+      eventConsumer = EventConsumerContainer.eventConsumer.start()
     }
     .start()
 
@@ -32,5 +33,6 @@ fun startServer(envMap: Map<String, String>?, wait: Boolean) {
 fun stopServer() {
   log.info("Stopping Kotlin business reference server...")
   if (::referenceKotlinServer.isInitialized) (referenceKotlinServer).stop(5000, 30000)
+  if (::eventConsumer.isInitialized) eventConsumer.stop()
   log.info("Kotlin reference server stopped...")
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventConsumer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/EventConsumer.kt
@@ -2,6 +2,7 @@ package org.stellar.reference.event
 
 import java.time.Duration
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.WakeupException
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.reference.event.processor.AnchorEventProcessor
@@ -11,17 +12,29 @@ class EventConsumer(
   private val consumer: KafkaConsumer<String, String>,
   private val processor: AnchorEventProcessor
 ) {
-  fun start() {
-    while (true) {
-      val records = consumer.poll(Duration.ofSeconds(10))
-      if (!records.isEmpty) {
-        log.info("Received ${records.count()} records")
-        records.forEach { record ->
-          processor.handleEvent(
-            GsonUtils.getInstance().fromJson(record.value(), AnchorEvent::class.java)
-          )
+  fun start(): EventConsumer {
+    try {
+      while (true) {
+        val records = consumer.poll(Duration.ofSeconds(10))
+        if (!records.isEmpty) {
+          log.info("Received ${records.count()} records")
+          records.forEach { record ->
+            processor.handleEvent(
+              GsonUtils.getInstance().fromJson(record.value(), AnchorEvent::class.java)
+            )
+          }
         }
       }
+    } catch (e: WakeupException) {
+      // ignore for shutdown
+    } finally {
+      consumer.close()
     }
+
+    return this
+  }
+
+  fun stop() {
+    consumer.wakeup()
   }
 }


### PR DESCRIPTION
### Description

Cleanly shut down the reference server's Kafka consumer.

### Context

I am making this small change to test why the CI passes in PR, but not after merging into `sep-6` branch.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

