### PR TITLE
[ANCHOR-526] Fix account not being forwarded in SEP-9's /customer callback

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
@@ -6,9 +6,5 @@ import org.stellar.anchor.auth.Sep10Jwt;
 
 public abstract class InteractiveUrlConstructor {
   public abstract String construct(
-      Sep24Transaction txn,
-      Map<String, String> request,
-      AssetInfo asset,
-      String homeDomain,
-      Sep10Jwt jwt);
+      Sep24Transaction txn, Map<String, String> request, AssetInfo asset, Sep10Jwt jwt);
 }

--- a/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/InteractiveUrlConstructor.java
@@ -1,12 +1,14 @@
 package org.stellar.anchor.sep24;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.Map;
 import org.stellar.anchor.api.sep.AssetInfo;
+import org.stellar.anchor.auth.Sep10Jwt;
 
 public abstract class InteractiveUrlConstructor {
   public abstract String construct(
-      Sep24Transaction txn, Map<String, String> sep9Fields, AssetInfo asset, String homeDomain)
-      throws URISyntaxException, MalformedURLException;
+      Sep24Transaction txn,
+      Map<String, String> request,
+      AssetInfo asset,
+      String homeDomain,
+      Sep10Jwt jwt);
 }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -268,7 +268,8 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(txn, withdrawRequest, asset, token.getHomeDomain()),
+            interactiveUrlConstructor.construct(
+                txn, withdrawRequest, asset, token.getHomeDomain(), token),
             txn.getTransactionId());
 
     // increment counter
@@ -429,7 +430,8 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(txn, depositRequest, asset, token.getHomeDomain()),
+            interactiveUrlConstructor.construct(
+                txn, depositRequest, asset, token.getHomeDomain(), token),
             txn.getTransactionId());
     // increment counter
     sep24DepositCounter.increment();

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -268,8 +268,7 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(
-                txn, withdrawRequest, asset, token.getHomeDomain(), token),
+            interactiveUrlConstructor.construct(txn, withdrawRequest, asset, token),
             txn.getTransactionId());
 
     // increment counter
@@ -430,8 +429,7 @@ public class Sep24Service {
     InteractiveTransactionResponse response =
         new InteractiveTransactionResponse(
             "interactive_customer_info_needed",
-            interactiveUrlConstructor.construct(
-                txn, depositRequest, asset, token.getHomeDomain(), token),
+            interactiveUrlConstructor.construct(txn, depositRequest, asset, token),
             txn.getTransactionId());
     // increment counter
     sep24DepositCounter.increment();

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -98,7 +98,7 @@ internal class Sep24ServiceTest {
     jwtService = spyk(JwtService(secretConfig, custodySecretConfig))
     testInteractiveUrlJwt = createTestInteractiveJwt(null)
     val strToken = jwtService.encode(testInteractiveUrlJwt)
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     every { moreInfoUrlConstructor.construct(any()) } returns
       "${TEST_SEP24_MORE_INFO_URL}?lang=en&token=$strToken"
@@ -122,7 +122,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -166,7 +166,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -251,7 +251,7 @@ internal class Sep24ServiceTest {
   @ValueSource(strings = ["true", "false"])
   fun `test deposit`(claimableBalanceSupported: String) {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -279,7 +279,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -336,7 +336,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit to whitelisted account`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -98,7 +98,7 @@ internal class Sep24ServiceTest {
     jwtService = spyk(JwtService(secretConfig, custodySecretConfig))
     testInteractiveUrlJwt = createTestInteractiveJwt(null)
     val strToken = jwtService.encode(testInteractiveUrlJwt)
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     every { moreInfoUrlConstructor.construct(any()) } returns
       "${TEST_SEP24_MORE_INFO_URL}?lang=en&token=$strToken"
@@ -122,7 +122,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -166,7 +166,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test withdraw with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -251,7 +251,7 @@ internal class Sep24ServiceTest {
   @ValueSource(strings = ["true", "false"])
   fun `test deposit`(claimableBalanceSupported: String) {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
 
     val slotTxn = slot<Sep24Transaction>()
@@ -279,7 +279,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit with token memo`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(TEST_MEMO))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
@@ -336,7 +336,7 @@ internal class Sep24ServiceTest {
   @Test
   fun `test deposit to whitelisted account`() {
     val strToken = jwtService.encode(createTestInteractiveJwt(null))
-    every { interactiveUrlConstructor.construct(any(), any(), any(), any(), any()) } returns
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -48,17 +48,13 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   @Override
   @SneakyThrows
   public String construct(
-      Sep24Transaction txn,
-      Map<String, String> request,
-      AssetInfo asset,
-      String homeDomain,
-      Sep10Jwt jwt) {
+      Sep24Transaction txn, Map<String, String> request, AssetInfo asset, Sep10Jwt jwt) {
     // If there are KYC fields in the request, they will be forwarded to PUT /customer before
     // returning the token.
     forwardKycFields(request, jwt);
 
     // construct the token
-    String token = constructToken(txn, request, asset, homeDomain);
+    String token = constructToken(txn, request, asset, jwt.getHomeDomain());
 
     // construct the URL
     String baseUrl = sep24Config.getInteractiveUrl().getBaseUrl();

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -17,6 +17,7 @@ import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.auth.JwtService;
+import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt;
 import org.stellar.anchor.platform.config.PropertyClientsConfig;
 import org.stellar.anchor.platform.config.PropertySep24Config;
@@ -47,10 +48,14 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   @Override
   @SneakyThrows
   public String construct(
-      Sep24Transaction txn, Map<String, String> request, AssetInfo asset, String homeDomain) {
+      Sep24Transaction txn,
+      Map<String, String> request,
+      AssetInfo asset,
+      String homeDomain,
+      Sep10Jwt jwt) {
     // If there are KYC fields in the request, they will be forwarded to PUT /customer before
     // returning the token.
-    forwardKycFields(request);
+    forwardKycFields(request, jwt);
 
     // construct the token
     String token = constructToken(txn, request, asset, homeDomain);
@@ -104,7 +109,7 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
     return jwtService.encode(token);
   }
 
-  void forwardKycFields(Map<String, String> request) throws AnchorException {
+  void forwardKycFields(Map<String, String> request, Sep10Jwt jwt) throws AnchorException {
     if (sep24Config.getKycFieldsForwarding().isEnabled()) {
       // Get sep-9 fields from request
       Map<String, String> sep9 = extractSep9Fields(request);
@@ -115,6 +120,11 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
         PutCustomerRequest putCustomerRequest =
             gson.fromJson(gsonRequest, PutCustomerRequest.class);
         putCustomerRequest.setType(FORWARD_KYC_CUSTOMER_TYPE);
+        putCustomerRequest.setAccount(jwt.getAccount());
+        if (jwt.getAccountMemo() != null) {
+          putCustomerRequest.setMemo(jwt.getAccountMemo());
+          putCustomerRequest.setMemoType("id");
+        }
         // forward kyc fields to PUT /customer
         customerIntegration.putCustomer(putCustomerRequest);
       }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -19,6 +19,7 @@ import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.api.sep.AssetInfo
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.JwtService.*
+import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
 import org.stellar.anchor.config.ClientsConfig.ClientConfig
 import org.stellar.anchor.config.ClientsConfig.ClientType
@@ -47,6 +48,7 @@ class SimpleInteractiveUrlConstructorTest {
   @MockK(relaxed = true) private lateinit var custodySecretConfig: CustodySecretConfig
   @MockK(relaxed = true) private lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) private lateinit var testAsset: AssetInfo
+  @MockK(relaxed = true) private lateinit var sep10Jwt: Sep10Jwt
 
   private lateinit var jwtService: JwtService
   private lateinit var sep24Config: PropertySep24Config
@@ -111,7 +113,8 @@ class SimpleInteractiveUrlConstructorTest {
           testTxn,
           testRequest as HashMap<String, String>?,
           testAsset,
-          TEST_HOME_DOMAIN
+          TEST_HOME_DOMAIN,
+          null
         )
       )
     testJwt(jwt)
@@ -124,7 +127,10 @@ class SimpleInteractiveUrlConstructorTest {
     // Unknown client domain
     testTxn.sep10AccountMemo = null
     testTxn.clientDomain = "unknown.com"
-    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN))
+    jwt =
+      parseJwtFromUrl(
+        constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN, null)
+      )
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
@@ -136,7 +142,10 @@ class SimpleInteractiveUrlConstructorTest {
     testTxn.sep10Account = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     testTxn.sep10AccountMemo = "1234"
     testTxn.clientDomain = null
-    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN))
+    jwt =
+      parseJwtFromUrl(
+        constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN, null)
+      )
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP:1234", jwt.sub)
@@ -160,7 +169,8 @@ class SimpleInteractiveUrlConstructorTest {
         testTxn,
         testRequest as HashMap<String, String>?,
         testAsset,
-        TEST_HOME_DOMAIN
+        TEST_HOME_DOMAIN,
+        null
       )
     }
   }
@@ -174,11 +184,22 @@ class SimpleInteractiveUrlConstructorTest {
     val constructor =
       SimpleInteractiveUrlConstructor(clientsConfig, sep24Config, customerIntegration, jwtService)
     sep24Config.kycFieldsForwarding.isEnabled = true
-    constructor.construct(txn, request as HashMap<String, String>?, testAsset, TEST_HOME_DOMAIN)
+    every { sep10Jwt.account }.returns("test_account")
+    every { sep10Jwt.accountMemo }.returns("123")
+    constructor.construct(
+      txn,
+      request as HashMap<String, String>?,
+      testAsset,
+      TEST_HOME_DOMAIN,
+      sep10Jwt
+    )
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
     assertEquals(capturedPutCustomerRequest.captured.lastName, request.get("last_name"))
     assertEquals(capturedPutCustomerRequest.captured.emailAddress, request.get("email_address"))
+    assertEquals("test_account", capturedPutCustomerRequest.captured.account)
+    assertEquals("123", capturedPutCustomerRequest.captured.memo)
+    assertEquals("id", capturedPutCustomerRequest.captured.memoType)
   }
 
   @Test
@@ -187,7 +208,13 @@ class SimpleInteractiveUrlConstructorTest {
     val constructor =
       SimpleInteractiveUrlConstructor(clientsConfig, sep24Config, customerIntegration, jwtService)
     sep24Config.kycFieldsForwarding.isEnabled = false
-    constructor.construct(txn, request as HashMap<String, String>?, testAsset, TEST_HOME_DOMAIN)
+    constructor.construct(
+      txn,
+      request as HashMap<String, String>?,
+      testAsset,
+      TEST_HOME_DOMAIN,
+      null
+    )
     verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -90,6 +90,7 @@ class SimpleInteractiveUrlConstructorTest {
       )
     every { testAsset.assetName } returns
       "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { sep10Jwt.homeDomain } returns TEST_HOME_DOMAIN
 
     jwtService = JwtService(secretConfig, custodySecretConfig)
     sep24Config = gson.fromJson(SEP24_CONFIG_JSON_1, PropertySep24Config::class.java)
@@ -109,13 +110,7 @@ class SimpleInteractiveUrlConstructorTest {
 
     var jwt =
       parseJwtFromUrl(
-        constructor.construct(
-          testTxn,
-          testRequest as HashMap<String, String>?,
-          testAsset,
-          TEST_HOME_DOMAIN,
-          null
-        )
+        constructor.construct(testTxn, testRequest as HashMap<String, String>?, testAsset, sep10Jwt)
       )
     testJwt(jwt)
     var claims = jwt.claims
@@ -127,10 +122,7 @@ class SimpleInteractiveUrlConstructorTest {
     // Unknown client domain
     testTxn.sep10AccountMemo = null
     testTxn.clientDomain = "unknown.com"
-    jwt =
-      parseJwtFromUrl(
-        constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN, null)
-      )
+    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, sep10Jwt))
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
@@ -142,10 +134,7 @@ class SimpleInteractiveUrlConstructorTest {
     testTxn.sep10Account = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     testTxn.sep10AccountMemo = "1234"
     testTxn.clientDomain = null
-    jwt =
-      parseJwtFromUrl(
-        constructor.construct(testTxn, testRequest, testAsset, TEST_HOME_DOMAIN, null)
-      )
+    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, sep10Jwt))
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP:1234", jwt.sub)
@@ -165,13 +154,7 @@ class SimpleInteractiveUrlConstructorTest {
 
     testTxn.clientDomain = null
     assertThrows<SepValidationException> {
-      constructor.construct(
-        testTxn,
-        testRequest as HashMap<String, String>?,
-        testAsset,
-        TEST_HOME_DOMAIN,
-        null
-      )
+      constructor.construct(testTxn, testRequest as HashMap<String, String>?, testAsset, sep10Jwt)
     }
   }
 
@@ -186,13 +169,7 @@ class SimpleInteractiveUrlConstructorTest {
     sep24Config.kycFieldsForwarding.isEnabled = true
     every { sep10Jwt.account }.returns("test_account")
     every { sep10Jwt.accountMemo }.returns("123")
-    constructor.construct(
-      txn,
-      request as HashMap<String, String>?,
-      testAsset,
-      TEST_HOME_DOMAIN,
-      sep10Jwt
-    )
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, sep10Jwt)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
     assertEquals(capturedPutCustomerRequest.captured.lastName, request.get("last_name"))
@@ -212,8 +189,7 @@ class SimpleInteractiveUrlConstructorTest {
       txn,
       request as HashMap<String, String>?,
       testAsset,
-      TEST_HOME_DOMAIN,
-      null
+      sep10Jwt,
     )
     verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }


### PR DESCRIPTION
### Description

Fix account not being forwarded in SEP-9's /customer callback

### Context

When receiving callback for SEP-9 field forwarding all JWT fields (account and memo) was missing. Turned out, they were not being forwarded properly 

### Testing

- `./gradlew test`
-  Adjusted test scenario 

### Documentation

There is a task for documenting this feature 

### Known limitations

N/A

