### PR TITLE
[ANCHOR-525] Introduce `NotifyAmountsAssetsUpdated` RPC

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/NotifyAmountsAssetsUpdatedRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/NotifyAmountsAssetsUpdatedRequest.java
@@ -1,0 +1,27 @@
+package org.stellar.anchor.api.rpc.method;
+
+import com.google.gson.annotations.SerializedName;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class NotifyAmountsAssetsUpdatedRequest extends RpcMethodParamsRequest {
+
+  @SerializedName("amount_in")
+  @NotNull
+  private AmountAssetRequest amountIn;
+
+  @SerializedName("amount_out")
+  @NotNull
+  private AmountAssetRequest amountOut;
+
+  @SerializedName("amount_fee")
+  @NotNull
+  private AmountAssetRequest amountFee;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
@@ -62,6 +62,9 @@ public enum RpcMethod {
   @SerializedName("request_onchain_funds")
   REQUEST_ONCHAIN_FUNDS("request_onchain_funds"),
 
+  @SerializedName("notify_amounts_assets_updated")
+  NOTIFY_AMOUNTS_ASSETS_UPDATED("notify_amounts_assets_updated"),
+
   @SerializedName("notify_amounts_updated")
   NOTIFY_AMOUNTS_UPDATED("notify_amounts_updated"),
 

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -89,14 +89,6 @@ public class Sep6Service {
             .type(request.getType())
             .assetCode(request.getAssetCode())
             .assetIssuer(asset.getIssuer())
-            // NB: these are purposely set to incorrect values.
-            // amount_out and amount_fee assets cannot be determined when the
-            // platform creates the transaction, but the RPC API requires
-            // these to be set during a notify_amounts_updated call.
-            .amountOut(request.getAmount())
-            .amountOutAsset(asset.getSep38AssetName())
-            .amountFee("0")
-            .amountFeeAsset(asset.getSep38AssetName())
             .amountExpected(request.getAmount())
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())
@@ -254,16 +246,6 @@ public class Sep6Service {
             .type(request.getType())
             .assetCode(request.getAssetCode())
             .assetIssuer(asset.getIssuer())
-            .amountIn(request.getAmount())
-            .amountInAsset(asset.getSep38AssetName())
-            // NB: these are purposely set to incorrect values.
-            // amount_out and amount_fee assets cannot be determined when the
-            // platform creates the transaction, but the RPC API requires
-            // these to be set during a notify_amounts_updated call.
-            .amountOut(request.getAmount())
-            .amountOutAsset(asset.getSep38AssetName())
-            .amountFee("0")
-            .amountFeeAsset(asset.getSep38AssetName())
             .amountExpected(request.getAmount())
             .startedAt(Instant.now())
             .sep10Account(token.getAccount())

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -75,9 +75,9 @@ data class RequestOffchainFundsRequest(
 data class RequestOnchainFundsRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String,
-  @SerialName("amount_in") val amountIn: AmountAssetRequest,
-  @SerialName("amount_out") val amountOut: AmountAssetRequest,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest,
+  @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
+  @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
   @SerialName("amount_expected") val amountExpected: AmountRequest? = null
 ) : RpcActionParamsRequest()
 
@@ -123,11 +123,20 @@ data class NotifyOffchainFundsPendingRequest(
 ) : RpcActionParamsRequest()
 
 @Serializable
+data class NotifyAmountsAssetsUpdatedRequest(
+  @SerialName("transaction_id") override val transactionId: String,
+  override val message: String? = null,
+  @SerialName("amount_in") val amountIn: AmountAssetRequest,
+  @SerialName("amount_out") val amountOut: AmountAssetRequest,
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest
+) : RpcActionParamsRequest()
+
+@Serializable
 data class NotifyAmountsUpdatedRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("amount_out") val amountOut: AmountAssetRequest,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest
+  @SerialName("amount_out") val amountOut: AmountRequest,
+  @SerialName("amount_fee") val amountFee: AmountRequest
 ) : RpcActionParamsRequest()
 
 @Serializable

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -12,28 +12,7 @@ import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.config.PropertyCustodyConfig;
 import org.stellar.anchor.platform.config.RpcConfig;
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
-import org.stellar.anchor.platform.rpc.DoStellarPaymentHandler;
-import org.stellar.anchor.platform.rpc.DoStellarRefundHandler;
-import org.stellar.anchor.platform.rpc.NotifyAmountsUpdatedHandler;
-import org.stellar.anchor.platform.rpc.NotifyCustomerInfoUpdatedHandler;
-import org.stellar.anchor.platform.rpc.NotifyInteractiveFlowCompletedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsAvailableHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsPendingHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsReceivedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyOnchainFundsReceivedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOnchainFundsSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyRefundPendingHandler;
-import org.stellar.anchor.platform.rpc.NotifyRefundSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionErrorHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionExpiredHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionRecoveryHandler;
-import org.stellar.anchor.platform.rpc.NotifyTrustSetHandler;
-import org.stellar.anchor.platform.rpc.RequestCustomerInfoUpdateHandler;
-import org.stellar.anchor.platform.rpc.RequestOffchainFundsHandler;
-import org.stellar.anchor.platform.rpc.RequestOnchainFundsHandler;
-import org.stellar.anchor.platform.rpc.RequestTrustlineHandler;
-import org.stellar.anchor.platform.rpc.RpcMethodHandler;
+import org.stellar.anchor.platform.rpc.*;
 import org.stellar.anchor.platform.service.RpcService;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24DepositInfoGenerator;
@@ -96,6 +75,25 @@ public class RpcActionBeans {
         custodyConfig,
         assetService,
         custodyService,
+        eventService,
+        metricsService);
+  }
+
+  @Bean
+  NotifyAmountsAssetsUpdatedHandler notifyAmountsAssetsUpdatedHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    return new NotifyAmountsAssetsUpdatedHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
         eventService,
         metricsService);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyAmountsAssetsUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyAmountsAssetsUpdatedHandler.java
@@ -1,0 +1,113 @@
+package org.stellar.anchor.platform.rpc;
+
+import static java.util.Collections.emptySet;
+import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_6;
+import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_AMOUNTS_ASSETS_UPDATED;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
+
+import java.util.Set;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.BadRequestException;
+import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep;
+import org.stellar.anchor.api.rpc.method.AmountAssetRequest;
+import org.stellar.anchor.api.rpc.method.NotifyAmountsAssetsUpdatedRequest;
+import org.stellar.anchor.api.rpc.method.RpcMethod;
+import org.stellar.anchor.api.sep.SepTransactionStatus;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSepTransaction;
+import org.stellar.anchor.platform.utils.AssetValidationUtils;
+import org.stellar.anchor.platform.validator.RequestValidator;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
+import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
+
+public class NotifyAmountsAssetsUpdatedHandler
+    extends RpcMethodHandler<NotifyAmountsAssetsUpdatedRequest> {
+
+  public NotifyAmountsAssetsUpdatedHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    super(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService,
+        NotifyAmountsAssetsUpdatedRequest.class);
+  }
+
+  @Override
+  protected void validate(JdbcSepTransaction txn, NotifyAmountsAssetsUpdatedRequest request)
+      throws BadRequestException, InvalidParamsException, InvalidRequestException {
+    super.validate(txn, request);
+
+    AssetValidationUtils.validateAsset(
+        "amount_in",
+        AmountAssetRequest.builder()
+            .amount(request.getAmountIn().getAmount())
+            .asset(request.getAmountIn().getAsset())
+            .build(),
+        assetService);
+
+    AssetValidationUtils.validateAsset(
+        "amount_out",
+        AmountAssetRequest.builder()
+            .amount(request.getAmountOut().getAmount())
+            .asset(request.getAmountOut().getAsset())
+            .build(),
+        assetService);
+
+    AssetValidationUtils.validateAsset(
+        "amount_fee",
+        AmountAssetRequest.builder()
+            .amount(request.getAmountFee().getAmount())
+            .asset(request.getAmountFee().getAsset())
+            .build(),
+        true,
+        assetService);
+  }
+
+  @Override
+  public RpcMethod getRpcMethod() {
+    return NOTIFY_AMOUNTS_ASSETS_UPDATED;
+  }
+
+  @Override
+  protected SepTransactionStatus getNextStatus(
+      JdbcSepTransaction txn, NotifyAmountsAssetsUpdatedRequest request)
+      throws InvalidRequestException, InvalidParamsException {
+    return PENDING_ANCHOR;
+  }
+
+  @Override
+  protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
+    if (Sep.from(txn.getProtocol()) == SEP_6) {
+      return Set.of(INCOMPLETE, PENDING_ANCHOR, PENDING_CUSTOMER_INFO_UPDATE);
+    }
+    return emptySet();
+  }
+
+  @Override
+  protected void updateTransactionWithRpcRequest(
+      JdbcSepTransaction txn, NotifyAmountsAssetsUpdatedRequest request) throws AnchorException {
+    txn.setAmountIn(request.getAmountIn().getAmount());
+    txn.setAmountInAsset(request.getAmountIn().getAsset());
+
+    txn.setAmountOut(request.getAmountOut().getAmount());
+    txn.setAmountOutAsset(request.getAmountOut().getAsset());
+
+    txn.setAmountFee(request.getAmountFee().getAmount());
+    txn.setAmountFeeAsset(request.getAmountFee().getAsset());
+  }
+}


### PR DESCRIPTION
### Description

This introduces the `NotifyAmountsAssetsUpdated` RPC which allows SEP-6 implementations to update all amounts/assets when it calculates fees.

### Context

The current `NotifyAmountsUpdated` RPC was previously created for the SEP-24 withdrawal flow where only the amount values for `amount_out` and `amount_fee` need to be updated. In SEP-6, the asset values need to be updated as well since in the case of a deposit, the `amount_in` asset and amount are not known at transaction creation time. In the SEP-6 withdrawal flow, the `amount_out` asset and amount are unknown.

The current reference implementation works around this by updating the `amount_in` value and asset when it requests off-chain funds which really could be down when it updates the fees initially ([`Sep6EventProcessor`](https://github.com/stellar/java-stellar-anchor-sdk/blob/c0eb22b53acc17cf1840d0617f768ded53d8160d/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt#L203-L207)). 

Additionally, by not using this RPC, the SEP-6 implementation would not need to purposely set wrong amount values when creating the transaction ([`Sep6Service`](https://github.com/stellar/java-stellar-anchor-sdk/blob/c0eb22b53acc17cf1840d0617f768ded53d8160d/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java#L259-L266)).

### Testing

- `./gradlew test`

### Documentation

TODO: make the stellar-docs change if this is ok.

### Known limitations

N/A

