### PR TITLE
[Chore] Bump version to 2.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.3.0"
+  version = "2.4.0"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.3.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.3.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.4.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.4.0)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/wk_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">


### PR DESCRIPTION
### Description

This bumps the version numbers to 2.4.0.

### Context

SEP-6 release

### Testing

- `./gradlew test`

### Documentation

Stellar docs PR: https://github.com/stellar/stellar-docs/pull/253

### Known limitations

N/A

