### PR TITLE
[ANCHOR-547] Fix: Add refunds pending/sent support for SEP-6

### DIFF
--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.skyscreamer.jsonassert.Customization
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
@@ -19,12 +21,14 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.*
 import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
 import org.stellar.anchor.api.rpc.method.AmountAssetRequest
 import org.stellar.anchor.api.rpc.method.NotifyRefundSentRequest
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.shared.*
+import org.stellar.anchor.api.shared.RefundPayment.IdType
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.event.EventService
@@ -95,6 +99,7 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     val spyTxn24 = spyk(txn24)
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { spyTxn24.protocol } returns SEP_38.sep.toString()
@@ -105,6 +110,7 @@ class NotifyRefundSentHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -118,6 +124,7 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
@@ -135,6 +142,7 @@ class NotifyRefundSentHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -148,12 +156,36 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
 
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("refund is required", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange", "withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_invalidRequest_missing_refunds(kind: String) {
+    val request = NotifyRefundSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("refund is required", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -167,6 +199,7 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     txn24.transferReceivedAt = Instant.now()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { requestValidator.validate(request) } throws
@@ -202,6 +235,7 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -215,6 +249,7 @@ class NotifyRefundSentHandlerTest {
     ex = assertThrows { handler.handle(request) }
     assertEquals("refund.amountFee.amount should be non-negative", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -241,6 +276,7 @@ class NotifyRefundSentHandlerTest {
     txn24.kind = DEPOSIT.kind
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -257,6 +293,50 @@ class NotifyRefundSentHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sent_more_then_amount_in() {
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("10", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0", FIAT_USD))
+            .id("1")
+            .build()
+        )
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+    txn24.requestAssetCode = FIAT_USD_CODE
+    txn24.amountIn = "1"
+    txn24.amountInAsset = STELLAR_USDC
+    txn24.amountFee = "1"
+    txn24.amountFeeAsset = FIAT_USD
+
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val payment = JdbcSep24RefundPayment()
+    payment.id = "1"
+    payment.amount = "1"
+    payment.fee = "0"
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("Refund amount exceeds amount_in", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -294,6 +374,7 @@ class NotifyRefundSentHandlerTest {
     payment.amount = request.refund.amount.amount
     payment.fee = request.refund.amountFee.amount
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -305,6 +386,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -342,7 +424,7 @@ class NotifyRefundSentHandlerTest {
     refundPayment.amount = Amount("1", txn24.amountInAsset)
     refundPayment.fee = Amount("0.1", txn24.amountInAsset)
     refundPayment.id = request.refund.id
-    refundPayment.idType = RefundPayment.IdType.STELLAR
+    refundPayment.idType = IdType.STELLAR
     val refunded = Amount("1.1", txn24.amountInAsset)
     val refundedFee = Amount("0.1", txn24.amountInAsset)
     expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
@@ -411,6 +493,7 @@ class NotifyRefundSentHandlerTest {
     refunds.payments = listOf(payment1)
     txn24.refunds = refunds
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -422,6 +505,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -460,12 +544,12 @@ class NotifyRefundSentHandlerTest {
     refundPayment1.amount = Amount("1", txn24.amountInAsset)
     refundPayment1.fee = Amount("0.1", txn24.amountInAsset)
     refundPayment1.id = "1"
-    refundPayment1.idType = RefundPayment.IdType.STELLAR
+    refundPayment1.idType = IdType.STELLAR
     val refundPayment2 = RefundPayment()
     refundPayment2.amount = Amount("1", txn24.amountInAsset)
     refundPayment2.fee = Amount("0.1", txn24.amountInAsset)
     refundPayment2.id = "2"
-    refundPayment2.idType = RefundPayment.IdType.STELLAR
+    refundPayment2.idType = IdType.STELLAR
     val refunded = Amount("2.2", txn24.amountInAsset)
     val refundedFee = Amount("0.2", txn24.amountInAsset)
     expectedResponse.refunds =
@@ -529,6 +613,7 @@ class NotifyRefundSentHandlerTest {
     payment.amount = "1"
     payment.fee = "0"
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -540,6 +625,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -578,7 +664,7 @@ class NotifyRefundSentHandlerTest {
     refundPayment.amount = Amount("1", txn24.amountInAsset)
     refundPayment.fee = Amount("0", txn24.amountInAsset)
     refundPayment.id = "1"
-    refundPayment.idType = RefundPayment.IdType.STELLAR
+    refundPayment.idType = IdType.STELLAR
     val refunded = Amount("1", txn24.amountInAsset)
     val refundedFee = Amount("0", txn24.amountInAsset)
     expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
@@ -611,47 +697,6 @@ class NotifyRefundSentHandlerTest {
   }
 
   @Test
-  fun test_handle_sent_more_then_amount_in() {
-    val request =
-      NotifyRefundSentRequest.builder()
-        .transactionId(TX_ID)
-        .refund(
-          NotifyRefundSentRequest.Refund.builder()
-            .amount(AmountAssetRequest("10", STELLAR_USDC))
-            .amountFee(AmountAssetRequest("0", FIAT_USD))
-            .id("1")
-            .build()
-        )
-        .build()
-    val txn24 = JdbcSep24Transaction()
-    txn24.status = PENDING_ANCHOR.toString()
-    txn24.kind = DEPOSIT.kind
-    txn24.transferReceivedAt = Instant.now()
-    txn24.requestAssetCode = FIAT_USD_CODE
-    txn24.amountIn = "1"
-    txn24.amountInAsset = STELLAR_USDC
-    txn24.amountFee = "1"
-    txn24.amountFeeAsset = FIAT_USD
-
-    val sep24TxnCapture = slot<JdbcSep24Transaction>()
-    val payment = JdbcSep24RefundPayment()
-    payment.id = "1"
-    payment.amount = "1"
-    payment.fee = "0"
-
-    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
-
-    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("Refund amount exceeds amount_in", ex.message)
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
   fun test_handle_ok_sep24_pending_external_empty_refund() {
     val transferReceivedAt = Instant.now()
     val request = NotifyRefundSentRequest.builder().transactionId(TX_ID).build()
@@ -677,6 +722,7 @@ class NotifyRefundSentHandlerTest {
     refunds.payments = listOf(payment)
     txn24.refunds = refunds
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -688,6 +734,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -725,7 +772,7 @@ class NotifyRefundSentHandlerTest {
     refundPayment.amount = Amount("1", txn24.amountInAsset)
     refundPayment.fee = Amount("0.1", txn24.amountInAsset)
     refundPayment.id = "1"
-    refundPayment.idType = RefundPayment.IdType.STELLAR
+    refundPayment.idType = IdType.STELLAR
     val refunded = Amount("1", txn24.amountInAsset)
     val refundedFee = Amount("0.1", txn24.amountInAsset)
     expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
@@ -794,6 +841,7 @@ class NotifyRefundSentHandlerTest {
     refunds.payments = listOf(payment1, payment2)
     txn24.refunds = refunds
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -805,6 +853,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
 
@@ -850,12 +899,12 @@ class NotifyRefundSentHandlerTest {
     refundPayment1.amount = Amount("1.5", txn24.amountInAsset)
     refundPayment1.fee = Amount("0.2", txn24.amountInAsset)
     refundPayment1.id = request.refund.id
-    refundPayment1.idType = RefundPayment.IdType.STELLAR
+    refundPayment1.idType = IdType.STELLAR
     val refundPayment2 = RefundPayment()
     refundPayment2.amount = Amount("0.1", txn24.amountInAsset)
     refundPayment2.fee = Amount("0", txn24.amountInAsset)
     refundPayment2.id = "2"
-    refundPayment2.idType = RefundPayment.IdType.STELLAR
+    refundPayment2.idType = IdType.STELLAR
     val refunded = Amount("1.8", txn24.amountInAsset)
     val refundedFee = Amount("0.2", txn24.amountInAsset)
     expectedResponse.refunds =
@@ -919,6 +968,7 @@ class NotifyRefundSentHandlerTest {
     refunds.payments = listOf(payment)
     txn24.refunds = refunds
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
@@ -926,6 +976,709 @@ class NotifyRefundSentHandlerTest {
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("Invalid refund id", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, EXTERNAL",
+        "deposit-exchange, EXTERNAL",
+        "withdrawal, STELLAR",
+        "withdrawal-exchange, STELLAR"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_ok_sep6_partial_refund(kind: String, refundIdType: IdType) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+            .id("1")
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.amountIn = "2"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountInAsset = STELLAR_USDC
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val payment = RefundPayment()
+    payment.id = request.refund.id
+    payment.idType = refundIdType
+    payment.amount = Amount("1", STELLAR_USDC)
+    payment.fee = Amount("0.1", FIAT_USD)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "2"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    val expectedRefunds = Refunds()
+    expectedRefunds.amountRefunded = Amount("1.1", STELLAR_USDC)
+    expectedRefunds.amountFee = Amount("0.1", FIAT_USD)
+    expectedRefunds.payments = arrayOf(payment)
+    expectedSep6Txn.refunds = expectedRefunds
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("2", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+    val refundPayment = RefundPayment()
+    refundPayment.amount = Amount("1", txn6.amountInAsset)
+    refundPayment.fee = Amount("0.1", txn6.amountFeeAsset)
+    refundPayment.id = request.refund.id
+    refundPayment.idType = refundIdType
+    val refunded = Amount("1.1", txn6.amountInAsset)
+    val refundedFee = Amount("0.1", txn6.amountFeeAsset)
+    expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, EXTERNAL",
+        "deposit-exchange, EXTERNAL",
+        "withdrawal, STELLAR",
+        "withdrawal-exchange, STELLAR"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_ok_sep6_full_refund(kind: String, refundIdType: IdType) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+            .id("2")
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "2.2"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val payment1 = RefundPayment()
+    payment1.id = "1"
+    payment1.idType = refundIdType
+    payment1.amount = Amount("1", STELLAR_USDC)
+    payment1.fee = Amount("0.1", FIAT_USD)
+    val payment2 = RefundPayment()
+    payment2.id = request.refund.id
+    payment2.idType = refundIdType
+    payment2.amount = Amount(request.refund.amount.amount, STELLAR_USDC)
+    payment2.fee = Amount(request.refund.amountFee.amount, FIAT_USD)
+    val refunds = Refunds()
+    refunds.amountRefunded = Amount("1.1", STELLAR_USDC)
+    refunds.amountFee = Amount("0.1", FIAT_USD)
+    refunds.payments = arrayOf(payment1)
+    txn6.refunds = refunds
+
+    every { txn6Store.findByTransactionId(any()) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = REFUNDED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "2.2"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    val expectedRefunds = Refunds()
+    expectedRefunds.amountRefunded = Amount("2.2", STELLAR_USDC)
+    expectedRefunds.amountFee = Amount("0.2", FIAT_USD)
+    expectedRefunds.payments = arrayOf(payment1, payment2)
+    expectedSep6Txn.refunds = expectedRefunds
+    expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      CustomComparator(JSONCompareMode.STRICT, Customization("completed_at") { _, _ -> true })
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = REFUNDED
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("2.2", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+    val refundPayment1 = RefundPayment()
+    refundPayment1.amount = Amount("1", txn6.amountInAsset)
+    refundPayment1.fee = Amount("0.1", txn6.amountFeeAsset)
+    refundPayment1.id = "1"
+    refundPayment1.idType = refundIdType
+    val refundPayment2 = RefundPayment()
+    refundPayment2.amount = Amount("1", txn6.amountInAsset)
+    refundPayment2.fee = Amount("0.1", txn6.amountFeeAsset)
+    refundPayment2.id = "2"
+    refundPayment2.idType = refundIdType
+    val refunded = Amount("2.2", txn6.amountInAsset)
+    val refundedFee = Amount("0.2", txn6.amountFeeAsset)
+    expectedResponse.refunds =
+      Refunds(refunded, refundedFee, arrayOf(refundPayment1, refundPayment2))
+    expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      CustomComparator(JSONCompareMode.STRICT, Customization("completed_at") { _, _ -> true })
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.completedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, EXTERNAL",
+        "deposit-exchange, EXTERNAL",
+        "withdrawal, STELLAR",
+        "withdrawal-exchange, STELLAR"
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_ok_sep6_full_refund_in_single_call(kind: String, refundIdType: IdType) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0", FIAT_USD))
+            .id("1")
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "1"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val payment = RefundPayment()
+    payment.id = "1"
+    payment.idType = refundIdType
+    payment.amount = Amount("1", STELLAR_USDC)
+    payment.fee = Amount("0", FIAT_USD)
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = REFUNDED.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    val expectedRefunds = Refunds()
+    expectedRefunds.amountRefunded = Amount("1", STELLAR_USDC)
+    expectedRefunds.amountFee = Amount("0", FIAT_USD)
+    expectedRefunds.payments = arrayOf(payment)
+    expectedSep6Txn.refunds = expectedRefunds
+    expectedSep6Txn.completedAt = sep6TxnCapture.captured.completedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      CustomComparator(JSONCompareMode.STRICT, Customization("completed_at") { _, _ -> true })
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = REFUNDED
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("1", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+    val refundPayment = RefundPayment()
+    refundPayment.amount = Amount("1", txn6.amountInAsset)
+    refundPayment.fee = Amount("0", txn6.amountFeeAsset)
+    refundPayment.id = "1"
+    refundPayment.idType = refundIdType
+    val refunded = Amount("1", txn6.amountInAsset)
+    val refundedFee = Amount("0", txn6.amountFeeAsset)
+    expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
+    expectedResponse.completedAt = sep6TxnCapture.captured.completedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      CustomComparator(JSONCompareMode.STRICT, Customization("completed_at") { _, _ -> true })
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+    assertTrue(sep6TxnCapture.captured.completedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.completedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, EXTERNAL",
+        "deposit-exchange, EXTERNAL",
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_ok_sep6_pending_external_empty_refund(kind: String, refundIdType: IdType) {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyRefundSentRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_EXTERNAL.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "2"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val payment = RefundPayment()
+    payment.id = "1"
+    payment.idType = refundIdType
+    payment.amount = Amount("1", STELLAR_USDC)
+    payment.fee = Amount("0.1", FIAT_USD)
+    val refunds = Refunds()
+    refunds.amountRefunded = Amount("1", STELLAR_USDC)
+    refunds.amountFee = Amount("0.1", FIAT_USD)
+    refunds.payments = arrayOf(payment)
+    txn6.refunds = refunds
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "2"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    val expectedRefunds = Refunds()
+    expectedRefunds.amountRefunded = Amount("1", STELLAR_USDC)
+    expectedRefunds.amountFee = Amount("0.1", FIAT_USD)
+    expectedRefunds.payments = arrayOf(payment)
+    expectedSep6Txn.refunds = expectedRefunds
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("2", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+    val refundPayment = RefundPayment()
+    refundPayment.amount = Amount("1", txn6.amountInAsset)
+    refundPayment.fee = Amount("0.1", txn6.amountFeeAsset)
+    refundPayment.id = "1"
+    refundPayment.idType = refundIdType
+    val refunded = Amount("1", txn6.amountInAsset)
+    val refundedFee = Amount("0.1", txn6.amountFeeAsset)
+    expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(
+    value =
+      [
+        "deposit, EXTERNAL",
+        "deposit-exchange, EXTERNAL",
+      ]
+  )
+  @ParameterizedTest
+  fun test_handle_ok_sep6_pending_external_override_amount(kind: String, refundIdType: IdType) {
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("1.5", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.2", FIAT_USD))
+            .id("1")
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_EXTERNAL.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "2"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+    val payment1 = RefundPayment()
+    payment1.id = request.refund.id
+    payment1.idType = refundIdType
+    payment1.amount = Amount("1", STELLAR_USDC)
+    payment1.fee = Amount("0.1", FIAT_USD)
+    val payment2 = RefundPayment()
+    payment2.id = "2"
+    payment2.idType = refundIdType
+    payment2.amount = Amount("0.1", STELLAR_USDC)
+    payment2.fee = Amount("0", FIAT_USD)
+    val refunds = Refunds()
+    refunds.amountRefunded = Amount("1", STELLAR_USDC)
+    refunds.amountFee = Amount("0.1", FIAT_USD)
+    refunds.payments = arrayOf(payment1, payment2)
+    txn6.refunds = refunds
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_ANCHOR.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = FIAT_USD_CODE
+    expectedSep6Txn.amountIn = "2"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = FIAT_USD
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+    val expectedRefunds = Refunds()
+    expectedRefunds.amountRefunded = Amount("1.8", STELLAR_USDC)
+    expectedRefunds.amountFee = Amount("0.2", FIAT_USD)
+    val expectedPayment1 = RefundPayment()
+    expectedPayment1.id = request.refund.id
+    expectedPayment1.idType = refundIdType
+    expectedPayment1.amount = Amount("1.5", STELLAR_USDC)
+    expectedPayment1.fee = Amount("0.2", FIAT_USD)
+    val expectedPayment2 = RefundPayment()
+    expectedPayment2.id = "2"
+    expectedPayment2.idType = refundIdType
+    expectedPayment2.amount = Amount("0.1", STELLAR_USDC)
+    expectedPayment2.fee = Amount("0", FIAT_USD)
+    expectedRefunds.payments = arrayOf(expectedPayment2, expectedPayment1)
+    expectedSep6Txn.refunds = expectedRefunds
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_ANCHOR
+    expectedResponse.amountExpected = Amount(null, FIAT_USD)
+    expectedResponse.amountIn = Amount("2", STELLAR_USDC)
+    expectedResponse.amountFee = Amount("0.1", FIAT_USD)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+    val refundPayment1 = RefundPayment()
+    refundPayment1.amount = Amount("1.5", txn6.amountInAsset)
+    refundPayment1.fee = Amount("0.2", txn6.amountFeeAsset)
+    refundPayment1.id = request.refund.id
+    refundPayment1.idType = refundIdType
+    val refundPayment2 = RefundPayment()
+    refundPayment2.amount = Amount("0.1", txn6.amountInAsset)
+    refundPayment2.fee = Amount("0", txn6.amountFeeAsset)
+    refundPayment2.id = "2"
+    refundPayment2.idType = refundIdType
+    val refunded = Amount("1.8", txn6.amountInAsset)
+    val refundedFee = Amount("0.2", txn6.amountFeeAsset)
+    expectedResponse.refunds =
+      Refunds(refunded, refundedFee, arrayOf(refundPayment2, refundPayment1))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_ok_sep6_pending_external_invalid_id(kind: String) {
+    val request =
+      NotifyRefundSentRequest.builder()
+        .transactionId(TX_ID)
+        .refund(
+          NotifyRefundSentRequest.Refund.builder()
+            .amount(AmountAssetRequest("1", STELLAR_USDC))
+            .amountFee(AmountAssetRequest("0.1", FIAT_USD))
+            .id("2")
+            .build()
+        )
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_EXTERNAL.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+    txn6.requestAssetCode = FIAT_USD_CODE
+    txn6.amountIn = "2"
+    txn6.amountInAsset = STELLAR_USDC
+    txn6.amountFee = "0.1"
+    txn6.amountFeeAsset = FIAT_USD
+
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val payment = RefundPayment()
+    payment.id = "1"
+    payment.idType = IdType.EXTERNAL
+    payment.amount = Amount("1", STELLAR_USDC)
+    payment.fee = Amount("0.1", FIAT_USD)
+    val refunds = Refunds()
+    refunds.amountRefunded = Amount("1", STELLAR_USDC)
+    refunds.amountFee = Amount("0.1", FIAT_USD)
+    refunds.payments = arrayOf(payment)
+    txn6.refunds = refunds
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals("Invalid refund id", ex.message)
+
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -963,6 +1716,7 @@ class NotifyRefundSentHandlerTest {
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns null
     every { txn31Store.findByTransactionId(any()) } returns txn31
     every { txn31Store.save(capture(sep31TxnCapture)) } returns null
@@ -972,6 +1726,7 @@ class NotifyRefundSentHandlerTest {
     val response = handler.handle(request)
     val endDate = Instant.now()
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
 
     val expectedSep31Txn = JdbcSep31Transaction()
@@ -1014,7 +1769,7 @@ class NotifyRefundSentHandlerTest {
     refundPayment.amount = Amount("1", txn31.amountInAsset)
     refundPayment.fee = Amount("0", txn31.amountInAsset)
     refundPayment.id = "1"
-    refundPayment.idType = RefundPayment.IdType.STELLAR
+    refundPayment.idType = IdType.STELLAR
     val refunded = Amount("1", txn31.amountInAsset)
     val refundedFee = Amount("0", txn31.amountInAsset)
     expectedResponse.refunds = Refunds(refunded, refundedFee, arrayOf(refundPayment))
@@ -1050,12 +1805,14 @@ class NotifyRefundSentHandlerTest {
     val txn31 = JdbcSep31Transaction()
     txn31.status = PENDING_RECEIVER.toString()
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns null
     every { txn31Store.findByTransactionId(any()) } returns txn31
 
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
     assertEquals("refund is required", ex.message)
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
@@ -1087,6 +1844,7 @@ class NotifyRefundSentHandlerTest {
     refunds.payments = listOf(payment)
     txn31.refunds = refunds
 
+    every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns null
     every { txn31Store.findByTransactionId(any()) } returns txn31
 
@@ -1096,6 +1854,7 @@ class NotifyRefundSentHandlerTest {
       ex.message
     )
 
+    verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }


### PR DESCRIPTION
### Description

This adds the missing implementation for the `NotifyRefundSent` and the `NotifyRefundPending` RPC actions.

### Context

They were missed in the previous PRs.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

