### PR TITLE
Update ubuntu to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY --chown=gradle:gradle . .
 
 RUN gradle clean bootJar --stacktrace -x test
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends openjdk-11-jre

--- a/docs/resources/deployment-examples/example-fargate/Dockerfile
+++ b/docs/resources/deployment-examples/example-fargate/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN mkdir /config_files
 ENV STELLAR_ANCHOR_CONFIG=file:/config/anchor-config.yaml
 ENV REFERENCE_SERVER_CONFIG_ENV=file:/config/reference-config.yaml


### PR DESCRIPTION
### Description

Update ubuntu to 22.04 from 20.04

### Context

We are updating all ubuntu base images in SDF projects to 22.04 LTS.

### Testing

I built the docker image and it built successfully.

### Documentation

NA
### Known limitations

NA

