### PR TITLE
[ANCHOR-539 ]Map empty request parameter strings to null

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/SepControllerConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/SepControllerConfig.java
@@ -1,0 +1,16 @@
+package org.stellar.anchor.platform.controller.sep;
+
+import org.springframework.beans.propertyeditors.StringTrimmerEditor;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+@ControllerAdvice
+public class SepControllerConfig {
+  @InitBinder
+  void initBinder(final WebDataBinder binder) {
+    // Maps empty strings to null when a @RequestParam is being bound.
+    // This is required due to a bug in Spring.
+    binder.registerCustomEditor(String.class, new StringTrimmerEditor(true));
+  }
+}


### PR DESCRIPTION
### Description

This maps empty request parameters (`param=`) to `null`. There is a bug in Spring that maps these to "".

### Context

Since we don't explicitly check for empty parameters in SEP-6, an empty amount causes a `NumberFormatException` when converting it to a `BigDecimal`, which surfaces to the client as a 500 error.

### Testing

- `./gradlew test`
- Manual testing SEP-6 withdraw with`&amount=`

### Documentation

N/A

### Known limitations

N/A

