### PR TITLE
[ANCHOR-567] Fix application startup without SEP-6 enabled

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,7 +178,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.5.0"
+  version = "2.5.1"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.5.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.5.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.5.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.5.1)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/wk_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -22,6 +22,7 @@ import org.stellar.anchor.filter.Sep10JwtFilter;
 import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.platform.apiclient.CustodyApiClient;
 import org.stellar.anchor.platform.condition.ConditionalOnAllSepsEnabled;
+import org.stellar.anchor.platform.condition.ConditionalOnAnySepsEnabled;
 import org.stellar.anchor.platform.config.*;
 import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountsManager;
 import org.stellar.anchor.platform.service.Sep31DepositInfoApiGenerator;
@@ -123,7 +124,7 @@ public class SepBeans {
   }
 
   @Bean
-  @ConditionalOnAllSepsEnabled(seps = {"sep6", "sep24"})
+  @ConditionalOnAnySepsEnabled(seps = {"sep6", "sep24", "sep31"})
   ClientFinder clientFinder(Sep10Config sep10Config, ClientsConfig clientsConfig) {
     return new ClientFinder(sep10Config, clientsConfig);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -124,7 +124,7 @@ public class SepBeans {
   }
 
   @Bean
-  @ConditionalOnAnySepsEnabled(seps = {"sep6", "sep24", "sep31"})
+  @ConditionalOnAnySepsEnabled(seps = {"sep6", "sep24"})
   ClientFinder clientFinder(Sep10Config sep10Config, ClientsConfig clientsConfig) {
     return new ClientFinder(sep10Config, clientsConfig);
   }


### PR DESCRIPTION
### Description

AP does not currently start up due to `ClientFinder` bean initialization.

### Context

`ClientFinder` bean initialization depends on both `sep6` and `sep24` being enabled in the config. It should initialize when either is enabled.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

