### PR TITLE
[ANCHOR-543] Fix content types for SEP/Platform endpoints

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/HealthController.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.controller;
 
 import java.util.List;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -17,7 +18,9 @@ public abstract class HealthController {
     this.healthCheckService = healthCheckService;
   }
 
-  @RequestMapping(method = {RequestMethod.GET})
+  @RequestMapping(
+      method = {RequestMethod.GET},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<HealthCheckResponse> health(
       @RequestParam(required = false) List<String> checks) {
     if (checks == null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyHealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyHealthController.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller.custody;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,7 +9,9 @@ import org.stellar.anchor.platform.service.HealthCheckService;
 
 @RestController
 @CrossOrigin(origins = "*")
-@RequestMapping(value = "/health")
+@RequestMapping(
+    value = "/health",
+    produces = {MediaType.APPLICATION_JSON_VALUE})
 public class CustodyHealthController extends HealthController {
   public CustodyHealthController(HealthCheckService healthCheckService) {
     super(healthCheckService);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyPaymentController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyPaymentController.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.controller.custody;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +26,7 @@ public class CustodyPaymentController {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/assets/{assetId}/addresses",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public GenerateDepositAddressResponse generateDepositAddress(@PathVariable String assetId)
       throws CustodyException, InvalidConfigException {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
@@ -31,6 +31,7 @@ public class CustodyTransactionController {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/transactions",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public void createCustodyTransaction(@RequestBody CreateCustodyTransactionRequest request) {
     custodyTransactionService.create(request, PAYMENT);
@@ -42,6 +43,7 @@ public class CustodyTransactionController {
   @RequestMapping(
       value = "/transactions/{id}/payments",
       method = {RequestMethod.POST},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       consumes = {MediaType.APPLICATION_JSON_VALUE})
   public CreateTransactionPaymentResponse createTransactionPayment(
       @PathVariable(name = "id") String txnId, @RequestBody String requestBody) {
@@ -54,6 +56,7 @@ public class CustodyTransactionController {
   @RequestMapping(
       value = "/transactions/{id}/refunds",
       method = {RequestMethod.POST},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       consumes = {MediaType.APPLICATION_JSON_VALUE})
   public CreateTransactionPaymentResponse createTransactionRefund(
       @PathVariable(name = "id") String txnId,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyWebhookController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyWebhookController.java
@@ -22,7 +22,8 @@ public class CustodyWebhookController {
   @RequestMapping(
       value = "/webhook",
       method = {RequestMethod.POST},
-      consumes = {MediaType.APPLICATION_JSON_VALUE})
+      consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Void> handleEvent(
       @RequestBody String eventObject, @RequestHeader Map<String, String> headers) {
     custodyEventService.handleEvent(eventObject, headers);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/observer/ObserverHealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/observer/ObserverHealthController.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller.observer;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,7 +9,9 @@ import org.stellar.anchor.platform.service.HealthCheckService;
 
 @RestController
 @CrossOrigin(origins = "*")
-@RequestMapping(value = "/health")
+@RequestMapping(
+    value = "/health",
+    produces = {MediaType.APPLICATION_JSON_VALUE})
 public class ObserverHealthController extends HealthController {
   public ObserverHealthController(HealthCheckService healthCheckService) {
     super(healthCheckService);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
@@ -40,6 +40,7 @@ public class PlatformController {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/transactions/{id}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionResponse getTransaction(@PathVariable(name = "id") String txnId)
       throws AnchorException {
@@ -50,7 +51,8 @@ public class PlatformController {
   @RequestMapping(
       value = "/transactions/{id}/payments",
       method = {RequestMethod.POST},
-      consumes = {MediaType.APPLICATION_JSON_VALUE})
+      consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public CreateTransactionPaymentResponse createCustodyTransactionPayment(
       @PathVariable(name = "id") String txnId, @RequestBody String requestBody)
       throws AnchorException {
@@ -62,6 +64,7 @@ public class PlatformController {
   @RequestMapping(
       value = "/transactions",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.PATCH})
   public PatchTransactionsResponse patchTransactions(@RequestBody PatchTransactionsRequest request)
       throws AnchorException {
@@ -72,6 +75,7 @@ public class PlatformController {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/transactions",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionsResponse getTransactions(
       @RequestParam(value = "sep") TransactionsSeps sep,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformHealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformHealthController.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller.platform;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,7 +9,9 @@ import org.stellar.anchor.platform.service.HealthCheckService;
 
 @RestController
 @CrossOrigin(origins = "*")
-@RequestMapping(value = "/health")
+@RequestMapping(
+    value = "/health",
+    produces = {MediaType.APPLICATION_JSON_VALUE})
 public class PlatformHealthController extends HealthController {
   public PlatformHealthController(HealthCheckService healthCheckService) {
     super(healthCheckService);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformRpcController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformRpcController.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.controller.platform;
 
 import java.util.List;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +23,9 @@ public class PlatformRpcController {
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(method = {RequestMethod.POST})
+  @RequestMapping(
+      method = {RequestMethod.POST},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   @ResponseStatus(value = HttpStatus.OK)
   public List<RpcResponse> handle(@RequestBody List<RpcRequest> rpcRequests) {
     return rpcService.handle(rpcRequests);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep10Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep10Controller.java
@@ -36,6 +36,7 @@ public class Sep10Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/auth",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public ChallengeResponse createChallenge(
       @RequestParam String account,
@@ -63,10 +64,10 @@ public class Sep10Controller {
   @RequestMapping(
       value = "/auth",
       consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public ValidationResponse validateChallenge(@RequestParam String transaction)
-      throws InvalidSep10ChallengeException, IOException, URISyntaxException,
-          SepValidationException {
+      throws InvalidSep10ChallengeException, IOException, SepValidationException {
     debugF("POST /auth transaction={}", transaction);
     return validateChallenge(ValidationRequest.of(transaction));
   }
@@ -75,6 +76,7 @@ public class Sep10Controller {
   @RequestMapping(
       value = "/auth",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public ValidationResponse validateChallenge(
       @RequestBody(required = false) ValidationRequest validationRequest)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
@@ -31,6 +31,7 @@ public class Sep12Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/customer",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public Sep12GetCustomerResponse getCustomer(
       HttpServletRequest request,
@@ -68,6 +69,7 @@ public class Sep12Controller {
   @RequestMapping(
       value = "/customer",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.PUT})
   public Sep12PutCustomerResponse putCustomer(
       HttpServletRequest request, @RequestBody Sep12PutCustomerRequest putCustomerRequest) {
@@ -82,7 +84,8 @@ public class Sep12Controller {
   @RequestMapping(
       value = "/customer",
       method = {RequestMethod.POST, RequestMethod.PUT},
-      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public Sep12PutCustomerResponse putCustomerMultipart(HttpServletRequest request) {
     debug("PUT /customer multipart body:", request.getParameterMap());
     Gson gson = GsonUtils.getInstance();
@@ -101,6 +104,7 @@ public class Sep12Controller {
   @RequestMapping(
       value = "/customer/{account}",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.DELETE})
   @ResponseStatus(code = HttpStatus.OK)
   public void deleteCustomer(
@@ -123,6 +127,7 @@ public class Sep12Controller {
   @RequestMapping(
       value = "/customer/{account}",
       consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.DELETE})
   @ResponseStatus(code = HttpStatus.OK)
   public void deleteCustomer(

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep1Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep1Controller.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.controller.sep;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
@@ -27,6 +28,7 @@ public class Sep1Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET, RequestMethod.OPTIONS})
   public RedirectView landingPage() throws SepNotFoundException {
     if (!sep1Config.isEnabled()) {
@@ -40,6 +42,7 @@ public class Sep1Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/.well-known/stellar.toml",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET, RequestMethod.OPTIONS})
   public ResponseEntity<String> getToml() throws SepException {
     if (!sep1Config.isEnabled()) {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
@@ -43,6 +43,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions/deposit/interactive",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public InteractiveTransactionResponse deposit(
       HttpServletRequest request, @RequestBody HashMap<String, String> requestData)
@@ -58,7 +59,8 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions/deposit/interactive",
       method = {RequestMethod.POST},
-      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public InteractiveTransactionResponse depositAllType(HttpServletRequest request)
       throws AnchorException, MalformedURLException, URISyntaxException {
     HashMap<String, String> requestData = new HashMap<>();
@@ -73,6 +75,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions/withdraw/interactive",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public InteractiveTransactionResponse withdraw(
       HttpServletRequest request, @RequestBody HashMap<String, String> requestData)
@@ -88,7 +91,8 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions/withdraw/interactive",
       method = {RequestMethod.POST},
-      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+      consumes = {MediaType.MULTIPART_FORM_DATA_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE})
   public InteractiveTransactionResponse withdrawAllType(HttpServletRequest request)
       throws AnchorException, MalformedURLException, URISyntaxException {
     HashMap<String, String> requestData = new HashMap<>();
@@ -103,6 +107,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionsResponse getTransactions(
       HttpServletRequest request, @RequestBody GetTransactionsRequest tr)
@@ -116,6 +121,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transactions",
       consumes = {MediaType.ALL_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionsResponse getTransactions(
       HttpServletRequest request,
@@ -142,6 +148,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transaction",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public Sep24GetTransactionResponse getTransaction(
       HttpServletRequest request, @RequestBody(required = false) GetTransactionRequest tr)
@@ -156,6 +163,7 @@ public class Sep24Controller {
   @RequestMapping(
       value = "/transaction",
       consumes = {MediaType.ALL_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public Sep24GetTransactionResponse getTransaction(
       HttpServletRequest request,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
@@ -42,6 +42,7 @@ public class Sep31Controller {
   @RequestMapping(
       value = "/transactions",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public Sep31PostTransactionResponse postTransaction(
       HttpServletRequest servletRequest, @RequestBody Sep31PostTransactionRequest request)
@@ -55,6 +56,7 @@ public class Sep31Controller {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/transactions/{id}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public Sep31GetTransactionResponse getTransaction(
       HttpServletRequest ignoredServletRequest, @PathVariable(name = "id") String txnId)
@@ -68,6 +70,7 @@ public class Sep31Controller {
   @RequestMapping(
       value = "/transactions/{id}",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.PATCH})
   public Sep31GetTransactionResponse patchTransaction(
       HttpServletRequest ignoredServletRequest,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep38Controller.java
@@ -30,6 +30,7 @@ public class Sep38Controller {
   public Sep38Controller(Sep38Service sep38Service) {
     this.sep38Service = sep38Service;
   }
+
   // TODO: add integration tests
 
   @CrossOrigin(origins = "*")
@@ -45,6 +46,7 @@ public class Sep38Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/prices",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetPricesResponse getPrices(
       @RequestParam(name = "sell_asset") String sellAssetName,
@@ -68,6 +70,7 @@ public class Sep38Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/price",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetPriceResponse getPrice(
       HttpServletRequest request, @RequestParam Map<String, String> params) {
@@ -89,6 +92,7 @@ public class Sep38Controller {
   @RequestMapping(
       value = "/quote",
       consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public Sep38QuoteResponse postQuote(
       HttpServletRequest request, @RequestBody Sep38PostQuoteRequest postQuoteRequest) {
@@ -102,6 +106,7 @@ public class Sep38Controller {
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/quote/{quote_id}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public Sep38QuoteResponse getQuote(
       HttpServletRequest request, @PathVariable(name = "quote_id") String quoteId) {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.controller.sep;
 import static org.stellar.anchor.util.Log.debugF;
 
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.SepException;
@@ -25,6 +26,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/info",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public InfoResponse getInfo() {
     debugF("GET /info");
@@ -34,6 +36,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/deposit",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public StartDepositResponse deposit(
       HttpServletRequest request,
@@ -74,6 +77,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/deposit-exchange",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public StartDepositResponse depositExchange(
       HttpServletRequest request,
@@ -112,6 +116,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/withdraw",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public StartWithdrawResponse withdraw(
       HttpServletRequest request,
@@ -139,6 +144,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/withdraw-exchange",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public StartWithdrawResponse withdraw(
       HttpServletRequest request,
@@ -170,6 +176,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/transactions",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionsResponse getTransactions(
       HttpServletRequest request,
@@ -206,6 +213,7 @@ public class Sep6Controller {
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/transaction",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.GET})
   public GetTransactionResponse getTransaction(
       HttpServletRequest request,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/SepHealthController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/SepHealthController.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.controller.sep;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,7 +9,9 @@ import org.stellar.anchor.platform.service.HealthCheckService;
 
 @RestController
 @CrossOrigin(origins = "*")
-@RequestMapping(value = "/health")
+@RequestMapping(
+    value = "/health",
+    produces = {MediaType.APPLICATION_JSON_VALUE})
 public class SepHealthController extends HealthController {
   public SepHealthController(HealthCheckService healthCheckService) {
     super(healthCheckService);


### PR DESCRIPTION
### Description

This sets the content types for all SEP and Platform endpoints.

### Context

The default content for Spring `@RestController` is not `application/json`.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

