### PR TITLE
[ANCHOR-566] [Fix] Wrap SEP-31 transaction submission in retry

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
@@ -141,15 +141,17 @@ open class Sep31End2EndTests : AbstractIntegrationTests(TestConfig()) {
       }
 
     // Submit transfer transaction
-    val transfer =
-      wallet
-        .stellar()
-        .transaction(keypair)
-        .transfer(postTxResponse.stellarAccountId, asset, amount)
-        .setMemo(Pair(memoType, postTxResponse.stellarMemo))
-        .build()
-    transfer.sign(keypair)
-    wallet.stellar().submitTransaction(transfer)
+    transactionWithRetry {
+      val transfer =
+        wallet
+          .stellar()
+          .transaction(keypair)
+          .transfer(postTxResponse.stellarAccountId, asset, amount)
+          .setMemo(Pair(memoType, postTxResponse.stellarMemo))
+          .build()
+      transfer.sign(keypair)
+      wallet.stellar().submitTransaction(transfer)
+    }
 
     // Wait for the status to change to COMPLETED
     waitStatus(postTxResponse.id, SepTransactionStatus.COMPLETED)


### PR DESCRIPTION
### Description

Wraps the SEP-31 test transaction submission in a retry.

### Context

Test stability improvement.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A
