### PR TITLE
[ANCHOR-575] Re-enable PlatformApiTests, PlatformApiCustodyTests, and CustodyApiTests

### DIFF
--- a/essential-tests/build.gradle.kts
+++ b/essential-tests/build.gradle.kts
@@ -43,7 +43,7 @@ apply(from = "$rootDir/scripts.gradle.kts")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
 tasks.test {
-  enableTestConcurrency(this)
+//  enableTestConcurrency(this)
   exclude("**/org/stellar/anchor/platform/*Test.class")
   exclude("**/org/stellar/anchor/platform/integrationtest/**")
   exclude("**/org/stellar/anchor/platform/e2etest/**")

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
@@ -570,7 +570,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 3",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           }
         ]
@@ -632,7 +632,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "5", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T21:42:15.946261Z",
               "updated_at": "2023-11-15T21:42:18.067475Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 2",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -668,23 +667,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T21:42:15.946261Z",
               "updated_at": "2023-11-15T21:42:19.160375Z",
               "completed_at": "2023-11-15T21:42:19.160373Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -761,7 +756,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "5", "asset": "iso4217:USD" },
               "started_at": "2023-11-16T21:17:23.259258Z",
               "updated_at": "2023-11-16T21:17:25.712902Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 2",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -797,23 +791,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-16T21:17:23.259258Z",
               "updated_at": "2023-11-16T21:17:26.934996Z",
               "completed_at": "2023-11-16T21:17:26.934991Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -919,7 +908,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 6",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           }
         ]
@@ -1010,7 +999,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T21:53:33.071238Z",
               "updated_at": "2023-11-15T21:53:36.146841Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 3",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1046,7 +1034,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T21:53:33.071238Z",
               "updated_at": "2023-11-15T21:53:36.165729Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 4",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1082,7 +1069,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T21:53:33.071238Z",
               "updated_at": "2023-11-15T21:53:37.180044Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 5",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1119,23 +1105,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T21:53:33.071238Z",
               "updated_at": "2023-11-15T21:53:38.259639Z",
               "completed_at": "2023-11-15T21:53:38.259637Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 6",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -1232,7 +1214,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 5",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           }
         ]
@@ -1294,7 +1276,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T22:02:41.822662Z",
               "updated_at": "2023-11-15T22:02:44.098221Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 2",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1329,7 +1310,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T22:02:41.822662Z",
               "updated_at": "2023-11-15T22:02:45.177536Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 3",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1364,7 +1344,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T22:02:41.822662Z",
               "updated_at": "2023-11-15T22:02:46.237378Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 4",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1400,23 +1379,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T22:02:41.822662Z",
               "updated_at": "2023-11-15T22:02:47.506156Z",
               "completed_at": "2023-11-15T22:02:47.506151Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 5",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -1534,7 +1509,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 5",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           }
         ]
@@ -1596,7 +1571,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T23:15:21.331844Z",
               "updated_at": "2023-11-15T23:15:23.614615Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 2",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
               "external_transaction_id": "ext-123456",
@@ -1631,7 +1605,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T23:15:21.331844Z",
               "updated_at": "2023-11-15T23:15:24.715809Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 3",
               "refunds": {
                 "amount_refunded": { "amount": "990.11", "asset": "iso4217:USD" },
@@ -1678,7 +1651,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "amount_fee": { "amount": "1.11", "asset": "iso4217:USD" },
               "started_at": "2023-11-15T23:15:21.331844Z",
               "updated_at": "2023-11-15T23:15:25.787787Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 4",
               "refunds": {
                 "amount_refunded": { "amount": "990.11", "asset": "iso4217:USD" },
@@ -1726,7 +1698,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T23:15:21.331844Z",
               "updated_at": "2023-11-15T23:15:27.000415Z",
               "completed_at": "2023-11-15T23:15:27.000411Z",
-              "transfer_received_at": "2023-07-04T12:34:56Z",
               "message": "test message 5",
               "refunds": {
                 "amount_refunded": { "amount": "990.11", "asset": "iso4217:USD" },
@@ -1742,19 +1713,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -1809,7 +1777,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 2",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           },
           {
@@ -1889,23 +1857,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T22:47:17.787600Z",
               "updated_at": "2023-11-15T22:47:20.258606Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 2",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -1948,23 +1912,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T22:47:17.787600Z",
               "updated_at": "2023-11-15T22:47:21.386785Z",
               "completed_at": "2023-11-15T22:47:21.386780Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2051,23 +2011,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-16T21:18:15.453486Z",
               "updated_at": "2023-11-16T21:18:17.599527Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 2",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2110,23 +2066,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-16T21:18:15.453486Z",
               "updated_at": "2023-11-16T21:18:18.643487Z",
               "completed_at": "2023-11-16T21:18:18.643485Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2183,7 +2135,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 2",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           },
           {
@@ -2273,23 +2225,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T23:00:49.250465Z",
               "updated_at": "2023-11-15T23:00:51.344410Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 2",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2331,23 +2279,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T23:00:49.250465Z",
               "updated_at": "2023-11-15T23:00:52.367691Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2391,23 +2335,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T23:00:49.250465Z",
               "updated_at": "2023-11-15T23:00:53.387796Z",
               "completed_at": "2023-11-15T23:00:53.387794Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 4",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2464,7 +2404,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 2",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           },
           {
@@ -2554,23 +2494,20 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T22:56:01.090169Z",
               "updated_at": "2023-11-15T22:56:03.177061Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 2",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
+                      "id": "1451136305336321",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2612,23 +2549,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T22:56:01.090169Z",
               "updated_at": "2023-11-15T22:56:04.197512Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 3",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
                   "payments": [
                     {
-                      "id": "563306435719169",
+                      "id": "1451136305336321",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2672,23 +2605,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T22:56:01.090169Z",
               "updated_at": "2023-11-15T22:56:05.214808Z",
               "completed_at": "2023-11-15T22:56:05.214806Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 4",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2745,7 +2673,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "params": {
               "transaction_id": "TX_ID",
               "message": "test message 2",
-              "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+              "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
             }
           },
           {
@@ -2835,23 +2763,19 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "started_at": "2023-11-15T23:17:41.318025Z",
               "updated_at": "2023-11-15T23:17:43.576954Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 2",
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -2894,7 +2818,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               "started_at": "2023-11-15T23:17:41.318025Z",
               "updated_at": "2023-11-15T23:17:44.626373Z",
               "completed_at": "2023-11-15T23:17:44.626370Z",
-              "transfer_received_at": "2023-06-22T08:46:56Z",
               "message": "test message 3",
               "refunds": {
                 "amount_refunded": {
@@ -2922,19 +2845,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
               },
               "stellar_transactions": [
                 {
-                  "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-                  "created_at": "2023-06-22T08:46:56Z",
-                  "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg\u003d\u003d",
+                  "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
                   "payments": [
                     {
-                      "id": "563306435719169",
                       "amount": {
                         "amount": "4.5000000",
                         "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
                       },
                       "payment_type": "payment",
-                      "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-                      "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+                      "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+                      "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
                     }
                   ]
                 }
@@ -3004,7 +2924,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 3",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   }
 ]
@@ -3103,19 +3023,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -3227,7 +3144,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 6",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   }
 ]
@@ -3418,19 +3335,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 6",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -3518,7 +3432,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 5",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   }
 ]
@@ -3679,19 +3593,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 5",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -3801,7 +3712,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 5",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   }
 ]    
@@ -4034,19 +3945,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4093,7 +4001,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 2",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -4173,21 +4081,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4228,21 +4133,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4292,7 +4194,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 2",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -4382,21 +4284,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4436,21 +4335,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4492,21 +4388,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 4",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4586,21 +4479,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4640,21 +4530,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4696,21 +4583,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 4",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4760,7 +4644,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 2",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -4820,7 +4704,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 2",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -4910,21 +4794,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -4989,21 +4870,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "MTkwYjA2NTAtMDcwNy00YmMzLTk1MjEtM2ZhYzY4MzU=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5028,7 +4906,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 1",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -5079,25 +4957,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-03T15:14:02.506800Z",
       "updated_at": "2023-08-03T15:14:05.060150Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 1",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "NTY3NWI1YzctMGVmNC00NTY2LWFmMGMtOWY4MGVmMjg=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5138,7 +5012,6 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-03T15:14:02.506800Z",
       "updated_at": "2023-08-03T15:14:06.437196Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 2",
       "refunds": {
         "amount_refunded": {
@@ -5166,21 +5039,18 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "NTY3NWI1YzctMGVmNC00NTY2LWFmMGMtOWY4MGVmMjg=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5212,7 +5082,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 1",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -5299,25 +5169,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:25.680087Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 1",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5358,25 +5224,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:26.692095Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5417,25 +5279,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:27.729558Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5476,25 +5334,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:28.769798Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 4",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5535,25 +5389,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:29.797331Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 5",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5594,25 +5444,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       },
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:30.816913Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 6",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -5655,25 +5501,21 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "started_at": "2023-08-07T08:01:24.478460Z",
       "updated_at": "2023-08-07T08:01:31.828811Z",
       "completed_at": "2023-08-07T08:01:31.828809Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 7",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "ZmQzY2I4M2YtY2UwNC00Mjc2LWFiYzEtY2QzNWUzNDk=",
           "memo_type": "hash",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -6017,7 +5859,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 14",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -6113,7 +5955,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 19",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -6123,7 +5965,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 20",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   }
 ]
@@ -6386,19 +6228,16 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
       "message": "test message 19",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/CustodyApiTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/CustodyApiTests.kt
@@ -182,7 +182,7 @@ class CustodyApiTests : AbstractIntegrationTests(TestConfig("custody")) {
           EXPECTED_TRANSACTION_RESPONSE.replace(TX_ID_KEY, txId),
           gson.toJson(txResponse),
           CustomComparator(
-            JSONCompareMode.STRICT,
+            JSONCompareMode.LENIENT,
             Customization("completed_at") { _, _ -> true },
             Customization("stellar_transactions[0].created_at") { _, _ -> true }
           )
@@ -270,7 +270,7 @@ class CustodyApiTests : AbstractIntegrationTests(TestConfig("custody")) {
       EXPECTED_TXN_REFUND_RESPONSE.replace(TX_ID_KEY, txId),
       gson.toJson(txResponse),
       CustomComparator(
-        JSONCompareMode.STRICT,
+        JSONCompareMode.LENIENT,
         Customization("completed_at") { _, _ -> true },
         Customization("stellar_transactions[0].created_at") { _, _ -> true }
       )
@@ -399,12 +399,12 @@ private const val WEBHOOK_REQUEST =
     "amount": 4.5,
     "networkFee": 0.00001,
     "netAmount": 4.5,
-    "sourceAddress": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-    "destinationAddress": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W",
+    "sourceAddress": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+    "destinationAddress": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB",
     "destinationAddressDescription": "",
     "destinationTag": "",
     "status": "CONFIRMING",
-    "txHash": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+    "txHash": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
     "subStatus": "CONFIRMED",
     "signedBy": [],
     "createdBy": "1444ed36-5bc0-4e3b-9b17-5df29fc0590f",
@@ -465,12 +465,12 @@ private const val REFUND_WEBHOOK_REQUEST =
     "amount": 4.5,
     "networkFee": 0.00001,
     "netAmount": 1,
-    "sourceAddress": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W",
+    "sourceAddress": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB",
     "destinationAddress": "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
     "destinationAddressDescription": "",
     "destinationTag": "12345",
     "status": "CONFIRMING",
-    "txHash": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+    "txHash": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
     "subStatus": "CONFIRMED",
     "signedBy": [],
     "createdBy": "1444ed36-5bc0-4e3b-9b17-5df29fc0590f",
@@ -539,19 +539,16 @@ private const val EXPECTED_TRANSACTION_RESPONSE =
   "external_transaction_id": "1",
   "stellar_transactions": [
     {
-      "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
-      "created_at": "2023-06-22T08:46:39.336Z",
-      "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
+      "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
       "payments": [
         {
-          "id": "563306435719169",
           "amount": {
             "amount": "4.5000000",
             "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
           },
           "payment_type": "payment",
-          "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-          "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+          "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+          "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
         }
       ]
     }
@@ -597,7 +594,7 @@ private const val EXPECTED_TXN_REFUND_RESPONSE =
     },
     "payments": [
       {
-        "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+        "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
         "id_type": "stellar",
         "amount": {
           "amount": "4.5000000",
@@ -612,21 +609,18 @@ private const val EXPECTED_TXN_REFUND_RESPONSE =
   },
   "stellar_transactions": [
     {
-      "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+      "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
       "memo": "testTag",
       "memo_type": "id",
-      "created_at": "2023-06-22T08:46:56Z",
-      "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
       "payments": [
         {
-          "id": "563306435719169",
           "amount": {
             "amount": "4.5000000",
             "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
           },
           "payment_type": "payment",
-          "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-          "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+          "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+          "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
         }
       ]
     }
@@ -709,7 +703,7 @@ private const val NOTIFY_ONCHAIN_FUNDS_RECEIVED_REQUEST =
   {
     "transaction_id": "TX_ID",
     "message": "test message 1",
-    "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+    "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
   }
 """
 

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
@@ -160,7 +160,7 @@ class PlatformApiCustodyTests : AbstractIntegrationTests(TestConfig("custody")) 
       expectedResult,
       actualResult,
       CustomComparator(
-        JSONCompareMode.STRICT,
+        JSONCompareMode.LENIENT,
         Customization("[*].result.started_at") { _, _ -> true },
         Customization("[*].result.updated_at") { _, _ -> true },
         Customization("[*].result.completed_at") { _, _ -> true }
@@ -442,7 +442,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_REQUESTS =
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 3",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
       "amount_in": {
         "amount": "1"
       }
@@ -553,7 +553,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       "updated_at": "2023-08-07T10:35:41.086448Z",
       "message": "test message 2",
       "source_account": "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
-      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "destination_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
       "memo": "testMemo",
       "memo_type": "id",
       "client_name": "referenceCustodial"
@@ -588,27 +588,24 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
       ],
       "source_account": "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
-      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "destination_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
       "memo": "testMemo",
       "memo_type": "id",
       "client_name": "referenceCustodial"
@@ -643,27 +640,24 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       "message": "test message 4",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
       ],
       "source_account": "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
-      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "destination_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
       "memo": "testMemo",
       "memo_type": "id",
       "client_name": "referenceCustodial"
@@ -723,27 +717,24 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       },
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
       ],
       "source_account": "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
-      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "destination_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
       "memo": "testMemo",
       "memo_type": "id",
       "client_name": "referenceCustodial"
@@ -763,7 +754,7 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_REQUESTS
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 1",
-      "stellar_transaction_id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1"
+      "stellar_transaction_id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4"
     }
   },
   {
@@ -834,25 +825,21 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       },
       "started_at": "2023-08-07T17:10:35.629708Z",
       "updated_at": "2023-08-07T17:10:36.899944Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 1",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -893,25 +880,21 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       },
       "started_at": "2023-08-07T17:10:35.629708Z",
       "updated_at": "2023-08-07T17:10:37.946812Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -953,7 +936,6 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       "started_at": "2023-08-07T17:10:35.629708Z",
       "updated_at": "2023-08-07T17:10:38.970241Z",
       "completed_at": "2023-08-07T17:10:38.970234Z",
-      "transfer_received_at": "2023-06-22T08:46:56Z",
       "message": "test message 3",
       "refunds": {
         "amount_refunded": {
@@ -981,21 +963,18 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       },
       "stellar_transactions": [
         {
-          "id": "fba01f815acfe1f493271017f02929e97e30656ba57a5ac8f3d1356dd4926ea1",
+          "id": "898e1d7c931e595004616b92f3479b3373f848d8a6fb170f6bd86364ed1eaaf4",
           "memo": "testMemo",
           "memo_type": "id",
-          "created_at": "2023-06-22T08:46:56Z",
-          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAACAAAAAEAAAAAIHqjOgAAAABklDSfAAAAAAAAAAEAAAAAAAAAAQAAAAC9yF4ErTewnyaxhbV7fzgFiY7A8k7xt62CIhYMXt/ovgAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAAKupUAAAAAAAAAAATQyHAMAAABAUjCaXkOy4VHDpkVwG42lF7ZKK471bMsKSjP2EZtYnBo4e/kYtcVNp+z15EX/qHZBvGWtbFiCBBLXQs7hmu15Cg==",
           "payments": [
             {
-              "id": "563306435719169",
               "amount": {
                 "amount": "4.5000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
-              "destination_account": "GC64QXQEVU33BHZGWGC3K637HACYTDWA6JHPDN5NQIRBMDC637UL4F2W"
+              "source_account": "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
+              "destination_account": "GATEYCIMJZ2F6Y437QSYH4XFQ6HLD5YP4MBJZFFPZVEQDJOY4QTCB7BB"
             }
           ]
         }
@@ -1095,7 +1074,7 @@ private const val CUSTODY_TRANSACTION_PAYMENT_RESPONSE =
 private const val CUSTODY_DEPOSIT_ADDRESS_RESPONSE =
   """
 {
-  "address":"GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+  "address":"GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O",
   "legacyAddress": "testLegacyAddress",
   "enterpriseAddress": "testEnterpriseAddress",
   "tag":"testMemo",


### PR DESCRIPTION
### Description

Re-enable PlatformApiTests, PlatformApiCustodyTests, and CustodyApiTests

### Context

Fix test failures due to testnet resets

### Testing

- `./gradlew test`

