### PR TITLE
[ANCHOR-561] Killing `gradlew dockerComposeUp` not shutting down docker containers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,12 +60,10 @@ subprojects {
       logger.warn("!!! WARNING !!!")
       logger.warn("=================")
       logger.warn(
-        "    You are running Java version:[{}]. Spotless may not work well with JDK 17.",
-        javaVersion
-      )
+          "    You are running Java version:[{}]. Spotless may not work well with JDK 17.",
+          javaVersion)
       logger.warn(
-        "    In IntelliJ, go to [File -> Build -> Execution, Build, Deployment -> Gradle] and check Gradle JVM"
-      )
+          "    In IntelliJ, go to [File -> Build -> Execution, Build, Deployment -> Gradle] and check Gradle JVM")
     }
 
     if (javaVersion < "11") {
@@ -142,9 +140,8 @@ subprojects {
     test {
       useJUnitPlatform()
       systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation"
-      )
+          "junit.jupiter.testclass.order.default",
+          "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation")
 
       exclude("**/AnchorPlatformCustodyEnd2EndTest**")
       exclude("**/AnchorPlatformCustodyApiRpcEnd2EndTest**")
@@ -183,9 +180,33 @@ allprojects {
   tasks.jar {
     manifest {
       attributes(
-        mapOf("Implementation-Title" to project.name, "Implementation-Version" to project.version)
-      )
+          mapOf(
+              "Implementation-Title" to project.name, "Implementation-Version" to project.version))
     }
   }
 }
 
+tasks.register("printUsage") {
+  doLast {
+    val green = "\u001B[32m"
+    val bold = "\u001B[1m"
+    // ANSI escape code to reset
+    val reset = "\u001B[0m"
+    println(
+        """
+                  ${green}${bold}Usage: ./gradlew <task>${reset}
+                  
+                  Available custom tasks:
+                    - ${bold}printVersionName${reset}: Prints the version of the project.
+                    - ${bold}updateGitHook${reset}: Updates the git hook to format the code before committing.
+                    - ${bold}startAllServers${reset}: Starts all the servers based on the `default` test configuration.
+                    - ${bold}startServersWithTestProfile${reset}: Starts the servers based on the test configuration specified by the TEST_PROFILE_NAME environment variable.
+                    - ${bold}dockerComposeStart${reset}: Runs docker-compose up to start Postgres, Kafka, etc.
+                    - ${bold}dockerComposeStop${reset}: Runs docker-compose down to stop Postgres, Kafka, etc.
+                    - ${bold}anchorTest${reset}: Runs stellar anchor tests. Set `TEST_HOME_DOMAIN` and `TEST_SEPS` environment variables to customize the tests.
+    """
+            .trimIndent())
+  }
+}
+
+defaultTasks("printUsage")

--- a/docs/01 - Contributing/A - Development Environment.md
+++ b/docs/01 - Contributing/A - Development Environment.md
@@ -110,9 +110,13 @@ Run all tests: `./gradlew test`
 
 Run subproject tests: `./gradlew :[subproject]:test`
 
-### Running `docker-compose up` for Kafka, Postgres, and SEP24 Reference UI
+### Running `docker-compose start` for Kafka, Postgres, and SEP24 Reference UI
 
-`./gradlew dockerComposeUp`
+`./gradlew dockerComposeStart`
+
+### Running `docker-compose stop` to shutdown Kafka, Postgres, and SEP24 Reference UI
+
+`./gradlew dockerComposeStop`
 
 ### Starting all servers
 
@@ -235,7 +239,7 @@ If you would like to debug the unit tests or the end-to-end tests, there are two
 - Make sure `docker` and `docker-compose` is available on your local machine.
 - Check if there are previous docker containers running on your machine. If there are, please stop and delete them.
 - Navigate to the directory to the project folder
-- `./gradlew dockerComposeUp` to start the development stack.
+- `./gradlew dockerComposeStart` to start the development stack.
 - `export TEST_PROFILE_NAME=rpc && ./gradlew startServersWithTestProfile` to start the servers with `rpc`. You can also
   choose other test profile name by changing the value of `TEST_PROFILE_NAME`.
 - `./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.RpcTestSuite`
@@ -251,7 +255,7 @@ If you would like to debug the unit tests or the end-to-end tests, there are two
 
 ### Run docker compose up
 
-`./gradlew dockerComposeUp`
+`./gradlew dockerComposeStart`
 
 ### Run the servers with the `host-docker-internal` profile
 

--- a/service-runner/build.gradle.kts
+++ b/service-runner/build.gradle.kts
@@ -2,6 +2,7 @@ import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
 import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
 import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+import java.io.ByteArrayOutputStream
 
 @Suppress(
     // The alias call in plugins scope produces IntelliJ false error which is suppressed here.
@@ -61,11 +62,35 @@ tasks.register<JavaExec>("startServersWithTestProfile") {
 }
 
 /** Run docker-compose up to start Postgres, Kafka, etc. */
-tasks.register<JavaExec>("dockerComposeUp") {
+tasks.register<JavaExec>("dockerComposeStart") {
   println("Running docker-compose up to start Postgres, Kafka ,etc.")
   group = "application"
   classpath = sourceSets["main"].runtimeClasspath
-  mainClass.set("org.stellar.anchor.platform.run_profiles.RunDockerDevStack")
+  mainClass.set("org.stellar.anchor.platform.run_profiles.RunDockerDevStackNoWait")
+}
+
+tasks.register<Exec>("dockerComposeStop") {
+  val outputStream = ByteArrayOutputStream()
+  standardOutput = outputStream
+  // Lists all running Docker containers with their labels
+  commandLine("bash", "-c", "docker compose ls | awk 'NR>1 {print $1}'")
+
+  doLast {
+    // Captures the output of the command
+    // Convert the output stream to a String
+    val outputString = outputStream.toString()
+
+    // Get the list of projects
+    val projectNames =
+        outputString.lineSequence().filter { it.isNotBlank() }.map { it.split(Regex("\\s+"))[0] }
+    // Iterate over each project name and process it
+    projectNames.forEach { projectName ->
+      exec {
+        println("docker compose -p $projectName down")
+        commandLine("bash", "-c", "docker compose -p $projectName down")
+      }
+    }
+  }
 }
 
 val dockerPullAnchorTest by

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunDockerDevStackNoWait.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunDockerDevStackNoWait.kt
@@ -1,0 +1,16 @@
+@file:JvmName("RunDockerDevStackNoWait")
+
+package org.stellar.anchor.platform.run_profiles
+
+import kotlinx.coroutines.runBlocking
+import org.stellar.anchor.platform.*
+
+fun main() = runBlocking {
+  testProfileExecutor = TestProfileExecutor(TestConfig())
+  // The "registerShutdownHook(testProfileExecutor)" is commented out to avoid shutting down the
+  // docker-compose stack when the JVM is shutdown.
+  testProfileExecutor.start(true) {
+    it.env[RUN_DOCKER] = "true"
+    it.env[RUN_ALL_SERVERS] = "false"
+  }
+}


### PR DESCRIPTION
### Description

When kill is sent to JVM, we do not get the chance to call `docker-compose down`. So the following is done:

- Remove `dockerComposeUp` task
- Add `dockerComposeStart` task to start docker containers async.
- Add `dockerComposeStop` task to stop and remove docker containers.

In addition, `./gradlew` without arguments will also print usages.

### Context

Developer experience improvements.

### Testing

- `./gradlew test`

### Documentation
README updated.