### PR TITLE
[ANCHOR-549] Add demo wallet support to SEP-6 reference

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -75,9 +75,9 @@ data class RequestOffchainFundsRequest(
 data class RequestOnchainFundsRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String,
-  @SerialName("amount_in") val amountIn: AmountAssetRequest,
-  @SerialName("amount_out") val amountOut: AmountAssetRequest,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest,
+  @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
+  @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
   @SerialName("amount_expected") val amountExpected: AmountRequest? = null
 ) : RpcActionParamsRequest()
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -126,8 +126,8 @@ data class NotifyOffchainFundsPendingRequest(
 data class NotifyAmountsUpdatedRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("amount_out") val amountOut: AmountAssetRequest,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest
+  @SerialName("amount_out") val amountOut: AmountRequest,
+  @SerialName("amount_fee") val amountFee: AmountRequest
 ) : RpcActionParamsRequest()
 
 @Serializable

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -170,7 +170,6 @@ class Sep6EventProcessor(
               )
             )
           } else if (transaction.transferReceivedAt != null) {
-            // TODO: check why this throws an exception
             sepHelper.rpcAction(
               RpcMethod.NOTIFY_OFFCHAIN_FUNDS_AVAILABLE.toString(),
               NotifyOffchainFundsAvailableRequest(

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -241,25 +241,35 @@ class Sep6EventProcessor(
           Kind.WITHDRAWAL -> {
             if (verifyKyc(customer.account, customer.memo, Kind.WITHDRAWAL).isEmpty()) {
               runBlocking {
-                sepHelper.rpcAction(
-                  RpcMethod.REQUEST_ONCHAIN_FUNDS.toString(),
-                  RequestOnchainFundsRequest(
-                    transactionId = transaction.id,
-                    message = "Please deposit the amount to the following address",
-                    amountIn =
-                      AmountAssetRequest(
-                        asset = transaction.amountExpected.asset,
-                        amount = transaction.amountExpected.amount
-                      ),
-                    amountOut =
-                      AmountAssetRequest(
-                        asset = "iso4217:USD",
-                        amount = transaction.amountExpected.amount
-                      ),
-                    amountFee =
-                      AmountAssetRequest(asset = transaction.amountExpected.asset, amount = "0")
+                if (transaction.amountExpected.amount != null) {
+                  sepHelper.rpcAction(
+                    RpcMethod.REQUEST_ONCHAIN_FUNDS.toString(),
+                    RequestOnchainFundsRequest(
+                      transactionId = transaction.id,
+                      message = "Please deposit the amount to the following address",
+                      amountIn =
+                        AmountAssetRequest(
+                          asset = transaction.amountExpected.asset,
+                          amount = transaction.amountExpected.amount
+                        ),
+                      amountOut =
+                        AmountAssetRequest(
+                          asset = "iso4217:USD",
+                          amount = transaction.amountExpected.amount
+                        ),
+                      amountFee =
+                        AmountAssetRequest(asset = transaction.amountExpected.asset, amount = "0")
+                    )
                   )
-                )
+                } else {
+                  sepHelper.rpcAction(
+                    RpcMethod.REQUEST_ONCHAIN_FUNDS.toString(),
+                    RequestOnchainFundsRequest(
+                      transactionId = transaction.id,
+                      message = "Please deposit to the following address",
+                    )
+                  )
+                }
               }
             }
           }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -143,7 +143,7 @@ class Sep6EventProcessor(
           return
         }
         runBlocking {
-          if (offchainPayments[transaction.id] == null) {
+          if (offchainPayments[transaction.id] == null && transaction.transferReceivedAt != null) {
             // If the amount was not specified at transaction initialization, set the
             // amountOut and amountFee fields after receiving the onchain deposit.
             if (transaction.amountOut.amount.equals("0")) {
@@ -166,7 +166,7 @@ class Sep6EventProcessor(
                 externalTransactionId = externalTxnId.toString()
               )
             )
-          } else {
+          } else if (transaction.transferReceivedAt != null) {
             // TODO: check why this throws an exception
             sepHelper.rpcAction(
               RpcMethod.NOTIFY_OFFCHAIN_FUNDS_AVAILABLE.toString(),

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedHandler.java
@@ -61,6 +61,7 @@ public class NotifyAmountsUpdatedHandler extends RpcMethodHandler<NotifyAmountsU
             .amount(request.getAmountOut().getAmount())
             .asset(txn.getAmountOutAsset())
             .build(),
+        true,
         assetService);
     AssetValidationUtils.validateAsset(
         "amount_fee",

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
@@ -70,13 +70,13 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
       if (AssetValidationUtils.isStellarAsset(request.getAmountIn().getAsset())) {
         throw new InvalidParamsException("amount_in.asset should be non-stellar asset");
       }
-      AssetValidationUtils.validateAsset("amount_in", request.getAmountIn(), assetService);
+      AssetValidationUtils.validateAsset("amount_in", request.getAmountIn(), true, assetService);
     }
     if (request.getAmountOut() != null) {
       if (!AssetValidationUtils.isStellarAsset(request.getAmountOut().getAsset())) {
         throw new InvalidParamsException("amount_out.asset should be stellar asset");
       }
-      AssetValidationUtils.validateAsset("amount_out", request.getAmountOut(), assetService);
+      AssetValidationUtils.validateAsset("amount_out", request.getAmountOut(), true, assetService);
     }
     if (request.getAmountFee() != null) {
       if (AssetValidationUtils.isStellarAsset(request.getAmountFee().getAsset())) {
@@ -92,6 +92,16 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
               .asset(request.getAmountIn().getAsset())
               .build(),
           assetService);
+    }
+
+    if (request.getAmountIn() == null && txn.getAmountIn() == null) {
+      throw new InvalidParamsException("amount_in is required");
+    }
+    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
+      throw new InvalidParamsException("amount_out is required");
+    }
+    if (request.getAmountFee() == null && txn.getAmountFee() == null) {
+      throw new InvalidParamsException("amount_fee is required");
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandler.java
@@ -93,16 +93,6 @@ public class RequestOffchainFundsHandler extends RpcMethodHandler<RequestOffchai
               .build(),
           assetService);
     }
-
-    if (request.getAmountIn() == null && txn.getAmountIn() == null) {
-      throw new InvalidParamsException("amount_in is required");
-    }
-    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
-      throw new InvalidParamsException("amount_out is required");
-    }
-    if (request.getAmountFee() == null && txn.getAmountFee() == null) {
-      throw new InvalidParamsException("amount_fee is required");
-    }
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -100,13 +100,13 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
       if (!AssetValidationUtils.isStellarAsset(request.getAmountIn().getAsset())) {
         throw new InvalidParamsException("amount_in.asset should be stellar asset");
       }
-      AssetValidationUtils.validateAsset("amount_in", request.getAmountIn(), assetService);
+      AssetValidationUtils.validateAsset("amount_in", request.getAmountIn(), true, assetService);
     }
     if (request.getAmountOut() != null) {
       if (AssetValidationUtils.isStellarAsset(request.getAmountOut().getAsset())) {
         throw new InvalidParamsException("amount_out.asset should be non-stellar asset");
       }
-      AssetValidationUtils.validateAsset("amount_out", request.getAmountOut(), assetService);
+      AssetValidationUtils.validateAsset("amount_out", request.getAmountOut(), true, assetService);
     }
     if (request.getAmountFee() != null) {
       if (!AssetValidationUtils.isStellarAsset(request.getAmountFee().getAsset())) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -124,16 +124,6 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
           assetService);
     }
 
-    if (request.getAmountIn() == null && txn.getAmountIn() == null) {
-      throw new InvalidParamsException("amount_in is required");
-    }
-    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
-      throw new InvalidParamsException("amount_out is required");
-    }
-    if (request.getAmountFee() == null && txn.getAmountFee() == null) {
-      throw new InvalidParamsException("amount_fee is required");
-    }
-
     boolean canGenerateSep6DepositInfo =
         SEP_6 == Sep.from(txn.getProtocol())
             && sep6DepositInfoGenerator instanceof Sep6DepositInfoNoneGenerator;

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -124,6 +124,16 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
           assetService);
     }
 
+    if (request.getAmountIn() == null && txn.getAmountIn() == null) {
+      throw new InvalidParamsException("amount_in is required");
+    }
+    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
+      throw new InvalidParamsException("amount_out is required");
+    }
+    if (request.getAmountFee() == null && txn.getAmountFee() == null) {
+      throw new InvalidParamsException("amount_fee is required");
+    }
+
     boolean canGenerateSep6DepositInfo =
         SEP_6 == Sep.from(txn.getProtocol())
             && sep6DepositInfoGenerator instanceof Sep6DepositInfoNoneGenerator;

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -125,7 +125,6 @@ public class PaymentOperationToEventListener implements PaymentListener {
     if (sep6Txn != null) {
       try {
         handleSep6Transaction(payment, sep6Txn);
-        return;
       } catch (AnchorException aex) {
         warnF("Error handling the SEP6 transaction id={}.", sep6Txn.getId());
         errorEx(aex);
@@ -242,9 +241,9 @@ public class PaymentOperationToEventListener implements PaymentListener {
 
     BigDecimal amountExpected = decimal(txn.getAmountExpected());
     BigDecimal gotAmount = decimal(payment.getAmount());
-    if (gotAmount.compareTo(amountExpected) >= 0) {
+    if (amountExpected != null && gotAmount.compareTo(amountExpected) >= 0) {
       Log.infoF("Incoming payment for SEP-6 transaction {}.", txn.getId());
-    } else {
+    } else if (amountExpected != null) {
       Log.warnF(
           "The incoming payment amount for SEP-6 transaction {} was insufficient! Expected: \"{}\", Received: \"{}\"",
           txn.getId(),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyAmountsUpdatedHandlerTest.kt
@@ -164,13 +164,8 @@ class NotifyAmountsUpdatedHandlerTest {
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    request.amountOut.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
     request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
+    val ex = assertThrows<BadRequestException> { handler.handle(request) }
     assertEquals("amount_fee.amount should be non-negative", ex.message)
     request.amountFee.amount = "1"
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOffchainFundsHandlerTest.kt
@@ -288,18 +288,8 @@ class RequestOffchainFundsHandlerTest {
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    request.amountIn.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_in.amount should be positive", ex.message)
-    request.amountIn.amount = "1"
-
-    request.amountOut.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
     request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
+    var ex = assertThrows<BadRequestException> { handler.handle(request) }
     assertEquals("amount_fee.amount should be non-negative", ex.message)
     request.amountFee.amount = "1"
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -43,11 +43,7 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.data.JdbcSep6Transaction
-import org.stellar.anchor.platform.service.AnchorMetrics
-import org.stellar.anchor.platform.service.Sep24DepositInfoNoneGenerator
-import org.stellar.anchor.platform.service.Sep24DepositInfoSelfGenerator
-import org.stellar.anchor.platform.service.Sep6DepositInfoNoneGenerator
-import org.stellar.anchor.platform.service.Sep6DepositInfoSelfGenerator
+import org.stellar.anchor.platform.service.*
 import org.stellar.anchor.platform.validator.RequestValidator
 import org.stellar.anchor.sep24.Sep24Transaction
 import org.stellar.anchor.sep24.Sep24TransactionStore
@@ -420,18 +416,8 @@ class RequestOnchainFundsHandlerTest {
     every { txn31Store.findByTransactionId(any()) } returns null
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
-    request.amountIn.amount = "-1"
-    var ex = assertThrows<BadRequestException> { handler.handle(request) }
-    assertEquals("amount_in.amount should be positive", ex.message)
-    request.amountIn.amount = "1"
-
-    request.amountOut.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
-    assertEquals("amount_out.amount should be positive", ex.message)
-    request.amountOut.amount = "1"
-
     request.amountFee.amount = "-1"
-    ex = assertThrows { handler.handle(request) }
+    var ex = assertThrows<BadRequestException> { handler.handle(request) }
     assertEquals("amount_fee.amount should be non-negative", ex.message)
     request.amountFee.amount = "1"
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -560,6 +560,99 @@ class PaymentOperationToEventListenerTest {
     assertEquals("payment received", messageCapture.captured)
   }
 
+  @ParameterizedTest
+  @CsvSource(
+    value =
+      [
+        "native,native,",
+        "credit_alphanum4,USD,GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+      ]
+  )
+  fun `test SEP-6 onReceived with payment but no expected amount patches the transaction`(
+    assetType: String,
+    assetCode: String,
+    assetIssuer: String?
+  ) {
+    val transferReceivedAt = Instant.now()
+    val transferReceivedAtStr = DateTimeFormatter.ISO_INSTANT.format(transferReceivedAt)
+    val asset = createAsset(assetType, assetCode, assetIssuer)
+
+    val p =
+      ObservedPayment.builder()
+        .transactionHash("1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30")
+        .transactionMemo("39623738663066612d393366392d343139382d386439332d6537366664303834")
+        .transactionMemoType("hash")
+        .assetType(assetType)
+        .assetCode(assetCode)
+        .assetName(asset.toString())
+        .assetIssuer(assetIssuer)
+        .amount("10.0000000")
+        .sourceAccount("GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4")
+        .from("GAJKV32ZXP5QLYHPCMLTV5QCMNJR3W6ZKFP6HMDN67EM2ULDHHDGEZYO")
+        .to("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364")
+        .type(ObservedPayment.Type.PAYMENT)
+        .createdAt(transferReceivedAtStr)
+        .transactionEnvelope(
+          "AAAAAgAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAAAB9AAAACwAAAABAAAAAEAAAAAAAAAAAAAAABiMbeEAAAAAAAAABQAAAAAAAAAAAAAAADcXPrnCDi+IDcGSvu/HjP779qjBv6K9Sie8i3WDySaIgAAAAA8M2CAAAAAAAAAAAAAAAAAJXdMB+xylKwEPk1tOLU82vnDM0u15RsK6/HCKsY1O3MAAAAAPDNggAAAAAAAAAAAAAAAALn+JaJ9iXEcrPeRFqEMGo6WWFeOwW15H/vvCOuMqCsSAAAAADwzYIAAAAAAAAAAAAAAAADbWpHlX0LQjIjY0x8jWkclnQDK8jFmqhzCmB+1EusXwAAAAAA8M2CAAAAAAAAAAAAAAAAAmy3UTqTnhNzIg8TjCYiRh9l07ls0Hi5FTqelhfZ4KqAAAAAAPDNggAAAAAAAAAAAAAAAAIwiZIIbYJn7MbHrrM+Pg85c6Lcn0ZGLb8NIiXLEIPTnAAAAADwzYIAAAAAAAAAAAAAAAAAYEjPKA/6lDpr/w1Cfif2hK4GHeNODhw0kk4kgLrmPrQAAAAA8M2CAAAAAAAAAAAAAAAAASMrE32C3vL39cj84pIg2mt6OkeWBz5OSZn0eypcjS4IAAAAAPDNggAAAAAAAAAAAAAAAAIuxsI+2mSeh3RkrkcpQ8bMqE7nXUmdvgwyJS/dBThIPAAAAADwzYIAAAAAAAAAAAAAAAACuZxdjR/GXaymdc9y5WFzz2A8Yk5hhgzBZsQ9R0/BmZwAAAAA8M2CAAAAAAAAAAAAAAAAAAtWBvyq0ToNovhQHSLeQYu7UzuqbVrm0i3d1TjRm7WEAAAAAPDNggAAAAAAAAAAAAAAAANtrzNON0u1IEGKmVsm80/Av+BKip0ioeS/4E+Ejs9YPAAAAADwzYIAAAAAAAAAAAAAAAAD+ejNcgNcKjR/ihUx1ikhdz5zmhzvRET3LGd7oOiBlTwAAAAA8M2CAAAAAAAAAAAAAAAAASXG3P6KJjS6e0dzirbso8vRvZKo6zETUsEv7OSP8XekAAAAAPDNggAAAAAAAAAAAAAAAAC5orVpxxvGEB8ISTho2YdOPZJrd7UBj1Bt8TOjLOiEKAAAAADwzYIAAAAAAAAAAAAAAAAAOQR7AqdGyIIMuFLw9JQWtHqsUJD94kHum7SJS9PXkOwAAAAA8M2CAAAAAAAAAAAAAAAAAIosijRx7xSP/+GA6eAjGeV9wJtKDySP+OJr90euE1yQAAAAAPDNggAAAAAAAAAAAAAAAAKlHXWQvwNPeT4Pp1oJDiOpcKwS3d9sho+ha+6pyFwFqAAAAADwzYIAAAAAAAAAAAAAAAABjCjnoL8+FEP0LByZA9PfMLwU1uAX4Cb13rVs83e1UZAAAAAA8M2CAAAAAAAAAAAAAAAAAokhNCZNGq9uAkfKTNoNGr5XmmMoY5poQEmp8OVbit7IAAAAAPDNggAAAAAAAAAABhlbgnAAAAEBa9csgF5/0wxrYM6oVsbM4Yd+/3uVIplS6iLmPOS4xf8oLQLtjKKKIIKmg9Gc/yYm3icZyU7icy9hGjcujenMN"
+        )
+        .id("755914248193")
+        .build()
+
+    val slotMemo = slot<String>()
+    val slotStatus = slot<String>()
+    val sep6TxMock = JdbcSep6Transaction()
+    sep6TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
+    sep6TxMock.requestAssetCode = assetCode
+    sep6TxMock.requestAssetIssuer = assetIssuer
+    sep6TxMock.memo = "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ"
+    sep6TxMock.memoType = "hash"
+    sep6TxMock.kind = PlatformTransactionData.Kind.WITHDRAWAL.kind
+
+    every {
+      sep31TransactionStore.findByStellarAccountIdAndMemoAndStatus(any(), any(), any())
+    } returns null
+    every { sep24TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      null
+
+    val sep6TxnCopy = gson.fromJson(gson.toJson(sep6TxMock), JdbcSep6Transaction::class.java)
+    every {
+      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+        capture(slotMemo),
+        capture(slotStatus)
+      )
+    } returns sep6TxnCopy
+
+    val txnIdCapture = slot<String>()
+    val stellarTxnIdCapture = slot<String>()
+    val amountCapture = slot<String>()
+    val messageCapture = slot<String>()
+
+    every { rpcConfig.customMessages.incomingPaymentReceived } returns "payment received"
+    every {
+      platformApiClient.notifyOnchainFundsReceived(
+        capture(txnIdCapture),
+        capture(stellarTxnIdCapture),
+        capture(amountCapture),
+        capture(messageCapture)
+      )
+    } just Runs
+
+    paymentOperationToEventListener.onReceived(p)
+    verify(exactly = 1) {
+      sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+        "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ=",
+        "pending_user_transfer_start"
+      )
+    }
+
+    assertEquals(sep6TxMock.id, txnIdCapture.captured)
+    assertEquals(p.transactionHash, stellarTxnIdCapture.captured)
+    assertEquals(p.amount, amountCapture.captured)
+    assertEquals("payment received", messageCapture.captured)
+  }
+
   private fun createAsset(assetType: String, assetCode: String, assetIssuer: String?): Asset {
     return if (assetType == "native") {
       AssetTypeNative()


### PR DESCRIPTION
### Description

This updates the SEP-6 reference implement to support wallet testing. The following was fixed:
- More than one deposit/withdraw be requested without restarting the server
- Empty `amount` requests are now supported

### Context

This is required for wallet testing.

### Testing

- `./gradlew test`
- Testing with the demo wallet

### Documentation

N/A

### Known limitations

N/A

