### PR TITLE
[ANCHOR-588] Fix `birth_date` field type

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.api.callback;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import java.time.Instant;
 import lombok.Builder;
 import lombok.Data;
 import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest;
@@ -57,7 +56,7 @@ public class PutCustomerRequest {
   String emailAddress;
 
   @SerializedName("birth_date")
-  Instant birthDate;
+  String birthDate;
 
   @SerializedName("birth_place")
   String birthPlace;

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -85,6 +85,11 @@ public class Sep12Service {
       request.setAccount(token.getAccount());
     }
 
+    if (StringUtils.isNotEmpty(request.getBirthDate())) {
+      if (!isValidISO8601Date(request.getBirthDate())) {
+        throw new SepValidationException("Invalid 'birth_date'");
+      }
+    }
     if (StringUtils.isNotEmpty(request.getIdIssueDate())) {
       if (!isValidISO8601Date(request.getIdIssueDate())) {
         throw new SepValidationException("Invalid 'id_issue_date'");

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -243,6 +243,7 @@ class Sep12ServiceTest {
         .memoType("id")
         .type("sending_user")
         .firstName("John")
+        .birthDate("2000-01-01")
         .idIssueDate("2023-12-13")
         .idExpirationDate("2023-12-13T19:33:07Z")
         .build()
@@ -257,6 +258,7 @@ class Sep12ServiceTest {
         .memoType("id")
         .type("sending_user")
         .firstName("John")
+        .birthDate("2000-01-01")
         .idIssueDate("2023-12-13")
         .idExpirationDate("2023-12-13T19:33:07Z")
         .build()
@@ -275,6 +277,24 @@ class Sep12ServiceTest {
     verify(exactly = 1) { customerIntegration.putCustomer(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
     assertEquals(TEST_ACCOUNT, mockPutRequest.account)
+  }
+
+  @Test
+  fun `Test put customer bad birth_date`() {
+    // Execute the request
+    val mockPutRequest =
+      Sep12PutCustomerRequest.builder()
+        .account(TEST_ACCOUNT)
+        .memo(TEST_MEMO)
+        .memoType("id")
+        .type("sending_user")
+        .firstName("John")
+        .birthDate("2023-12-13T19:33:07X")
+        .build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    assertThrows<SepValidationException> { sep12Service.putCustomer(jwtToken, mockPutRequest) }
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }
 
   @Test

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -45,6 +45,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
         "last_name" to "Doe",
         "address" to "123 Bay Street",
         "email_address" to "john@email.com",
+        "birth_date" to "1990-01-01",
         "id_type" to "drivers_license",
         "id_country_code" to "CAN",
         "id_issue_date" to "2023-01-01",

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -57,6 +57,7 @@ class CustomerService(private val customerRepository: CustomerRepository) {
           lastName = request.lastName ?: customer.lastName,
           address = request.address ?: customer.address,
           emailAddress = request.emailAddress ?: customer.emailAddress,
+          birthDate = request.birthDate ?: customer.birthDate,
           bankAccountNumber = request.bankAccountNumber ?: customer.bankAccountNumber,
           bankAccountType = request.bankAccountType ?: customer.bankAccountType,
           bankNumber = request.bankNumber ?: customer.bankNumber,
@@ -82,6 +83,7 @@ class CustomerService(private val customerRepository: CustomerRepository) {
           lastName = request.lastName,
           address = request.address,
           emailAddress = request.emailAddress,
+          birthDate = request.birthDate,
           bankAccountNumber = request.bankAccountNumber,
           bankAccountType = request.bankAccountType,
           bankNumber = request.bankNumber,
@@ -122,6 +124,7 @@ class CustomerService(private val customerRepository: CustomerRepository) {
           createField(customer.address, "string", "The customer's address", optional = true),
         "email_address" to
           createField(customer.emailAddress, "string", "The customer's email address"),
+        "birth_date" to createField(customer.birthDate, "string", "The customer's birth date"),
         "bank_account_number" to
           createField(
             customer.bankAccountNumber,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -123,8 +123,13 @@ class CustomerService(private val customerRepository: CustomerRepository) {
         "address" to
           createField(customer.address, "string", "The customer's address", optional = true),
         "email_address" to
-          createField(customer.emailAddress, "string", "The customer's email address"),
-        "birth_date" to createField(customer.birthDate, "string", "The customer's birth date"),
+          createField(
+            customer.emailAddress,
+            "string",
+            "The customer's email address",
+          ),
+        "birth_date" to
+          createField(customer.birthDate, "string", "The customer's birth date", optional = true),
         "bank_account_number" to
           createField(
             customer.bankAccountNumber,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/CustomerRepository.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/CustomerRepository.kt
@@ -36,6 +36,7 @@ class JdbcCustomerRepository(private val db: Database) : CustomerRepository {
               address = it[Customers.address],
               lastName = it[Customers.lastName],
               emailAddress = it[Customers.emailAddress],
+              birthDate = it[Customers.birthDate],
               bankAccountNumber = it[Customers.bankAccountNumber],
               bankAccountType = it[Customers.bankAccountType],
               bankNumber = it[Customers.bankNumber],
@@ -77,6 +78,7 @@ class JdbcCustomerRepository(private val db: Database) : CustomerRepository {
               lastName = it[Customers.lastName],
               address = it[Customers.address],
               emailAddress = it[Customers.emailAddress],
+              birthDate = it[Customers.birthDate],
               bankAccountNumber = it[Customers.bankAccountNumber],
               bankAccountType = it[Customers.bankAccountType],
               bankNumber = it[Customers.bankNumber],
@@ -104,6 +106,7 @@ class JdbcCustomerRepository(private val db: Database) : CustomerRepository {
           it[lastName] = customer.lastName
           it[address] = customer.address
           it[emailAddress] = customer.emailAddress
+          it[birthDate] = customer.birthDate
           it[bankAccountNumber] = customer.bankAccountNumber
           it[bankAccountType] = customer.bankAccountType
           it[bankNumber] = customer.bankNumber
@@ -130,6 +133,7 @@ class JdbcCustomerRepository(private val db: Database) : CustomerRepository {
         it[lastName] = customer.lastName
         it[address] = customer.address
         it[emailAddress] = customer.emailAddress
+        it[birthDate] = customer.birthDate
         it[bankAccountNumber] = customer.bankAccountNumber
         it[bankAccountType] = customer.bankAccountType
         it[bankNumber] = customer.bankNumber

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/Customers.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/Customers.kt
@@ -12,6 +12,7 @@ object Customers : Table() {
   val lastName = varchar("last_name", 255).nullable()
   val address = varchar("address", 255).nullable()
   val emailAddress = varchar("email_address", 255).nullable()
+  val birthDate = varchar("birth_date", 255).nullable()
   val bankAccountNumber = varchar("bank_account_number", 255).nullable()
   val bankAccountType = varchar("bank_account_type", 255).nullable()
   val bankNumber = varchar("bank_number", 255).nullable()

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -31,7 +31,14 @@ class Sep6EventProcessor(
 ) : SepAnchorEventProcessor {
   companion object {
     val requiredKyc =
-      listOf("id_type", "id_country_code", "id_issue_date", "id_expiration_date", "id_number")
+      listOf(
+        "birth_date",
+        "id_type",
+        "id_country_code",
+        "id_issue_date",
+        "id_expiration_date",
+        "id_number"
+      )
     val depositRequiredKyc = listOf("address")
     val withdrawRequiredKyc =
       listOf("bank_account_number", "bank_account_type", "bank_number", "bank_branch_number")

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/Customer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/Customer.kt
@@ -13,6 +13,7 @@ data class Customer(
   @SerialName("last_name") val lastName: String? = null,
   val address: String? = null,
   @SerialName("email_address") val emailAddress: String? = null,
+  @SerialName("birth_date") val birthDate: String? = null,
   @SerialName("bank_account_number") val bankAccountNumber: String? = null,
   @SerialName("bank_account_type") val bankAccountType: String? = null,
   @SerialName("bank_number") val bankNumber: String? = null,


### PR DESCRIPTION
### Description

This changes the `birth_date` type from an `Instant` to an ISO-8601 date validated String.

### Context

SEP-12 dates are ISO-8601 date strings.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

