### PR TITLE
[ANCHOR-590] Support wildcard `homeDomains` for sep10

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
@@ -51,6 +51,15 @@ public class Sep10Helper {
     }
   }
 
+  /**
+   * Checks if the given domain name matches any pattern or exact domain in the provided list.
+   *
+   * @param patternsAndDomains A list containing patterns and/or exact domain names to match
+   *     against.
+   * @param domainName The domain name to check for a match.
+   * @return true if the domain name matches any pattern or exact domain in the list, false
+   *     otherwise.
+   */
   public static Boolean isDomainNameMatch(List<String> patternsAndDomains, String domainName) {
     for (String patternOrDomain : patternsAndDomains) {
       if (patternOrDomain.contains("*")) {
@@ -72,6 +81,12 @@ public class Sep10Helper {
     return false;
   }
 
+  /**
+   * Retrieves the first non-wildcard domain name from the provided list of patterns and domains.
+   *
+   * @param patternsAndDomains A list containing patterns and/or exact domain names to search.
+   * @return The first exact domain name found in the list, or null if no exact domain is present.
+   */
   public static String getDefaultDomainName(List<String> patternsAndDomains) {
     for (String patternOrDomain : patternsAndDomains) {
       if (!patternOrDomain.contains("*")) {

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
@@ -4,6 +4,9 @@ import static org.stellar.anchor.util.Log.debugF;
 import static org.stellar.anchor.util.Log.infoF;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.util.Sep1Helper;
@@ -46,5 +49,35 @@ public class Sep10Helper {
       infoF("Invalid config: {}", e.getMessage());
       throw new SepException(String.format("Invalid config: %s", e.getMessage()));
     }
+  }
+
+  public static Boolean isDomainNameMatch(List<String> patternsAndDomains, String domainName) {
+    for (String patternOrDomain : patternsAndDomains) {
+      if (patternOrDomain.contains("*")) {
+        // wildcard domain
+        // Escape special characters in the pattern and replace '*' with '.*'
+        String regex = patternOrDomain.replace(".", "\\.").replace("*", ".*");
+        Pattern patternObject = Pattern.compile(regex);
+        Matcher matcher = patternObject.matcher(domainName);
+        if (matcher.matches()) {
+          return true;
+        }
+      } else {
+        // exact domain
+        if (patternOrDomain.equals(domainName)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public static String getDefaultDomainName(List<String> patternsAndDomains) {
+    for (String patternOrDomain : patternsAndDomains) {
+      if (!patternOrDomain.contains("*")) {
+        return patternOrDomain;
+      }
+    }
+    return null;
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestConstants.kt
@@ -10,6 +10,7 @@ class TestConstants {
     const val TEST_CLIENT_DOMAIN = "test.client.stellar.org"
     const val TEST_CLIENT_NAME = "test_client"
     const val TEST_HOME_DOMAIN = "test.stellar.org"
+    const val TEST_HOME_DOMAIN_PATTERN = "*.wildcard.stellar.org"
     const val TEST_JWT_SECRET = "jwt_secret"
     const val TEST_ASSET = "USDC"
     const val TEST_ASSET_ISSUER_ACCOUNT_ID =

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -34,6 +34,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_TOML
 import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
+import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN_PATTERN
 import org.stellar.anchor.TestConstants.Companion.TEST_JWT_SECRET
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_SIGNING_SEED
@@ -111,7 +112,7 @@ internal class Sep10ServiceTest {
     every { sep10Config.webAuthDomain } returns TEST_WEB_AUTH_DOMAIN
     every { sep10Config.authTimeout } returns 900
     every { sep10Config.jwtTimeout } returns 900
-    every { sep10Config.homeDomains } returns listOf(TEST_HOME_DOMAIN)
+    every { sep10Config.homeDomains } returns listOf(TEST_HOME_DOMAIN, TEST_HOME_DOMAIN_PATTERN)
 
     every { appConfig.stellarNetworkPassphrase } returns TESTNET.networkPassphrase
 
@@ -420,6 +421,22 @@ internal class Sep10ServiceTest {
     cr.homeDomain = "bad.homedomain.com"
 
     assertThrows<SepValidationException> { sep10Service.createChallenge(cr) }
+  }
+
+  @Test
+  @LockAndMockStatic([NetUtil::class])
+  fun `Test create challenge with wildcard matched home domain success`() {
+    every { NetUtil.fetch(any()) } returns TEST_CLIENT_TOML
+    val cr =
+      ChallengeRequest.builder()
+        .account(TEST_ACCOUNT)
+        .memo(TEST_MEMO)
+        .homeDomain(null)
+        .clientDomain(TEST_CLIENT_DOMAIN)
+        .build()
+    cr.homeDomain = "abc.def.wildcard.stellar.org"
+
+    sep10Service.createChallenge(cr)
   }
 
   @Test

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -137,7 +137,9 @@ public class PropertySep10Config implements Sep10Config, Validator {
             "sep10-web-auth-domain-invalid",
             "The sep10.web_auth_domain does not have valid format.");
       }
-    } else if (homeDomains != null && homeDomains.size() > 1) {
+    } else if (homeDomains != null
+        && !homeDomains.isEmpty()
+        && (homeDomains.size() > 1 || homeDomains.get(0).contains("*"))) {
       errors.rejectValue(
           "webAuthDomain",
           "sep10-web-auth-domain-empty",

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -326,22 +326,24 @@ sep10:
   enabled: false
   #
   # The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
-  # The `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if
-  #   1) the `home_domain` is in use,
-  #   2) or the `home_domains` is in use and has only one value
-  # The `web_auth_domain` is required if
-  #   1) the `home_domains` is in use has more than one value
+  # The `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if it can only be translated to one domain.
+  # 1) web_auth_domain is optional:
+  #    Ex: home_domain: ap.stellar.org
+  #    Ex: home_domains: ap.stellar.org
+  # 2) web_auth_domain is required:
+  #    Ex: home_domains: ap.stellar.org, sdp.stellar.org
+  #    Ex: home_domains: *.sdp.stellar.org
   web_auth_domain:
   # The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
   # `home_domain` value must be equal to the host of the toml file. If sep1 is enabled, toml file will be hosted on the SEP server.
   # This property cannot coexist with `home_domains` and is going to be deprecated. Please use `home_domains` instead.
   home_domain:
-  # The `home_domains` property of SEP-10. This is a list of domains that the client can use to authenticate.
+  # The `home_domains` property of SEP-10. This is a list of domains and/or wildcard patterns that the client can use to authenticate.
   # https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
   # This property cannot coexist with `home_domain`. Please also set web_auth_domain if you have more than one home domain in this list.
   # The following lists are examples:
-  # Ex: home_domains: [ap.stellar.org, sdp.stellar.org]
-  # Ex: home_domains: ap.stellar.org, sdp.stellar.org
+  # Ex: home_domains: [ap.stellar.org, *.sdp.stellar.org]
+  # Ex: home_domains: ap.stellar.org, *.sdp.stellar.org
   home_domains:
   # Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing
   # a domain in the challenge transaction request and signing the challenge with the ``SIGNING_KEY`` on that domain's

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -247,6 +247,8 @@ class Sep10ConfigTest {
         Arguments.of(null, "www.stellar.org", listOf("www.stellar.org", "www.losbstr.co"), true, 0),
         Arguments.of(null, "www.stellar.org", emptyList<String>(), false, 1),
         Arguments.of("localhost:8080", "", listOf("www.stellar.org", "www.losbstr.co"), false, 2),
+        Arguments.of("localhost:8080", "", listOf("*.stellar.org"), false, 1),
+        Arguments.of("", "", listOf("*.stellar.org"), true, 1),
       )
     }
   }


### PR DESCRIPTION
### Description

Introduce the capability to use a wildcard prefix in the SEP10_HOME_DOMAINS configuration. This enhancement will allow for more dynamic and flexible domain management, especially beneficial in multi-tenant settings.

### Context

1. Support wildcard match (e.g., *.stellar.org).

2. To Ensure backward compatibility, the existing configurations with specific domains (e.g. ap.stellar.org) continue to work seamlessly.

### Testing

- `./gradlew test`

