### PR TITLE
[ANCHOR-563 ]Add reference server to `docker-compose.yaml`

### DIFF
--- a/kotlin-reference-server/src/main/resources/default-config.yaml
+++ b/kotlin-reference-server/src/main/resources/default-config.yaml
@@ -44,7 +44,7 @@ event:
   # Enables the Kafka event processor.
   enabled: true
   # The Kafka boostrap server.
-  bootstrapServer: localhost:29092
+  bootstrapServer: kafka:29092
   # The AnchorEvent topic to subscribe to.
   topic: TRANSACTION
 

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -33,6 +33,13 @@ services:
       # add mounts for the new config directory
       - ../config:/config
 
+  reference-server:
+    image: stellar/anchor-platform:edge
+    command: "--kotlin-reference-server"
+    volumes:
+      # add mounts for the new config directory
+      - ../config:/config
+
   kafka:
     platform: linux/x86_64
     image: confluentinc/cp-kafka:7.4.3

--- a/service-runner/src/main/resources/docker-compose.yaml
+++ b/service-runner/src/main/resources/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
       file: common/docker-compose.yaml
       service: reference-server
     depends_on:
-      - db
       - kafka
 
   sep24-reference-ui:
@@ -46,5 +45,3 @@ services:
     extends:
       file: common/docker-compose.yaml
       service: db
-
-


### PR DESCRIPTION
### Description

This adds `reference-server` service to the existing `docker-compose.yaml`.  

### Context

Ease of wallet testing.

### Testing

- `./gradlew test`
- Testing with demo wallet revealed that the reference server is incorrectly configured when running from docker. The Kafka bootstrap server is modified to point to the `kafka` hostname instead.

### Documentation

Will update the README with instructions for running a pre-configured AP.

### Known limitations

This will be fully tested after the PR is merged the `edge` image is updated in Dockerhub

