### PR TITLE
[Fix] Start platform server in docker compose

### DIFF
--- a/kotlin-reference-server/src/main/resources/default-config.yaml
+++ b/kotlin-reference-server/src/main/resources/default-config.yaml
@@ -7,7 +7,7 @@ app:
   # The URL of the Stellar network to which the Anchor will connect.
   horizonEndpoint: https://horizon-testnet.stellar.org
   # The URL of the platform server.
-  platformApiEndpoint: http://localhost:8085
+  platformApiEndpoint: http://platform:8085
   # The Stellar wallet to which the customer will send the Stellar assets.
   distributionWallet: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
   distributionWalletMemo:

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -2,12 +2,12 @@ version: '2.4'
 services:
   platform:
     image: stellar/anchor-platform:edge
-    command: --sep-server
+    command: --sep-server --platform-server
     volumes:
       - ../config:/config
     ports:
-      - "8080:8080" # sep-server
-      - "8082:8082" # Java management server
+      - "8080:8080" # SEP server
+      - "8085:8085" # Platform server
 
   sep24-reference-ui:
     image: stellar/sep24-reference-ui


### PR DESCRIPTION
### Description

Starts the platform server as part of docker compose up.

### Context

This is a bug fix for ANCHOR-563

### Testing

- `./gradlew test`
- Testing with demo wallet after this is merged

### Documentation

N/A

### Known limitations

N/A

