### PR TITLE
[ANCHOR-587] Disable URL encoding of SEP-10 challenge response

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/util/GsonUtils.java
+++ b/api-schema/src/main/java/org/stellar/anchor/util/GsonUtils.java
@@ -16,6 +16,7 @@ public class GsonUtils {
 
   public static GsonBuilder builder() {
     return new GsonBuilder()
+        .disableHtmlEscaping()
         .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
         .registerTypeAdapter(Instant.class, new InstantConverter())
         .registerTypeAdapter(Duration.class, new DurationConverter())

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.integrationtest
 
+import java.util.*
 import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
@@ -18,7 +19,7 @@ class Sep10Tests : AbstractIntegrationTests(TestConfig()) {
           toml.getString("WEB_AUTH_ENDPOINT"),
           toml.getString("SIGNING_KEY"),
           CLIENT_WALLET_ACCOUNT,
-          CLIENT_WALLET_SECRET
+          CLIENT_WALLET_SECRET,
         )
     }
     if (!::sep10ClientMultiSig.isInitialized) {
@@ -30,10 +31,16 @@ class Sep10Tests : AbstractIntegrationTests(TestConfig()) {
           arrayOf(
             CLIENT_WALLET_SECRET,
             CLIENT_WALLET_EXTRA_SIGNER_1_SECRET,
-            CLIENT_WALLET_EXTRA_SIGNER_2_SECRET
-          )
+            CLIENT_WALLET_EXTRA_SIGNER_2_SECRET,
+          ),
         )
     }
+  }
+
+  @Test
+  fun testChallengeSerialization() {
+    val challenge = sep10Client.challenge()
+    Base64.getDecoder().decode(challenge.transaction)
   }
 
   @Test
@@ -52,7 +59,7 @@ class Sep10Tests : AbstractIntegrationTests(TestConfig()) {
 
     assertFailsWith(
       exceptionClass = SepNotAuthorizedException::class,
-      block = { sep10Client.validate(ValidationRequest.of(challenge.transaction)) }
+      block = { sep10Client.validate(ValidationRequest.of(challenge.transaction)) },
     )
   }
 }

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep10Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep10Client.kt
@@ -39,6 +39,11 @@ class Sep10Client(
     return gson.fromJson(responseBody, ChallengeResponse::class.java)
   }
 
+  fun challengeJson(): String {
+    val url = String.format("%s?account=%s", this.endpoint, walletAccount)
+    return httpGet(url)!!
+  }
+
   private fun sign(
     challengeResponse: ChallengeResponse,
     signingKeys: Array<String>,


### PR DESCRIPTION
### Description

This commit fixes the URL encoding of the challenge transaction returned by the SEP-10 endpoint. This is done by disabling the "HTML escaping" done by the Gson instance used throughout the project. It is safe to do so because Anchor Platform only returns HTTP responses with the `application/json` content type, which does not require URL encoding.

### Context

The challenge transaction returned by the `/auth` endpoint is not decodable.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

