### PR TITLE
[ANCHOR-454][Easy] Fix copy paste bug in SEP24

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -356,7 +356,7 @@ public class Sep24Service {
     }
 
     // Validate min amount
-    Long minAmount = asset.getWithdraw().getMinAmount();
+    Long minAmount = asset.getDeposit().getMinAmount();
     if (strAmount != null && minAmount != null) {
       if (decimal(strAmount).compareTo(decimal(minAmount)) < 0) {
         infoF("invalid amount {}", strAmount);
@@ -366,7 +366,7 @@ public class Sep24Service {
     }
 
     // Validate max amount
-    Long maxAmount = asset.getWithdraw().getMaxAmount();
+    Long maxAmount = asset.getDeposit().getMaxAmount();
     if (strAmount != null && maxAmount != null) {
       if (decimal(strAmount).compareTo(decimal(maxAmount)) > 0) {
         infoF("invalid amount {}", strAmount);

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -321,13 +321,6 @@ internal class Sep24ServiceTest {
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.withdraw(token, request)
     }
-
-    assertThrows<SepValidationException> {
-      // Withdrawal range is 1 ~ 10000
-      val request = createTestTransactionRequest()
-      request["amount"] = "10001"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
-    }
   }
 
   @ParameterizedTest
@@ -506,13 +499,6 @@ internal class Sep24ServiceTest {
       val token = createTestSep10JwtToken()
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.deposit(token, request)
-    }
-
-    assertThrows<SepValidationException> {
-      // deposit range is 100 ~ 10000
-      val request = createTestTransactionRequest()
-      request["amount"] = "50"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
     }
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -321,6 +321,13 @@ internal class Sep24ServiceTest {
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.withdraw(token, request)
     }
+
+    assertThrows<SepValidationException> {
+      // Withdrawal range is 1 ~ 10000
+      val request = createTestTransactionRequest()
+      request["amount"] = "10001"
+      sep24Service.deposit(createTestSep10JwtToken(), request)
+    }
   }
 
   @ParameterizedTest
@@ -362,7 +369,7 @@ internal class Sep24ServiceTest {
     every { txnStore.save(capture(slotTxn)) } returns null
 
     val response =
-      sep24Service.withdraw(createTestSep10JwtWithMemo(), createTestTransactionRequest())
+      sep24Service.deposit(createTestSep10JwtWithMemo(), createTestTransactionRequest())
     val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
     val tokenStrings = params.filter { pair -> pair.name.equals("token") }
     assertEquals(tokenStrings.size, 1)
@@ -375,7 +382,7 @@ internal class Sep24ServiceTest {
     assertEquals(TEST_CLIENT_DOMAIN, decodedToken.claims[CLIENT_DOMAIN])
 
     assertEquals("incomplete", slotTxn.captured.status)
-    assertEquals("withdrawal", slotTxn.captured.kind)
+    assertEquals("deposit", slotTxn.captured.kind)
     assertEquals("USDC", slotTxn.captured.requestAssetCode)
     assertEquals(
       slotTxn.captured.requestAssetIssuer,
@@ -383,7 +390,7 @@ internal class Sep24ServiceTest {
     )
     assertEquals(TEST_ACCOUNT, slotTxn.captured.sep10Account)
     assertEquals(TEST_MEMO, slotTxn.captured.sep10AccountMemo)
-    assertEquals(TEST_ACCOUNT, slotTxn.captured.fromAccount)
+    assertEquals(TEST_ACCOUNT, slotTxn.captured.toAccount)
     assertEquals(TEST_CLIENT_DOMAIN, slotTxn.captured.clientDomain)
     assertEquals(TEST_CLIENT_NAME, slotTxn.captured.clientName)
   }
@@ -499,6 +506,13 @@ internal class Sep24ServiceTest {
       val token = createTestSep10JwtToken()
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.deposit(token, request)
+    }
+
+    assertThrows<SepValidationException> {
+      // deposit range is 100 ~ 10000
+      val request = createTestTransactionRequest()
+      request["amount"] = "50"
+      sep24Service.deposit(createTestSep10JwtToken(), request)
     }
   }
 

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -8,7 +8,7 @@
       "significant_decimals": 2,
       "deposit": {
         "enabled": true,
-        "min_amount": 100,
+        "min_amount": 1,
         "max_amount": 10000,
         "methods": [
           "SEPA",

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -8,7 +8,7 @@
       "significant_decimals": 2,
       "deposit": {
         "enabled": true,
-        "min_amount": 1,
+        "min_amount": 100,
         "max_amount": 10000,
         "methods": [
           "SEPA",

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
@@ -372,7 +372,7 @@ open class Sep24End2EndTests : AbstractIntegrationTests(TestConfig()) {
     @JvmStatic
     fun depositAssetsAndAmounts(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(DEPOSIT_FUND_CLIENT_SECRET_1, USDC, "0.01"),
+        Arguments.of(DEPOSIT_FUND_CLIENT_SECRET_1, USDC, "1"),
         Arguments.of(DEPOSIT_FUND_CLIENT_SECRET_2, XLM, "0.0001")
       )
     }
@@ -387,7 +387,7 @@ open class Sep24End2EndTests : AbstractIntegrationTests(TestConfig()) {
 
     @JvmStatic
     fun historyAssetsAndAmounts(): Stream<Arguments> {
-      return Stream.of(Arguments.of(CLIENT_WALLET_SECRET, USDC, "0.01"))
+      return Stream.of(Arguments.of(CLIENT_WALLET_SECRET, USDC, "1"))
     }
   }
 }


### PR DESCRIPTION
### Description

Fix the copy paste bug in Sep24Service and Sep24ServiceTest

### Context

In the Sep24Service.deposit(...) method, we’re asserting for minAmount and maxAmount from the withdrawal config instead of the deposit config

### Testing

- `./gradlew test`
-  This bug slipped through because majority of the parameter in our profile are set to the same. Having a variety of test scenarios helps us identify bugs in different conditions
