### PR TITLE
[ANCHOR-616] Lower request validation error log level

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.22"
+  version = "1.2.23"
 
   tasks.jar {
     manifest {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -1,6 +1,6 @@
 package org.stellar.anchor.platform.controller;
 
-import static org.stellar.anchor.util.Log.errorEx;
+import static org.stellar.anchor.util.Log.*;
 
 import javax.transaction.NotSupportedException;
 import org.springframework.http.HttpStatus;
@@ -18,14 +18,14 @@ public class GlobalControllerExceptionHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({SepValidationException.class, BadRequestException.class})
   public SepExceptionResponse handleBadRequest(AnchorException ex) {
-    errorEx(ex);
+    info(ex.getMessage());
     return new SepExceptionResponse(ex.getMessage());
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public SepExceptionResponse handleMissingParams(MissingServletRequestParameterException ex) {
-    errorEx(ex);
+    info(ex.getMessage());
     String name = ex.getParameterName();
     return new SepExceptionResponse(String.format("The \"%s\" parameter is missing.", name));
   }
@@ -41,6 +41,7 @@ public class GlobalControllerExceptionHandler {
   @ExceptionHandler({SepNotAuthorizedException.class})
   public SepExceptionResponse handleAuthError(SepException ex) {
     errorEx(ex);
+
     return new SepExceptionResponse(ex.getMessage());
   }
 


### PR DESCRIPTION
### Description

This lowers the log level and removes the stack trace for bad request exceptions. 

### Context

Our partners are monitoring ERROR logs. Bad requests are currently triggering their alarms.

### Testing

- `./gradlew test`
- Manual testing by submitting bad requests creates `INFO` logs.

### Documentation

N/A

### Known limitations

N/A

