### PR TITLE
[Dead Code] Clean up isKnownCustodialAccountRequired

### DIFF
--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -651,22 +651,6 @@ internal class Sep10ServiceTest {
   }
 
   @Test
-  fun `Test createChallenge() when isKnownCustodialAccountRequired is not enabled`() {
-    every { sep10Config.knownCustodialAccountList } returns
-      listOf("G321E23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP")
-    val cr =
-      ChallengeRequest.builder()
-        .account(TEST_ACCOUNT)
-        .memo(TEST_MEMO)
-        .homeDomain(TEST_HOME_DOMAIN)
-        .clientDomain(null)
-        .build()
-
-    assertDoesNotThrow { sep10Service.createChallenge(cr) }
-    verify(exactly = 2) { sep10Config.knownCustodialAccountList }
-  }
-
-  @Test
   fun `test the challenge with existent account, multisig, and client domain`() {
     // 1 ------ Create Test Transaction
 

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -366,11 +366,6 @@ sep10:
   # Set the timeout in seconds of the authenticated JSON Web Token. An expired JWT will be rejected.
   # This is the timeout period after the client has authenticated.
   jwt_timeout: 86400
-  # Whether to require authenticating clients to be in the list of known custodial accounts.
-  #
-  # If the flag is set to true, the client must be one of the custodial clients defined in the clients section
-  # of this configuration file.
-  known_custodial_account_required: false
 
 ######################
 # SEP-12 Configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -76,7 +76,6 @@ sep10.enabled:
 sep10.home_domain:
 sep10.home_domains:
 sep10.jwt_timeout:
-sep10.known_custodial_account_required:
 sep10.web_auth_domain:
 sep12.enabled:
 sep24.enabled:


### PR DESCRIPTION
### Description

Clean up dead code.
All uses has been removed in https://github.com/stellar/java-stellar-anchor-sdk/pull/1068

### Context

Better engineering