### PR TITLE
[ANCHOR-391] Use Postgres in reference server

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -38,6 +38,7 @@ jobs:
           sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 sep24-reference-ui" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 reference-server" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 reference-db" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 wallet-server" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 platform" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 custody-server" | sudo tee -a /etc/hosts

--- a/.github/workflows/sub_extended_tests.yml
+++ b/.github/workflows/sub_extended_tests.yml
@@ -38,6 +38,7 @@ jobs:
           sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 sep24-reference-ui" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 reference-server" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 reference-db" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 wallet-server" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 platform" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 custody-server" | sudo tee -a /etc/hosts

--- a/.github/workflows/sub_jacoco_report.yml
+++ b/.github/workflows/sub_jacoco_report.yml
@@ -44,6 +44,7 @@ jobs:
           sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 sep24-reference-ui" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 reference-server" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 reference-db" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 wallet-server" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 platform" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 custody-server" | sudo tee -a /etc/hosts

--- a/docs/01 - Contributing/A - Development Environment.md
+++ b/docs/01 - Contributing/A - Development Environment.md
@@ -82,6 +82,7 @@ communicate with each other.
 127.0.0.1 kafka
 127.0.0.1 sep24-reference-ui
 127.0.0.1 reference-server
+127.0.0.1 reference-db
 127.0.0.1 wallet-server
 127.0.0.1 platform
 127.0.0.1 custody-server

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
@@ -27,10 +27,10 @@ object ServiceContainer {
 
   private val database =
     Database.connect(
-      "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
-      driver = "org.h2.Driver",
-      user = "sa",
-      password = ""
+      "jdbc:postgresql://reference-db:5433/postgres",
+      driver = "org.postgresql.Driver",
+      user = "postgres",
+      password = "password"
     )
   private val customerRepo = JdbcCustomerRepository(database)
   private val quotesRepo = JdbcQuoteRepository(database)

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -68,3 +68,11 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
+
+  reference-db:
+    image: postgres:15.2-alpine
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password

--- a/service-runner/src/main/resources/docker-compose-test.yaml
+++ b/service-runner/src/main/resources/docker-compose-test.yaml
@@ -15,3 +15,8 @@ services:
     extends:
       file: common/docker-compose.yaml
       service: sep24-reference-ui
+  reference-db:
+    hostname: reference-db
+    extends:
+      file: common/docker-compose.yaml
+      service: reference-db

--- a/service-runner/src/main/resources/docker-compose.yaml
+++ b/service-runner/src/main/resources/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       service: reference-server
     depends_on:
       - kafka
+      - reference-db
 
   sep24-reference-ui:
     extends:
@@ -45,3 +46,8 @@ services:
     extends:
       file: common/docker-compose.yaml
       service: db
+
+  reference-db:
+    extends:
+      file: common/docker-compose.yaml
+      service: reference-db


### PR DESCRIPTION
### Description

This adds a Postgres DB for the reference server.

### Context

We need a persistent data store for permanent deployment.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

