### PR TITLE
[Fix] Reduce log level for client errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "1.2.23"
+  version = "1.2.24"
 
   tasks.jar {
     manifest {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -40,15 +40,14 @@ public class GlobalControllerExceptionHandler {
   @ResponseStatus(HttpStatus.FORBIDDEN)
   @ExceptionHandler({SepNotAuthorizedException.class})
   public SepExceptionResponse handleAuthError(SepException ex) {
-    errorEx(ex);
-
+    info(ex.getMessage());
     return new SepExceptionResponse(ex.getMessage());
   }
 
   @ExceptionHandler({SepNotFoundException.class, NotFoundException.class})
   @ResponseStatus(value = HttpStatus.NOT_FOUND)
   SepExceptionResponse handleNotFound(AnchorException ex) {
-    errorEx(ex);
+    info(ex.getMessage());
     return new SepExceptionResponse(ex.getMessage());
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/GlobalControllerExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalControllerExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
   public SepExceptionResponse handleRandomException(HttpMessageNotReadableException ex) {
-    errorEx(ex);
+    info(ex.getMessage());
     return new SepExceptionResponse("Your request body is wrong in some way.");
   }
 
@@ -54,7 +54,7 @@ public class GlobalControllerExceptionHandler {
   @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
   @ExceptionHandler({NotSupportedException.class})
   public SepExceptionResponse handleNotImplementedError(Exception ex) {
-    errorEx(ex);
+    info(ex.getMessage());
     return new SepExceptionResponse(ex.getMessage());
   }
 


### PR DESCRIPTION
### Description

This reduces the log levels for client-sided errors.

### Context

These are client-sided errors. They should be set to `info` as some partners are alerting on `error`.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

