### PR TITLE
[ANCHOR-625] Fix docker compose stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-## TODO: this should use alpine when the platform is not Apple Silicon
-FROM gradle:7.6.4-jdk11 AS build
+ARG BASE_IMAGE=gradle:7.6.4-jdk11-alpine
+
+FROM ${BASE_IMAGE} AS build
 WORKDIR /code
 COPY --chown=gradle:gradle . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gradle:7.6.0-jdk11-alpine AS build
+## TODO: this should use alpine when the platform is not Apple Silicon
+FROM gradle:7.6.4-jdk11 AS build
 WORKDIR /code
 COPY --chown=gradle:gradle . .
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Anchor Platform can be run locally using Docker Compose. This will start an inst
 Kotlin reference server.
 
 ```shell
-docker build -t anchor-platform:local ./
+docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk11 -t anchor-platform:local ./
 docker-compose -f service-runner/src/main/resources/docker-compose.yaml up -d
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Anchor Platform can be run locally using Docker Compose. This will start an inst
 Kotlin reference server.
 
 ```shell
+docker build -t anchor-platform:local ./
 docker-compose -f service-runner/src/main/resources/docker-compose.yaml up -d
 ```
 

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -72,7 +72,8 @@ services:
   reference-db:
     image: postgres:15.2-alpine
     ports:
-      - "5433:5432"
+      - "5433:5433"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
+    command: -p 5433

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   platform:
-    image: stellar/anchor-platform:edge
+    image: anchor-platform:local
     command: --sep-server --platform-server
     volumes:
       - ../config:/config
@@ -15,7 +15,7 @@ services:
       - "3000:80"
 
   observer:
-    image: stellar/anchor-platform:edge
+    image: anchor-platform:local
     build:
       context: ../../../../../essential-tests/src/test
       dockerfile: essential-tests/docker-compose-configs/Dockerfile
@@ -27,14 +27,14 @@ services:
       - "host.docker.internal:host-gateway"
 
   custody-server:
-    image: stellar/anchor-platform:edge
+    image: anchor-platform:local
     command: "--custody-server"
     volumes:
       # add mounts for the new config directory
       - ../config:/config
 
   reference-server:
-    image: stellar/anchor-platform:edge
+    image: anchor-platform:local
     command: "--kotlin-reference-server"
     volumes:
       # add mounts for the new config directory

--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
   platform:
     image: anchor-platform:local
-    command: --sep-server --platform-server
+    command: --sep-server --platform-server --event-processor
     volumes:
       - ../config:/config
     ports:


### PR DESCRIPTION
### Description

This commit fixes the docker-compose stack. Also, this replaces the Anchor Platform image used by the stack with a locally built one.

### Context

Two things broke the stack:
- We are listening to webhook events instead of directly consuming Kafka, we need to start the `event-processor`.
- Docker ports were incorrectly mapped

### Testing

- `./gradlew test`
- Tested SEP-6 deposit and withdrawal using demo-wallet

### Documentation

N/A

### Known limitations

Future bugs like this will be difficult to catch without running automated tests against the docker-compose stack. Rather than directly running the `ServiceRunner` in GH actions, we can use docker-compose instead and run our tests against that.