### PR TITLE
[ANCHOR-580] Replace ConfigManager HC result with config keys

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigManager.java
@@ -6,6 +6,7 @@ import static org.stellar.anchor.util.Log.*;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import lombok.Builder;
@@ -178,7 +179,10 @@ public abstract class ConfigManager
 
   @Override
   public HealthCheckResult check() {
-    return ConfigManagerHealthCheckResult.builder().name(getName()).configMap(configMap).build();
+    return ConfigManagerHealthCheckResult.builder()
+        .name(getName())
+        .configured(configMap.names())
+        .build();
   }
 
   @Override
@@ -192,7 +196,7 @@ public abstract class ConfigManager
 class ConfigManagerHealthCheckResult implements HealthCheckResult {
   transient String name;
 
-  ConfigMap configMap;
+  Collection<String> configured;
 
   @Override
   public String name() {

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/ConfigMap.java
@@ -5,23 +5,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 
 public class ConfigMap {
-  int version;
-  final Map<String, ConfigEntry> data;
+
+  @Getter @Setter int version;
+  final TreeMap<String, ConfigEntry> data;
 
   // ConfigMap keys will be in normalized form (dot separated hierarchy)
   public ConfigMap() {
-    data = new HashMap<>();
-  }
-
-  public int getVersion() {
-    return version;
-  }
-
-  public void setVersion(int version) {
-    this.version = version;
+    data = new TreeMap<>();
   }
 
   public ConfigEntry get(String name) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
@@ -126,8 +126,8 @@ class ConfigManagerTestExt {
       }
     val ex = assertThrows<InvalidConfigException> { configManager.processConfigurations(null) }
     assertEquals(2, ex.messages.size)
-    assertEquals("Invalid configuration: stellar.apollo=star. (version=1)", ex.messages[0])
-    assertEquals("Invalid configuration: horizon.aster=star. (version=1)", ex.messages[1])
+    assertEquals("Invalid configuration: horizon.aster=star. (version=1)", ex.messages[0])
+    assertEquals("Invalid configuration: stellar.apollo=star. (version=1)", ex.messages[1])
   }
 
   @Test


### PR DESCRIPTION
### Description

The existing health check result dumps the full config with values. This replaces the result with a list of the configured keys instead.

### Context

Environment variables are being exposed by the `/health` endpoints.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

