### PR TITLE
[ANCHOR-618] Fix auth header not configurable for callback API and platform API

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/AuthHelper.java
+++ b/core/src/main/java/org/stellar/anchor/auth/AuthHelper.java
@@ -30,8 +30,8 @@ public class AuthHelper {
   }
 
   public static AuthHelper forJwtToken(
-      String httpHeader, JwtService jwtService, long jwtExpirationMilliseconds) {
-    AuthHelper authHelper = new AuthHelper(AuthType.JWT, httpHeader);
+      String authorizationHeader, JwtService jwtService, long jwtExpirationMilliseconds) {
+    AuthHelper authHelper = new AuthHelper(AuthType.JWT, authorizationHeader);
     authHelper.jwtService = jwtService;
     authHelper.jwtExpirationMilliseconds = jwtExpirationMilliseconds;
     return authHelper;
@@ -73,7 +73,7 @@ public class AuthHelper {
       case JWT:
         return new AuthHeader<>(authorizationHeader, "Bearer " + createJwt(jwtClass));
       case API_KEY:
-        return new AuthHeader<>("X-Api-Key", apiKey);
+        return new AuthHeader<>(authorizationHeader, apiKey);
       default:
         return null;
     }

--- a/core/src/main/java/org/stellar/anchor/filter/AbstractJwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/AbstractJwtFilter.java
@@ -19,9 +19,11 @@ public abstract class AbstractJwtFilter implements Filter {
   static final String APPLICATION_JSON_VALUE = "application/json";
   static final Gson gson = GsonUtils.builder().setPrettyPrinting().create();
   protected final JwtService jwtService;
+  protected final String authorizationHeader;
 
-  public AbstractJwtFilter(JwtService jwtService) {
+  public AbstractJwtFilter(JwtService jwtService, String authorizationHeader) {
     this.jwtService = jwtService;
+    this.authorizationHeader = authorizationHeader;
   }
 
   @Override
@@ -52,7 +54,7 @@ public abstract class AbstractJwtFilter implements Filter {
       return;
     }
 
-    String authorization = request.getHeader("Authorization");
+    String authorization = request.getHeader(authorizationHeader);
     if (authorization == null) {
       sendForbiddenError(response);
       return;

--- a/core/src/main/java/org/stellar/anchor/filter/ApiKeyFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/ApiKeyFilter.java
@@ -17,12 +17,13 @@ import org.stellar.anchor.util.Log;
 public class ApiKeyFilter implements Filter {
   private static final String OPTIONS = "OPTIONS";
   private static final String APPLICATION_JSON_VALUE = "application/json";
-  private static final String HEADER_NAME = "X-Api-Key";
   private static final Gson gson = GsonUtils.builder().setPrettyPrinting().create();
   private final String apiKey;
+  private final String authorizationHeader;
 
-  public ApiKeyFilter(@NotNull String apiKey) {
+  public ApiKeyFilter(@NotNull String apiKey, String authorizationHeader) {
     this.apiKey = apiKey;
+    this.authorizationHeader = authorizationHeader;
   }
 
   @Override
@@ -53,7 +54,7 @@ public class ApiKeyFilter implements Filter {
       return;
     }
 
-    String gotApiKey = request.getHeader(HEADER_NAME);
+    String gotApiKey = request.getHeader(authorizationHeader);
     if (!apiKey.equals(gotApiKey)) {
       sendForbiddenError(response);
       return;

--- a/core/src/main/java/org/stellar/anchor/filter/CustodyAuthJwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/CustodyAuthJwtFilter.java
@@ -9,8 +9,8 @@ import org.stellar.anchor.auth.JwtService;
 
 public class CustodyAuthJwtFilter extends AbstractJwtFilter {
 
-  public CustodyAuthJwtFilter(JwtService jwtService) {
-    super(jwtService);
+  public CustodyAuthJwtFilter(JwtService jwtService, String authorizationHeader) {
+    super(jwtService, authorizationHeader);
   }
 
   @Override

--- a/core/src/main/java/org/stellar/anchor/filter/PlatformAuthJwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/PlatformAuthJwtFilter.java
@@ -8,8 +8,8 @@ import org.stellar.anchor.auth.ApiAuthJwt.PlatformAuthJwt;
 import org.stellar.anchor.auth.JwtService;
 
 public class PlatformAuthJwtFilter extends AbstractJwtFilter {
-  public PlatformAuthJwtFilter(JwtService jwtService) {
-    super(jwtService);
+  public PlatformAuthJwtFilter(JwtService jwtService, String authorizationHeader) {
+    super(jwtService, authorizationHeader);
   }
 
   @Override

--- a/core/src/main/java/org/stellar/anchor/filter/Sep10JwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/Sep10JwtFilter.java
@@ -10,7 +10,8 @@ import org.stellar.anchor.auth.Sep10Jwt;
 
 public class Sep10JwtFilter extends AbstractJwtFilter {
   public Sep10JwtFilter(JwtService jwtService) {
-    super(jwtService);
+    // SEP-10 tokens are passed in the Authorization header.
+    super(jwtService, "Authorization");
   }
 
   @Override

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -36,7 +36,7 @@ class AuthHelperTest {
   @MethodSource("authHelperTests")
   fun `test AuthHeader creation with different AuthType and authorization headers`(
     authType: AuthType,
-    headerName: String?
+    headerName: String?,
   ) {
     lockAndMockStatic(Calendar::class) {
       val calendarSingleton = mockk<Calendar>(relaxed = true)

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -3,11 +3,13 @@ package org.stellar.anchor.auth
 import io.mockk.*
 import java.time.Instant
 import java.util.*
+import java.util.stream.Stream
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.stellar.anchor.auth.ApiAuthJwt.*
 import org.stellar.anchor.auth.AuthType.*
 import org.stellar.anchor.lockAndMockStatic
@@ -17,11 +19,25 @@ import org.stellar.anchor.util.AuthHeader
 class AuthHelperTest {
   companion object {
     const val JWT_EXPIRATION_MILLISECONDS: Long = 90000
+
+    @JvmStatic
+    fun authHelperTests(): Stream<Arguments> {
+      return Stream.of(
+        Arguments.of(JWT, "Authorization"),
+        Arguments.of(JWT, "Custom_Authorization"),
+        Arguments.of(API_KEY, "Authorization"),
+        Arguments.of(API_KEY, "Custom_Authorization"),
+        Arguments.of(NONE, null),
+      )
+    }
   }
 
   @ParameterizedTest
-  @EnumSource(AuthType::class)
-  fun `test AuthHeader creation based on the AuthType`(authType: AuthType) {
+  @MethodSource("authHelperTests")
+  fun `test AuthHeader creation with different AuthType and authorization headers`(
+    authType: AuthType,
+    headerName: String?
+  ) {
     lockAndMockStatic(Calendar::class) {
       val calendarSingleton = mockk<Calendar>(relaxed = true)
       // Mock calendar to guarantee the jwt token format
@@ -37,33 +53,33 @@ class AuthHelperTest {
           val wantPlatformJwt =
             PlatformAuthJwt(
               currentTimeMilliseconds / 1000L,
-              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L,
             )
           val wantCallbackJwt =
             CallbackAuthJwt(
               currentTimeMilliseconds / 1000L,
-              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L,
             )
           val wantCustodyJwt =
             CustodyAuthJwt(
               currentTimeMilliseconds / 1000L,
-              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L
+              (currentTimeMilliseconds + JWT_EXPIRATION_MILLISECONDS) / 1000L,
             )
 
           val jwtService = JwtService(null, null, null, "secret", "secret", "secret")
           val authHelper =
-            AuthHelper.forJwtToken("Authorization", jwtService, JWT_EXPIRATION_MILLISECONDS)
+            AuthHelper.forJwtToken(headerName, jwtService, JWT_EXPIRATION_MILLISECONDS)
           val gotPlatformAuthHeader = authHelper.createPlatformServerAuthHeader()
           val wantPlatformAuthHeader =
-            AuthHeader("Authorization", "Bearer ${jwtService.encode(wantPlatformJwt)}")
+            AuthHeader(headerName, "Bearer ${jwtService.encode(wantPlatformJwt)}")
           assertEquals(wantPlatformAuthHeader, gotPlatformAuthHeader)
           val gotCallbackAuthHeader = authHelper.createCallbackAuthHeader()
           val wantCallbackAuthHeader =
-            AuthHeader("Authorization", "Bearer ${jwtService.encode(wantCallbackJwt)}")
+            AuthHeader(headerName, "Bearer ${jwtService.encode(wantCallbackJwt)}")
           assertEquals(wantCallbackAuthHeader, gotCallbackAuthHeader)
           val gotCustodyAuthHeader = authHelper.createCustodyAuthHeader()
           val wantCustodyAuthHeader =
-            AuthHeader("Authorization", "Bearer ${jwtService.encode(wantCustodyJwt)}")
+            AuthHeader(headerName, "Bearer ${jwtService.encode(wantCustodyJwt)}")
           assertEquals(wantCustodyAuthHeader, gotCustodyAuthHeader)
         }
         API_KEY -> {

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -51,7 +51,8 @@ class AuthHelperTest {
             )
 
           val jwtService = JwtService(null, null, null, "secret", "secret", "secret")
-          val authHelper = AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS)
+          val authHelper =
+            AuthHelper.forJwtToken("Authorization", jwtService, JWT_EXPIRATION_MILLISECONDS)
           val gotPlatformAuthHeader = authHelper.createPlatformServerAuthHeader()
           val wantPlatformAuthHeader =
             AuthHeader("Authorization", "Bearer ${jwtService.encode(wantPlatformJwt)}")
@@ -66,7 +67,7 @@ class AuthHelperTest {
           assertEquals(wantCustodyAuthHeader, gotCustodyAuthHeader)
         }
         API_KEY -> {
-          val authHelper = AuthHelper.forApiKey("secret")
+          val authHelper = AuthHelper.forApiKey("X-Api-Key", "secret")
           val gotPlatformAuthHeader = authHelper.createPlatformServerAuthHeader()
           val wantPlatformAuthHeader = AuthHeader("X-Api-Key", "secret")
           assertEquals(wantPlatformAuthHeader, gotPlatformAuthHeader)

--- a/core/src/test/kotlin/org/stellar/anchor/filter/AbstractJwtFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/AbstractJwtFilterTest.kt
@@ -17,14 +17,10 @@ import org.stellar.anchor.config.CustodySecretConfig
 import org.stellar.anchor.config.SecretConfig
 
 class AbstractJwtFilterTest {
-  private lateinit var request: HttpServletRequest
-  private lateinit var response: HttpServletResponse
   private lateinit var jwtService: JwtService
 
   @BeforeEach
   fun setup() {
-    this.request = mockk(relaxed = true)
-    this.response = mockk(relaxed = true)
     val secretConfig = mockk<SecretConfig>(relaxed = true)
     val custodySecretConfig = mockk<CustodySecretConfig>(relaxed = true)
     every { secretConfig.sep10JwtSecretKey } returns "secret"
@@ -36,6 +32,8 @@ class AbstractJwtFilterTest {
   fun `make sure FORBIDDEN is returned when the filter requires header names other than Authorization`(
     method: String
   ) {
+    val request = mockk<HttpServletRequest>(relaxed = true)
+    val response = mockk<HttpServletResponse>(relaxed = true)
     val filterChain = mockk<FilterChain>(relaxed = true)
 
     every { request.method } returns method

--- a/core/src/test/kotlin/org/stellar/anchor/filter/AbstractJwtFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/AbstractJwtFilterTest.kt
@@ -1,0 +1,60 @@
+package org.stellar.anchor.filter
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import javax.servlet.FilterChain
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.apache.http.HttpStatus
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.config.CustodySecretConfig
+import org.stellar.anchor.config.SecretConfig
+
+class AbstractJwtFilterTest {
+  private lateinit var request: HttpServletRequest
+  private lateinit var response: HttpServletResponse
+  private lateinit var jwtService: JwtService
+
+  @BeforeEach
+  fun setup() {
+    this.request = mockk(relaxed = true)
+    this.response = mockk(relaxed = true)
+    val secretConfig = mockk<SecretConfig>(relaxed = true)
+    val custodySecretConfig = mockk<CustodySecretConfig>(relaxed = true)
+    every { secretConfig.sep10JwtSecretKey } returns "secret"
+    this.jwtService = JwtService(secretConfig, custodySecretConfig)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["GET", "PUT", "POST", "DELETE"])
+  fun `make sure FORBIDDEN is returned when the filter requires header names other than Authorization`(
+    method: String
+  ) {
+    val filterChain = mockk<FilterChain>(relaxed = true)
+
+    every { request.method } returns method
+    every { request.getHeader("Authorization") } returns "Authorization_Header_Value"
+    val filter =
+      object : AbstractJwtFilter(jwtService, "Authorization-custom") {
+        @Throws(Exception::class)
+        override fun check(
+          jwtCipher: String?,
+          request: HttpServletRequest,
+          servletResponse: ServletResponse?,
+        ) {}
+      }
+
+    filter.doFilter(request, response, filterChain)
+    verify(exactly = 1) {
+      response.setStatus(HttpStatus.SC_FORBIDDEN)
+      response.contentType = Sep10JwtFilter.APPLICATION_JSON_VALUE
+    }
+    verify { filterChain wasNot Called }
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/filter/ApiKeyFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/ApiKeyFilterTest.kt
@@ -110,4 +110,23 @@ internal class ApiKeyFilterTest {
 
     verify { mockFilterChain.doFilter(request, response) }
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["GET", "PUT", "POST", "DELETE"])
+  fun `make sure FORBIDDEN is returned when the filter requires header names other than X-Api-Key`(
+    method: String
+  ) {
+    val filterChain = mockk<FilterChain>(relaxed = true)
+
+    every { request.method } returns method
+    every { request.getHeader("X-Api-Key") } returns API_KEY
+    apiKeyFilter = ApiKeyFilter(API_KEY, "X-Api-Key-custom")
+
+    apiKeyFilter.doFilter(request, response, filterChain)
+    verify(exactly = 1) {
+      response.setStatus(HttpStatus.SC_FORBIDDEN)
+      response.contentType = APPLICATION_JSON_VALUE
+    }
+    verify { filterChain wasNot Called }
+  }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/filter/ApiKeyFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/ApiKeyFilterTest.kt
@@ -28,7 +28,7 @@ internal class ApiKeyFilterTest {
   fun setup() {
     this.request = mockk(relaxed = true)
     this.response = mockk(relaxed = true)
-    this.apiKeyFilter = ApiKeyFilter(API_KEY)
+    this.apiKeyFilter = ApiKeyFilter(API_KEY, "X-Api-Key")
     this.mockFilterChain = mockk(relaxed = true)
   }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
@@ -62,7 +62,7 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
     )
 
   private val authHelper =
-    AuthHelper.forJwtToken(platformToAnchorJwtService, JWT_EXPIRATION_MILLISECONDS)
+    AuthHelper.forJwtToken("Authorization", platformToAnchorJwtService, JWT_EXPIRATION_MILLISECONDS)
 
   private val gson: Gson = GsonUtils.getInstance()
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
@@ -43,7 +43,8 @@ public class CustodyBeans {
         break;
 
       case API_KEY:
-        platformToCustody = new ApiKeyFilter(authSecret);
+        platformToCustody =
+            new ApiKeyFilter(authSecret, custodyApiConfig.getAuth().getApiKey().getHttpHeader());
         break;
 
       default:

--- a/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/custody/CustodyBeans.java
@@ -37,7 +37,9 @@ public class CustodyBeans {
     switch (custodyApiConfig.getAuth().getType()) {
       case JWT:
         JwtService jwtService = new JwtService(null, null, null, null, null, authSecret);
-        platformToCustody = new CustodyAuthJwtFilter(jwtService);
+        platformToCustody =
+            new CustodyAuthJwtFilter(
+                jwtService, custodyApiConfig.getAuth().getJwt().getHttpHeader());
         break;
 
       case API_KEY:

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -46,7 +46,8 @@ public class PlatformServerBeans {
     switch (config.getAuth().getType()) {
       case JWT:
         JwtService jwtService = new JwtService(null, null, null, null, authSecret, null);
-        anchorToPlatformFilter = new PlatformAuthJwtFilter(jwtService);
+        anchorToPlatformFilter =
+            new PlatformAuthJwtFilter(jwtService, config.getAuth().getJwt().getHttpHeader());
         break;
 
       case API_KEY:

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -51,7 +51,8 @@ public class PlatformServerBeans {
         break;
 
       case API_KEY:
-        anchorToPlatformFilter = new ApiKeyFilter(authSecret);
+        anchorToPlatformFilter =
+            new ApiKeyFilter(authSecret, config.getAuth().getApiKey().getHttpHeader());
         break;
 
       default:

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/CustodyApiBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/CustodyApiBeans.java
@@ -38,10 +38,12 @@ public class CustodyApiBeans {
     switch (custodyApiConfig.getAuth().getType()) {
       case JWT:
         return AuthHelper.forJwtToken(
+            custodyApiConfig.getAuth().getJwt().getHttpHeader(),
             new JwtService(null, null, null, null, null, authSecret),
             Long.parseLong(custodyApiConfig.getAuth().getJwt().getExpirationMilliseconds()));
       case API_KEY:
-        return AuthHelper.forApiKey(authSecret);
+        return AuthHelper.forApiKey(
+            custodyApiConfig.getAuth().getApiKey().getHttpHeader(), authSecret);
       default:
         return AuthHelper.forNone();
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/PlatformApiClientBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/PlatformApiClientBeans.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.auth.AuthHelper;
+import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.platform.config.PlatformApiConfig;
 
 @Configuration
@@ -15,9 +16,18 @@ public class PlatformApiClientBeans {
 
   @Bean
   AuthHelper authHelper(PlatformApiConfig platformApiConfig) {
-    return AuthHelper.from(
-        platformApiConfig.getAuth().getType(),
-        platformApiConfig.getAuth().getSecret(),
-        Long.parseLong(platformApiConfig.getAuth().getJwt().getExpirationMilliseconds()));
+    String secret = platformApiConfig.getAuth().getSecret();
+    switch (platformApiConfig.getAuth().getType()) {
+      case JWT:
+        return AuthHelper.forJwtToken(
+            platformApiConfig.getAuth().getJwt().getHttpHeader(),
+            new JwtService(null, null, null, secret, secret, secret),
+            Long.parseLong(platformApiConfig.getAuth().getJwt().getExpirationMilliseconds()));
+      case API_KEY:
+        return AuthHelper.forApiKey(
+            platformApiConfig.getAuth().getApiKey().getHttpHeader(), secret);
+      default:
+        return AuthHelper.forNone();
+    }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/CallbackApiConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/CallbackApiConfig.java
@@ -10,6 +10,7 @@ import org.springframework.validation.Validator;
 import org.stellar.anchor.auth.AuthConfig;
 import org.stellar.anchor.auth.AuthHelper;
 import org.stellar.anchor.auth.AuthType;
+import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.util.NetUtil;
 
 @Data
@@ -78,6 +79,17 @@ public class CallbackApiConfig implements Validator {
   }
 
   public AuthHelper buildAuthHelper() {
-    return AuthHelper.from(getAuth().getType(), getAuth().getSecret(), 60000);
+    String secret = getAuth().getSecret();
+    switch (getAuth().getType()) {
+      case JWT:
+        return AuthHelper.forJwtToken(
+            getAuth().getJwt().getHttpHeader(),
+            new JwtService(null, null, null, secret, secret, secret),
+            Long.parseLong(getAuth().getJwt().getExpirationMilliseconds()));
+      case API_KEY:
+        return AuthHelper.forApiKey(getAuth().getApiKey().getHttpHeader(), secret);
+      default:
+        return AuthHelper.forNone();
+    }
   }
 }


### PR DESCRIPTION
### Description

[ANCHOR-618] Fix auth header not configurable for callback API and platform API

### Context

Bug fixes.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A



[ANCHOR-618]: https://stellarorg.atlassian.net/browse/ANCHOR-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ