### PR TITLE
[ANCHOR-640] Remove SEP10 home_domain

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Helper.java
@@ -52,9 +52,9 @@ public class Sep10Helper {
   }
 
   /**
-   * Checks if the given domain name matches any pattern or exact domain in the provided list.
+   * Checks if the given domain name matches any pattern or fixed domain in the provided list.
    *
-   * @param patternsAndDomains A list containing patterns and/or exact domain names to match
+   * @param patternsAndDomains A list containing patterns and/or fixed domain names to match
    *     against.
    * @param domainName The domain name to check for a match.
    * @return true if the domain name matches any pattern or exact domain in the list, false
@@ -82,9 +82,9 @@ public class Sep10Helper {
   }
 
   /**
-   * Retrieves the first non-wildcard domain name from the provided list of patterns and domains.
+   * Retrieves the first fixed domain name from the provided list of patterns and domains.
    *
-   * @param patternsAndDomains A list containing patterns and/or exact domain names to search.
+   * @param patternsAndDomains A list containing patterns and/or fixed domain names to search.
    * @return The first exact domain name found in the list, or null if no exact domain is present.
    */
   public static String getDefaultDomainName(List<String> patternsAndDomains) {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/EventProcessingTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/EventProcessingTests.kt
@@ -21,6 +21,7 @@ class EventProcessingServerTests : AbstractIntegrationTests(TestConfig()) {
     val session = eventService.createSession("testOk", TRANSACTION)
     val quoteEvent = GsonUtils.getInstance().fromJson(testQuoteEvent, AnchorEvent::class.java)
 
+    // TODO: this test doesn't fail when the event is not published
     session.publish(quoteEvent)
   }
 }
@@ -67,7 +68,8 @@ val eventConfigJson =
         "retries": 0,
         "lingerMs": 1000,
         "batchSize": 10,
-        "pollTimeoutSeconds": 10
+        "pollTimeoutSeconds": 10,
+        "securityProtocol": "PLAINTEXT"
       }
     }
   }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -338,25 +338,20 @@ sep10:
   enabled: false
   #
   # The `web_auth_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#response
-  # The `web_auth_domain` is optional and will be set to the value of the `home_domain` or `home_domains` if it can only be translated to one domain.
+  # The `web_auth_domain` is optional and will be set to the value of the `home_domains` if "home_domains" can only be translated to one domain.
   # 1) web_auth_domain is optional:
-  #    Ex: home_domain: ap.stellar.org
   #    Ex: home_domains: ap.stellar.org
   # 2) web_auth_domain is required:
   #    Ex: home_domains: ap.stellar.org, sdp.stellar.org
   #    Ex: home_domains: *.sdp.stellar.org
   web_auth_domain:
-  # The `home_domain` property of SEP-10. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
-  # `home_domain` value must be equal to the host of the toml file. If sep1 is enabled, toml file will be hosted on the SEP server.
-  # This property cannot coexist with `home_domains` and is going to be deprecated. Please use `home_domains` instead.
-  home_domain:
   # The `home_domains` property of SEP-10. This is a list of domains and/or wildcard patterns that the client can use to authenticate.
   # https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#request
-  # This property cannot coexist with `home_domain`. Please also set web_auth_domain if you have more than one home domain in this list.
+  # Please also set web_auth_domain if you have more than one home domain in this list.
   # The following lists are examples:
   # Ex: home_domains: [ap.stellar.org, *.sdp.stellar.org]
   # Ex: home_domains: ap.stellar.org, *.sdp.stellar.org
-  home_domains:
+  home_domains: localhost:8080
   # Set if the client attribution is required. Client Attribution requires clients to verify their identity by passing
   # a domain in the challenge transaction request and signing the challenge with the ``SIGNING_KEY`` on that domain's
   # SEP-1 stellar.toml. See the SEP-10 section `Verifying Client Application Identity` for more information

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -77,7 +77,6 @@ sep10.auth_timeout:
 sep10.client_allow_list:
 sep10.client_attribution_required:
 sep10.enabled:
-sep10.home_domain:
 sep10.home_domains:
 sep10.jwt_timeout:
 sep10.web_auth_domain:

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -75,7 +75,7 @@ sep1:
 
 sep10:
   enabled: true
-  home_domain: localhost:8080
+  home_domains: localhost:8080
 
 sep12:
   enabled: true

--- a/service-runner/build.gradle.kts
+++ b/service-runner/build.gradle.kts
@@ -108,7 +108,7 @@ val dockerCreateAnchorTest by
       dependsOn(dockerPullAnchorTest)
       targetImageId { dockerPullAnchorTest.image.get() }
 
-      val homeDomain = System.getenv("TEST_HOME_DO`MAIN") ?: "http://host.docker.internal:8080"
+      val homeDomain = System.getenv("TEST_HOME_DOMAIN") ?: "http://host.docker.internal:8080"
       println("TEST_HOME_DOMAIN=$homeDomain")
       val seps = System.getenv().getOrDefault("TEST_SEPS", "1,6,10,12,24,31,38").split(",")
       println("TEST_SEPS=$seps")

--- a/service-runner/src/main/resources/profiles/host-docker-internal/config.env
+++ b/service-runner/src/main/resources/profiles/host-docker-internal/config.env
@@ -1,3 +1,3 @@
-sep10.home_domain=host.docker.internal:8080
+sep10.home_domains=host.docker.internal:8080
 sep1.toml.value=/config/stellar.host.docker.internal.toml
 sep24.more_info_url.base_url=http://host.docker.internal:8091/sep24/transaction/more_info


### PR DESCRIPTION
### Description

The `home_domain` was retained for backward compatibility purposes.  
Removed as part of the efforts for v3.0.

### Testing

- `./gradlew test`