### PR TITLE
[ANCHOR-605] Parameterize secrets by namespace

### DIFF
--- a/helm-charts/reference-server/templates/configmap.yaml
+++ b/helm-charts/reference-server/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: reference-config
+  namespace: {{ .Values.namespace }}
 data:
   config.yaml: |
     app:

--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-reference-server
     helm.sh/chart: {{ include "common.chart" . }}

--- a/helm-charts/reference-server/templates/externalsecrets.yaml
+++ b/helm-charts/reference-server/templates/externalsecrets.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets
+  namespace: {{ .Values.namespace }}
 spec:
   secretStoreRef:
     name: {{ .Values.secretStoreRefName }}
@@ -11,29 +12,29 @@ spec:
   data:
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_PASSWORD
     - secretKey: POSTGRES_USER
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_USER
     - secretKey: SEP6_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP6_SECRET
     - secretKey: SEP24_INTERACTIVE_JWT_KEY
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_INTERACTIVE_JWT_KEY
     - secretKey: SEP24_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_SECRET
     - secretKey: PLATFORM_ANCHOR_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: PLATFORM_ANCHOR_SECRET
     - secretKey: ANCHOR_PLATFORM_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: ANCHOR_PLATFORM_SECRET

--- a/helm-charts/reference-server/templates/service.yaml
+++ b/helm-charts/reference-server/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.ref.labels }}
       {{- range $key, $value := .Values.services.ref.labels }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -1,4 +1,5 @@
 fullName: reference-server
+namespace: default
 
 secretStoreRefName: fake-secret-store
 

--- a/helm-charts/secret-store/templates/secretstore.yaml
+++ b/helm-charts/secret-store/templates/secretstore.yaml
@@ -2,11 +2,12 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: fake-secret-store
+  namespace: {{ .Values.namespace }}
 spec:
   provider:
     fake:
       data:
-        - key: "anchor-platform/anchor-platform-secrets"
+        - key: {{ .Values.namespace }}/anchor-platform-secrets
           value: |
             {
               "POSTGRES_USER": "postgres",
@@ -18,7 +19,7 @@ spec:
               "EVENTS_QUEUE_KAFKA_USERNAME": "user1",
               "EVENTS_QUEUE_KAFKA_PASSWORD": "INfioH5l7N",
             }
-        - key: "anchor-platform/reference-server-secrets"
+        - key: {{ .Values.namespace}}/reference-server-secrets
           value: |
             {
               "POSTGRES_USER": "postgres",

--- a/helm-charts/secret-store/values.yaml
+++ b/helm-charts/secret-store/values.yaml
@@ -1,0 +1,1 @@
+namespace: default

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: anchor-config
+  namespace: {{ .Values.namespace }}
 data:
   {{ include "common.addMultiline" (list "anchor-config.yaml" .Values.anchor_config )}}
   {{ include "common.addMultiline" (list "sep1.toml" .Values.sep1_toml )}}

--- a/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-event-processor
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
     spec:

--- a/helm-charts/sep-service/templates/eventprocessor-service.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.eventProcessor.labels }}
       {{- range $key, $value := .Values.services.eventProcessor.labels }}

--- a/helm-charts/sep-service/templates/externalsecrets.yaml
+++ b/helm-charts/sep-service/templates/externalsecrets.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets
+  namespace: {{ .Values.namespace }}
 spec:
   secretStoreRef:
     name: {{ .Values.secretStoreRefName }}
@@ -11,33 +12,33 @@ spec:
   data:
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_PASSWORD
     - secretKey: POSTGRES_USER
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_USER
     - secretKey: SEP24_INTERACTIVE_URL_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_INTERACTIVE_URL_JWT_SECRET
     - secretKey: SEP24_MORE_INFO_URL_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_MORE_INFO_URL_JWT_SECRET
     - secretKey: SEP10_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP10_JWT_SECRET
     - secretKey: SEP10_SIGNING_SEED
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP10_SIGNING_SEED
     - secretKey: EVENTS_QUEUE_KAFKA_USERNAME
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: EVENTS_QUEUE_KAFKA_USERNAME
     - secretKey: EVENTS_QUEUE_KAFKA_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: EVENTS_QUEUE_KAFKA_PASSWORD

--- a/helm-charts/sep-service/templates/observer-deployment.yaml
+++ b/helm-charts/sep-service/templates/observer-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-observer
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
     spec:

--- a/helm-charts/sep-service/templates/observer-service.yaml
+++ b/helm-charts/sep-service/templates/observer-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.observer.labels }}
       {{- range $key, $value := .Values.services.observer.labels }}

--- a/helm-charts/sep-service/templates/platform-deployment.yaml
+++ b/helm-charts/sep-service/templates/platform-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-platform
     helm.sh/chart: {{ include "common.chart" . }}

--- a/helm-charts/sep-service/templates/platform-service.yaml
+++ b/helm-charts/sep-service/templates/platform-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.platform.labels }}
       {{- range $key, $value := .Values.services.platform.labels }}

--- a/helm-charts/sep-service/templates/sepserver-deployment.yaml
+++ b/helm-charts/sep-service/templates/sepserver-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-sep
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
     spec:

--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name}}
+  namespace: {{ .Values.namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}

--- a/helm-charts/sep-service/templates/sepserver-service.yaml
+++ b/helm-charts/sep-service/templates/sepserver-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.sep.labels }}
       {{- range $key, $value := .Values.services.sep.labels }}

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -1,4 +1,5 @@
 fullName: anchor-platform
+namespace: default
 
 secretStoreRefName: fake-secret-store
 


### PR DESCRIPTION
### Description

This parameterizes the secret keys by namespace.

### Context

Secrets are prefixed by namespace in SDF's Vault cluster.

### Testing

- `./gradlew test`
- Testing with demo wallet.

### Documentation

N/A

### Known limitations

N/A

