### PR TITLE
[ANCHOR-635] Use platform API fields for the SEP-24 and SEP-6 `txn_fields` extractions

### DIFF
--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -131,10 +131,15 @@ public class TransactionHelper {
         .kind(PlatformTransactionData.Kind.from(txn.getKind()))
         .status(SepTransactionStatus.from(txn.getStatus()))
         .type(txn.getType())
-        .amountExpected(new Amount(txn.getAmountExpected(), amountExpectedAsset))
-        .amountIn(Amount.create(txn.getAmountIn(), amountInAsset))
-        .amountOut(Amount.create(txn.getAmountOut(), amountOutAsset))
-        .amountFee(Amount.create(txn.getAmountFee(), amountFeeAsset))
+        .amountExpected(
+            (amountExpectedAsset != null)
+                ? new Amount(txn.getAmountExpected(), amountExpectedAsset)
+                : null)
+        .amountIn((amountInAsset != null) ? Amount.create(txn.getAmountIn(), amountInAsset) : null)
+        .amountOut(
+            (amountOutAsset != null) ? Amount.create(txn.getAmountOut(), amountOutAsset) : null)
+        .amountFee(
+            (amountFeeAsset != null) ? Amount.create(txn.getAmountFee(), amountFeeAsset) : null)
         .feeDetails(txn.getFeeDetails())
         .quoteId(txn.getQuoteId())
         .startedAt(txn.getStartedAt())
@@ -180,10 +185,15 @@ public class TransactionHelper {
         .sep(PlatformTransactionData.Sep.SEP_24)
         .kind(PlatformTransactionData.Kind.from(txn.getKind()))
         .status(SepTransactionStatus.from(txn.getStatus()))
-        .amountExpected(new Amount(txn.getAmountExpected(), amountExpectedAsset))
-        .amountIn(Amount.create(txn.getAmountIn(), amountInAsset))
-        .amountOut(Amount.create(txn.getAmountOut(), amountOutAsset))
-        .amountFee(Amount.create(txn.getAmountFee(), amountFeeAsset))
+        .amountExpected(
+            (amountExpectedAsset != null)
+                ? new Amount(txn.getAmountExpected(), amountExpectedAsset)
+                : null)
+        .amountIn((amountInAsset != null) ? Amount.create(txn.getAmountIn(), amountInAsset) : null)
+        .amountOut(
+            (amountOutAsset != null) ? Amount.create(txn.getAmountOut(), amountOutAsset) : null)
+        .amountFee(
+            (amountFeeAsset != null) ? Amount.create(txn.getAmountFee(), amountFeeAsset) : null)
         .feeDetails(txn.getFeeDetails())
         .startedAt(txn.getStartedAt())
         .updatedAt(txn.getUpdatedAt())
@@ -215,7 +225,7 @@ public class TransactionHelper {
     AssetInfo info = service.getAsset(txn.getRequestAssetCode(), txn.getRequestAssetIssuer());
 
     // Already validated in the interactive flow
-    return info.getSep38AssetName();
+    return (info != null) ? info.getSep38AssetName() : null;
   }
 
   private static String makeAsset(

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -135,11 +135,18 @@ public class TransactionHelper {
             (amountExpectedAsset != null)
                 ? new Amount(txn.getAmountExpected(), amountExpectedAsset)
                 : null)
-        .amountIn((amountInAsset != null) ? Amount.create(txn.getAmountIn(), amountInAsset) : null)
+        .amountIn(
+            (amountInAsset != null && txn.getAmountIn() != null)
+                ? Amount.create(txn.getAmountIn(), amountInAsset)
+                : null)
         .amountOut(
-            (amountOutAsset != null) ? Amount.create(txn.getAmountOut(), amountOutAsset) : null)
+            (amountOutAsset != null && txn.getAmountOut() != null)
+                ? Amount.create(txn.getAmountOut(), amountOutAsset)
+                : null)
         .amountFee(
-            (amountFeeAsset != null) ? Amount.create(txn.getAmountFee(), amountFeeAsset) : null)
+            (amountFeeAsset != null && txn.getAmountFee() != null)
+                ? Amount.create(txn.getAmountFee(), amountFeeAsset)
+                : null)
         .feeDetails(txn.getFeeDetails())
         .quoteId(txn.getQuoteId())
         .startedAt(txn.getStartedAt())
@@ -189,11 +196,18 @@ public class TransactionHelper {
             (amountExpectedAsset != null)
                 ? new Amount(txn.getAmountExpected(), amountExpectedAsset)
                 : null)
-        .amountIn((amountInAsset != null) ? Amount.create(txn.getAmountIn(), amountInAsset) : null)
+        .amountIn(
+            (amountInAsset != null && txn.getAmountIn() != null)
+                ? Amount.create(txn.getAmountIn(), amountInAsset)
+                : null)
         .amountOut(
-            (amountOutAsset != null) ? Amount.create(txn.getAmountOut(), amountOutAsset) : null)
+            (amountOutAsset != null && txn.getAmountOut() != null)
+                ? Amount.create(txn.getAmountOut(), amountOutAsset)
+                : null)
         .amountFee(
-            (amountFeeAsset != null) ? Amount.create(txn.getAmountFee(), amountFeeAsset) : null)
+            (amountFeeAsset != null && txn.getAmountFee() != null)
+                ? Amount.create(txn.getAmountFee(), amountFeeAsset)
+                : null)
         .feeDetails(txn.getFeeDetails())
         .startedAt(txn.getStartedAt())
         .updatedAt(txn.getUpdatedAt())

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/EventProcessingTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/EventProcessingTests.kt
@@ -21,6 +21,7 @@ class EventProcessingServerTests : AbstractIntegrationTests(TestConfig()) {
     val session = eventService.createSession("testOk", TRANSACTION)
     val quoteEvent = GsonUtils.getInstance().fromJson(testQuoteEvent, AnchorEvent::class.java)
 
+    // TODO: this test doesn't fail when the event is not published
     session.publish(quoteEvent)
   }
 }
@@ -67,7 +68,8 @@ val eventConfigJson =
         "retries": 0,
         "lingerMs": 1000,
         "batchSize": 10,
-        "pollTimeoutSeconds": 10
+        "pollTimeoutSeconds": 10,
+        "securityProtocol": "PLAINTEXT"
       }
     }
   }

--- a/helm-charts/reference-server/templates/configmap.yaml
+++ b/helm-charts/reference-server/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: reference-config
+  namespace: {{ .Values.namespace }}
 data:
   config.yaml: |
     app:

--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-reference-server
     helm.sh/chart: {{ include "common.chart" . }}

--- a/helm-charts/reference-server/templates/externalsecrets.yaml
+++ b/helm-charts/reference-server/templates/externalsecrets.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets
+  namespace: {{ .Values.namespace }}
 spec:
   secretStoreRef:
     name: {{ .Values.secretStoreRefName }}
@@ -11,29 +12,29 @@ spec:
   data:
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_PASSWORD
     - secretKey: POSTGRES_USER
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_USER
     - secretKey: SEP6_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP6_SECRET
     - secretKey: SEP24_INTERACTIVE_JWT_KEY
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_INTERACTIVE_JWT_KEY
     - secretKey: SEP24_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_SECRET
     - secretKey: PLATFORM_ANCHOR_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: PLATFORM_ANCHOR_SECRET
     - secretKey: ANCHOR_PLATFORM_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: ANCHOR_PLATFORM_SECRET

--- a/helm-charts/reference-server/templates/service.yaml
+++ b/helm-charts/reference-server/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.ref.labels }}
       {{- range $key, $value := .Values.services.ref.labels }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -1,4 +1,5 @@
 fullName: reference-server
+namespace: default
 
 secretStoreRefName: fake-secret-store
 

--- a/helm-charts/secret-store/templates/secretstore.yaml
+++ b/helm-charts/secret-store/templates/secretstore.yaml
@@ -2,11 +2,12 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: fake-secret-store
+  namespace: {{ .Values.namespace }}
 spec:
   provider:
     fake:
       data:
-        - key: "anchor-platform/anchor-platform-secrets"
+        - key: {{ .Values.namespace }}/anchor-platform-secrets
           value: |
             {
               "POSTGRES_USER": "postgres",
@@ -18,7 +19,7 @@ spec:
               "EVENTS_QUEUE_KAFKA_USERNAME": "user1",
               "EVENTS_QUEUE_KAFKA_PASSWORD": "INfioH5l7N",
             }
-        - key: "anchor-platform/reference-server-secrets"
+        - key: {{ .Values.namespace}}/reference-server-secrets
           value: |
             {
               "POSTGRES_USER": "postgres",

--- a/helm-charts/secret-store/values.yaml
+++ b/helm-charts/secret-store/values.yaml
@@ -1,0 +1,1 @@
+namespace: default

--- a/helm-charts/sep-service/templates/configmap.yaml
+++ b/helm-charts/sep-service/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: anchor-config
+  namespace: {{ .Values.namespace }}
 data:
   {{ include "common.addMultiline" (list "anchor-config.yaml" .Values.anchor_config )}}
   {{ include "common.addMultiline" (list "sep1.toml" .Values.sep1_toml )}}

--- a/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-event-processor
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
     spec:

--- a/helm-charts/sep-service/templates/eventprocessor-service.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.eventProcessor.labels }}
       {{- range $key, $value := .Values.services.eventProcessor.labels }}

--- a/helm-charts/sep-service/templates/externalsecrets.yaml
+++ b/helm-charts/sep-service/templates/externalsecrets.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets
+  namespace: {{ .Values.namespace }}
 spec:
   secretStoreRef:
     name: {{ .Values.secretStoreRefName }}
@@ -11,33 +12,33 @@ spec:
   data:
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_PASSWORD
     - secretKey: POSTGRES_USER
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: POSTGRES_USER
     - secretKey: SEP24_INTERACTIVE_URL_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_INTERACTIVE_URL_JWT_SECRET
     - secretKey: SEP24_MORE_INFO_URL_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP24_MORE_INFO_URL_JWT_SECRET
     - secretKey: SEP10_JWT_SECRET
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP10_JWT_SECRET
     - secretKey: SEP10_SIGNING_SEED
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: SEP10_SIGNING_SEED
     - secretKey: EVENTS_QUEUE_KAFKA_USERNAME
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: EVENTS_QUEUE_KAFKA_USERNAME
     - secretKey: EVENTS_QUEUE_KAFKA_PASSWORD
       remoteRef:
-        key: anchor-platform/{{ .Values.fullName }}-secrets
+        key: {{ .Values.namespace }}/{{ .Values.fullName }}-secrets
         property: EVENTS_QUEUE_KAFKA_PASSWORD

--- a/helm-charts/sep-service/templates/observer-deployment.yaml
+++ b/helm-charts/sep-service/templates/observer-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-observer
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
     spec:

--- a/helm-charts/sep-service/templates/observer-service.yaml
+++ b/helm-charts/sep-service/templates/observer-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.observer.labels }}
       {{- range $key, $value := .Values.services.observer.labels }}

--- a/helm-charts/sep-service/templates/platform-deployment.yaml
+++ b/helm-charts/sep-service/templates/platform-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-platform
     helm.sh/chart: {{ include "common.chart" . }}

--- a/helm-charts/sep-service/templates/platform-service.yaml
+++ b/helm-charts/sep-service/templates/platform-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.platform.labels }}
       {{- range $key, $value := .Values.services.platform.labels }}

--- a/helm-charts/sep-service/templates/sepserver-deployment.yaml
+++ b/helm-charts/sep-service/templates/sepserver-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.fullName }}-sep
     helm.sh/chart: {{ include "common.chart" . }}
@@ -14,6 +15,7 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
   template:
     metadata:
+      namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
     spec:

--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name}}
+  namespace: {{ .Values.namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}

--- a/helm-charts/sep-service/templates/sepserver-service.yaml
+++ b/helm-charts/sep-service/templates/sepserver-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- if .Values.services.sep.labels }}
       {{- range $key, $value := .Values.services.sep.labels }}

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -1,4 +1,5 @@
 fullName: anchor-platform
+namespace: default
 
 secretStoreRefName: fake-secret-store
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -207,12 +207,13 @@ public class SepBeans {
 
   @Bean
   InteractiveUrlConstructor interactiveUrlConstructor(
+      AssetService assetService,
       PropertyClientsConfig clientsConfig,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
       JwtService jwtService) {
     return new SimpleInteractiveUrlConstructor(
-        clientsConfig, sep24Config, customerIntegration, jwtService);
+        assetService, clientsConfig, sep24Config, customerIntegration, jwtService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/UtilityBeans.java
@@ -44,15 +44,23 @@ public class UtilityBeans {
   @Bean
   @Qualifier("sep6MoreInfoUrlConstructor")
   MoreInfoUrlConstructor sep6MoreInfoUrlConstructor(
-      PropertyClientsConfig clientsConfig, PropertySep6Config sep6Config, JwtService jwtService) {
-    return new Sep6MoreInfoUrlConstructor(clientsConfig, sep6Config.getMoreInfoUrl(), jwtService);
+      AssetService assetService,
+      PropertyClientsConfig clientsConfig,
+      PropertySep6Config sep6Config,
+      JwtService jwtService) {
+    return new Sep6MoreInfoUrlConstructor(
+        assetService, clientsConfig, sep6Config.getMoreInfoUrl(), jwtService);
   }
 
   @Bean
   @Qualifier("sep24MoreInfoUrlConstructor")
   MoreInfoUrlConstructor sep24MoreInfoUrlConstructor(
-      PropertyClientsConfig clientsConfig, PropertySep24Config sep24Config, JwtService jwtService) {
-    return new Sep24MoreInfoUrlConstructor(clientsConfig, sep24Config.getMoreInfoUrl(), jwtService);
+      AssetService assetService,
+      PropertyClientsConfig clientsConfig,
+      PropertySep24Config sep24Config,
+      JwtService jwtService) {
+    return new Sep24MoreInfoUrlConstructor(
+        assetService, clientsConfig, sep24Config.getMoreInfoUrl(), jwtService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructor.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.service;
 import java.time.Instant;
 import lombok.SneakyThrows;
 import org.stellar.anchor.SepTransaction;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.MoreInfoUrlJwt;
 import org.stellar.anchor.auth.MoreInfoUrlJwt.*;
@@ -14,8 +15,11 @@ import org.stellar.anchor.util.ConfigHelper;
 
 public class Sep24MoreInfoUrlConstructor extends SimpleMoreInfoUrlConstructor {
   public Sep24MoreInfoUrlConstructor(
-      PropertyClientsConfig clientsConfig, MoreInfoUrlConfig config, JwtService jwtService) {
-    super(clientsConfig, config, jwtService);
+      AssetService asserService,
+      PropertyClientsConfig clientsConfig,
+      MoreInfoUrlConfig config,
+      JwtService jwtService) {
+    super(asserService, clientsConfig, config, jwtService);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep6MoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep6MoreInfoUrlConstructor.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.service;
 import java.time.Instant;
 import lombok.SneakyThrows;
 import org.stellar.anchor.SepTransaction;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.MoreInfoUrlJwt;
 import org.stellar.anchor.auth.MoreInfoUrlJwt.*;
@@ -15,8 +16,11 @@ import org.stellar.anchor.util.ConfigHelper;
 public class Sep6MoreInfoUrlConstructor extends SimpleMoreInfoUrlConstructor {
 
   public Sep6MoreInfoUrlConstructor(
-      PropertyClientsConfig clientsConfig, MoreInfoUrlConfig config, JwtService jwtService) {
-    super(clientsConfig, config, jwtService);
+      AssetService assetService,
+      PropertyClientsConfig clientsConfig,
+      MoreInfoUrlConfig config,
+      JwtService jwtService) {
+    super(assetService, clientsConfig, config, jwtService);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.service;
 
 import static org.stellar.anchor.auth.JwtService.HOME_DOMAIN;
+import static org.stellar.anchor.platform.service.UrlConstructorHelper.addTxnFields;
 import static org.stellar.anchor.sep24.Sep24Service.INTERACTIVE_URL_JWT_REQUIRED_FIELDS_FROM_REQUEST;
 import static org.stellar.anchor.sep9.Sep9Fields.extractSep9Fields;
 import static org.stellar.anchor.util.Log.debugF;
@@ -16,6 +17,7 @@ import org.stellar.anchor.api.callback.CustomerIntegration;
 import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.sep.AssetInfo;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt;
@@ -28,17 +30,19 @@ import org.stellar.anchor.util.GsonUtils;
 
 public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   public static final String FORWARD_KYC_CUSTOMER_TYPE = "sep24-customer";
-
+  private final AssetService assetService;
   private final PropertyClientsConfig clientsConfig;
   private final PropertySep24Config sep24Config;
   private final CustomerIntegration customerIntegration;
   private final JwtService jwtService;
 
   public SimpleInteractiveUrlConstructor(
+      AssetService assetService,
       PropertyClientsConfig clientsConfig,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
       JwtService jwtService) {
+    this.assetService = assetService;
     this.clientsConfig = clientsConfig;
     this.sep24Config = sep24Config;
     this.customerIntegration = customerIntegration;
@@ -96,7 +100,7 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
     Map<String, String> data =
         new HashMap<>(extractRequiredJwtFieldsFromRequest(request, asset, homeDomain));
     // Add fields defined in txnFields
-    UrlConstructorHelper.addTxnFields(data, txn, sep24Config.getInteractiveUrl().getTxnFields());
+    addTxnFields(assetService, data, txn, sep24Config.getInteractiveUrl().getTxnFields());
 
     token.claim("data", data);
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.service;
 
+import static org.stellar.anchor.platform.service.UrlConstructorHelper.addTxnFields;
+
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -7,18 +9,24 @@ import lombok.SneakyThrows;
 import org.apache.http.client.utils.URIBuilder;
 import org.stellar.anchor.MoreInfoUrlConstructor;
 import org.stellar.anchor.SepTransaction;
+import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.MoreInfoUrlJwt;
 import org.stellar.anchor.platform.config.MoreInfoUrlConfig;
 import org.stellar.anchor.platform.config.PropertyClientsConfig;
 
 public abstract class SimpleMoreInfoUrlConstructor implements MoreInfoUrlConstructor {
+  final AssetService assetService;
   PropertyClientsConfig clientsConfig;
   final MoreInfoUrlConfig config;
   private final JwtService jwtService;
 
   public SimpleMoreInfoUrlConstructor(
-      PropertyClientsConfig clientsConfig, MoreInfoUrlConfig config, JwtService jwtService) {
+      AssetService assetService,
+      PropertyClientsConfig clientsConfig,
+      MoreInfoUrlConfig config,
+      JwtService jwtService) {
+    this.assetService = assetService;
     this.clientsConfig = clientsConfig;
     this.config = config;
     this.jwtService = jwtService;
@@ -38,7 +46,8 @@ public abstract class SimpleMoreInfoUrlConstructor implements MoreInfoUrlConstru
 
     // add txn_fields to token
     Map<String, String> data = new HashMap<>();
-    UrlConstructorHelper.addTxnFields(data, txn, config.getTxnFields());
+    addTxnFields(assetService, data, txn, config.getTxnFields());
+
     token.claim("data", data);
 
     // build url


### PR DESCRIPTION
### Description

Use platform API fields for the SEP-24 and SEP-6 txn_fields extractions for more info URL and interactive URLs.

### Context

Feature enhancement

### Testing

- `./gradlew test`

### Documentation

- Update `txn_fields` description for stellar doc. 
- [ANCHOR-647](https://stellarorg.atlassian.net/browse/ANCHOR-647)




[ANCHOR-647]: https://stellarorg.atlassian.net/browse/ANCHOR-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ