### PR TITLE
[ANCHOR-603] Add `fee_details` to SEP31 response and tests

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.shared.FeeDetails;
 
 /**
  * The response to the GET /transaction endpoint of SEP-31.
@@ -46,6 +47,9 @@ public class Sep31GetTransactionResponse {
 
     @SerializedName("amount_fee")
     String amountFee;
+
+    @SerializedName("fee_details")
+    FeeDetails feeDetails;
 
     @SerializedName("amount_fee_asset")
     String amountFeeAsset;

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -600,5 +600,6 @@ public class Sep24Service {
     builder.amountInAsset(quote.getSellAsset());
     builder.amountOut(quote.getBuyAmount());
     builder.amountOutAsset(quote.getBuyAsset());
+    builder.feeDetails(quote.getFee());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
@@ -145,6 +145,7 @@ public interface Sep31Transaction extends SepTransaction {
                 .amountOutAsset(getAmountOutAsset())
                 .amountFee(getAmountFee())
                 .amountFeeAsset(getAmountFeeAsset())
+                .feeDetails(getFeeDetails())
                 .stellarAccountId(getStellarAccountId())
                 .stellarMemo(getStellarMemo())
                 .stellarMemoType(getStellarMemoType())

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -492,6 +492,7 @@ class Sep31ServiceTest {
           .amountOutAsset("USD")
           .amountFee("2")
           .amountFeeAsset("USDC")
+          .feeDetails(FeeDetails("2", "USDC"))
           .stellarAccountId("GAYR3FVW2PCXTNHHWHEAFOCKZQV4PEY2ZKGIKB47EKPJ3GSBYA52XJBY")
           .stellarMemo("123456")
           .stellarMemoType("text")

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -157,6 +157,7 @@ class Sep31TransactionTest {
             .amountOutAsset(stellarUSDC)
             .amountFee("2.0000")
             .amountFeeAsset(fiatUSD)
+            .feeDetails(FeeDetails("2.0000", fiatUSD))
             .stellarAccountId(TEST_ACCOUNT)
             .stellarMemo(TEST_MEMO)
             .stellarMemoType("text")


### PR DESCRIPTION
### Description

Add missing `fee_details` fields to SEP31 response. Add test to make sure `fee_details` is present in the response

### Testing

- `./gradlew test`
