### PR TITLE
[ANCHOR-629] Add `lang` to more_info_url jwt

### DIFF
--- a/core/src/main/java/org/stellar/anchor/MoreInfoUrlConstructor.java
+++ b/core/src/main/java/org/stellar/anchor/MoreInfoUrlConstructor.java
@@ -1,5 +1,5 @@
 package org.stellar.anchor;
 
 public interface MoreInfoUrlConstructor {
-  String construct(SepTransaction txn);
+  String construct(SepTransaction txn, String lang);
 }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
@@ -6,8 +6,6 @@ import static org.stellar.anchor.util.MathHelper.decimal;
 
 import com.google.gson.Gson;
 import java.math.BigDecimal;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.BeanUtils;
@@ -74,25 +72,25 @@ public class Sep24Helper {
    * @param assetService The asset service.
    * @param moreInfoUrlConstructor The more info URL constructor.
    * @param txn The SEP-24 transaction.
+   * @param lang The language code from the SEP-24 GET /transaction(s) request.
    * @return The SEP-24 transaction response.
-   * @throws MalformedURLException If the more info URL is malformed.
-   * @throws URISyntaxException If the more info URL is malformed.
    * @throws SepException If the transaction kind is not supported.
    */
   public static TransactionResponse fromTxn(
       AssetService assetService,
       MoreInfoUrlConstructor moreInfoUrlConstructor,
-      Sep24Transaction txn)
-      throws MalformedURLException, URISyntaxException, SepException {
+      Sep24Transaction txn,
+      String lang)
+      throws SepException {
     debugF(
         "Converting Sep24Transaction to Transaction Response. kind={}, transactionId={}",
         txn.getKind(),
         txn.getTransactionId());
     TransactionResponse response;
     if (txn.getKind().equals(Sep24Transaction.Kind.DEPOSIT.toString())) {
-      response = fromDepositTxn(txn, moreInfoUrlConstructor);
+      response = fromDepositTxn(txn, moreInfoUrlConstructor, lang);
     } else if (txn.getKind().equals(WITHDRAWAL.toString())) {
-      response = fromWithdrawTxn(txn, moreInfoUrlConstructor);
+      response = fromWithdrawTxn(txn, moreInfoUrlConstructor, lang);
     } else {
       throw new SepException(String.format("unsupported txn kind:%s", txn.getKind()));
     }
@@ -104,8 +102,7 @@ public class Sep24Helper {
   }
 
   public static TransactionResponse fromDepositTxn(
-      Sep24Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor)
-      throws MalformedURLException, URISyntaxException {
+      Sep24Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor, String lang) {
 
     DepositTransactionResponse txnR =
         gson.fromJson(gson.toJson(txn), DepositTransactionResponse.class);
@@ -115,14 +112,13 @@ public class Sep24Helper {
     txnR.setDepositMemo(txn.getMemo());
     txnR.setDepositMemoType(txn.getMemoType());
 
-    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
+    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn, lang));
 
     return txnR;
   }
 
   public static WithdrawTransactionResponse fromWithdrawTxn(
-      Sep24Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor)
-      throws MalformedURLException, URISyntaxException {
+      Sep24Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor, String lang) {
 
     WithdrawTransactionResponse txnR =
         gson.fromJson(gson.toJson(txn), WithdrawTransactionResponse.class);
@@ -133,7 +129,7 @@ public class Sep24Helper {
     txnR.setWithdrawMemoType(txn.getMemoType());
     txnR.setWithdrawAnchorAccount(txn.getWithdrawAnchorAccount());
 
-    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn));
+    txnR.setMoreInfoUrl(moreInfoUrlConstructor.construct(txn, lang));
 
     return txnR;
   }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -493,7 +493,9 @@ public class Sep24Service {
     List<TransactionResponse> list = new ArrayList<>();
     debugF("found {} transactions", txns.size());
     for (Sep24Transaction txn : txns) {
-      TransactionResponse transactionResponse = fromTxn(assetService, moreInfoUrlConstructor, txn);
+      String lang = validateLanguage(appConfig, txReq.getLang());
+      TransactionResponse transactionResponse =
+          fromTxn(assetService, moreInfoUrlConstructor, txn, lang);
       list.add(transactionResponse);
     }
     result.setTransactions(list);
@@ -549,7 +551,8 @@ public class Sep24Service {
     }
     // increment counter
     sep24TransactionQueriedCounter.increment();
-    return Sep24GetTransactionResponse.of(fromTxn(assetService, moreInfoUrlConstructor, txn));
+    String lang = validateLanguage(appConfig, txReq.getLang());
+    return Sep24GetTransactionResponse.of(fromTxn(assetService, moreInfoUrlConstructor, txn, lang));
   }
 
   public InfoResponse getInfo() {

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.sep6;
 
 import static io.micrometer.core.instrument.Metrics.counter;
 import static org.stellar.anchor.util.MemoHelper.*;
+import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
 import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.Counter;
@@ -18,6 +19,7 @@ import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.client.ClientFinder;
+import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.Sep6Config;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep6.ExchangeAmountsCalculator.Amounts;
@@ -27,6 +29,7 @@ import org.stellar.anchor.util.TransactionHelper;
 import org.stellar.sdk.Memo;
 
 public class Sep6Service {
+  private final AppConfig appConfig;
   private final Sep6Config sep6Config;
   private final AssetService assetService;
   private final RequestValidator requestValidator;
@@ -62,6 +65,7 @@ public class Sep6Service {
           MetricConstants.TV_SEP6_DEPOSIT_EXCHANGE);
 
   public Sep6Service(
+      AppConfig appConfig,
       Sep6Config sep6Config,
       AssetService assetService,
       RequestValidator requestValidator,
@@ -70,6 +74,7 @@ public class Sep6Service {
       ExchangeAmountsCalculator exchangeAmountsCalculator,
       EventService eventService,
       MoreInfoUrlConstructor moreInfoUrlConstructor) {
+    this.appConfig = appConfig;
     this.sep6Config = sep6Config;
     this.assetService = assetService;
     this.requestValidator = requestValidator;
@@ -429,7 +434,8 @@ public class Sep6Service {
         txnStore.findTransactions(token.getAccount(), token.getAccountMemo(), request);
     List<Sep6TransactionResponse> responses = new ArrayList<>();
     for (Sep6Transaction txn : transactions) {
-      Sep6TransactionResponse tr = Sep6TransactionUtils.fromTxn(txn, moreInfoUrlConstructor);
+      String lang = validateLanguage(appConfig, request.getLang());
+      Sep6TransactionResponse tr = Sep6TransactionUtils.fromTxn(txn, moreInfoUrlConstructor, lang);
       responses.add(tr);
     }
 
@@ -472,7 +478,9 @@ public class Sep6Service {
     }
 
     sep6TransactionQueriedCounter.increment();
-    return new GetTransactionResponse(Sep6TransactionUtils.fromTxn(txn, moreInfoUrlConstructor));
+    String lang = validateLanguage(appConfig, request.getLang());
+    return new GetTransactionResponse(
+        Sep6TransactionUtils.fromTxn(txn, moreInfoUrlConstructor, lang));
   }
 
   private InfoResponse buildInfoResponse() {

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
@@ -14,10 +14,11 @@ public class Sep6TransactionUtils {
    *
    * @param txn the SEP-6 database transaction object
    * @param moreInfoUrlConstructor the more_info_url constructor created from SEP-6 config
+   * @param lang the language code from the SEP-6 GET /transaction(s) request.
    * @return the SEP-6 API transaction object
    */
   public static Sep6TransactionResponse fromTxn(
-      Sep6Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor) {
+      Sep6Transaction txn, MoreInfoUrlConstructor moreInfoUrlConstructor, String lang) {
     Refunds refunds = null;
     if (txn.getRefunds() != null && txn.getRefunds().getPayments() != null) {
       List<RefundPayment> payments = new ArrayList<>();
@@ -43,7 +44,7 @@ public class Sep6TransactionUtils {
             .kind(txn.getKind())
             .status(txn.getStatus())
             .statusEta(txn.getStatusEta())
-            .moreInfoUrl(moreInfoUrlConstructor.construct(txn))
+            .moreInfoUrl(moreInfoUrlConstructor.construct(txn, lang))
             .amountIn(txn.getAmountIn())
             .amountInAsset(txn.getAmountInAsset())
             .amountOut(txn.getAmountOut())

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -151,7 +151,7 @@ internal class Sep24ServiceTest {
     val strToken = jwtService.encode(testInteractiveUrlJwt)
     every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
       "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
-    every { moreInfoUrlConstructor.construct(any()) } returns
+    every { moreInfoUrlConstructor.construct(any(), any()) } returns
       "${TEST_SEP24_MORE_INFO_URL}?lang=en&token=$strToken"
     every { clientsConfig.getClientConfigByDomain(any()) } returns clientConfig
     every { clientFinder.getClientName(any()) } returns TEST_CLIENT_NAME

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -31,6 +31,7 @@ import org.stellar.anchor.api.shared.Refunds
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.client.ClientFinder
+import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.Sep6Config
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.sep6.ExchangeAmountsCalculator.Amounts
@@ -44,6 +45,7 @@ class Sep6ServiceTest {
 
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
 
+  @MockK(relaxed = true) lateinit var appConfig: AppConfig
   @MockK(relaxed = true) lateinit var sep6Config: Sep6Config
   @MockK(relaxed = true) lateinit var requestValidator: RequestValidator
   @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
@@ -65,9 +67,11 @@ class Sep6ServiceTest {
     every { eventService.createSession(any(), any()) } returns eventSession
     every { requestValidator.getDepositAsset(TEST_ASSET) } returns asset
     every { requestValidator.getWithdrawAsset(TEST_ASSET) } returns asset
-    every { sep6MoreInfoUrlConstructor.construct(any()) } returns "https://example.com/more_info"
+    every { sep6MoreInfoUrlConstructor.construct(any(), any()) } returns
+      "https://example.com/more_info"
     sep6Service =
       Sep6Service(
+        appConfig,
         sep6Config,
         assetService,
         requestValidator,

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
@@ -27,7 +27,8 @@ class Sep6TransactionUtilsTest {
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
-    every { sep6MoreInfoUrlConstructor.construct(any()) } returns "https://example.com/more_info"
+    every { sep6MoreInfoUrlConstructor.construct(any(), any()) } returns
+      "https://example.com/more_info"
   }
 
   private val apiTxn =
@@ -202,7 +203,7 @@ class Sep6TransactionUtilsTest {
 
     JSONAssert.assertEquals(
       apiTxn,
-      gson.toJson(Sep6TransactionUtils.fromTxn(databaseTxn, sep6MoreInfoUrlConstructor)),
+      gson.toJson(Sep6TransactionUtils.fromTxn(databaseTxn, sep6MoreInfoUrlConstructor, null)),
       JSONCompareMode.STRICT
     )
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -132,6 +132,7 @@ public class SepBeans {
   @Bean
   @ConditionalOnAllSepsEnabled(seps = {"sep6"})
   Sep6Service sep6Service(
+      AppConfig appConfig,
       Sep6Config sep6Config,
       AssetService assetService,
       ClientFinder clientFinder,
@@ -143,6 +144,7 @@ public class SepBeans {
     ExchangeAmountsCalculator exchangeAmountsCalculator =
         new ExchangeAmountsCalculator(sep38QuoteStore);
     return new Sep6Service(
+        appConfig,
         sep6Config,
         assetService,
         requestValidator,

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -8,8 +8,6 @@ import static org.stellar.anchor.util.OkHttpUtil.buildJsonRequestBody;
 import static org.stellar.anchor.util.StringHelper.json;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -111,8 +109,7 @@ public class ClientStatusCallbackHandler extends EventHandler {
         .build();
   }
 
-  private String getPayload(AnchorEvent event)
-      throws AnchorException, MalformedURLException, URISyntaxException {
+  private String getPayload(AnchorEvent event) throws AnchorException {
     switch (event.getTransaction().getSep()) {
       case SEP_6:
         // TODO: remove dependence on the transaction store
@@ -120,13 +117,13 @@ public class ClientStatusCallbackHandler extends EventHandler {
             sep6TransactionStore.findByTransactionId(event.getTransaction().getId());
         org.stellar.anchor.api.sep.sep6.GetTransactionResponse sep6TxnRes =
             new org.stellar.anchor.api.sep.sep6.GetTransactionResponse(
-                Sep6TransactionUtils.fromTxn(sep6Txn, sep6MoreInfoUrlConstructor));
+                Sep6TransactionUtils.fromTxn(sep6Txn, sep6MoreInfoUrlConstructor, null));
         return json(sep6TxnRes);
       case SEP_24:
         Sep24Transaction sep24Txn = fromSep24Txn(event.getTransaction());
         Sep24GetTransactionResponse txn24Response =
             Sep24GetTransactionResponse.of(
-                fromTxn(assetService, sep24MoreInfoUrlConstructor, sep24Txn));
+                fromTxn(assetService, sep24MoreInfoUrlConstructor, sep24Txn, null));
         return json(txn24Response);
       case SEP_31:
         Sep31Transaction sep31Txn = fromSep31Txn(event.getTransaction());

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructor.java
@@ -19,14 +19,15 @@ public class Sep24MoreInfoUrlConstructor extends SimpleMoreInfoUrlConstructor {
   }
 
   @Override
-  public String construct(SepTransaction txn) {
+  public String construct(SepTransaction txn, String lang) {
     Sep24Transaction sep24Txn = (Sep24Transaction) txn;
     return construct(
         sep24Txn.getClientDomain(),
         sep24Txn.getSep10Account(),
         sep24Txn.getSep10AccountMemo(),
         sep24Txn.getTransactionId(),
-        sep24Txn);
+        sep24Txn,
+        lang);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/Sep6MoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/Sep6MoreInfoUrlConstructor.java
@@ -20,14 +20,15 @@ public class Sep6MoreInfoUrlConstructor extends SimpleMoreInfoUrlConstructor {
   }
 
   @Override
-  public String construct(SepTransaction txn) {
+  public String construct(SepTransaction txn, String lang) {
     Sep6Transaction sep6Txn = (Sep6Transaction) txn;
     return construct(
         sep6Txn.getClientDomain(),
         sep6Txn.getSep10Account(),
         sep6Txn.getSep10AccountMemo(),
         sep6Txn.getTransactionId(),
-        sep6Txn);
+        sep6Txn,
+        lang);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleMoreInfoUrlConstructor.java
@@ -24,7 +24,7 @@ public abstract class SimpleMoreInfoUrlConstructor implements MoreInfoUrlConstru
     this.jwtService = jwtService;
   }
 
-  public abstract String construct(SepTransaction txn);
+  public abstract String construct(SepTransaction txn, String lang);
 
   @SneakyThrows
   public String construct(
@@ -32,12 +32,15 @@ public abstract class SimpleMoreInfoUrlConstructor implements MoreInfoUrlConstru
       String memo,
       String sep10Account,
       String transactionId,
-      SepTransaction txn) {
+      SepTransaction txn,
+      String lang) {
 
     MoreInfoUrlJwt token = getBaseToken(clientDomain, memo, sep10Account, transactionId);
 
-    // add txn_fields to token
+    // add lang to token
     Map<String, String> data = new HashMap<>();
+    data.put("lang", lang);
+    // add txn_fields to token
     UrlConstructorHelper.addTxnFields(data, txn, config.getTxnFields());
     token.claim("data", data);
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -92,8 +92,9 @@ class ClientStatusCallbackHandlerTest {
     // header example: "X-Stellar-Signature": "t=....., s=......"
     // Get the signature from request
 
-    every { Sep6TransactionUtils.fromTxn(any(), any()) } returns mockk<Sep6TransactionResponse>()
-    every { fromTxn(any(), any(), any()) } returns mockk<TransactionResponse>()
+    every { Sep6TransactionUtils.fromTxn(any(), any(), any()) } returns
+      mockk<Sep6TransactionResponse>()
+    every { fromTxn(any(), any(), any(), any()) } returns mockk<TransactionResponse>()
 
     val payload = json(event)
     val request =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructorTest.kt
@@ -30,6 +30,7 @@ import org.stellar.anchor.util.GsonUtils
 class Sep24MoreInfoUrlConstructorTest {
   companion object {
     private val gson = GsonUtils.getInstance()
+    private const val LANG = "en"
   }
 
   @MockK(relaxed = true) private lateinit var secretConfig: SecretConfig
@@ -81,7 +82,7 @@ class Sep24MoreInfoUrlConstructorTest {
     val config = gson.fromJson(SIMPLE_CONFIG_JSON, MoreInfoUrlConfig::class.java)
     val constructor = Sep24MoreInfoUrlConstructor(clientsConfig, config, jwtService)
     val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
-    val url = constructor.construct(txn)
+    val url = constructor.construct(txn, LANG)
 
     val params = UriComponentsBuilder.fromUriString(url).build().queryParams
     val cipher = params["token"]!![0]
@@ -103,7 +104,7 @@ class Sep24MoreInfoUrlConstructorTest {
     txn.clientDomain = "unknown.com"
     txn.sep10AccountMemo = null
 
-    val url = constructor.construct(txn)
+    val url = constructor.construct(txn, LANG)
     val params = UriComponentsBuilder.fromUriString(url).build().queryParams
     val cipher = params["token"]!![0]
 
@@ -112,7 +113,6 @@ class Sep24MoreInfoUrlConstructorTest {
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
     assertEquals("unknown.com", claims["client_domain"])
-    assertEquals(null, claims["client_name"])
   }
 
   @Test
@@ -124,7 +124,7 @@ class Sep24MoreInfoUrlConstructorTest {
     txn.sep10Account = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     txn.clientDomain = null
 
-    val url = constructor.construct(txn)
+    val url = constructor.construct(txn, LANG)
 
     val params = UriComponentsBuilder.fromUriString(url).build().queryParams
     val cipher = params["token"]!![0]
@@ -145,12 +145,15 @@ class Sep24MoreInfoUrlConstructorTest {
     val txn = gson.fromJson(TXN_JSON, JdbcSep24Transaction::class.java)
     txn.clientDomain = null
 
-    assertThrows<SepValidationException> { constructor.construct(txn) }
+    assertThrows<SepValidationException> { constructor.construct(txn, LANG) }
   }
 
   private fun testJwt(jwt: Sep24MoreInfoUrlJwt) {
     assertEquals("txn_123", jwt.jti as String)
     Assertions.assertTrue(Instant.ofEpochSecond(jwt.exp).isAfter(Instant.now()))
+
+    val data = jwt.claims["data"] as Map<String, String>
+    assertEquals(LANG, data["lang"] as String)
   }
 }
 


### PR DESCRIPTION
### Description

We receive a lang parameter as part of the requests (GET /transaction and GET /transactions) 

Right now the generated more_info_url doesn’t have this request argument forwarded to the JWT, which should be used by the Anchor’s UI

### Testing

- `./gradlew test`