### PR TITLE
[ANCHOR-605] Fix ingress rules host value

### DIFF
--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -25,8 +25,8 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - {{- if .Values.ingress.host }}
-      host: {{ .Values.ingress.host }}
+    - {{- if .Values.ingress.rules.host }}
+      host: {{ .Values.ingress.rules.host }}
     {{- end }}
       http:
         paths:


### PR DESCRIPTION
### Description

This sets the `ingress.rules.host` to the value set by the same name in the values file.

### Context

Bug discovered during development deployment.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

