### PR TITLE
[Fix] Properly set ingress rules host

### DIFF
--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -29,7 +29,7 @@ spec:
   rules:
     - {{- if .Values.ingress.rules }}
       {{- if .Values.ingress.rules.host }}
-      host: {{ .Values.ingress.rules }}
+      host: {{ .Values.ingress.rules.host }}
       {{- end }}
       {{- end }}
       http:


### PR DESCRIPTION
### Description

This fixes the Ingress rules host value.

### Context

It should be set to `ingress.rules.host` instead of `ingress.rules`. This is currently causing deployment failure.

```
client.go:261: [debug] error updating the resource "anchor-platform-sep-server":
	 cannot patch "anchor-platform-sep-server" with kind Ingress: Ingress.networking.k8s.io "anchor-platform-sep-server" is invalid: spec.rules[0].host: Invalid value: "map[host:anchor-sep-server-dev.stellar.org]": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```
 
### Testing

- `./gradlew test`
- Checked the YAML generated by `helm template`

### Documentation

N/A

### Known limitations

N/A
