### PR TITLE
[ANCHOR-680] Enable only security updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: "weekly"
       time: "09:00"
       timezone: "US/Pacific"
+    # ignore all version updates but keep security updates
+    ignore:
+      - dependency-name: "*"
+        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
     commit-message:
       prefix: "[Gradle]"
     open-pull-requests-limit: 10
@@ -26,6 +30,9 @@ updates:
       interval: "weekly"
       time: "09:00"
       timezone: "US/Pacific"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ version-update:semver-major, version-update:semver-minor, version-update:semver-patch ]
     commit-message:
       prefix: "[Docker]"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
       time: "09:00"
       timezone: "US/Pacific"
     # ignore all version updates but keep security updates
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
       time: "09:00"
       timezone: "US/Pacific"
     ignore:


### PR DESCRIPTION
### Description

As title. 
Updates on every version are causing spamming and instability
Reference: [Specifying dependencies and versions to ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore)

### Testing

- `./gradlew test`