### PR TITLE
[ANCHOR-681] Fix the 64-byte limit error message to 59-byte of the `sep10.home_domain` and `sep10.home_domains`

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -132,7 +132,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
             "webAuthDomain",
             "sep10-web-auth-domain-too-long",
             format(
-                "The sep10.web_auth_home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
+                "The sep10.web_auth_home_domain (%s) is longer than the maximum length (59) of a domain. Error=%s",
                 webAuthDomain, iaex));
       }
 
@@ -213,7 +213,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
           "homeDomain",
           "sep10-home-domain-too-long",
           format(
-              "The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s",
+              "The sep10.home_domain (%s) is longer than the maximum length (59) of a domain. Error=%s",
               domain, iaex));
     }
 


### PR DESCRIPTION
### Description

The error message is confusing because the actual limitation is 59 bytes.
```
The sep10.home_domain (%s) is longer than the maximum length (64) of a domain. Error=%s
``` 

### Context

Bug fix.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

