### PR TITLE
Fix reference server config map

### DIFF
--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: /config/config.yaml
             - name: APP.PLATFORM_API_ENDPOINT
               value: {{ .Values.config.app.platformApiEndpoint }}
+            - name: APP.HORIZON_ENDPOINT
+              value: {{ .Values.config.app.horizonEndpoint }}
             - name: DATA.URL
               value: {{ .Values.config.data.url }}
             - name: DATA.USER


### PR DESCRIPTION
### Description

A previous commit refactored the config map by moving `horizonEndpoint` into the values file but did not set the associated environment variable.

### Context

The reference server is crashing in dev.

### Testing

- `./gradlew test`
- Tested with demo wallet.

### Documentation

N/A

### Known limitations

N/A

