### PR TITLE
[ANCHOR-604] Add deployment annotations

### DIFF
--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
   template:
     metadata:
+      {{- if .Values.services.ref.deployment.annotations }}
+      annotations:
+        {{- toYaml .Values.services.ref.deployment.annotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
     spec:

--- a/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}
   template:
     metadata:
+      {{- if .Values.services.eventProcessor.deployment.annotations }}
+      annotations:
+        {{- toYaml .Values.services.eventProcessor.deployment.annotations | nindent 8 }}
+      {{- end }}
       namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.eventProcessor.name }}

--- a/helm-charts/sep-service/templates/observer-deployment.yaml
+++ b/helm-charts/sep-service/templates/observer-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}
   template:
     metadata:
+      {{- if .Values.services.observer.deployment.annotations }}
+      annotations:
+        {{- toYaml .Values.services.observer.deployment.annotations | nindent 8 }}
+      {{- end }}
       namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.observer.name }}

--- a/helm-charts/sep-service/templates/platform-deployment.yaml
+++ b/helm-charts/sep-service/templates/platform-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
   template:
     metadata:
+      {{- if .Values.services.platform.deployment.annotations }}
+      annotations:
+        {{- toYaml .Values.services.platform.deployment.annotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.platform.name }}
     spec:

--- a/helm-charts/sep-service/templates/sepserver-deployment.yaml
+++ b/helm-charts/sep-service/templates/sepserver-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
   template:
     metadata:
+      {{- if .Values.services.sep.deployment.annotations }}
+      annotations:
+        {{- toYaml .Values.services.sep.deployment.annotations | nindent 8 }}
+      {{- end }}
       namespace: {{ .Values.namespace }}
       labels:
         app: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}


### PR DESCRIPTION
### Description

This allows pod-level annotations to be set.

### Context

We need to tell which port and endpoint Prometheus should scrape the metrics from using annotations.

### Testing

- `./gradlew test`
- Verified the manifest is correctly generated using `helm template`

### Documentation

N/A

### Known limitations

N/A

