### PR TITLE
[ANCHOR-605] Enable metric prefix

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/MetricsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/MetricsBeans.java
@@ -1,5 +1,8 @@
 package org.stellar.anchor.platform.component.share;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,5 +23,18 @@ public class MetricsBeans {
   @Bean
   MetricsService metricsService() {
     return new MetricsService();
+  }
+
+  @Bean
+  public MeterFilter meterFilter(MetricConfig metricConfig) {
+    return new MeterFilter() {
+      @Override
+      public Meter.Id map(Meter.Id id) {
+        if (StringUtils.isEmpty(metricConfig.getPrefix())) {
+          return id;
+        }
+        return id.withName(metricConfig.getPrefix() + id.getName());
+      }
+    };
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/MetricConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/MetricConfig.java
@@ -9,6 +9,7 @@ import org.stellar.anchor.config.AppConfig;
 @Data
 public class MetricConfig implements Validator {
   private boolean enabled = false;
+  private String prefix = "";
 
   @Override
   public boolean supports(@NotNull Class<?> clazz) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -624,6 +624,8 @@ custody:
 metrics:
   # If true, enable metrics will be enabled.
   enabled: false
+  # If set, all metrics will be prefixed with the specified prefix.
+  prefix:
 
 
 #########################

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -46,6 +46,7 @@ events.queue.sqs.use_iam:
 events.queue.type:
 languages:
 metrics.enabled:
+metrics.prefix:
 metrics.extended_metrics.enabled:
 metrics.extended_metrics.run_interval:
 payment_observer.context_path:


### PR DESCRIPTION
### Description

This adds the `metric.prefix` configuration. When set, all metrics will be prefixed with the specified prefix value.

### Context

We need to prefix all metrics with `ap` for Prometheus.

### Testing

- `./gradlew test`
- Checked the metrics have the specified endpoint when set, and nothing when not set.

### Documentation

N/A

### Known limitations

N/A

