### PR TITLE
[ANCNHOR-626] Update ClientsConfig with SigningKeys and Domains

### DIFF
--- a/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.client;
 
+import java.util.HashSet;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +43,7 @@ public class ClientFinder {
       throw new SepNotAuthorizedException("Client not found");
     }
 
-    if (clientDomain != null && !isDomainAllowed(client.getDomain())) {
+    if (clientDomain != null && !isClientDomainsAllowed(client)) {
       throw new SepNotAuthorizedException("Client domain not allowed");
     }
     if (!isClientNameAllowed(client.getName())) {
@@ -62,6 +63,11 @@ public class ClientFinder {
     ClientConfig clientByDomain = clientsConfig.getClientConfigByDomain(clientDomain);
     ClientConfig clientByAccount = clientsConfig.getClientConfigBySigningKey(account);
     return clientByDomain != null ? clientByDomain : clientByAccount;
+  }
+
+  private boolean isClientDomainsAllowed(ClientConfig client) {
+    return new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains())
+        || sep10Config.getAllowedClientDomains().isEmpty();
   }
 
   private boolean isDomainAllowed(String domain) {

--- a/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.client;
 
-import java.util.HashSet;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -38,15 +37,12 @@ public class ClientFinder {
       return client != null ? client.getName() : null;
     }
 
-    // Check if the client domain and name are allowed
+    // Check if the client is allowed
     if (client == null) {
       throw new SepNotAuthorizedException("Client not found");
     }
 
-    if (clientDomain != null && !isClientAllowed(client)) {
-      throw new SepNotAuthorizedException("Client domain not allowed");
-    }
-    if (!isClientNameAllowed(client.getName())) {
+    if (!sep10Config.getAllowedClientNames().contains(client.getName())) {
       throw new SepNotAuthorizedException("Client name not allowed");
     }
 
@@ -63,15 +59,5 @@ public class ClientFinder {
     ClientConfig clientByDomain = clientsConfig.getClientConfigByDomain(clientDomain);
     ClientConfig clientByAccount = clientsConfig.getClientConfigBySigningKey(account);
     return clientByDomain != null ? clientByDomain : clientByAccount;
-  }
-
-  private boolean isClientAllowed(ClientConfig client) {
-    return new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains())
-        || sep10Config.getAllowedClientDomains().isEmpty();
-  }
-
-  private boolean isClientNameAllowed(String name) {
-    return sep10Config.getAllowedClientNames().contains(name)
-        || sep10Config.getAllowedClientNames().isEmpty();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientFinder.java
@@ -43,7 +43,7 @@ public class ClientFinder {
       throw new SepNotAuthorizedException("Client not found");
     }
 
-    if (clientDomain != null && !isClientDomainsAllowed(client)) {
+    if (clientDomain != null && !isClientAllowed(client)) {
       throw new SepNotAuthorizedException("Client domain not allowed");
     }
     if (!isClientNameAllowed(client.getName())) {
@@ -65,13 +65,8 @@ public class ClientFinder {
     return clientByDomain != null ? clientByDomain : clientByAccount;
   }
 
-  private boolean isClientDomainsAllowed(ClientConfig client) {
+  private boolean isClientAllowed(ClientConfig client) {
     return new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains())
-        || sep10Config.getAllowedClientDomains().isEmpty();
-  }
-
-  private boolean isDomainAllowed(String domain) {
-    return sep10Config.getAllowedClientDomains().contains(domain)
         || sep10Config.getAllowedClientDomains().isEmpty();
   }
 

--- a/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
@@ -12,9 +12,9 @@ public interface ClientsConfig {
   class ClientConfig {
     String name;
     ClientType type;
-    @Deprecated String signingKey;
+    @Deprecated String signingKey; // ANCHOR-696
     Set<String> signingKeys;
-    @Deprecated String domain;
+    @Deprecated String domain; // ANCHOR-696
     Set<String> domains;
     String callbackUrl;
     boolean allowAnyDestination = false;

--- a/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
@@ -12,8 +12,10 @@ public interface ClientsConfig {
   class ClientConfig {
     String name;
     ClientType type;
-    String signingKey;
-    String domain;
+    @Deprecated String signingKey;
+    Set<String> signingKeys;
+    @Deprecated String domain;
+    Set<String> domains;
     String callbackUrl;
     boolean allowAnyDestination = false;
     Set<String> destinationAccounts;

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -591,7 +591,7 @@ public class Sep31Service {
     if (sep10Config.isClientAttributionRequired() && client == null) {
       throw new BadRequestException("Client not found");
     }
-
+    System.out.println(Arrays.toString(sep10Config.getAllowedClientNames().toArray()));
     if (client != null && !sep10Config.getAllowedClientNames().contains(client.getName()))
       client = null;
     return client == null ? null : client.getName();

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -592,13 +592,8 @@ public class Sep31Service {
       throw new BadRequestException("Client not found");
     }
 
-    if (client != null && client.getDomains() != null) {
-      boolean hasDomainIntersection =
-          new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains());
-      if (!hasDomainIntersection) {
-        client = null;
-      }
-    }
+    if (client != null && !sep10Config.getAllowedClientNames().contains(client.getName()))
+      client = null;
     return client == null ? null : client.getName();
   }
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -24,12 +24,7 @@ import static org.stellar.sdk.xdr.MemoType.MEMO_NONE;
 import io.micrometer.core.instrument.Counter;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import lombok.Data;
@@ -596,8 +591,13 @@ public class Sep31Service {
     if (sep10Config.isClientAttributionRequired() && client == null) {
       throw new BadRequestException("Client not found");
     }
-    if (client != null && !sep10Config.getAllowedClientDomains().contains(client.getDomain())) {
-      client = null;
+
+    if (client != null) {
+      boolean hasDomainIntersection =
+          new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains());
+      if (!hasDomainIntersection) {
+        client = null;
+      }
     }
     return client == null ? null : client.getName();
   }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -592,7 +592,7 @@ public class Sep31Service {
       throw new BadRequestException("Client not found");
     }
 
-    if (client != null) {
+    if (client != null && client.getDomains() != null) {
       boolean hasDomainIntersection =
           new HashSet<>(sep10Config.getAllowedClientDomains()).containsAll(client.getDomains());
       if (!hasDomainIntersection) {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -289,18 +289,8 @@ class Sep31ServiceTest {
       return Stream.of(
         Arguments.of(listOf<String>(), false, null, false),
         Arguments.of(listOf<String>(), true, null, true),
-        Arguments.of(
-          listOf(lobstrClientConfig.domains.first()),
-          false,
-          lobstrClientConfig.name,
-          false
-        ),
-        Arguments.of(
-          listOf(lobstrClientConfig.domains.first()),
-          true,
-          lobstrClientConfig.name,
-          true
-        ),
+        Arguments.of(listOf(lobstrClientConfig.name), false, lobstrClientConfig.name, false),
+        Arguments.of(listOf(lobstrClientConfig.name), true, lobstrClientConfig.name, true),
       )
     }
   }
@@ -798,7 +788,7 @@ class Sep31ServiceTest {
       }
 
     // mock client config
-    every { sep10Config.allowedClientDomains } returns listOf("vibrant.stellar.org")
+    every { sep10Config.allowedClientNames } returns listOf("vibrant")
     every { clientsConfig.getClientConfigBySigningKey(any()) } returns
       ClientsConfig.ClientConfig().apply {
         domains = setOf("vibrant.stellar.org")
@@ -1100,12 +1090,12 @@ class Sep31ServiceTest {
   @ParameterizedTest
   @MethodSource("generateGetClientNameTestConfig")
   fun `test getClientName when`(
-    allowedClientDomains: List<String>,
+    allowedClientNames: List<String>,
     isClientAttributionRequired: Boolean,
     expectedClientName: String?,
     shouldThrowExceptionWithInvalidInput: Boolean,
   ) {
-    every { sep10Config.allowedClientDomains } returns allowedClientDomains
+    every { sep10Config.allowedClientNames } returns allowedClientNames
     every { sep10Config.isClientAttributionRequired } returns isClientAttributionRequired
     every {
       clientsConfig.getClientConfigBySigningKey(lobstrClientConfig.signingKeys.first())

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -275,8 +275,10 @@ class Sep31ServiceTest {
       ClientsConfig.ClientConfig(
         "lobstr",
         ClientsConfig.ClientType.NONCUSTODIAL,
-        "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-        "lobstr.co",
+        null,
+        setOf("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"),
+        null,
+        setOf("lobstr.co"),
         "https://callback.lobstr.co/api/v2/anchor/callback",
         false,
         null
@@ -287,8 +289,18 @@ class Sep31ServiceTest {
       return Stream.of(
         Arguments.of(listOf<String>(), false, null, false),
         Arguments.of(listOf<String>(), true, null, true),
-        Arguments.of(listOf(lobstrClientConfig.domain), false, lobstrClientConfig.name, false),
-        Arguments.of(listOf(lobstrClientConfig.domain), true, lobstrClientConfig.name, true),
+        Arguments.of(
+          listOf(lobstrClientConfig.domains.first()),
+          false,
+          lobstrClientConfig.name,
+          false
+        ),
+        Arguments.of(
+          listOf(lobstrClientConfig.domains.first()),
+          true,
+          lobstrClientConfig.name,
+          true
+        ),
       )
     }
   }
@@ -789,7 +801,7 @@ class Sep31ServiceTest {
     every { sep10Config.allowedClientDomains } returns listOf("vibrant.stellar.org")
     every { clientsConfig.getClientConfigBySigningKey(any()) } returns
       ClientsConfig.ClientConfig().apply {
-        domain = "vibrant.stellar.org"
+        domains = setOf("vibrant.stellar.org")
         name = "vibrant"
       }
 
@@ -1095,11 +1107,12 @@ class Sep31ServiceTest {
   ) {
     every { sep10Config.allowedClientDomains } returns allowedClientDomains
     every { sep10Config.isClientAttributionRequired } returns isClientAttributionRequired
-    every { clientsConfig.getClientConfigBySigningKey(lobstrClientConfig.signingKey) } returns
-      lobstrClientConfig
+    every {
+      clientsConfig.getClientConfigBySigningKey(lobstrClientConfig.signingKeys.first())
+    } returns lobstrClientConfig
 
     // client name should be returned for valid input
-    val clientName = sep31Service.getClientName(lobstrClientConfig.signingKey)
+    val clientName = sep31Service.getClientName(lobstrClientConfig.signingKeys.first())
     assertEquals(expectedClientName, clientName)
 
     // exception maybe thrown for invalid input

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
@@ -24,8 +24,10 @@ class ClientFinderTest {
       ClientsConfig.ClientConfig(
         "name",
         ClientsConfig.ClientType.CUSTODIAL,
-        "signing-key",
-        "domain",
+        null,
+        setOf("signing-key"),
+        null,
+        setOf("domain"),
         "http://localhost:8000",
         false,
         emptySet()
@@ -41,7 +43,7 @@ class ClientFinderTest {
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { sep10Config.isClientAttributionRequired } returns true
-    every { sep10Config.allowedClientDomains } returns listOf(clientConfig.domain)
+    every { sep10Config.allowedClientDomains } returns clientConfig.domains.toList()
     every { sep10Config.allowedClientNames } returns listOf(clientConfig.name)
     every {
       clientsConfig.getClientConfigByDomain(ExchangeAmountsCalculatorTest.token.clientDomain)

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
@@ -81,7 +81,7 @@ class ClientFinderTest {
 
   @Test
   fun `test getClientName with client not found by domain`() {
-    every { sep10Config.allowedClientDomains } returns listOf("nothing")
+    every { sep10Config.allowedClientNames } returns listOf("nothing")
 
     assertThrows<SepNotAuthorizedException> { clientFinder.getClientName(token) }
   }
@@ -94,16 +94,8 @@ class ClientFinderTest {
   }
 
   @Test
-  fun `test getClientName with all domains allowed`() {
-    every { sep10Config.allowedClientDomains } returns emptyList()
-    val clientId = clientFinder.getClientName(token)
-
-    assertEquals(clientConfig.name, clientId)
-  }
-
-  @Test
   fun `test getClientName with all names allowed`() {
-    every { sep10Config.allowedClientNames } returns emptyList()
+    every { sep10Config.allowedClientNames } returns listOf(clientConfig.name)
     val clientId = clientFinder.getClientName(token)
 
     assertEquals(clientConfig.name, clientId)

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
@@ -8,7 +8,7 @@ import org.stellar.anchor.platform.config.PropertyClientsConfig;
 @Configuration
 public class ClientsBeans {
   @Bean
-  @ConfigurationProperties(prefix = "clients")
+  @ConfigurationProperties(prefix = "")
   PropertyClientsConfig clientsConfig() {
     return new PropertyClientsConfig();
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
@@ -8,7 +8,7 @@ import org.stellar.anchor.platform.config.PropertyClientsConfig;
 @Configuration
 public class ClientsBeans {
   @Bean
-  @ConfigurationProperties(prefix = "")
+  @ConfigurationProperties(prefix = "clients")
   PropertyClientsConfig clientsConfig() {
     return new PropertyClientsConfig();
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.config;
 
+import static io.jsonwebtoken.lang.Collections.setOf;
 import static org.stellar.anchor.util.Log.debugF;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
@@ -9,13 +10,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.PostConstruct;
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.config.ClientsConfig;
-import org.stellar.anchor.sep10.Sep10Helper;
 
 @Data
 public class PropertyClientsConfig implements ClientsConfig, Validator {
@@ -24,14 +24,32 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   Map<String, String> domainToClientNameMap = null;
   Map<String, String> signingKeyToClientNameMap = null;
 
+  @PostConstruct
+  public void postConstruct() {
+    clients.forEach(
+        clientConfig -> {
+          if (!isEmpty(clientConfig.getSigningKey())
+              && (clientConfig.getSigningKeys() == null
+                  || clientConfig.getSigningKeys().isEmpty())) {
+            clientConfig.setSigningKeys(setOf(clientConfig.getSigningKey()));
+          }
+          if (!isEmpty(clientConfig.getDomain())
+              && (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty())) {
+            clientConfig.setDomains(setOf(clientConfig.getDomain()));
+          }
+        });
+  }
+
   @Override
   public ClientsConfig.ClientConfig getClientConfigBySigningKey(String signingKey) {
     if (signingKeyToClientNameMap == null) {
       signingKeyToClientNameMap = Maps.newHashMap();
       clients.forEach(
           clientConfig -> {
-            if (clientConfig.getSigningKey() != null) {
-              signingKeyToClientNameMap.put(clientConfig.getSigningKey(), clientConfig.getName());
+            if (clientConfig.getSigningKeys() != null && !clientConfig.getSigningKeys().isEmpty()) {
+              for (String key : clientConfig.getSigningKeys()) {
+                signingKeyToClientNameMap.put(key, clientConfig.getName());
+              }
             }
           });
     }
@@ -44,8 +62,10 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
       domainToClientNameMap = Maps.newHashMap();
       clients.forEach(
           clientConfig -> {
-            if (clientConfig.getDomain() != null) {
-              domainToClientNameMap.put(clientConfig.getDomain(), clientConfig.getName());
+            if (clientConfig.getDomains() != null && !clientConfig.getDomains().isEmpty()) {
+              for (String domainName : clientConfig.getDomains()) {
+                domainToClientNameMap.put(domainName, clientConfig.getName());
+              }
             }
           });
     }
@@ -84,9 +104,10 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   }
 
   public void validateCustodialClient(ClientConfig clientConfig, Errors errors) {
-    if (isEmpty(clientConfig.getSigningKey())) {
+    if (clientConfig.getSigningKeys() == null || clientConfig.getSigningKeys().isEmpty()) {
       errors.reject(
-          "empty-client-signing-key", "The client.signingKey cannot be empty and must be defined");
+          "empty-client-signing-keys",
+          "The client.signingKeys cannot be empty and must be defined");
     }
     if (!isEmpty(clientConfig.getCallbackUrl())) {
       try {
@@ -98,24 +119,9 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   }
 
   public void validateNonCustodialClient(ClientConfig clientConfig, Errors errors) {
-    if (isEmpty(clientConfig.getDomain())) {
-      errors.reject("empty-client-domain", "The client.domain cannot be empty and must be defined");
-    }
-
-    if (!isEmpty(clientConfig.getSigningKey())) {
-      try {
-        String clientSigningKey =
-            Sep10Helper.fetchSigningKeyFromClientDomain(clientConfig.getDomain(), false);
-        if (!clientConfig.getSigningKey().equals(clientSigningKey)) {
-          errors.reject(
-              "client-signing-key-does-not-match",
-              "The client.signingKey does not matched any valid registered keys");
-        }
-      } catch (SepException e) {
-        errors.reject(
-            "client-signing-key-toml-read-failure",
-            "SIGNING_KEY not present in 'client_domain' TOML or TOML file does not exist");
-      }
+    if (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty()) {
+      errors.reject(
+          "empty-client-domains", "The client.domains cannot be empty and must be defined");
     }
 
     if (!isEmpty(clientConfig.getCallbackUrl())) {

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -104,7 +104,8 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   }
 
   public void validateCustodialClient(ClientConfig clientConfig, Errors errors) {
-    if (clientConfig.getSigningKeys() == null || clientConfig.getSigningKeys().isEmpty()) {
+    if (isEmpty(clientConfig.getSigningKey())
+        && (clientConfig.getSigningKeys() == null || clientConfig.getSigningKeys().isEmpty())) {
       errors.reject(
           "empty-client-signing-keys",
           "The client.signingKeys cannot be empty and must be defined");
@@ -119,7 +120,8 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   }
 
   public void validateNonCustodialClient(ClientConfig clientConfig, Errors errors) {
-    if (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty()) {
+    if (isEmpty(clientConfig.getDomain())
+        && (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty())) {
       errors.reject(
           "empty-client-domains", "The client.domains cannot be empty and must be defined");
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -27,17 +27,13 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   @PostConstruct
   public void postConstruct() {
     // In favor of migrating to signingKeys and domains, copy signingKey to signingKeys and domain
-    // to domains if signingKeys and domains are not set, otherwise signingKey and domain will be
-    // ignored
+    // to domains if signingKeys and domains are not set.
     clients.forEach(
         clientConfig -> {
-          if (!isEmpty(clientConfig.getSigningKey())
-              && (clientConfig.getSigningKeys() == null
-                  || clientConfig.getSigningKeys().isEmpty())) {
+          if (!isEmpty(clientConfig.getSigningKey())) {
             clientConfig.setSigningKeys(setOf(clientConfig.getSigningKey()));
           }
-          if (!isEmpty(clientConfig.getDomain())
-              && (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty())) {
+          if (!isEmpty(clientConfig.getDomain())) {
             clientConfig.setDomains(setOf(clientConfig.getDomain()));
           }
         });
@@ -113,6 +109,13 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
           "empty-client-signing-keys",
           "The client.signingKeys cannot be empty and must be defined");
     }
+    if (!isEmpty(clientConfig.getSigningKey())
+        && clientConfig.getSigningKeys() != null
+        && !clientConfig.getSigningKeys().isEmpty()) {
+      errors.reject(
+          "client-signing-keys-conflict",
+          "The client.signingKey and The client.signingKeys cannot coexist, please choose one to use");
+    }
     if (!isEmpty(clientConfig.getCallbackUrl())) {
       try {
         new URL(clientConfig.getCallbackUrl());
@@ -127,6 +130,13 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
         && (clientConfig.getDomains() == null || clientConfig.getDomains().isEmpty())) {
       errors.reject(
           "empty-client-domains", "The client.domains cannot be empty and must be defined");
+    }
+    if (!isEmpty(clientConfig.getDomain())
+        && clientConfig.getDomains() != null
+        && !clientConfig.getDomains().isEmpty()) {
+      errors.reject(
+          "client-domains-conflict",
+          "The client.domain and the client.domains cannot coexist, please choose one to use");
     }
 
     if (!isEmpty(clientConfig.getCallbackUrl())) {

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -26,6 +26,9 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
 
   @PostConstruct
   public void postConstruct() {
+    // In favor of migrating to signingKeys and domains, copy signingKey to signingKeys and domain
+    // to domains if signingKeys and domains are not set, otherwise signingKey and domain will be
+    // ignored
     clients.forEach(
         clientConfig -> {
           if (!isEmpty(clientConfig.getSigningKey())

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -236,11 +236,8 @@ public class PropertySep10Config implements Sep10Config, Validator {
 
     // If clientAllowList is defined, only the clients in the allow list are allowed.
     return clientAllowList.stream()
-        .flatMap(
-            domain ->
-                (clientsConfig.getClientConfigByName(domain) == null)
-                    ? null
-                    : clientsConfig.getClientConfigByName(domain).getDomains().stream())
+        .filter(domain -> clientsConfig.getClientConfigByName(domain) != null)
+        .flatMap(domain -> clientsConfig.getClientConfigByName(domain).getDomains().stream())
         .filter(StringHelper::isNotEmpty)
         .collect(Collectors.toList());
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -169,8 +169,8 @@ public class PropertySep10Config implements Sep10Config, Validator {
     if (clientAttributionRequired) {
       List<String> nonCustodialClientNames =
           clientsConfig.clients.stream()
-              .filter(cfg -> cfg.getType() == NONCUSTODIAL && !cfg.getDomains().isEmpty())
-              .flatMap(cfg -> cfg.getDomains().stream())
+              .filter(cfg -> cfg.getType() == NONCUSTODIAL)
+              .map(ClientConfig::getName)
               .collect(Collectors.toList());
 
       if (nonCustodialClientNames.isEmpty()) {

--- a/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
@@ -93,11 +93,13 @@ public class EventProcessorManager {
         switch (clientConfig.getType()) {
           case CUSTODIAL:
             processorName =
-                CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX + clientConfig.getSigningKey();
+                CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX
+                    + clientConfig.getSigningKeys().stream().findFirst();
             break;
           case NONCUSTODIAL:
             processorName =
-                CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX + clientConfig.getDomain();
+                CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX
+                    + clientConfig.getDomains().stream().findFirst();
             break;
           default:
             errorF("Unknown client type: {}", clientConfig.getType());

--- a/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/EventProcessorManager.java
@@ -94,12 +94,12 @@ public class EventProcessorManager {
           case CUSTODIAL:
             processorName =
                 CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX
-                    + clientConfig.getSigningKeys().stream().findFirst();
+                    + clientConfig.getSigningKeys().stream();
             break;
           case NONCUSTODIAL:
             processorName =
                 CLIENT_STATUS_CALLBACK_EVENT_PROCESSOR_NAME_PREFIX
-                    + clientConfig.getDomains().stream().findFirst();
+                    + clientConfig.getDomains().stream();
             break;
           default:
             errorF("Unknown client type: {}", clientConfig.getType());

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -180,8 +180,7 @@ event_processor:
 #   - type: (required) `custodial` or `noncustodial`
 #
 #   If the type is `custodial`,
-#   - signing_key: (required) the custodial SEP-10 signing key of the client. If the signing key of the client
-#                  is the same as the `signing_key`, the callback will be activated.
+#   - signing_keys: (required) the custodial SEP-10 signing keys of the client.
 #   - callback_url: (optional) the URL of the client's callback API endpoint. Optional due to some wallets may opt to
 #                  poll instead, or may use polling first before implementing callbacks at a later stage.
 #   - allow_any_destination: (optional) default to false. If set to true, allows any destination for deposits.
@@ -189,39 +188,33 @@ event_processor:
 #                  authenticated account can be used to deposit funds into. If allows_any_destinations set to true,
 #                  this configuration option is ignored.
 #   If the type is `noncustodial`,
-#   - domain: (required) the domain of the client. If the `client_domain` field of the transaction is the same as this
-#             domain, the callback will be activated.
+#   - domains: (required) the domain of the client.
 #   - callback_url: (optional) the URL of the client's callback API endpoint
-#   - signing_key: (optional) the signing key of the client. If the public key is specified, the client domain's TOML
-#                 file will be fetched and the `SIGNING_KEY` of the TOML file will be compared with the public key.
-#                 If they don't match, a validation error will be thrown.
 #
 # Examples:
 #     - name: circle
 #       type: custodial
-#       signing_key: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2
+#       signing_keys: GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2,GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F
 #       callback_url: https://callback.circle.com/api/v1/anchor/callback
 #     - name: lobstr
 #       type: noncustodial
-#       domain: lobstr.co
+#       domains: lobstr.co,lobstr.com
 #       callback_url: https://callback.lobstr.co/api/v2/anchor/callback
 #     - name: vibrant
 #       type: noncustodial
 #       domain: vibrant.co
 #       callback_url: https://callback.vibrant.com/api/v2/anchor/callback
-#       signing_key: GA22WORKYRXB6AW7XR5GIOAOQUY4KKCENEAI34FN3KJNWHKDZTZSVLTU
 clients:
 #     - name:
 #       type: custodial
-#       signing_key:
+#       signing_keys:
 #       callback_url:
 #       allow_any_destination:
 #       destination_accounts:
 #     - name:
 #       type: noncustodial
-#       domain:
+#       domains:
 #       callback_url:
-#       signing_key:
 
 ######################
 ## Platform Server Configuration

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -77,6 +77,22 @@ class PropertyClientsConfigTest {
   }
 
   @Test
+  fun `test invalid custodial client with both signing key and signing keys`() {
+    val config = ClientConfig()
+    config.signingKey = "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"
+    config.signingKeys =
+      setOf(
+        "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2",
+        "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
+      )
+    configs.clients.add(config)
+
+    configs.validateCustodialClient(config, errors)
+    Assertions.assertEquals(1, errors.errorCount)
+    assertErrorCode(errors, "client-signing-keys-conflict")
+  }
+
+  @Test
   fun `test valid non-custodial client with multiple domains`() {
     val config = ClientConfig()
     config.name = "lobstr"
@@ -105,5 +121,17 @@ class PropertyClientsConfigTest {
 
     configs.validateNonCustodialClient(config, errors)
     Assertions.assertEquals(2, errors.errorCount)
+  }
+
+  @Test
+  fun `test invalid non-custodial client with both domain and domains`() {
+    val config = ClientConfig()
+    config.domain = "lobstr.co"
+    config.domains = setOf("lobstr.co", "lobstr.com")
+    configs.clients.add(config)
+
+    configs.validateNonCustodialClient(config, errors)
+    Assertions.assertEquals(1, errors.errorCount)
+    assertErrorCode(errors, "client-domains-conflict")
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -29,7 +29,9 @@ class PropertyClientsConfigTest {
     configs.clients.add(config)
     configs.postConstruct()
 
+    Assertions.assertEquals(1, config.signingKeys.size)
     Assertions.assertEquals(config.signingKey, config.signingKeys.first())
+    Assertions.assertEquals(1, config.signingKeys.size)
     Assertions.assertEquals(config.domain, config.domains.first())
   }
 
@@ -48,6 +50,18 @@ class PropertyClientsConfigTest {
 
     configs.validate(configs, errors)
     Assertions.assertFalse(errors.hasErrors())
+
+    val getConfigResult1 =
+      configs.getClientConfigBySigningKey(
+        "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"
+      )
+    Assertions.assertEquals(config, getConfigResult1)
+
+    val getConfigResult2 =
+      configs.getClientConfigBySigningKey(
+        "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
+      )
+    Assertions.assertEquals(config, getConfigResult2)
   }
 
   @Test
@@ -73,6 +87,12 @@ class PropertyClientsConfigTest {
 
     configs.validate(configs, errors)
     Assertions.assertFalse(errors.hasErrors())
+
+    val getConfigResult1 = configs.getClientConfigByDomain("lobstr.co")
+    Assertions.assertEquals(config, getConfigResult1)
+
+    val getConfigResult2 = configs.getClientConfigByDomain("lobstr.com")
+    Assertions.assertEquals(config, getConfigResult2)
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep10ConfigTest.kt
@@ -32,7 +32,9 @@ class Sep10ConfigTest {
       ClientConfig(
         "unknown",
         CUSTODIAL,
-        "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2",
+        null,
+        setOf("GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"),
+        null,
         null,
         null,
         false,
@@ -44,8 +46,10 @@ class Sep10ConfigTest {
       ClientConfig(
         "lobstr",
         NONCUSTODIAL,
-        "GC4HAYCFQYQLJV5SE6FB3LGC37D6XGIXGMAXCXWNBLH7NWW2JH4OZLHQ",
-        "lobstr.co",
+        null,
+        setOf("GC4HAYCFQYQLJV5SE6FB3LGC37D6XGIXGMAXCXWNBLH7NWW2JH4OZLHQ"),
+        null,
+        setOf("lobstr.co"),
         "https://callback.lobstr.co/api/v2/anchor/callback",
         false,
         null
@@ -56,8 +60,10 @@ class Sep10ConfigTest {
       ClientConfig(
         "circle",
         NONCUSTODIAL,
-        "GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE",
-        "circle.com",
+        null,
+        setOf("GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE"),
+        null,
+        setOf("circle.com"),
         "https://callback.circle.com/api/v2/anchor/callback",
         false,
         null
@@ -101,25 +107,28 @@ class Sep10ConfigTest {
 
   @Test
   fun `test ClientsConfig getClientConfigByDomain`() {
-    assertEquals(clientsConfig.getClientConfigByDomain("unknown"), null)
-    assertEquals(clientsConfig.getClientConfigByDomain("lobstr.co"), clientsConfig.clients[1])
-    assertEquals(clientsConfig.getClientConfigByDomain("circle.com"), clientsConfig.clients[2])
+    assertEquals(
+      null,
+      clientsConfig.getClientConfigByDomain("unknown"),
+    )
+    assertEquals(clientsConfig.clients[1], clientsConfig.getClientConfigByDomain("lobstr.co"))
+    assertEquals(clientsConfig.clients[2], clientsConfig.getClientConfigByDomain("circle.com"))
   }
 
   @Test
   fun `test ClientsConfig getClientConfigBySigningKey`() {
     assertEquals(clientsConfig.getClientConfigBySigningKey("unknown"), null)
     assertEquals(
+      clientsConfig.clients[1],
       clientsConfig.getClientConfigBySigningKey(
         "GC4HAYCFQYQLJV5SE6FB3LGC37D6XGIXGMAXCXWNBLH7NWW2JH4OZLHQ"
-      ),
-      clientsConfig.clients[1]
+      )
     )
     assertEquals(
+      clientsConfig.clients[2],
       clientsConfig.getClientConfigBySigningKey(
         "GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE"
-      ),
-      clientsConfig.clients[2]
+      )
     )
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/Sep24MoreInfoUrlConstructorTest.kt
@@ -49,15 +49,18 @@ class Sep24MoreInfoUrlConstructorTest {
       ClientConfig(
         "lobstr",
         NONCUSTODIAL,
-        "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-        "lobstr.co",
+        null,
+        setOf("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"),
+        null,
+        setOf("lobstr.co"),
         "https://callback.lobstr.co/api/v2/anchor/callback",
         false,
         null
       )
     every { clientsConfig.getClientConfigByDomain(any()) } returns null
-    every { clientsConfig.getClientConfigByDomain(clientConfig.domain) } returns clientConfig
-    every { clientsConfig.getClientConfigBySigningKey(clientConfig.signingKey) } returns
+    every { clientsConfig.getClientConfigByDomain(clientConfig.domains.first()) } returns
+      clientConfig
+    every { clientsConfig.getClientConfigBySigningKey(clientConfig.signingKeys.first()) } returns
       clientConfig
     every {
       clientsConfig.getClientConfigBySigningKey(
@@ -67,7 +70,9 @@ class Sep24MoreInfoUrlConstructorTest {
       ClientConfig(
         "some-wallet",
         CUSTODIAL,
-        "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        null,
+        setOf("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"),
+        null,
         null,
         null,
         false,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -65,15 +65,18 @@ class SimpleInteractiveUrlConstructorTest {
       ClientConfig(
         "lobstr",
         NONCUSTODIAL,
-        "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO",
-        "lobstr.co",
+        null,
+        setOf("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"),
+        null,
+        setOf("lobstr.co"),
         "https://callback.lobstr.co/api/v2/anchor/callback",
         false,
         null
       )
     every { clientsConfig.getClientConfigByDomain(any()) } returns null
-    every { clientsConfig.getClientConfigByDomain(clientConfig.domain) } returns clientConfig
-    every { clientsConfig.getClientConfigBySigningKey(clientConfig.signingKey) } returns
+    every { clientsConfig.getClientConfigByDomain(clientConfig.domains.first()) } returns
+      clientConfig
+    every { clientsConfig.getClientConfigBySigningKey(clientConfig.signingKeys.first()) } returns
       clientConfig
     every {
       clientsConfig.getClientConfigBySigningKey(
@@ -83,8 +86,10 @@ class SimpleInteractiveUrlConstructorTest {
       ClientConfig(
         "some-wallet",
         CUSTODIAL,
-        "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         null,
+        setOf("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"),
+        null,
+        emptySet(),
         null,
         false,
         null


### PR DESCRIPTION
### Description

- Deprecate `signing_key` and `domain`, replace with `signing_keys` and `domains`
- Remove `signing_key` field for noncustodial client (usage only found in validation)
- Replace the use of `signing_key` and `domain` with `signing_keys` and `domains` in related function and test cases


### Testing

- `./gradlew test`

### Documentation

Will update in https://developers.stellar.org/network/anchor-platform/admin-guide/sep10

