### PR TITLE
[ANCHOR-692] Disable JUnit test parallel execution

### DIFF
--- a/api-schema/build.gradle.kts
+++ b/api-schema/build.gradle.kts
@@ -14,9 +14,4 @@ dependencies {
   annotationProcessor(libs.lombok)
 }
 
-apply(from = "$rootDir/scripts.gradle.kts")
-@Suppress("UNCHECKED_CAST")
-val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
-// Disable for test stability
-//tasks.test { enableTestConcurrency(this) }

--- a/api-schema/build.gradle.kts
+++ b/api-schema/build.gradle.kts
@@ -18,4 +18,5 @@ apply(from = "$rootDir/scripts.gradle.kts")
 @Suppress("UNCHECKED_CAST")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
-tasks.test { enableTestConcurrency(this) }
+// Disable for test stability
+//tasks.test { enableTestConcurrency(this) }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -125,4 +125,5 @@ apply(from = "$rootDir/scripts.gradle.kts")
 @Suppress("UNCHECKED_CAST")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
-tasks.test { enableTestConcurrency(this) }
+// Disable for test stability
+//tasks.test { enableTestConcurrency(this) }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -119,11 +119,3 @@ publishing {
   apply<SigningPlugin>()
   configure<SigningExtension> { sign(publishing.publications) }
 }
-
-apply(from = "$rootDir/scripts.gradle.kts")
-
-@Suppress("UNCHECKED_CAST")
-val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
-
-// Disable for test stability
-//tasks.test { enableTestConcurrency(this) }

--- a/essential-tests/build.gradle.kts
+++ b/essential-tests/build.gradle.kts
@@ -35,15 +35,7 @@ dependencies {
 
 tasks { bootJar { enabled = false } }
 
-// The following is to enable test concurrency
-apply(from = "$rootDir/scripts.gradle.kts")
-@Suppress("UNCHECKED_CAST")
-val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
-
 tasks.test {
-  // Disable for test stability
-
-  // enableTestConcurrency(this)
   exclude("**/org/stellar/anchor/platform/*Test.class")
   exclude("**/org/stellar/anchor/platform/integrationtest/**")
   exclude("**/org/stellar/anchor/platform/e2etest/**")

--- a/essential-tests/build.gradle.kts
+++ b/essential-tests/build.gradle.kts
@@ -41,7 +41,9 @@ apply(from = "$rootDir/scripts.gradle.kts")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
 tasks.test {
-  enableTestConcurrency(this)
+  // Disable for test stability
+
+  // enableTestConcurrency(this)
   exclude("**/org/stellar/anchor/platform/*Test.class")
   exclude("**/org/stellar/anchor/platform/integrationtest/**")
   exclude("**/org/stellar/anchor/platform/e2etest/**")

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
@@ -58,7 +58,7 @@ open class Sep24End2EndTests : AbstractIntegrationTests(TestConfig()) {
       socketTimeoutMillis = 300000
     }
   }
-  private val maxTries = 30
+  private val maxTries = 60
   private val anchorReferenceServerClient =
     AnchorReferenceServerClient(Url(config.env["reference.server.url"]!!))
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
@@ -13,8 +13,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -52,7 +50,6 @@ const val DEPOSIT_FUND_CLIENT_SECRET_1 = "SDNZAK6LCYNR4HYEFBZY3I2KLRDLSCE5RCF6HZ
 const val DEPOSIT_FUND_CLIENT_SECRET_2 = "SCW2SJEPTL4K7FFPFOFABFEFZJCG6LHULWVJX6JLIJ7TYIKTL6P473HM"
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
 open class Sep24End2EndTests : AbstractIntegrationTests(TestConfig()) {
   private val client = HttpClient {
     install(HttpTimeout) {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.fail
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 import org.stellar.anchor.api.callback.SendEventRequest
 import org.stellar.anchor.api.callback.SendEventRequestPayload
 import org.stellar.anchor.api.event.AnchorEvent
@@ -42,7 +40,6 @@ import org.stellar.walletsdk.horizon.SigningKeyPair
 import org.stellar.walletsdk.horizon.sign
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.CONCURRENT)
 open class Sep31End2EndTests : AbstractIntegrationTests(TestConfig()) {
 
   private val gson = GsonUtils.getInstance()

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -9,8 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 import org.stellar.anchor.api.sep.SepTransactionStatus
 import org.stellar.anchor.api.sep.SepTransactionStatus.*
 import org.stellar.anchor.api.sep.sep6.GetTransactionResponse
@@ -28,7 +26,6 @@ import org.stellar.walletsdk.asset.IssuedAssetId
 import org.stellar.walletsdk.horizon.sign
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.CONCURRENT)
 open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
   private val maxTries = 30
   private val anchorReferenceServerClient =

--- a/extended-tests/build.gradle.kts
+++ b/extended-tests/build.gradle.kts
@@ -34,4 +34,5 @@ apply(from = "$rootDir/scripts.gradle.kts")
 @Suppress("UNCHECKED_CAST")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
-tasks.test { exclude("**/org/stellar/anchor/platform/extendedtest/**") }
+// Disable for test stability
+//tasks.test { exclude("**/org/stellar/anchor/platform/extendedtest/**") }

--- a/extended-tests/build.gradle.kts
+++ b/extended-tests/build.gradle.kts
@@ -28,11 +28,4 @@ dependencies {
 
 tasks { bootJar { enabled = false } }
 
-// The following is to enable test concurrency
-apply(from = "$rootDir/scripts.gradle.kts")
-
-@Suppress("UNCHECKED_CAST")
-val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
-
-// Disable for test stability
-//tasks.test { exclude("**/org/stellar/anchor/platform/extendedtest/**") }
+tasks.test { exclude("**/org/stellar/anchor/platform/extendedtest/**") }

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/rpc/RpcEnd2EndTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/rpc/RpcEnd2EndTests.kt
@@ -1,8 +1,5 @@
 package org.stellar.anchor.platform.extendedtest.rpc
 
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.sep.SepTransactionStatus
 import org.stellar.anchor.platform.e2etest.Sep24End2EndTests
@@ -10,13 +7,9 @@ import org.stellar.anchor.platform.e2etest.Sep31End2EndTests
 import org.stellar.anchor.platform.e2etest.Sep6End2EndTest
 
 // use TEST_PROFILE_NAME = "rpc"
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.SAME_THREAD)
 class CustodyRpcSep31End2EndTests : Sep31End2EndTests()
 
 // use TEST_PROFILE_NAME = "rpc"
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.SAME_THREAD)
 class CustodyRpcSep24End2EndTests : Sep24End2EndTests() {
   // These are to override the default expected statuses for RPC configuration
   override fun getExpectedDepositStatus(): List<Pair<AnchorEvent.Type, SepTransactionStatus>> {
@@ -41,6 +34,4 @@ class CustodyRpcSep24End2EndTests : Sep24End2EndTests() {
 }
 
 // use TEST_PROFILE_NAME = "rpc"
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.SAME_THREAD)
 class CustodyRpcSep6End2EndTests : Sep6End2EndTest()

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -61,7 +61,8 @@ apply(from = "$rootDir/scripts.gradle.kts")
 val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
 
 tasks.test {
-  enableTestConcurrency(this)
+  // Disable for test stability
+  // enableTestConcurrency(this)
   testLogging {
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     events = setOf(org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED)

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -56,13 +56,7 @@ dependencies {
   testImplementation(libs.okhttp3.tls)
 }
 
-apply(from = "$rootDir/scripts.gradle.kts")
-@Suppress("UNCHECKED_CAST")
-val enableTestConcurrency = extra["enableTestConcurrency"] as (Test) -> Unit
-
 tasks.test {
-  // Disable for test stability
-  // enableTestConcurrency(this)
   testLogging {
     exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     events = setOf(org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED)


### PR DESCRIPTION
### Description

Disable the Junit concurrency for test stability reason. 

### Context

The tests had been unstable due to the concurrency that fails some of the tests. 

### Testing

- `./gradlew test`
- The workflow is successful for 5 consecutive runs.

### Documentation
NA.

### Known limitations
NA.

