### PR TITLE
Add Futurenet in Network config

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAppConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyAppConfig.java
@@ -1,8 +1,7 @@
 package org.stellar.anchor.platform.config;
 
 import static org.stellar.anchor.util.StringHelper.isEmpty;
-import static org.stellar.sdk.Network.PUBLIC;
-import static org.stellar.sdk.Network.TESTNET;
+import static org.stellar.sdk.Network.*;
 
 import java.util.List;
 import lombok.Data;
@@ -93,6 +92,8 @@ public class PropertyAppConfig implements AppConfig, Validator {
         return TESTNET.getNetworkPassphrase();
       case "PUBLIC":
         return PUBLIC.getNetworkPassphrase();
+      case "FUTURENET":
+        return FUTURENET.getNetworkPassphrase();
       default:
         throw new RuntimeException(
             "Invalid stellar network " + stellarNetwork + ". Please check the configuration.");

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -4,7 +4,6 @@ host_url: http://localhost:8080
 
 stellar_network:
   network: TESTNET
-  network_passphrase: Test SDF Network ; September 2015
   horizon_url: https://horizon-testnet.stellar.org
 
 callback_api:


### PR DESCRIPTION
### Description

Add Futurenet in Network config

### Context

Previously, Futurenet was not supported 

### Testing

- `./gradlew test`


### Documentation

N/A

### Known limitations

N/A

