### PR TITLE
Bump version 2.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,7 +176,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.6.2"
+  version = "2.7.0"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.6.2/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.6.2)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.7.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.7.0)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=2.6.2
+version=2.7.0


### PR DESCRIPTION
### Description

Bumps the version numbers to 2.7.0.

### Context

2.7.0 release

### Testing

- `./gradlew test`