### PR TITLE
[ANCHOR-698] Enable PaymentObservingAccountsManager for SEP-31 only

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -220,6 +220,7 @@ public class SepBeans {
   }
 
   @Bean
+  @ConditionalOnAnySepsEnabled(seps = {"sep31"})
   Sep31DepositInfoGenerator sep31DepositInfoGenerator(
       Sep31Config sep31Config,
       PaymentObservingAccountsManager paymentObservingAccountsManager,

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ObservingAccountsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ObservingAccountsBeans.java
@@ -2,14 +2,28 @@ package org.stellar.anchor.platform.component.share;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountStore;
 import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountsManager;
 
 @Configuration
 public class ObservingAccountsBeans {
+  private final Environment env;
+
+  public ObservingAccountsBeans(Environment env) {
+    this.env = env;
+  }
+
   @Bean
   public PaymentObservingAccountsManager paymentObservingAccountsManager(
       PaymentObservingAccountStore paymentObservingAccountStore) {
-    return new PaymentObservingAccountsManager(paymentObservingAccountStore);
+    PaymentObservingAccountsManager bean =
+        new PaymentObservingAccountsManager(paymentObservingAccountStore);
+
+    if (env.getProperty("sep31.enabled", Boolean.class, false)) {
+      bean.start();
+    }
+
+    return bean;
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -36,8 +36,10 @@ public class PaymentObservingAccountsManager {
               account.getAccount(), account.getLastObserved(), AccountType.TRANSIENT);
       upsert(oa);
     }
+  }
 
-    // Start the eviction task
+  public void start() {
+    Log.debug("Start the eviction task...");
     ScheduledExecutorService scheduler = DaemonExecutors.newScheduledThreadPool(1);
     scheduler.scheduleAtFixedRate(
         this::evictAndPersist, 60, getEvictPeriod().getSeconds(), TimeUnit.SECONDS);


### PR DESCRIPTION
### Description

This PR add check to `ObservingAccountsBeans ` to check if SEP-31 is enabled. In this case the bean is always created, but only activate if SEP-31 is enabled.

This is because this bean is required in the presence for the creation of `PaymentObserverBeans`. We can't simply use conditional annotation that disable the bean's creation

### Context

The PaymentObseringAccountManager should only be restarted when needed. Currently only SEP-31 requires the service.

### Testing

- `./gradlew test`

