### PR TITLE
[ANCHOR-695] Add missing `idType` to `JdbcSep24RefundPayment`

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           docker run --network host -v /home/runner/java-stellar-anchor-sdk/platform/src/test/resources://config stellar/anchor-tests:v0.6.10 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
-      - name: Upload Essential Tests Report
+      - name: Upload Essential Tests report
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24RefundPayment.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24RefundPayment.java
@@ -12,6 +12,16 @@ public interface Sep24RefundPayment {
   String getId();
 
   void setId(String id);
+
+  /**
+   * "stellar" or "external".
+   *
+   * @return the idType field.
+   */
+  String getIdType();
+
+  void setIdType(String idType);
+
   /**
    * The amount sent back to the user for the payment identified by id, in units of amount_in_asset.
    *
@@ -38,6 +48,7 @@ public interface Sep24RefundPayment {
 
     Sep24RefundPayment refundPayment = factory.newRefundPayment();
     refundPayment.setId(platformApiRefundPayment.getId());
+    refundPayment.setIdType(platformApiRefundPayment.getIdType().toString());
     refundPayment.setAmount(platformApiRefundPayment.getAmount().getAmount());
     refundPayment.setFee(platformApiRefundPayment.getFee().getAmount());
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
@@ -334,6 +334,7 @@ private const val patchWithdrawTransactionRequest =
           "payments": [
             {
               "id": 1,
+              "id_type": "stellar",
               "amount": {
                 "amount": "0.6",
                 "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
@@ -345,6 +346,7 @@ private const val patchWithdrawTransactionRequest =
             },
             {
               "id": 2,
+              "id_type": "stellar",
               "amount": {
                 "amount": "0.4",
                 "asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24RefundPayment.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24RefundPayment.java
@@ -14,6 +14,7 @@ import org.stellar.anchor.sep24.Sep24RefundPayment;
 @NoArgsConstructor
 public class JdbcSep24RefundPayment implements Sep24RefundPayment {
   String id;
+  String idType;
   String amount;
   String fee;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -172,7 +172,7 @@ public class ClientStatusCallbackHandler extends EventHandler {
                     payment.setAmount(refundPayment.getAmount().getAmount());
                     payment.setFee(refundPayment.getFee().getAmount());
                     payment.setId(refundPayment.getId());
-
+                    payment.setIdType(refundPayment.getIdType().toString());
                     return payment;
                   })
               .collect(Collectors.toList());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandler.java
@@ -260,6 +260,7 @@ public class NotifyRefundPendingHandler extends RpcMethodHandler<NotifyRefundPen
         Sep24RefundPayment refundPayment =
             JdbcSep24RefundPayment.builder()
                 .id(requestRefund.getId())
+                .idType(RefundPayment.IdType.EXTERNAL.toString())
                 .amount(requestRefund.getAmount().getAmount())
                 .fee(requestRefund.getAmountFee().getAmount())
                 .build();

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyRefundSentHandler.java
@@ -375,14 +375,17 @@ public class NotifyRefundSentHandler extends RpcMethodHandler<NotifyRefundSentRe
           txn6.setRefunds(refunds);
           break;
         case SEP_24:
+          JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+          boolean isTxn24Deposit =
+              ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn24.getKind()));
           Sep24RefundPayment sep24RefundPayment =
               JdbcSep24RefundPayment.builder()
                   .id(requestRefund.getId())
+                  .idType(isTxn24Deposit ? EXTERNAL.toString() : STELLAR.toString())
                   .amount(requestRefund.getAmount().getAmount())
                   .fee(requestRefund.getAmountFee().getAmount())
                   .build();
 
-          JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
           Sep24Refunds sep24Refunds = txn24.getRefunds();
           if (sep24Refunds == null) {
             sep24Refunds = new JdbcSep24Refunds();

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/DoStellarRefundHandlerTest.kt
@@ -355,6 +355,7 @@ class DoStellarRefundHandlerTest {
 
     val payment = JdbcSep24RefundPayment()
     payment.id = "1"
+    payment.idType = RefundPayment.IdType.STELLAR.toString()
     payment.amount = "0.1"
     payment.fee = "0"
     val refunds = JdbcSep24Refunds()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundPendingHandlerTest.kt
@@ -297,6 +297,7 @@ class NotifyRefundPendingHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment = JdbcSep24RefundPayment()
     payment.id = request.refund.id
+    payment.idType = RefundPayment.IdType.EXTERNAL.toString()
     payment.amount = request.refund.amount.amount
     payment.fee = request.refund.amountFee.amount
 
@@ -408,6 +409,7 @@ class NotifyRefundPendingHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment = JdbcSep24RefundPayment()
     payment.id = request.refund.id
+    payment.idType = RefundPayment.IdType.EXTERNAL.toString()
     payment.amount = request.refund.amount.amount
     payment.fee = request.refund.amountFee.amount
     val refunds = JdbcSep24Refunds()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyRefundSentHandlerTest.kt
@@ -6,6 +6,7 @@ import io.mockk.impl.annotations.MockK
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.bouncycastle.jcajce.provider.asymmetric.EXTERNAL
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -326,6 +327,7 @@ class NotifyRefundSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val payment = JdbcSep24RefundPayment()
     payment.id = "1"
+    payment.idType = IdType.EXTERNAL.toString()
     payment.amount = "1"
     payment.fee = "0"
 
@@ -373,6 +375,7 @@ class NotifyRefundSentHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment = JdbcSep24RefundPayment()
     payment.id = request.refund.id
+    payment.idType = IdType.EXTERNAL.toString()
     payment.amount = request.refund.amount.amount
     payment.fee = request.refund.amountFee.amount
 
@@ -484,10 +487,12 @@ class NotifyRefundSentHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment1 = JdbcSep24RefundPayment()
     payment1.id = "1"
+    payment1.idType = IdType.EXTERNAL.toString()
     payment1.amount = "1"
     payment1.fee = "0.1"
     val payment2 = JdbcSep24RefundPayment()
     payment2.id = request.refund.id
+    payment2.idType = IdType.EXTERNAL.toString()
     payment2.amount = request.refund.amount.amount
     payment2.fee = request.refund.amountFee.amount
     val refunds = JdbcSep24Refunds()
@@ -614,6 +619,7 @@ class NotifyRefundSentHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment = JdbcSep24RefundPayment()
     payment.id = "1"
+    payment.idType = IdType.EXTERNAL.toString()
     payment.amount = "1"
     payment.fee = "0"
 
@@ -719,6 +725,7 @@ class NotifyRefundSentHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment = JdbcSep24RefundPayment()
     payment.id = "1"
+    payment.idType = IdType.EXTERNAL.toString()
     payment.amount = "1"
     payment.fee = "0.1"
     val refunds = JdbcSep24Refunds()
@@ -835,10 +842,12 @@ class NotifyRefundSentHandlerTest {
     val anchorEventCapture = slot<AnchorEvent>()
     val payment1 = JdbcSep24RefundPayment()
     payment1.id = request.refund.id
+    payment1.idType = IdType.EXTERNAL.toString()
     payment1.amount = "1"
     payment1.fee = "0.1"
     val payment2 = JdbcSep24RefundPayment()
     payment2.id = "2"
+    payment2.idType = IdType.EXTERNAL.toString()
     payment2.amount = "0.1"
     payment2.fee = "0"
     val refunds = JdbcSep24Refunds()
@@ -878,10 +887,12 @@ class NotifyRefundSentHandlerTest {
     expectedRefunds.amountFee = "0.2"
     val expectedPayment1 = JdbcSep24RefundPayment()
     expectedPayment1.id = request.refund.id
+    expectedPayment1.idType = IdType.EXTERNAL.toString()
     expectedPayment1.amount = "1.5"
     expectedPayment1.fee = "0.2"
     val expectedPayment2 = JdbcSep24RefundPayment()
     expectedPayment2.id = "2"
+    expectedPayment2.idType = IdType.EXTERNAL.toString()
     expectedPayment2.amount = "0.1"
     expectedPayment2.fee = "0"
     expectedRefunds.payments = listOf(expectedPayment2, expectedPayment1)
@@ -967,6 +978,7 @@ class NotifyRefundSentHandlerTest {
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val payment = JdbcSep24RefundPayment()
     payment.id = "1"
+    payment.idType = IdType.EXTERNAL.toString()
     payment.amount = "1"
     payment.fee = "0.1"
     val refunds = JdbcSep24Refunds()


### PR DESCRIPTION
### Description

As title

### Context

id_type is part of refunds' payments object schema
However, it’s missing in JdbcSep24RefundPayment object

### Testing

- `./gradlew test

### Known limitations

Right now SEP6/24/31 are using different pattern for refund payment and that should be unified

