### PR TITLE
Remove version from docker-compose YAMLs

### DIFF
--- a/service-runner/src/main/resources/common/docker-compose.yaml
+++ b/service-runner/src/main/resources/common/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   platform:
     image: anchor-platform:local

--- a/service-runner/src/main/resources/docker-compose-test.yaml
+++ b/service-runner/src/main/resources/docker-compose-test.yaml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   kafka:
     hostname: kafka

--- a/service-runner/src/main/resources/docker-compose.yaml
+++ b/service-runner/src/main/resources/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2.4'
 services:
   platform:
     extends:


### PR DESCRIPTION
### Description

This removes the version field from the docker compose YAMLs.

### Context

This field is obsolete and is preventing the `TestProfileRunner` from starting up the dependencies.

```
Exception in thread "main" com.palantir.docker.compose.execution.DockerExecutionException: 'docker-compose ps -q time="2024-06-10T15:15:34-04:00" level=warning msg="/Users/philipliu/Documents/work/java-stellar-anchor-sdk/service-runner/out/production/resources/docker-compose-test.yaml: `version` is obsolete"' returned exit code 1
The output was:
time="2024-06-10T15:15:34-04:00" level=warning msg="/Users/philipliu/Documents/work/java-stellar-anchor-sdk/service-runner/out/production/resources/docker-compose-test.yaml: `version` is obsolete"
no such service: time="2024-06-10T15:15:34-04:00" level=warning msg="/Users/philipliu/Documents/work/java-stellar-anchor-sdk/service-runner/out/production/resources/docker-compose-test.yaml: `version` is obsolete"
```


### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

