### PR TITLE
[ANCHOR-712] Add transaction_id field to SEP-12 PUT/GET requests

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/GetCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/GetCustomerRequest.java
@@ -20,6 +20,9 @@ public class GetCustomerRequest {
   String account;
   String memo;
 
+  @SerializedName("transaction_id")
+  String transactionId;
+
   @SerializedName("memo_type")
   String memoType;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/PutCustomerRequest.java
@@ -22,6 +22,9 @@ public class PutCustomerRequest {
   String account;
   String memo;
 
+  @SerializedName("transaction_id")
+  String transactionId;
+
   @SerializedName("memo_type")
   String memoType;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12GetCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12GetCustomerRequest.java
@@ -18,6 +18,9 @@ public class Sep12GetCustomerRequest implements Sep12CustomerRequestBase {
   String account;
   String memo;
 
+  @SerializedName("transaction_id")
+  String transactionId;
+
   @SerializedName("memo_type")
   String memoType;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12PutCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12PutCustomerRequest.java
@@ -18,6 +18,9 @@ public class Sep12PutCustomerRequest implements Sep12CustomerRequestBase {
   String account;
   String memo;
 
+  @SerializedName("transaction_id")
+  String transactionId;
+
   @SerializedName("memo_type")
   String memoType;
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCRepository.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCRepository.kt
@@ -1,0 +1,63 @@
+package org.stellar.reference.dao
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.reference.model.TransactionKYC
+
+interface TransactionKYCRepository {
+  fun get(transactionId: String): TransactionKYC?
+
+  fun create(transactionKYC: TransactionKYC)
+
+  fun update(transactionId: String, requiredFields: String, customerId: String?)
+
+  fun delete(transactionId: String)
+}
+
+class JdbcTransactionKYCRepository(private val db: Database) : TransactionKYCRepository {
+  init {
+    transaction(db) { SchemaUtils.create(TransactionKYCs) }
+  }
+
+  override fun get(transactionId: String): TransactionKYC? =
+    transaction(db) {
+        TransactionKYCs.select { TransactionKYCs.transactionId.eq(transactionId) }
+          .mapNotNull {
+            TransactionKYC(
+              transactionId = it[TransactionKYCs.transactionId],
+              customerId = it[TransactionKYCs.customerId],
+              requiredFields =
+                GsonUtils.getInstance()
+                  .fromJson<List<String>>(it[TransactionKYCs.requiredFields], List::class.java),
+            )
+          }
+      }
+      .singleOrNull()
+
+  override fun create(transactionKYC: TransactionKYC) {
+    transaction(db) {
+      TransactionKYCs.insert {
+        it[transactionId] = transactionKYC.transactionId
+        it[customerId] = transactionKYC.customerId
+        it[requiredFields] = GsonUtils.getInstance().toJson(transactionKYC.requiredFields)
+      }
+    }
+  }
+
+  override fun update(transactionId: String, requiredFields: String, customerId: String?) {
+    transaction(db) {
+      TransactionKYCs.update({ TransactionKYCs.transactionId.eq(transactionId) }) {
+        it[TransactionKYCs.customerId] = customerId
+        it[TransactionKYCs.requiredFields] = requiredFields
+      }
+    }
+  }
+
+  override fun delete(transactionId: String) {
+    transaction(db) {
+      TransactionKYCs.deleteWhere { TransactionKYCs.transactionId.eq(transactionId) }
+    }
+  }
+}

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCs.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCs.kt
@@ -1,0 +1,10 @@
+package org.stellar.reference.dao
+
+import org.jetbrains.exposed.sql.Table
+
+/** Exposed table for the TransactionKYC model. */
+object TransactionKYCs : Table() {
+  val transactionId = text("transaction_id").uniqueIndex()
+  val customerId = text("customer_id").index().nullable()
+  val requiredFields = text("required_fields").nullable()
+}

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
@@ -10,6 +10,7 @@ import org.stellar.reference.callbacks.uniqueaddress.UniqueAddressService
 import org.stellar.reference.client.PlatformClient
 import org.stellar.reference.dao.JdbcCustomerRepository
 import org.stellar.reference.dao.JdbcQuoteRepository
+import org.stellar.reference.dao.JdbcTransactionKYCRepository
 import org.stellar.reference.event.EventService
 import org.stellar.reference.sep24.DepositService
 import org.stellar.reference.sep24.WithdrawalService
@@ -30,11 +31,12 @@ object ServiceContainer {
       "jdbc:postgresql://${config.dataSettings.url}/${config.dataSettings.database}",
       driver = "org.postgresql.Driver",
       user = config.dataSettings.user,
-      password = config.dataSettings.password
+      password = config.dataSettings.password,
     )
   private val customerRepo = JdbcCustomerRepository(database)
+  private val transactionKYCRepo = JdbcTransactionKYCRepository(database)
   private val quotesRepo = JdbcQuoteRepository(database)
-  val customerService = CustomerService(customerRepo)
+  val customerService = CustomerService(customerRepo, transactionKYCRepo)
   val feeService = FeeService(customerRepo)
   val rateService = RateService(quotesRepo)
   val uniqueAddressService = UniqueAddressService(config.appSettings)
@@ -48,6 +50,6 @@ object ServiceContainer {
           socketTimeoutMillis = 5000
         }
       },
-      config.appSettings.platformApiEndpoint
+      config.appSettings.platformApiEndpoint,
     )
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/TransactionKYC.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/TransactionKYC.kt
@@ -1,0 +1,9 @@
+package org.stellar.reference.model
+
+import kotlinx.serialization.SerialName
+
+data class TransactionKYC(
+  @SerialName("transaction_id") val transactionId: String,
+  @SerialName("customer_id") val customerId: String? = null,
+  @SerialName("required_fields") val requiredFields: List<String> = emptyList(),
+)


### PR DESCRIPTION
### Description

This adds the `transaction_id` fields to the SEP-12 GET/PUT endpoints. This also updates the Customer callback implementation to return different required fields if the transaction requires additional fields. The required fields will be determined by a transaction "classifier" service, which creates records in the KYC table whenever a transaction requires additional KYC.

This implementation assumes that the KYC information is shared across all customer transactions. This means that the `transaction_id` is ignored by PUT /customer callback as KYC.

### Context

This is to support the new SEP-12 protocol and SEP-6 KYC flows. A separate PR will update the flows and tests.

### Testing

- `./gradlew test`

### Documentation

Customer callback documentation will be updated with the `transaction_id` field.

### Known limitations

N/A

