### PR TITLE
Temporarily disable extended tests

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -24,7 +24,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [ gradle_build, essential_tests, extended_tests, jacoco_report, codeql_analysis ]
+    needs: [ gradle_build, essential_tests, jacoco_report, codeql_analysis ]
     runs-on: ubuntu-22.04
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -15,10 +15,6 @@ jobs:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
 
-  extended_tests:
-    needs: [ gradle_build ]
-    uses: ./.github/workflows/sub_extended_tests.yml
-
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml
 


### PR DESCRIPTION
### Description

This PR temporarily disables extended tests.

### Context

The custody API tests depend on Circle USDC, which was not issued when creating this PR. They will be re-enabled when Circle USDC is available.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

