### PR TITLE
Disable extended tests on develop merge

### DIFF
--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -22,16 +22,12 @@ jobs:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
 
-  extended_tests:
-    needs: [ gradle_build ]
-    uses: ./.github/workflows/sub_extended_tests.yml
-
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml
 
   build_and_push_docker_image:
     name: Push to DockerHub
-    needs: [ gradle_build, essential_tests, extended_tests, codeql_analysis ]
+    needs: [ gradle_build, essential_tests, codeql_analysis ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description

This disables extended tests on `develop` merge as well.

### Context

The tests have been disabled for PR builds but also should be disabled on `develop` builds until Circle USDC is available.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

