### PR TITLE
[ANCHOR-715] Update SEP-6 test with new KYC flow

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -111,9 +111,11 @@ public class PlatformTransactionData {
   @SerializedName("required_info_updates")
   List<String> requiredInfoUpdates;
 
+  @Deprecated
   @SerializedName("required_customer_info_message")
   String requiredCustomerInfoMessage;
 
+  @Deprecated
   @SerializedName("required_customer_info_updates")
   List<String> requiredCustomerInfoUpdates;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
@@ -16,9 +16,11 @@ import org.stellar.anchor.api.rpc.method.features.SupportsUserActionRequiredBy;
 public class RequestCustomerInfoUpdateRequest extends RpcMethodParamsRequest
     implements SupportsUserActionRequiredBy {
 
+  @Deprecated
   @SerializedName("required_customer_info_message")
   private String requiredCustomerInfoMessage;
 
+  @Deprecated
   @SerializedName("required_customer_info_updates")
   private List<String> requiredCustomerInfoUpdates;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12CustomerRequestBase.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12CustomerRequestBase.java
@@ -14,4 +14,8 @@ public interface Sep12CustomerRequestBase {
   String getMemoType();
 
   void setMemoType(String memoType);
+
+  String getTransactionId();
+
+  void setTransactionId(String transactionId);
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/Sep6TransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/Sep6TransactionResponse.java
@@ -97,9 +97,11 @@ public class Sep6TransactionResponse {
   @SerializedName("required_info_updates")
   List<String> requiredInfoUpdates;
 
+  @Deprecated
   @SerializedName("required_customer_info_message")
   String requiredCustomerInfoMessage;
 
+  @Deprecated
   @SerializedName("required_customer_info_updates")
   List<String> requiredCustomerInfoUpdates;
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,6 @@ subprojects {
     maven { url = uri("https://packages.confluent.io/maven") }
     maven { url = uri("https://repository.mulesoft.org/nexus/content/repositories/public/") }
     maven { url = uri("https://jitpack.io") }
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 
   /** Specifies JDK-17 */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ subprojects {
     maven { url = uri("https://packages.confluent.io/maven") }
     maven { url = uri("https://repository.mulesoft.org/nexus/content/repositories/public/") }
     maven { url = uri("https://jitpack.io") }
+    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
   }
 
   /** Specifies JDK-17 */

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -20,7 +20,9 @@ import org.stellar.anchor.api.callback.*;
 import org.stellar.anchor.api.event.AnchorEvent;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.platform.CustomerUpdatedResponse;
+import org.stellar.anchor.api.platform.GetTransactionResponse;
 import org.stellar.anchor.api.sep.sep12.*;
+import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.event.EventService;
@@ -39,11 +41,13 @@ public class Sep12Service {
 
   private final Set<String> knownTypes;
 
+  private final PlatformApiClient platformApiClient;
   private final EventService.Session eventSession;
 
   public Sep12Service(
       CustomerIntegration customerIntegration,
       AssetService assetService,
+      PlatformApiClient platformApiClient,
       EventService eventService) {
     this.customerIntegration = customerIntegration;
     Stream<String> receiverTypes =
@@ -55,6 +59,7 @@ public class Sep12Service {
             .filter(x -> x.getSep31() != null)
             .flatMap(x -> x.getSep31().getSep12().getSender().getTypes().keySet().stream());
     this.knownTypes = Stream.concat(receiverTypes, senderTypes).collect(Collectors.toSet());
+    this.platformApiClient = platformApiClient;
     this.eventSession =
         eventService.createSession(this.getClass().getName(), EventService.EventQueue.TRANSACTION);
 
@@ -168,6 +173,16 @@ public class Sep12Service {
 
   void validateGetOrPutRequest(Sep12CustomerRequestBase requestBase, Sep10Jwt token)
       throws SepException {
+    if (requestBase.getTransactionId() != null) {
+      try {
+        GetTransactionResponse txn =
+            platformApiClient.getTransaction(requestBase.getTransactionId());
+        requestBase.setAccount(txn.getCustomers().getSender().getAccount());
+        requestBase.setMemo(txn.getCustomers().getSender().getMemo());
+      } catch (Exception e) {
+        throw new SepNotAuthorizedException("The transaction specified does not exist");
+      }
+    }
     validateRequestAndTokenAccounts(requestBase, token);
     validateRequestAndTokenMemos(requestBase, token);
     updateRequestMemoAndMemoType(requestBase, token);

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -14,12 +14,16 @@ import org.stellar.anchor.api.callback.*
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.platform.CustomerUpdatedResponse
+import org.stellar.anchor.api.platform.GetTransactionResponse
 import org.stellar.anchor.api.sep.sep12.Sep12CustomerRequestBase
 import org.stellar.anchor.api.sep.sep12.Sep12GetCustomerRequest
 import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
 import org.stellar.anchor.api.sep.sep12.Sep12Status
 import org.stellar.anchor.api.shared.CustomerField
+import org.stellar.anchor.api.shared.Customers
 import org.stellar.anchor.api.shared.ProvidedCustomerField
+import org.stellar.anchor.api.shared.StellarId
+import org.stellar.anchor.apiclient.PlatformApiClient
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.Sep10Jwt
@@ -84,6 +88,7 @@ class Sep12ServiceTest {
   private lateinit var sep12Service: Sep12Service
   @MockK(relaxed = true) private lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) private lateinit var assetService: AssetService
+  @MockK(relaxed = true) private lateinit var platformApiClient: PlatformApiClient
   @MockK(relaxed = true) private lateinit var eventService: EventService
   @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
 
@@ -97,7 +102,7 @@ class Sep12ServiceTest {
     every { assetService.listAllAssets() } returns assets
     every { eventService.createSession(any(), any()) } returns eventSession
 
-    sep12Service = Sep12Service(customerIntegration, assetService, eventService)
+    sep12Service = Sep12Service(customerIntegration, assetService, platformApiClient, eventService)
   }
 
   @Test
@@ -169,6 +174,30 @@ class Sep12ServiceTest {
     jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
     every { mockRequestBase.memo } returns TEST_MEMO
     assertDoesNotThrow { sep12Service.validateRequestAndTokenMemos(mockRequestBase, jwtToken) }
+  }
+
+  @Test
+  fun `test get and put sets request account and memo using transaction`() {
+    val transaction =
+      GetTransactionResponse.builder()
+        .customers(
+          Customers.builder()
+            .sender(StellarId.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).build())
+            .build()
+        )
+        .build()
+    every { platformApiClient.getTransaction(any()) } returns transaction
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val putRequestBase = Sep12PutCustomerRequest.builder().transactionId("id").build()
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(putRequestBase, jwtToken) }
+    assertEquals(TEST_ACCOUNT, putRequestBase.account)
+    assertEquals(TEST_MEMO, putRequestBase.memo)
+
+    val getRequestBase = Sep12GetCustomerRequest.builder().transactionId("id").build()
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(getRequestBase, jwtToken) }
+    assertEquals(TEST_ACCOUNT, getRequestBase.account)
+    assertEquals(TEST_MEMO, getRequestBase.memo)
   }
 
   @Test
@@ -272,7 +301,7 @@ class Sep12ServiceTest {
     assertEquals(AnchorEvent.Type.CUSTOMER_UPDATED, kycUpdateEventSlot.captured.type)
     assertEquals(
       CustomerUpdatedResponse(mockCallbackApiPutCustomerResponse.id),
-      kycUpdateEventSlot.captured.customer
+      kycUpdateEventSlot.captured.customer,
     )
 
     // validate the response

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -63,7 +63,8 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+    val customer =
+      anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
 
     val deposit =
       sep6Client.deposit(
@@ -79,7 +80,13 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
 
     // Supply missing KYC info to continue with the transaction
     val additionalRequiredFields =
-      sep6Client.getTransaction(mapOf("id" to deposit.id)).transaction.requiredCustomerInfoUpdates
+      anchor
+        .customer(token)
+        .get(id = customer.id, memo = memo, transactionId = deposit.id)
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
     anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! }, memo)
     Log.info("Submitted additional KYC info: $additionalRequiredFields")
     Log.info("Bank transfer complete")
@@ -127,7 +134,8 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+    val customer =
+      anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
 
     val withdraw =
       sep6Client.withdraw(
@@ -138,7 +146,13 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
 
     // Supply missing financial account info to continue with the transaction
     val additionalRequiredFields =
-      sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction.requiredCustomerInfoUpdates
+      anchor
+        .customer(token)
+        .get(id = customer.id, memo = memo, transactionId = withdraw.id)
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
     anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! }, memo)
     Log.info("Submitted additional KYC info: $additionalRequiredFields")
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -82,7 +82,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val additionalRequiredFields =
       anchor
         .customer(token)
-        .get(id = customer.id, memo = memo, transactionId = deposit.id)
+        .get(transactionId = deposit.id)
         .fields
         ?.filter { it.key != null && it.value?.optional == false }
         ?.map { it.key!! }
@@ -148,7 +148,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val additionalRequiredFields =
       anchor
         .customer(token)
-        .get(id = customer.id, memo = memo, transactionId = withdraw.id)
+        .get(transactionId = withdraw.id)
         .fields
         ?.filter { it.key != null && it.value?.optional == false }
         ?.map { it.key!! }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ aws-java-sdk-s3 = "1.12.342"
 sqlite-jdbc = "3.43.2.2"
 slf4j = "1.7.35"
 slf4j2 = "2.0.13"
-stellar-wallet-sdk = "1.4.0"
+stellar-wallet-sdk = "1.7.0-SNAPSHOT"
 toml4j = "0.7.2"
 tomcat-embed-core = "9.0.87"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ aws-java-sdk-s3 = "1.12.342"
 sqlite-jdbc = "3.43.2.2"
 slf4j = "1.7.35"
 slf4j2 = "2.0.13"
-stellar-wallet-sdk = "1.7.0-SNAPSHOT"
+stellar-wallet-sdk = "1.7.0"
 toml4j = "0.7.2"
 tomcat-embed-core = "9.0.87"
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
@@ -30,6 +30,7 @@ fun Route.customer(customerService: CustomerService) {
             .account(call.parameters["account"])
             .memo(call.parameters["memo"])
             .memoType(call.parameters["memo_type"])
+            .transactionId(call.parameters["transaction_id"])
             .type(call.parameters["type"])
             .lang(call.parameters["lang"])
             .build()

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -15,6 +15,7 @@ import org.stellar.reference.dao.CustomerRepository
 import org.stellar.reference.dao.TransactionKYCRepository
 import org.stellar.reference.log
 import org.stellar.reference.model.Customer
+import org.stellar.reference.model.TransactionKYC
 
 class CustomerService(
   private val customerRepository: CustomerRepository,
@@ -41,6 +42,7 @@ class CustomerService(
       }
     if (request.transactionId != null) {
       val transactionKYC = transactionKYCRepository.get(request.transactionId)
+      log.info { "Transaction KYC: $transactionKYC" }
       if (transactionKYC != null) {
         return convertCustomerToResponse(customer, request.type, transactionKYC.requiredFields)
       }
@@ -166,6 +168,11 @@ class CustomerService(
       )
       return PutCustomerResponse(id)
     }
+  }
+
+  fun requestKycForTransaction(id: String, requiredFields: List<String>) {
+    val kyc = TransactionKYC(id, null, requiredFields)
+    transactionKYCRepository.create(kyc)
   }
 
   fun deleteCustomer(id: String) {

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -170,8 +170,11 @@ class CustomerService(
     }
   }
 
-  fun requestKycForTransaction(id: String, requiredFields: List<String>) {
-    val kyc = TransactionKYC(id, null, requiredFields)
+  fun requestAdditionalFieldsForTransaction(id: String, requiredFields: List<String>) {
+    val kyc = TransactionKYC(id, requiredFields)
+    if (transactionKYCRepository.get(id) != null) {
+      transactionKYCRepository.delete(id)
+    }
     transactionKYCRepository.create(kyc)
   }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -42,7 +42,6 @@ class CustomerService(
       }
     if (request.transactionId != null) {
       val transactionKYC = transactionKYCRepository.get(request.transactionId)
-      log.info { "Transaction KYC: $transactionKYC" }
       if (transactionKYC != null) {
         return convertCustomerToResponse(customer, request.type, transactionKYC.requiredFields)
       }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerService.kt
@@ -16,14 +16,35 @@ import org.stellar.reference.dao.TransactionKYCRepository
 import org.stellar.reference.log
 import org.stellar.reference.model.Customer
 import org.stellar.reference.model.TransactionKYC
+import org.stellar.reference.service.SepHelper
 
 class CustomerService(
   private val customerRepository: CustomerRepository,
   private val transactionKYCRepository: TransactionKYCRepository,
+  private val sepHelper: SepHelper,
 ) {
-  fun getCustomer(request: GetCustomerRequest): GetCustomerResponse {
+  suspend fun getCustomer(request: GetCustomerRequest): GetCustomerResponse {
     val customer =
       when {
+        // FIXME: This implementation relies on transaction.customer.sender account and memo to be
+        // set which means it only works for SEP-6 transactions.
+        request.transactionId != null -> {
+          val transaction = sepHelper.getTransaction(request.transactionId)
+          val sender = transaction.customers!!.sender
+          val memoType = if (sender!!.memo != null) "id" else null
+
+          val customer =
+            customerRepository.get(sender.account!!, sender.memo, memoType)
+              ?: Customer(stellarAccount = sender.account, memo = sender.memo, memoType = memoType)
+
+          // Determine if this transaction requires additional fields
+          val transactionKYC = transactionKYCRepository.get(request.transactionId)
+          if (transactionKYC != null) {
+            return convertCustomerToResponse(customer, request.type, transactionKYC.requiredFields)
+          }
+
+          customer
+        }
         request.id != null -> {
           customerRepository.get(request.id)
             ?: throw NotFoundException("customer for 'id' '${request.id}' not found", request.id)
@@ -40,12 +61,6 @@ class CustomerService(
           throw BadRequestException("Either id or account must be provided")
         }
       }
-    if (request.transactionId != null) {
-      val transactionKYC = transactionKYCRepository.get(request.transactionId)
-      if (transactionKYC != null) {
-        return convertCustomerToResponse(customer, request.type, transactionKYC.requiredFields)
-      }
-    }
     return convertCustomerToResponse(customer, request.type, emptyList())
   }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCRepository.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCRepository.kt
@@ -27,7 +27,6 @@ class JdbcTransactionKYCRepository(private val db: Database) : TransactionKYCRep
           .mapNotNull {
             TransactionKYC(
               transactionId = it[TransactionKYCs.transactionId],
-              customerId = it[TransactionKYCs.customerId],
               requiredFields =
                 GsonUtils.getInstance()
                   .fromJson<List<String>>(it[TransactionKYCs.requiredFields], List::class.java),
@@ -40,7 +39,6 @@ class JdbcTransactionKYCRepository(private val db: Database) : TransactionKYCRep
     transaction(db) {
       TransactionKYCs.insert {
         it[transactionId] = transactionKYC.transactionId
-        it[customerId] = transactionKYC.customerId
         it[requiredFields] = GsonUtils.getInstance().toJson(transactionKYC.requiredFields)
       }
     }
@@ -49,7 +47,6 @@ class JdbcTransactionKYCRepository(private val db: Database) : TransactionKYCRep
   override fun update(transactionId: String, requiredFields: String, customerId: String?) {
     transaction(db) {
       TransactionKYCs.update({ TransactionKYCs.transactionId.eq(transactionId) }) {
-        it[TransactionKYCs.customerId] = customerId
         it[TransactionKYCs.requiredFields] = requiredFields
       }
     }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCs.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/dao/TransactionKYCs.kt
@@ -5,6 +5,5 @@ import org.jetbrains.exposed.sql.Table
 /** Exposed table for the TransactionKYC model. */
 object TransactionKYCs : Table() {
   val transactionId = text("transaction_id").uniqueIndex()
-  val customerId = text("customer_id").index().nullable()
   val requiredFields = text("required_fields").nullable()
 }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -18,8 +18,14 @@ data class Transaction(
   @SerialName("memo_type") val memoType: String? = null,
   @SerialName("source_account") var sourceAccount: String? = null,
   @SerialName("destination_account") var destinationAccount: String? = null,
-  @SerialName("stellar_transactions") val stellarTransactions: List<StellarTransaction>? = null
+  @SerialName("stellar_transactions") val stellarTransactions: List<StellarTransaction>? = null,
+  val customers: Customers? = null,
 )
+
+@Serializable data class Customers(val sender: StellarId?, val receiver: StellarId?)
+
+@Serializable
+data class StellarId(val id: String? = null, val account: String? = null, val memo: String? = null)
 
 @Serializable data class PatchTransactionsRequest(val records: List<PatchTransactionRecord>)
 
@@ -43,7 +49,7 @@ data class RpcResponse(
   val id: String,
   val jsonrpc: String,
   @Contextual val result: Any?,
-  @Contextual val error: Any?
+  @Contextual val error: Any?,
 )
 
 @Serializable
@@ -51,7 +57,7 @@ data class RpcRequest(
   val id: String,
   val jsonrpc: String,
   val method: String,
-  val params: RpcActionParamsRequest
+  val params: RpcActionParamsRequest,
 )
 
 @Serializable
@@ -68,7 +74,7 @@ data class RequestOffchainFundsRequest(
   @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
   @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
   @SerialName("amount_expected") val amountExpected: AmountRequest? = null,
-  @SerialName("instructions") val instructions: Map<String, InstructionField>? = null
+  @SerialName("instructions") val instructions: Map<String, InstructionField>? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -78,7 +84,7 @@ data class RequestOnchainFundsRequest(
   @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
   @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
   @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
-  @SerialName("amount_expected") val amountExpected: AmountRequest? = null
+  @SerialName("amount_expected") val amountExpected: AmountRequest? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -87,14 +93,14 @@ data class RequestCustomerInfoUpdateHandler(
   override val message: String?,
   @SerialName("required_customer_info_message") val requiredCustomerInfoMessage: String? = null,
   @SerialName("required_customer_info_updates")
-  val requiredCustomerInfoUpdates: List<String>? = null
+  val requiredCustomerInfoUpdates: List<String>? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
 data class NotifyOnchainFundsSentRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("stellar_transaction_id") val stellarTransactionId: String
+  @SerialName("stellar_transaction_id") val stellarTransactionId: String,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -105,21 +111,21 @@ data class NotifyOffchainFundsReceivedRequest(
   @SerialName("external_transaction_id") val externalTransactionId: String? = null,
   @SerialName("amount_in") val amountIn: AmountAssetRequest? = null,
   @SerialName("amount_out") val amountOut: AmountAssetRequest? = null,
-  @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null
+  @SerialName("amount_fee") val amountFee: AmountAssetRequest? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
 data class NotifyOffchainFundsAvailableRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("external_transaction_id") val externalTransactionId: String? = null
+  @SerialName("external_transaction_id") val externalTransactionId: String? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
 data class NotifyOffchainFundsPendingRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
-  @SerialName("external_transaction_id") val externalTransactionId: String? = null
+  @SerialName("external_transaction_id") val externalTransactionId: String? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -127,7 +133,7 @@ data class NotifyAmountsUpdatedRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String? = null,
   @SerialName("amount_out") val amountOut: AmountRequest,
-  @SerialName("amount_fee") val amountFee: AmountRequest
+  @SerialName("amount_fee") val amountFee: AmountRequest,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -135,7 +141,7 @@ data class NotifyOffchainFundsSentRequest(
   @SerialName("transaction_id") override val transactionId: String,
   override val message: String,
   @SerialName("funds_sent_at") val fundsReceivedAt: String? = null,
-  @SerialName("external_transaction_id") val externalTransactionId: String? = null
+  @SerialName("external_transaction_id") val externalTransactionId: String? = null,
 ) : RpcActionParamsRequest()
 
 @Serializable
@@ -169,7 +175,7 @@ data class DepositRequest(
   val amount: String,
   val name: String,
   val surname: String,
-  val email: String
+  val email: String,
 )
 
 @Serializable
@@ -179,7 +185,7 @@ data class WithdrawalRequest(
   val surname: String,
   val email: String,
   val bank: String,
-  val account: String
+  val account: String,
 )
 
 @Serializable
@@ -187,7 +193,7 @@ data class StellarTransaction(
   val id: String,
   val memo: String? = null,
   @SerialName("memo_type") val memoType: String? = null,
-  val payments: List<StellarPayment>
+  val payments: List<StellarPayment>,
 )
 
 @Serializable data class StellarPayment(val id: String, val amount: Amount)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
@@ -36,7 +36,7 @@ object ServiceContainer {
   private val customerRepo = JdbcCustomerRepository(database)
   private val transactionKYCRepo = JdbcTransactionKYCRepository(database)
   private val quotesRepo = JdbcQuoteRepository(database)
-  val customerService = CustomerService(customerRepo, transactionKYCRepo)
+  val customerService = CustomerService(customerRepo, transactionKYCRepo, sepHelper)
   val feeService = FeeService(customerRepo)
   val rateService = RateService(quotesRepo)
   val uniqueAddressService = UniqueAddressService(config.appSettings)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -335,12 +335,12 @@ class Sep6EventProcessor(
     val missingFields = verifyKyc(customer.account, customer.memo, kind)
     runBlocking {
       if (missingFields.isNotEmpty()) {
+        customerService.requestKycForTransaction(event.payload.transaction.id, missingFields)
         sepHelper.rpcAction(
           RpcMethod.REQUEST_CUSTOMER_INFO_UPDATE.toString(),
           RequestCustomerInfoUpdateHandler(
             transactionId = event.payload.transaction.id,
             message = "Please update your info",
-            requiredCustomerInfoUpdates = missingFields,
           ),
         )
       }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -335,7 +335,10 @@ class Sep6EventProcessor(
     val missingFields = verifyKyc(customer.account, customer.memo, kind)
     runBlocking {
       if (missingFields.isNotEmpty()) {
-        customerService.requestKycForTransaction(event.payload.transaction.id, missingFields)
+        customerService.requestAdditionalFieldsForTransaction(
+          event.payload.transaction.id,
+          missingFields
+        )
         sepHelper.rpcAction(
           RpcMethod.REQUEST_CUSTOMER_INFO_UPDATE.toString(),
           RequestCustomerInfoUpdateHandler(

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -315,7 +315,7 @@ class Sep6EventProcessor(
   }
 
   private fun verifyKyc(sep10Account: String, sep10AccountMemo: String?, kind: Kind): List<String> {
-    val customer =
+    val customer = runBlocking {
       customerService.getCustomer(
         GetCustomerRequest.builder()
           .account(sep10Account)
@@ -323,6 +323,7 @@ class Sep6EventProcessor(
           .memoType(if (sep10AccountMemo != null) "id" else null)
           .build()
       )
+    }
     val providedFields = customer.providedFields.keys
     return requiredKyc
       .plus(if (kind == Kind.DEPOSIT) depositRequiredKyc else withdrawRequiredKyc)
@@ -337,7 +338,7 @@ class Sep6EventProcessor(
       if (missingFields.isNotEmpty()) {
         customerService.requestAdditionalFieldsForTransaction(
           event.payload.transaction.id,
-          missingFields
+          missingFields,
         )
         sepHelper.rpcAction(
           RpcMethod.REQUEST_CUSTOMER_INFO_UPDATE.toString(),

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/TransactionKYC.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/model/TransactionKYC.kt
@@ -4,6 +4,5 @@ import kotlinx.serialization.SerialName
 
 data class TransactionKYC(
   @SerialName("transaction_id") val transactionId: String,
-  @SerialName("customer_id") val customerId: String? = null,
   @SerialName("required_fields") val requiredFields: List<String> = emptyList(),
 )

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -13,6 +13,7 @@ import org.stellar.anchor.api.callback.FeeIntegration;
 import org.stellar.anchor.api.callback.RateIntegration;
 import org.stellar.anchor.api.callback.UniqueAddressIntegration;
 import org.stellar.anchor.api.exception.InvalidConfigException;
+import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.client.ClientFinder;
@@ -173,8 +174,9 @@ public class SepBeans {
   Sep12Service sep12Service(
       CustomerIntegration customerIntegration,
       AssetService assetService,
+      PlatformApiClient platformApiClient,
       EventService eventService) {
-    return new Sep12Service(customerIntegration, assetService, eventService);
+    return new Sep12Service(customerIntegration, assetService, platformApiClient, eventService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
@@ -44,14 +44,16 @@ public class Sep12Controller {
       @RequestParam(required = false) String account,
       @RequestParam(required = false) String memo,
       @RequestParam(required = false, name = "memo_type") String memoType,
+      @RequestParam(required = false, name = "transaction_id") String transactionId,
       @RequestParam(required = false) String lang) {
     debugF(
-        "GET /customer type={} id={} account={} memo={}, memoType={}, lang={}",
+        "GET /customer type={} id={} account={} memo={}, memoType={}, transactionId={}, lang={}",
         type,
         id,
         account,
         memo,
         memoType,
+        transactionId,
         lang);
     Sep10Jwt sep10Jwt = Sep10Helper.getSep10Token(request);
     Sep12GetCustomerRequest getCustomerRequest =
@@ -61,6 +63,7 @@ public class Sep12Controller {
             .account(account)
             .memo(memo)
             .memoType(memoType)
+            .transactionId(transactionId)
             .lang(lang)
             .build();
 

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -21,7 +21,7 @@ events.queue.kafka.bootstrap_server=kafka:29092
 # callback API endpoint
 callback_api.base_url=http://reference-server:8091/
 # platform API endpoint
-platform_api.base_url=http://platform:8085/
+platform_api.base_url=http://platform:8085
 custody_server.base_url=http://custody-server:8086
 # data
 data.type=postgres


### PR DESCRIPTION
### Description

This adds support for the `transaction_id` field in SEP-12 GET/PUT endpoints. It also updates the SEP-6 test to use the new flow.

### Context

This is to support the latest protocol version of SEP-6.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

