### PR TITLE
[ANCHOR-716] Re-enable extended tests

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -15,12 +15,16 @@ jobs:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
 
+  extended_tests:
+    needs: [ gradle_build ]
+    uses: ./.github/workflows/sub_extended_tests.yml
+
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml
 
   complete:
     if: always()
-    needs: [ gradle_build, essential_tests, jacoco_report, codeql_analysis ]
+    needs: [ gradle_build, essential_tests, extended_tests, jacoco_report, codeql_analysis ]
     runs-on: ubuntu-22.04
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -22,12 +22,16 @@ jobs:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
 
+  extended_tests:
+    needs: [ gradle_build ]
+    uses: ./.github/workflows/sub_extended_tests.yml
+
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml
 
   build_and_push_docker_image:
     name: Push to DockerHub
-    needs: [ gradle_build, essential_tests, codeql_analysis ]
+    needs: [ gradle_build, essential_tests, extended_tests, codeql_analysis ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/CustodyApiTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/CustodyApiTests.kt
@@ -404,7 +404,7 @@ private const val WEBHOOK_REQUEST =
     "destinationAddressDescription": "",
     "destinationTag": "",
     "status": "CONFIRMING",
-    "txHash": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+    "txHash": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
     "subStatus": "CONFIRMED",
     "signedBy": [],
     "createdBy": "1444ed36-5bc0-4e3b-9b17-5df29fc0590f",
@@ -470,7 +470,7 @@ private const val REFUND_WEBHOOK_REQUEST =
     "destinationAddressDescription": "",
     "destinationTag": "12345",
     "status": "CONFIRMING",
-    "txHash": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+    "txHash": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
     "subStatus": "CONFIRMED",
     "signedBy": [],
     "createdBy": "1444ed36-5bc0-4e3b-9b17-5df29fc0590f",
@@ -539,7 +539,7 @@ private const val EXPECTED_TRANSACTION_RESPONSE =
   "external_transaction_id": "1",
   "stellar_transactions": [
     {
-      "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+      "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
       "payments": [
         {
           "amount": {
@@ -594,7 +594,7 @@ private const val EXPECTED_TXN_REFUND_RESPONSE =
     },
     "payments": [
       {
-        "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+        "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
         "id_type": "stellar",
         "amount": {
           "amount": "1.0000000",
@@ -609,7 +609,7 @@ private const val EXPECTED_TXN_REFUND_RESPONSE =
   },
   "stellar_transactions": [
     {
-      "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+      "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
       "memo": "testTag",
       "memo_type": "id",
       "payments": [
@@ -703,7 +703,7 @@ private const val NOTIFY_ONCHAIN_FUNDS_RECEIVED_REQUEST =
   {
     "transaction_id": "TX_ID",
     "message": "test message 1",
-    "stellar_transaction_id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2"
+    "stellar_transaction_id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15"
   }
 """
 

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
@@ -442,7 +442,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_REQUESTS =
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 3",
-      "stellar_transaction_id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+      "stellar_transaction_id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
       "amount_in": {
         "amount": "1"
       }
@@ -588,7 +588,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       "message": "test message 3",
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [
@@ -640,7 +640,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       "message": "test message 4",
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [
@@ -717,7 +717,7 @@ private const val SEP_24_WITHDRAW_FULL_REFUND_FLOW_ACTION_RESPONSES =
       },
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [
@@ -754,7 +754,7 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_REQUESTS
     "params": {
       "transaction_id": "TX_ID",
       "message": "test message 1",
-      "stellar_transaction_id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2"
+      "stellar_transaction_id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15"
     }
   },
   {
@@ -828,7 +828,7 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       "message": "test message 1",
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [
@@ -883,7 +883,7 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       "message": "test message 2",
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [
@@ -963,7 +963,7 @@ private const val SEP_31_RECEIVE_REFUNDED_DO_STELLAR_REFUND_FLOW_ACTION_RESPONSE
       },
       "stellar_transactions": [
         {
-          "id": "68eafbdf2aa95c4a5aaddb7021f321a607096b2aa1913096b8d6f06e44ea0ec2",
+          "id": "a6d3819777fc7f4f92b8085d0020951b89014c746418316024786776db100b15",
           "memo": "testMemo",
           "memo_type": "id",
           "payments": [


### PR DESCRIPTION
### Description

This re-enables the extended tests.

### Context

They were disabled to unblock PRs.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

