### PR TITLE
Add on_hold status support

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/NotifyTransactionOnHoldRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/NotifyTransactionOnHoldRequest.java
@@ -1,0 +1,19 @@
+package org.stellar.anchor.api.rpc.method;
+
+import com.google.gson.annotations.SerializedName;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.stellar.anchor.api.rpc.method.features.SupportsUserActionRequiredBy;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class NotifyTransactionOnHoldRequest extends RpcMethodParamsRequest
+    implements SupportsUserActionRequiredBy {
+  @SerializedName("user_action_required_by")
+  Instant userActionRequiredBy;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
@@ -66,7 +66,10 @@ public enum RpcMethod {
   NOTIFY_AMOUNTS_UPDATED("notify_amounts_updated"),
 
   @SerializedName("notify_transaction_recovery")
-  NOTIFY_TRANSACTION_RECOVERY("notify_transaction_recovery");
+  NOTIFY_TRANSACTION_RECOVERY("notify_transaction_recovery"),
+
+  @SerializedName("notify_transaction_on_hold")
+  NOTIFY_TRANSACTION_ON_HOLD("notify_transaction_on_hold");
 
   private final String method;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/SepTransactionStatus.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/SepTransactionStatus.java
@@ -50,7 +50,11 @@ public enum SepTransactionStatus {
   @SerializedName("pending_external")
   PENDING_EXTERNAL("pending_external", "waiting on an external entity"),
   @SerializedName("pending_stellar")
-  PENDING_STELLAR("pending_stellar", "stellar is executing the transaction");
+  PENDING_STELLAR("pending_stellar", "stellar is executing the transaction"),
+  @SerializedName("on_hold")
+  ON_HOLD(
+      "on_hold",
+      "deposit/withdrawal is currently on hold for additional checks after receiving user's funds");
 
   private final String status;
   private final String description;

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -12,28 +12,7 @@ import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.config.PropertyCustodyConfig;
 import org.stellar.anchor.platform.config.RpcConfig;
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
-import org.stellar.anchor.platform.rpc.DoStellarPaymentHandler;
-import org.stellar.anchor.platform.rpc.DoStellarRefundHandler;
-import org.stellar.anchor.platform.rpc.NotifyAmountsUpdatedHandler;
-import org.stellar.anchor.platform.rpc.NotifyCustomerInfoUpdatedHandler;
-import org.stellar.anchor.platform.rpc.NotifyInteractiveFlowCompletedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsAvailableHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsPendingHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsReceivedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOffchainFundsSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyOnchainFundsReceivedHandler;
-import org.stellar.anchor.platform.rpc.NotifyOnchainFundsSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyRefundPendingHandler;
-import org.stellar.anchor.platform.rpc.NotifyRefundSentHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionErrorHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionExpiredHandler;
-import org.stellar.anchor.platform.rpc.NotifyTransactionRecoveryHandler;
-import org.stellar.anchor.platform.rpc.NotifyTrustSetHandler;
-import org.stellar.anchor.platform.rpc.RequestCustomerInfoUpdateHandler;
-import org.stellar.anchor.platform.rpc.RequestOffchainFundsHandler;
-import org.stellar.anchor.platform.rpc.RequestOnchainFundsHandler;
-import org.stellar.anchor.platform.rpc.RequestTrustlineHandler;
-import org.stellar.anchor.platform.rpc.RpcMethodHandler;
+import org.stellar.anchor.platform.rpc.*;
 import org.stellar.anchor.platform.service.RpcService;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24DepositInfoGenerator;
@@ -338,6 +317,25 @@ public class RpcActionBeans {
         eventService,
         metricsService,
         transactionPendingTrustRepo);
+  }
+
+  @Bean
+  NotifyTransactionOnHoldHandler notifyTransactionOnHoldHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    return new NotifyTransactionOnHoldHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
@@ -7,6 +7,7 @@ import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_
 import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
 import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
 import java.util.Set;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind;
@@ -86,6 +87,9 @@ public class NotifyOffchainFundsAvailableHandler
       JdbcSepTransaction txn, NotifyOffchainFundsAvailableRequest request) {
     if (request.getExternalTransactionId() != null) {
       txn.setExternalTransactionId(request.getExternalTransactionId());
+    }
+    if (txn.getTransferReceivedAt() == null) {
+      txn.setTransferReceivedAt(Instant.now());
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsAvailableHandler.java
@@ -7,7 +7,6 @@ import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_
 import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
 import com.google.common.collect.ImmutableSet;
-import java.time.Instant;
 import java.util.Set;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind;
@@ -87,9 +86,6 @@ public class NotifyOffchainFundsAvailableHandler
       JdbcSepTransaction txn, NotifyOffchainFundsAvailableRequest request) {
     if (request.getExternalTransactionId() != null) {
       txn.setExternalTransactionId(request.getExternalTransactionId());
-    }
-    if (txn.getTransferReceivedAt() == null) {
-      txn.setTransferReceivedAt(Instant.now());
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
@@ -3,9 +3,7 @@ package org.stellar.anchor.platform.rpc;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT_EXCHANGE;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_OFFCHAIN_FUNDS_RECEIVED;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_EXTERNAL;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_START;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
@@ -149,6 +147,7 @@ public class NotifyOffchainFundsReceivedHandler
         JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
         if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          supportedStatuses.add(ON_HOLD);
           if (areFundsReceived(txn6)) {
             supportedStatuses.add(PENDING_EXTERNAL);
           }
@@ -158,6 +157,7 @@ public class NotifyOffchainFundsReceivedHandler
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         if (DEPOSIT == Kind.from(txn24.getKind())) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          supportedStatuses.add(ON_HOLD);
           if (areFundsReceived(txn24)) {
             supportedStatuses.add(PENDING_EXTERNAL);
           }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -3,10 +3,7 @@ package org.stellar.anchor.platform.rpc;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL;
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL_EXCHANGE;
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_ONCHAIN_FUNDS_RECEIVED;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_ANCHOR;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_RECEIVER;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_SENDER;
-import static org.stellar.anchor.api.sep.SepTransactionStatus.PENDING_USR_TRANSFER_START;
+import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 import static org.stellar.anchor.platform.utils.PaymentsUtil.addStellarTransaction;
 import static org.stellar.anchor.util.Log.errorEx;
 
@@ -150,12 +147,14 @@ public class NotifyOnchainFundsReceivedHandler
         JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
         if (ImmutableSet.of(WITHDRAWAL, WITHDRAWAL_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          supportedStatuses.add(ON_HOLD);
         }
         break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
         if (WITHDRAWAL == Kind.from(txn24.getKind())) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
+          supportedStatuses.add(ON_HOLD);
         }
         break;
       case SEP_31:

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionOnHoldHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyTransactionOnHoldHandler.java
@@ -8,6 +8,7 @@ import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_TRANSACTION_ON_
 import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 
 import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import org.stellar.anchor.api.platform.PlatformTransactionData;
@@ -84,5 +85,9 @@ public class NotifyTransactionOnHoldHandler
 
   @Override
   protected void updateTransactionWithRpcRequest(
-      JdbcSepTransaction txn, NotifyTransactionOnHoldRequest request) {}
+      JdbcSepTransaction txn, NotifyTransactionOnHoldRequest request) {
+    if (txn.getTransferReceivedAt() == null) {
+      txn.setTransferReceivedAt(Instant.now());
+    }
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionOnHoldHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyTransactionOnHoldHandlerTest.kt
@@ -1,0 +1,505 @@
+package org.stellar.anchor.platform.rpc
+
+import io.micrometer.core.instrument.Counter
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException
+import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.DEPOSIT
+import org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHDRAWAL
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep.*
+import org.stellar.anchor.api.rpc.method.NotifyTransactionOnHoldRequest
+import org.stellar.anchor.api.sep.SepTransactionStatus.*
+import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.event.EventService
+import org.stellar.anchor.event.EventService.EventQueue.TRANSACTION
+import org.stellar.anchor.event.EventService.Session
+import org.stellar.anchor.metrics.MetricsService
+import org.stellar.anchor.platform.data.JdbcSep24Transaction
+import org.stellar.anchor.platform.data.JdbcSep6Transaction
+import org.stellar.anchor.platform.service.AnchorMetrics.PLATFORM_RPC_TRANSACTION
+import org.stellar.anchor.platform.validator.RequestValidator
+import org.stellar.anchor.sep24.Sep24TransactionStore
+import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
+import org.stellar.anchor.util.GsonUtils
+
+class NotifyTransactionOnHoldHandlerTest {
+
+  companion object {
+    private val gson = GsonUtils.getInstance()
+    private const val TX_ID = "testId"
+    private const val EXTERNAL_TX_ID = "testExternalTxId"
+    private const val VALIDATION_ERROR_MESSAGE = "Invalid request"
+  }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn31Store: Sep31TransactionStore
+
+  @MockK(relaxed = true) private lateinit var requestValidator: RequestValidator
+
+  @MockK(relaxed = true) private lateinit var assetService: AssetService
+
+  @MockK(relaxed = true) private lateinit var eventService: EventService
+
+  @MockK(relaxed = true) private lateinit var metricsService: MetricsService
+
+  @MockK(relaxed = true) private lateinit var eventSession: Session
+
+  @MockK(relaxed = true) private lateinit var sepTransactionCounter: Counter
+
+  private lateinit var handler: NotifyTransactionOnHoldHandler
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    every { eventService.createSession(any(), TRANSACTION) } returns eventSession
+    this.handler =
+      NotifyTransactionOnHoldHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService
+      )
+  }
+
+  @Test
+  fun test_handle_unsupportedProtocol() {
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = Instant.now()
+    val spyTxn24 = spyk(txn24)
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns spyTxn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { spyTxn24.protocol } returns SEP_38.sep.toString()
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_transaction_on_hold] is not supported. Status[pending_anchor], kind[null], protocol[38], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatus() {
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_TRUST.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_transaction_on_hold] is not supported. Status[pending_trust], kind[withdrawal], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_unsupportedStatusDeposit() {
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_transaction_on_hold] is not supported. Status[pending_anchor], kind[deposit], protocol[24], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep24_ok_withdrawal() {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.transferReceivedAt = transferReceivedAt
+    txn24.userActionRequiredBy = Instant.now()
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep24") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep24Txn = JdbcSep24Transaction()
+    expectedSep24Txn.kind = WITHDRAWAL.kind
+    expectedSep24Txn.status = ON_HOLD.toString()
+    expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedSep24Txn.transferReceivedAt = transferReceivedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep24Txn),
+      gson.toJson(sep24TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_24
+    expectedResponse.kind = WITHDRAWAL
+    expectedResponse.status = ON_HOLD
+    expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_24.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @Test
+  fun test_handle_sep24_ok_deposit_with_userActionRequiredBy() {
+    val actionRequiredBy = Instant.now().plusSeconds(100)
+    val transferReceivedAt = Instant.now()
+    val request =
+      NotifyTransactionOnHoldRequest.builder()
+        .transactionId(TX_ID)
+        .userActionRequiredBy(actionRequiredBy)
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_USR_TRANSFER_START.toString()
+    txn24.kind = DEPOSIT.kind
+    txn24.transferReceivedAt = transferReceivedAt
+    val sep24TxnCapture = slot<JdbcSep24Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(capture(sep24TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep24") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep24Txn = JdbcSep24Transaction()
+    expectedSep24Txn.kind = DEPOSIT.kind
+    expectedSep24Txn.status = ON_HOLD.toString()
+    expectedSep24Txn.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedSep24Txn.transferReceivedAt = transferReceivedAt
+    expectedSep24Txn.userActionRequiredBy = actionRequiredBy
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep24Txn),
+      gson.toJson(sep24TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_24
+    expectedResponse.kind = DEPOSIT
+    expectedResponse.status = ON_HOLD
+    expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.userActionRequiredBy = actionRequiredBy
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_24.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep24TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep24TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatus(kind: String) {
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_TRUST.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_transaction_on_hold] is not supported. Status[pending_trust], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_unsupportedStatusDeposit(kind: String) {
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = Instant.now()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(
+      "RPC method[notify_transaction_on_hold] is not supported. Status[pending_anchor], kind[$kind], protocol[6], funds received[true]",
+      ex.message
+    )
+
+    verify(exactly = 0) { txn6Store.save(any()) }
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_withdrawal(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_ANCHOR.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = ON_HOLD.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = ON_HOLD
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["deposit", "deposit-exchange"])
+  @ParameterizedTest
+  fun test_handle_sep6_ok_deposit(kind: String) {
+    val transferReceivedAt = Instant.now()
+    val request = NotifyTransactionOnHoldRequest.builder().transactionId(TX_ID).build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = PENDING_USR_TRANSFER_START.toString()
+    txn6.kind = kind
+    txn6.transferReceivedAt = transferReceivedAt
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = ON_HOLD.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.transferReceivedAt = transferReceivedAt
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = ON_HOLD
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.transferReceivedAt = transferReceivedAt
+    expectedResponse.amountExpected = Amount(null, "")
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+}


### PR DESCRIPTION
### Description

Added new RPC request (`notify_transaction_on_hold`) and handler for it

### Context

Add on_hold status support (introduced in https://github.com/stellar/stellar-protocol/pull/1479)

### Testing

- `./gradlew test`
- Add test for new handler

### Documentation

TODO: add documentation for this request + update diagrams (https://stellarorg.atlassian.net/browse/ANCHOR-679 and https://stellarorg.atlassian.net/browse/ANCHOR-688)

### Known limitations

N/A

