### PR TITLE
Fix SEP-10 clientFinder bug

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -125,7 +125,7 @@ public class SepBeans {
   }
 
   @Bean
-  @ConditionalOnAnySepsEnabled(seps = {"sep6", "sep24"})
+  @ConditionalOnAnySepsEnabled(seps = {"sep6", "sep10", "sep24"})
   ClientFinder clientFinder(Sep10Config sep10Config, ClientsConfig clientsConfig) {
     return new ClientFinder(sep10Config, clientsConfig);
   }


### PR DESCRIPTION
### Description

Create ClientFinder bean when sep-10 is enabled

### Context

ClientFinder is required for SEP-10, but currently bean is not created in this case

### Testing

N/A

### Documentation

N/A

### Known limitations

N/A
