### PR TITLE
[ANCHOR-713] Add exchange tests for SEP-6

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -17,7 +17,6 @@ import org.stellar.anchor.client.Sep6Client
 import org.stellar.anchor.platform.AbstractIntegrationTests
 import org.stellar.anchor.platform.TestConfig
 import org.stellar.anchor.util.Log
-import org.stellar.reference.client.AnchorReferenceServerClient
 import org.stellar.reference.wallet.WalletServerClient
 import org.stellar.walletsdk.anchor.MemoType
 import org.stellar.walletsdk.anchor.auth
@@ -28,8 +27,6 @@ import org.stellar.walletsdk.horizon.sign
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
   private val maxTries = 30
-  private val anchorReferenceServerClient =
-    AnchorReferenceServerClient(Url(config.env["reference.server.url"]!!))
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
 
   companion object {
@@ -63,8 +60,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    val customer =
-      anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
 
     val deposit =
       sep6Client.deposit(
@@ -127,19 +123,155 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
   }
 
   @Test
+  fun `test typical deposit-exchange without quote end-to-end flow`() = runBlocking {
+    val memo = (20000..30000).random().toULong()
+    val token = anchor.auth().authenticate(walletKeyPair, memoId = memo)
+    val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
+
+    // Create a customer before starting the transaction
+    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+
+    val deposit =
+      sep6Client.deposit(
+        mapOf(
+          "destination_asset" to USDC.code,
+          "source_asset" to "iso4217:CAD",
+          "amount" to "1",
+          "account" to walletKeyPair.address,
+          "type" to "SWIFT",
+        ),
+        exchange = true,
+      )
+    Log.info("Deposit initiated: ${deposit.id}")
+    waitStatus(deposit.id, PENDING_CUSTOMER_INFO_UPDATE, sep6Client)
+
+    // Supply missing KYC info to continue with the transaction
+    val additionalRequiredFields =
+      anchor
+        .customer(token)
+        .get(transactionId = deposit.id)
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
+    anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! }, memo)
+    Log.info("Submitted additional KYC info: $additionalRequiredFields")
+    Log.info("Bank transfer complete")
+    waitStatus(deposit.id, COMPLETED, sep6Client)
+
+    val completedDepositTxn = sep6Client.getTransaction(mapOf("id" to deposit.id))
+    assertEquals(
+      mapOf(
+        "organization.bank_number" to
+          InstructionField.builder()
+            .value("121122676")
+            .description("CA Bank routing number")
+            .build(),
+        "organization.bank_account_number" to
+          InstructionField.builder()
+            .value("13719713158835300")
+            .description("CA Bank account number")
+            .build(),
+      ),
+      completedDepositTxn.transaction.instructions,
+    )
+    val transactionByStellarId: GetTransactionResponse =
+      sep6Client.getTransaction(
+        mapOf("stellar_transaction_id" to completedDepositTxn.transaction.stellarTransactionId)
+      )
+    assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
+
+    val expectedStatuses =
+      listOf(
+        INCOMPLETE,
+        PENDING_CUSTOMER_INFO_UPDATE, // request KYC
+        PENDING_USR_TRANSFER_START, // provide deposit instructions
+        PENDING_ANCHOR, // deposit into user wallet
+        PENDING_STELLAR,
+        COMPLETED,
+      )
+    assertWalletReceivedStatuses(deposit.id, expectedStatuses)
+  }
+
+  @Test
   fun `test typical withdraw end-to-end flow`() = runBlocking {
-    val memo = (30000..40000).random().toULong()
+    val memo = (40000..50000).random().toULong()
     val token = anchor.auth().authenticate(walletKeyPair, memoId = memo)
     // TODO: migrate this to wallet-sdk when it's available
     val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
 
     // Create a customer before starting the transaction
-    val customer =
-      anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
 
     val withdraw =
       sep6Client.withdraw(
         mapOf("asset_code" to USDC.code, "amount" to "1", "type" to "bank_account")
+      )
+    Log.info("Withdrawal initiated: ${withdraw.id}")
+    waitStatus(withdraw.id, PENDING_CUSTOMER_INFO_UPDATE, sep6Client)
+
+    // Supply missing financial account info to continue with the transaction
+    val additionalRequiredFields =
+      anchor
+        .customer(token)
+        .get(transactionId = withdraw.id)
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
+    anchor.customer(token).add(additionalRequiredFields.associateWith { customerInfo[it]!! }, memo)
+    Log.info("Submitted additional KYC info: $additionalRequiredFields")
+
+    waitStatus(withdraw.id, PENDING_USR_TRANSFER_START, sep6Client)
+
+    val withdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction
+
+    // Transfer the withdrawal amount to the Anchor
+    Log.info("Transferring 1 USDC to Anchor account: ${withdrawTxn.withdrawAnchorAccount}")
+    transactionWithRetry {
+      val transfer =
+        wallet
+          .stellar()
+          .transaction(walletKeyPair, memo = Pair(MemoType.HASH, withdrawTxn.withdrawMemo))
+          .transfer(withdrawTxn.withdrawAnchorAccount, USDC, "1")
+          .build()
+      transfer.sign(walletKeyPair)
+      wallet.stellar().submitTransaction(transfer)
+    }
+    Log.info("Transfer complete")
+    waitStatus(withdraw.id, COMPLETED, sep6Client)
+
+    val expectedStatuses =
+      listOf(
+        INCOMPLETE,
+        PENDING_CUSTOMER_INFO_UPDATE, // request KYC
+        PENDING_USR_TRANSFER_START, // wait for onchain user transfer
+        PENDING_ANCHOR, // funds available for pickup
+        PENDING_EXTERNAL,
+        COMPLETED,
+      )
+    assertWalletReceivedStatuses(withdraw.id, expectedStatuses)
+  }
+
+  @Test
+  fun `test typical withdraw-exchange without quote end-to-end flow`() = runBlocking {
+    val memo = (50000..60000).random().toULong()
+    val token = anchor.auth().authenticate(walletKeyPair, memoId = memo)
+    // TODO: migrate this to wallet-sdk when it's available
+    val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token.token)
+
+    // Create a customer before starting the transaction
+    anchor.customer(token).add(basicInfoFields.associateWith { customerInfo[it]!! }, memo)
+
+    val withdraw =
+      sep6Client.withdraw(
+        mapOf(
+          "destination_asset" to "iso4217:CAD",
+          "source_asset" to USDC.code,
+          "amount" to "1",
+          "type" to "bank_account",
+        ),
+        exchange = true,
       )
     Log.info("Withdrawal initiated: ${withdraw.id}")
     waitStatus(withdraw.id, PENDING_CUSTOMER_INFO_UPDATE, sep6Client)

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
@@ -462,54 +462,19 @@ private const val expectedAfterPatchDeposit =
 
 private const val expectedSep24Info =
   """
-{
-  "deposit": {
-    "JPYC": {
-      "enabled": true
+  {
+    "deposit": {
+      "native": { "enabled": true, "minAmount": 0.0, "maxAmount": 10.0 },
+      "USDC": { "enabled": true, "minAmount": 0.0, "maxAmount": 10.0 }
     },
-    "native": {
-      "enabled": true,
-      "maxAmount": 1000000.0
+    "withdraw": {
+      "native": { "enabled": true, "minAmount": 0.0, "maxAmount": 10.0 },
+      "USDC": { "enabled": true, "minAmount": 0.0, "maxAmount": 10.0 }
     },
-    "USD": {
-      "enabled": true,
-      "minAmount": 0.0,
-      "maxAmount": 10000.0
-    },
-    "USDC": {
-      "enabled": true,
-      "minAmount": 1.0,
-      "maxAmount": 1000000.0
-    }
-  },
-  "withdraw": {
-    "JPYC": {
-      "enabled": true
-    },
-    "native": {
-      "enabled": true,
-      "maxAmount": 1000000.0
-    },
-    "USD": {
-      "enabled": true,
-      "minAmount": 0.0,
-      "maxAmount": 10000.0
-    },
-    "USDC": {
-      "enabled": true,
-      "minAmount": 1.0,
-      "maxAmount": 1000000.0
-    }
-  },
-  "fee": {
-    "enabled": false
-  },
-  "features": {
-    "accountCreation": false,
-    "claimableBalances": false
+    "fee": { "enabled": false },
+    "features": { "accountCreation": false, "claimableBalances": false }
   }
-}
-"""
+  """
 
 private const val expectedWithdrawTransactionResponse =
   """

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -54,7 +54,6 @@ class Sep31Tests : AbstractIntegrationTests(TestConfig()) {
   fun `test info endpoint`() {
     printRequest("Calling GET /info")
     val info = sep31Client.getInfo()
-    println(gson.toJson(info))
     JSONAssert.assertEquals(gson.toJson(info), expectedSep31Info, JSONCompareMode.STRICT)
   }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -54,6 +54,7 @@ class Sep31Tests : AbstractIntegrationTests(TestConfig()) {
   fun `test info endpoint`() {
     printRequest("Calling GET /info")
     val info = sep31Client.getInfo()
+    println(gson.toJson(info))
     JSONAssert.assertEquals(gson.toJson(info), expectedSep31Info, JSONCompareMode.STRICT)
   }
 
@@ -439,9 +440,7 @@ private const val expectedSep31Info =
           },
           "receiver": {
             "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving JPY"
-              },
+              "sep31-receiver": { "description": "U.S. citizens receiving JPY" },
               "sep31-foreign-receiver": {
                 "description": "non-U.S. citizens receiving JPY"
               }
@@ -460,10 +459,7 @@ private const val expectedSep31Info =
             },
             "type": {
               "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ],
+              "choices": ["SEPA", "SWIFT"],
               "optional": false
             }
           }
@@ -475,8 +471,8 @@ private const val expectedSep31Info =
         "quotes_required": false,
         "fee_fixed": 0,
         "fee_percent": 0,
-        "max_amount": 1000000,
-        "min_amount": 1,
+        "min_amount": 0,
+        "max_amount": 10,
         "sep12": {
           "sender": {
             "types": {
@@ -493,9 +489,7 @@ private const val expectedSep31Info =
           },
           "receiver": {
             "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
+              "sep31-receiver": { "description": "U.S. citizens receiving USD" },
               "sep31-foreign-receiver": {
                 "description": "non-U.S. citizens receiving USD"
               }
@@ -514,63 +508,7 @@ private const val expectedSep31Info =
             },
             "type": {
               "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ],
-              "optional": false
-            }
-          }
-        }
-      },
-      "native": {
-        "enabled": true,
-        "quotes_supported": true,
-        "quotes_required": true,
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "max_amount": 1000000,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account",
-              "optional": false
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination",
-              "optional": false
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ],
+              "choices": ["SEPA", "SWIFT"],
               "optional": false
             }
           }
@@ -578,7 +516,7 @@ private const val expectedSep31Info =
       }
     }
   }
-"""
+  """
 
 private const val patchRequest =
   """

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -20,6 +20,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
   @Test
   fun `test Sep6 info endpoint`() {
     val info = sep6Client.getInfo()
+    println(gson.toJson(info))
     JSONAssert.assertEquals(expectedSep6Info, gson.toJson(info), JSONCompareMode.STRICT)
   }
 
@@ -176,88 +177,60 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
     private val expectedSep6Info =
       """
       {
-          "deposit": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "min_amount": 1,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
+        "deposit": {
+          "USDC": {
+            "enabled": true,
+            "authentication_required": true,
+            "min_amount": 0,
+            "max_amount": 10,
+            "fields": {
+              "type": {
+                "description": "type of deposit to make",
+                "choices": ["SEPA", "SWIFT"],
+                "optional": false
               }
-          },
-          "deposit-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "min_amount": 1,
-                  "fields": {
-                      "type": {
-                          "description": "type of deposit to make",
-                          "choices": [
-                              "SEPA",
-                              "SWIFT"
-                          ],
-                          "optional": false
-                      }
-                  }
-              }
-          },
-          "withdraw": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "max_amount": 1000000,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "withdraw-exchange": {
-              "USDC": {
-                  "enabled": true,
-                  "authentication_required": true,
-                  "max_amount": 1000000,
-                  "types": {
-                      "cash": {
-                          "fields": {}
-                      },
-                      "bank_account": {
-                          "fields": {}
-                      }
-                  }
-              }
-          },
-          "fee": {
-              "enabled": false,
-              "description": "Fee endpoint is not supported."
-          },
-          "transactions": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "transaction": {
-              "enabled": true,
-              "authentication_required": true
-          },
-          "features": {
-              "account_creation": false,
-              "claimable_balances": false
+            }
           }
+        },
+        "deposit-exchange": {
+          "USDC": {
+            "enabled": true,
+            "authentication_required": true,
+            "min_amount": 0,
+            "max_amount": 10,
+            "fields": {
+              "type": {
+                "description": "type of deposit to make",
+                "choices": ["SEPA", "SWIFT"],
+                "optional": false
+              }
+            }
+          }
+        },
+        "withdraw": {
+          "USDC": {
+            "enabled": true,
+            "authentication_required": true,
+            "min_amount": 0,
+            "max_amount": 10,
+            "types": { "cash": { "fields": {} }, "bank_account": { "fields": {} } }
+          }
+        },
+        "withdraw-exchange": {
+          "USDC": {
+            "enabled": true,
+            "authentication_required": true,
+            "min_amount": 0,
+            "max_amount": 10,
+            "types": { "cash": { "fields": {} }, "bank_account": { "fields": {} } }
+          }
+        },
+        "fee": { "enabled": false, "description": "Fee endpoint is not supported." },
+        "transactions": { "enabled": true, "authentication_required": true },
+        "transaction": { "enabled": true, "authentication_required": true },
+        "features": { "account_creation": false, "claimable_balances": false }
       }
-    """
+      """
         .trimIndent()
 
     private val expectedSep6DepositResponse =
@@ -345,7 +318,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
           "status": "incomplete",
           "amount_in": "10",
           "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amount_out": "8.5714",
+          "amount_out": "8.57",
           "amount_out_asset": "iso4217:USD",
           "amount_fee": "1.00",
           "amount_fee_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -20,7 +20,6 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
   @Test
   fun `test Sep6 info endpoint`() {
     val info = sep6Client.getInfo()
-    println(gson.toJson(info))
     JSONAssert.assertEquals(expectedSep6Info, gson.toJson(info), JSONCompareMode.STRICT)
   }
 

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
@@ -185,6 +185,7 @@ class RateService(private val quoteRepository: QuoteRepository) {
 
   companion object {
     val fiatUSD = "iso4217:USD"
+    val fiatCAD = "iso4217:CAD"
     val stellarCircleUSDCtest =
       "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
     val stellarUSDCtest = "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
@@ -206,6 +207,8 @@ class RateService(private val quoteRepository: QuoteRepository) {
         Pair(stellarJPYC, stellarCircleUSDCtest) to "120",
         Pair(stellarUSDCprod, stellarJPYC) to "0.0084",
         Pair(stellarJPYC, stellarUSDCprod) to "120",
+        Pair(fiatCAD, stellarUSDCtest) to "0.73",
+        Pair(stellarUSDCtest, fiatCAD) to "1.37",
       )
 
     private fun getPrice(sellAsset: String, buyAsset: String): String? {

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -50,9 +50,15 @@ class Sep6EventProcessor(
   override suspend fun onTransactionCreated(event: SendEventRequest) {
     when (val kind = event.payload.transaction!!.kind) {
       Kind.DEPOSIT,
-      Kind.WITHDRAWAL -> {
+      Kind.DEPOSIT_EXCHANGE,
+      Kind.WITHDRAWAL,
+      Kind.WITHDRAWAL_EXCHANGE -> {
         requestKyc(event)
-        requestCustomerFunds(event.payload.transaction)
+        try {
+          requestCustomerFunds(event.payload.transaction)
+        } catch (e: Exception) {
+          log.error("Error requesting customer funds", e)
+        }
       }
       else -> {
         log.warn("Received transaction created event with unsupported kind: $kind")
@@ -66,8 +72,10 @@ class Sep6EventProcessor(
 
   override suspend fun onTransactionStatusChanged(event: SendEventRequest) {
     when (val kind = event.payload.transaction!!.kind) {
-      Kind.DEPOSIT -> onDepositTransactionStatusChanged(event)
-      Kind.WITHDRAWAL -> onWithdrawTransactionStatusChanged(event)
+      Kind.DEPOSIT,
+      Kind.DEPOSIT_EXCHANGE -> onDepositTransactionStatusChanged(event)
+      Kind.WITHDRAWAL,
+      Kind.WITHDRAWAL_EXCHANGE -> onWithdrawTransactionStatusChanged(event)
       else -> {
         log.warn("Received transaction created event with unsupported kind: $kind")
       }
@@ -79,7 +87,7 @@ class Sep6EventProcessor(
     when (val status = transaction.status) {
       PENDING_ANCHOR -> {
         val customer = transaction.customers.sender
-        if (verifyKyc(customer.account, customer.memo, Kind.DEPOSIT).isNotEmpty()) {
+        if (verifyKyc(customer.account, customer.memo, transaction.kind).isNotEmpty()) {
           requestKyc(event)
           return
         }
@@ -221,15 +229,40 @@ class Sep6EventProcessor(
   private fun requestCustomerFunds(transaction: GetTransactionResponse) {
     val customer = transaction.customers.sender
     when (transaction.kind) {
-      Kind.DEPOSIT -> {
-        val instructions =
+      Kind.DEPOSIT,
+      Kind.DEPOSIT_EXCHANGE -> {
+        val usdDepositInstructions =
           mapOf(
             "organization.bank_number" to
               InstructionField(value = "121122676", description = "US Bank routing number"),
             "organization.bank_account_number" to
               InstructionField(value = "13719713158835300", description = "US Bank account number"),
           )
-        if (verifyKyc(customer.account, customer.memo, Kind.DEPOSIT).isEmpty()) {
+        val cadDepositInstructions =
+          mapOf(
+            "organization.bank_number" to
+              InstructionField(value = "121122676", description = "CA Bank routing number"),
+            "organization.bank_account_number" to
+              InstructionField(value = "13719713158835300", description = "CA Bank account number"),
+          )
+        val sourceAsset =
+          when (transaction.kind) {
+            Kind.DEPOSIT -> "iso4217:USD"
+            Kind.DEPOSIT_EXCHANGE -> transaction.amountIn.asset
+            else -> throw RuntimeException("Unsupported kind: ${transaction.kind}")
+          }
+        val isDepositExchange = transaction.kind == Kind.DEPOSIT_EXCHANGE
+        val isUsdOrCadAsset = sourceAsset == "iso4217:USD" || sourceAsset == "iso4217:CAD"
+
+        val instructions =
+          when {
+            isDepositExchange && isUsdOrCadAsset ->
+              if (sourceAsset == "iso4217:USD") usdDepositInstructions else cadDepositInstructions
+            isDepositExchange -> throw RuntimeException("Unsupported asset: $sourceAsset")
+            else -> usdDepositInstructions
+          }
+
+        if (verifyKyc(customer.account, customer.memo, transaction.kind).isEmpty()) {
           runBlocking {
             if (transaction.amountExpected.amount != null) {
               // The amount was specified at transaction initialization
@@ -240,7 +273,7 @@ class Sep6EventProcessor(
                   message = "Please deposit the amount to the following bank account",
                   amountIn =
                     AmountAssetRequest(
-                      asset = "iso4217:USD",
+                      asset = sourceAsset,
                       amount = transaction.amountExpected.amount,
                     ),
                   amountOut =
@@ -248,7 +281,7 @@ class Sep6EventProcessor(
                       asset = transaction.amountExpected.asset,
                       amount = transaction.amountExpected.amount,
                     ),
-                  amountFee = AmountAssetRequest(asset = "iso4217:USD", amount = "0"),
+                  amountFee = AmountAssetRequest(asset = sourceAsset, amount = "0"),
                   instructions = instructions,
                 ),
               )
@@ -258,10 +291,10 @@ class Sep6EventProcessor(
                 RequestOffchainFundsRequest(
                   transactionId = transaction.id,
                   message = "Please deposit to the following bank account",
-                  amountIn = AmountAssetRequest(asset = "iso4217:USD", amount = "0"),
+                  amountIn = AmountAssetRequest(asset = sourceAsset, amount = "0"),
                   amountOut =
                     AmountAssetRequest(asset = transaction.amountExpected.asset, amount = "0"),
-                  amountFee = AmountAssetRequest(asset = "iso4217:USD", amount = "0"),
+                  amountFee = AmountAssetRequest(asset = sourceAsset, amount = "0"),
                   instructions = instructions,
                 ),
               )
@@ -269,8 +302,15 @@ class Sep6EventProcessor(
           }
         }
       }
-      Kind.WITHDRAWAL -> {
-        if (verifyKyc(customer.account, customer.memo, Kind.WITHDRAWAL).isEmpty()) {
+      Kind.WITHDRAWAL,
+      Kind.WITHDRAWAL_EXCHANGE -> {
+        val destinationAsset =
+          when (transaction.kind) {
+            Kind.WITHDRAWAL -> "iso4217:USD"
+            Kind.WITHDRAWAL_EXCHANGE -> transaction.amountOut.asset
+            else -> throw RuntimeException("Unsupported kind: ${transaction.kind}")
+          }
+        if (verifyKyc(customer.account, customer.memo, transaction.kind).isEmpty()) {
           runBlocking {
             if (transaction.amountExpected.amount != null) {
               // The amount was specified at transaction initialization
@@ -286,7 +326,7 @@ class Sep6EventProcessor(
                     ),
                   amountOut =
                     AmountAssetRequest(
-                      asset = "iso4217:USD",
+                      asset = destinationAsset,
                       amount = transaction.amountExpected.amount,
                     ),
                   amountFee =
@@ -300,7 +340,7 @@ class Sep6EventProcessor(
                   transactionId = transaction.id,
                   message = "Please deposit to the following address",
                   amountIn = AmountAssetRequest(transaction.amountExpected.asset, "0"),
-                  amountOut = AmountAssetRequest("iso4217:USD", "0"),
+                  amountOut = AmountAssetRequest(destinationAsset, "0"),
                   amountFee = AmountAssetRequest(transaction.amountExpected.asset, "0"),
                 ),
               )
@@ -326,7 +366,10 @@ class Sep6EventProcessor(
     }
     val providedFields = customer.providedFields.keys
     return requiredKyc
-      .plus(if (kind == Kind.DEPOSIT) depositRequiredKyc else withdrawRequiredKyc)
+      .plus(
+        if (kind == Kind.DEPOSIT || kind == Kind.DEPOSIT_EXCHANGE) depositRequiredKyc
+        else withdrawRequiredKyc
+      )
       .filter { !providedFields.contains(it) }
   }
 

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -1,4 +1,5 @@
 assets:
+  # Stellar assets
   - schema: stellar
     code: USDC
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
@@ -6,13 +7,15 @@ assets:
     significant_decimals: 2
     deposit:
       enabled: true
-      min_amount: 1
+      min_amount: 0
+      max_amount: 10
       methods:
         - SEPA
         - SWIFT
     withdraw:
       enabled: true
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
       methods:
         - bank_account
         - cash
@@ -53,7 +56,9 @@ assets:
               - SWIFT
     sep38:
       exchangeable_assets:
+        - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - iso4217:USD
+        - iso4217:CAD
     sep6_enabled: true
     sep24_enabled: true
     sep31_enabled: true
@@ -65,17 +70,17 @@ assets:
     significant_decimals: 2
     deposit:
       enabled: true
-      min_amount: 1
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
     withdraw:
       enabled: true
-      min_amount: 1
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
     send:
       fee_fixed: 0
       fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
     sep31:
       quotes_supported: true
       quotes_required: false
@@ -109,7 +114,9 @@ assets:
               - SWIFT
     sep38:
       exchangeable_assets:
+        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - iso4217:USD
+        - iso4217:CAD
     sep24_enabled: true
     sep31_enabled: true
     sep38_enabled: true
@@ -119,9 +126,9 @@ assets:
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 4
     deposit:
-      enabled: true
+      enabled: false
     withdraw:
-      enabled: true
+      enabled: false
     send:
       fee_fixed: 0
       fee_percent: 0
@@ -160,93 +167,76 @@ assets:
       exchangeable_assets:
         - iso4217:USD
     sep6_enabled: false
-    sep24_enabled: true
+    sep24_enabled: false
     sep31_enabled: true
     sep38_enabled: true
-  - schema: iso4217
-    code: USD
-    significant_decimals: 7
-    deposit:
-      enabled: true
-      min_amount: 0
-      max_amount: 10000
-    withdraw:
-      enabled: true
-      min_amount: 0
-      max_amount: 10000
-    send:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10000
-    sep38:
-      exchangeable_assets:
-        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-        - stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-      country_codes:
-        - USA
-      decimals: 4
-      sell_delivery_methods:
-        - name: WIRE
-          description: Send USD directly to the Anchor's bank account.
-      buy_delivery_methods:
-        - name: WIRE
-          description: Have USD sent directly to your bank account.
-    sep6_enabled: false
-    sep24_enabled: false
-    sep31_enabled: false
-    sep38_enabled: true
+
+  # Native asset
   - schema: stellar
     code: native
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 7
     deposit:
       enabled: true
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
     withdraw:
       enabled: true
-      max_amount: 1000000
+      min_amount: 0
+      max_amount: 10
+    sep6_enabled: false
+    sep31_enabled: false
+    sep38_enabled: false
+    sep24_enabled: true
+
+  # Fiat
+  - schema: iso4217
+    code: USD
+    significant_decimals: 2
+    # TODO: these should not be checked
+    deposit:
+      enabled: false
+    withdraw:
+      enabled: false
     send:
-      fee_fixed: 0
-      fee_percent: 0
+      min_amount: 0
       max_amount: 1000000
-    sep31:
-      quotes_supported: true
-      quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
-      # todo assume this is right for now
-      fields:
-        transaction:
-          receiver_routing_number:
-            description: routing number of the destination bank account
-          receiver_account_number:
-            description: bank account number of the destination
-          type:
-            description: type of deposit to make
-            choices:
-              - SEPA
-              - SWIFT
     sep38:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-      decimals: 7
-    sep6_enabled: false
-    sep31_enabled: true
+        - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+      country_codes:
+        - USA
+      decimals: 2
+      sell_delivery_methods:
+        - name: WIRE
+          description: Send USD directly to the Anchor's bank account.
+      buy_delivery_methods:
+        - name: WIRE
+          description: Have USD sent directly to your bank account.
     sep38_enabled: true
-    sep24_enabled: true
+  - schema: iso4217
+    code: CAD
+    significant_decimals: 2
+    # TODO: these should not be checked
+    deposit:
+      enabled: false
+    withdraw:
+      enabled: false
+    send:
+      min_amount: 0
+      max_amount: 1000000
+    sep38:
+      exchangeable_assets:
+        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+        - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+      country_codes:
+        - CAN
+      decimals: 2
+      sell_delivery_methods:
+        - name: WIRE
+          description: Send CAD directly to the Anchor's bank account.
+      buy_delivery_methods:
+        - name: WIRE
+          description: Have CAD sent directly to your bank account.
+    sep38_enabled: true

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -56,7 +56,6 @@ assets:
               - SWIFT
     sep38:
       exchangeable_assets:
-        - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - iso4217:USD
         - iso4217:CAD
     sep6_enabled: true
@@ -114,7 +113,6 @@ assets:
               - SWIFT
     sep38:
       exchangeable_assets:
-        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - iso4217:USD
         - iso4217:CAD
     sep24_enabled: true

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -190,7 +190,7 @@ assets:
   # Fiat
   - schema: iso4217
     code: USD
-    significant_decimals: 2
+    significant_decimals: 7
     # TODO: these should not be checked
     deposit:
       enabled: false
@@ -215,7 +215,7 @@ assets:
     sep38_enabled: true
   - schema: iso4217
     code: CAD
-    significant_decimals: 2
+    significant_decimals: 7
     # TODO: these should not be checked
     deposit:
       enabled: false

--- a/service-runner/src/main/resources/config/stellar.host.docker.internal.toml
+++ b/service-runner/src/main/resources/config/stellar.host.docker.internal.toml
@@ -15,7 +15,7 @@ code = "USDC"
 issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"
 is_asset_anchored = false
-desc = "Circle USDC Token"
+desc = "Anchor Issued USDC Token"
 anchor_asset_type = "crypto"
 
 [[CURRENCIES]]

--- a/service-runner/src/main/resources/config/stellar.localhost.toml
+++ b/service-runner/src/main/resources/config/stellar.localhost.toml
@@ -15,7 +15,7 @@ code = "USDC"
 issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"
 is_asset_anchored = false
-desc = "Circle USDC Token"
+desc = "Anchor Issued USDC Token"
 anchor_asset_type = "crypto"
 
 [[CURRENCIES]]


### PR DESCRIPTION
### Description

This adds the end-to-end for the SEP-6 exchange endpoints. It also cleans up the `stellar.toml` a bit.

### Context

These endpoints do not have any test coverage.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

