### PR TITLE
Update JDK version in compose instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Kotlin reference server.
 
 ```shell
 docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk17 -t anchor-platform:local ./
-docker-compose -f service-runner/src/main/resources/docker-compose.yaml up -d
+docker compose -f service-runner/src/main/resources/docker-compose.yaml up -d
 ```
 
 The [Stellar Demo Wallet](https://demo-wallet.stellar.org) can be used to interact with the Anchor Platform. To get

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Anchor Platform can be run locally using Docker Compose. This will start an inst
 Kotlin reference server.
 
 ```shell
-docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk11 -t anchor-platform:local ./
+docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk17 -t anchor-platform:local ./
 docker-compose -f service-runner/src/main/resources/docker-compose.yaml up -d
 ```
 


### PR DESCRIPTION
### Description

This updates the JDK image version in the docker compose instructions. This also recommends using `docker compose` instead of `docker-compose` as the latter is being deprecated.

### Context

We are now building against JDK 17.

### Testing

- `./gradlew test`
- Tested docker compose starts AP.

### Documentation

N/A

### Known limitations

N/A

