### PR TITLE
[ANCHOR-730] Remove deposit/withdraw config on iso4217 assets

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -571,13 +571,17 @@ public class Sep24Service {
     Map<String, InfoResponse.OperationResponse> depositMap = new HashMap<>();
     Map<String, InfoResponse.OperationResponse> withdrawMap = new HashMap<>();
     for (AssetInfo asset : assets) {
-      if (asset.getDeposit().getEnabled())
-        depositMap.put(
-            asset.getCode(), InfoResponse.OperationResponse.fromAssetOperation(asset.getDeposit()));
-      if (asset.getWithdraw().getEnabled())
-        withdrawMap.put(
-            asset.getCode(),
-            InfoResponse.OperationResponse.fromAssetOperation(asset.getWithdraw()));
+      // iso4217 assets do not have deposit/withdraw configurations
+      if (asset.getSchema().equals(AssetInfo.Schema.stellar)) {
+        if (asset.getDeposit().getEnabled())
+          depositMap.put(
+              asset.getCode(),
+              InfoResponse.OperationResponse.fromAssetOperation(asset.getDeposit()));
+        if (asset.getWithdraw().getEnabled())
+          withdrawMap.put(
+              asset.getCode(),
+              InfoResponse.OperationResponse.fromAssetOperation(asset.getWithdraw()));
+      }
     }
 
     return InfoResponse.builder()

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -523,7 +523,7 @@ public class Sep6Service {
             .build();
 
     for (AssetInfo asset : assetService.listAllAssets()) {
-      if (asset.getSep6Enabled()) {
+      if (asset.getSep6Enabled() && asset.getSchema().equals(AssetInfo.Schema.stellar)) {
 
         if (asset.getDeposit().getEnabled()) {
           List<String> methods = asset.getDeposit().getMethods();

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -676,7 +676,9 @@ internal class Sep24ServiceTest {
   fun `test GET info`() {
     val response = sep24Service.info
 
-    assertEquals(4, response.deposit.size)
+    println(gson.toJson(response))
+
+    assertEquals(3, response.deposit.size)
     assertEquals(2, response.withdraw.size)
     assertNotNull(response.deposit["USDC"])
     assertNotNull(response.withdraw["USDC"])

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -676,8 +676,6 @@ internal class Sep24ServiceTest {
   fun `test GET info`() {
     val response = sep24Service.info
 
-    println(gson.toJson(response))
-
     assertEquals(3, response.deposit.size)
     assertEquals(2, response.withdraw.size)
     assertNotNull(response.deposit["USDC"])

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -191,11 +191,6 @@ assets:
   - schema: iso4217
     code: USD
     significant_decimals: 7
-    # TODO: these should not be checked
-    deposit:
-      enabled: false
-    withdraw:
-      enabled: false
     send:
       min_amount: 0
       max_amount: 1000000
@@ -216,11 +211,6 @@ assets:
   - schema: iso4217
     code: CAD
     significant_decimals: 7
-    # TODO: these should not be checked
-    deposit:
-      enabled: false
-    withdraw:
-      enabled: false
     send:
       min_amount: 0
       max_amount: 1000000


### PR DESCRIPTION
### Description

This removes the deposit/withdraw config object checks on `iso4217` assets.

### Context

These configurations are currently required but are unused.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

