### PR TITLE
[ANCHOR-731] Only check send limits for SEP-31

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -201,17 +201,19 @@ public class Sep38Service {
     }
 
     // Check SEP31 send limits
-    if (sellAsset == null) {
-      throw new BadRequestException("Unsupported sell asset.");
-    }
-    String[] assetCode = sellAsset.getAsset().split(":");
-    AssetInfo asset = assetService.getAsset(assetCode[1]);
-    Long sendMinLimit = asset.getSend().getMinAmount();
-    Long sendMaxLimit = asset.getSend().getMaxAmount();
+    if (context == SEP31) {
+      if (sellAsset == null) {
+        throw new BadRequestException("Unsupported sell asset.");
+      }
+      String[] assetCode = sellAsset.getAsset().split(":");
+      AssetInfo asset = assetService.getAsset(assetCode[1]);
+      Long sendMinLimit = asset.getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSend().getMaxAmount();
 
-    // SEP31: when sell_amount is specified
-    if (context == SEP31 && sellAmount != null) {
-      validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
+      // When sell_amount is specified
+      if (sellAmount != null) {
+        validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
+      }
     }
 
     GetRateRequest.GetRateRequestBuilder rrBuilder =
@@ -235,8 +237,13 @@ public class Sep38Service {
     GetRateResponse rateResponse = this.rateIntegration.getRate(request);
     GetRateResponse.Rate rate = rateResponse.getRate();
 
-    // SEP31: when buy_amount is specified (sell amount found from rate integration)
-    if (context == SEP31 && buyAmount != null) {
+    // Check SEP31 sell_amount from rate integration when buy_amount is specified
+    if (context == SEP31 && isNotEmpty(buyAmount)) {
+      String[] assetCode = sellAsset.getAsset().split(":");
+      AssetInfo asset = assetService.getAsset(assetCode[1]);
+      Long sendMinLimit = asset.getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSend().getMaxAmount();
+
       validateAmountLimit("sell_", rate.getSellAmount(), sendMinLimit, sendMaxLimit);
     }
 
@@ -341,17 +348,19 @@ public class Sep38Service {
     }
 
     // Check SEP31 send limits
-    if (sellAsset == null) {
-      throw new BadRequestException("Unsupported sell asset.");
-    }
-    String[] assetCode = sellAsset.getAsset().split(":");
-    AssetInfo asset = assetService.getAsset(assetCode[1]);
-    Long sendMinLimit = asset.getSend().getMinAmount();
-    Long sendMaxLimit = asset.getSend().getMaxAmount();
+    if (context == SEP31) {
+      if (sellAsset == null) {
+        throw new BadRequestException("Unsupported sell asset.");
+      }
+      String[] assetCode = sellAsset.getAsset().split(":");
+      AssetInfo asset = assetService.getAsset(assetCode[1]);
+      Long sendMinLimit = asset.getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSend().getMaxAmount();
 
-    // SEP31: when sell_amount is specified
-    if (context == SEP31 && request.getSellAmount() != null) {
-      validateAmountLimit("sell_", request.getSellAmount(), sendMinLimit, sendMaxLimit);
+      // When sell_amount is specified
+      if (request.getSellAmount() != null) {
+        validateAmountLimit("sell_", request.getSellAmount(), sendMinLimit, sendMaxLimit);
+      }
     }
 
     GetRateRequest.GetRateRequestBuilder getRateRequestBuilder =
@@ -401,8 +410,13 @@ public class Sep38Service {
     responseBuilder =
         responseBuilder.totalPrice(totalPrice).sellAmount(sellAmount).buyAmount(buyAmount);
 
-    // SEP31: when buy_amount is specified (sell amount found from rate integration)
+    // Check SEP31 sell_amount from rate integration when buy_amount is specified
     if (context == SEP31 && isNotEmpty(buyAmount)) {
+      String[] assetCode = sellAsset.getAsset().split(":");
+      AssetInfo asset = assetService.getAsset(assetCode[1]);
+      Long sendMinLimit = asset.getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSend().getMaxAmount();
+
       validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
     }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
@@ -4,9 +4,11 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
+import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP6
 import org.stellar.anchor.client.Sep38Client
 import org.stellar.anchor.platform.AbstractIntegrationTests
 import org.stellar.anchor.platform.TestConfig
@@ -36,7 +38,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "iso4217:USD",
         "100",
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP31
+        SEP31,
       )
     printResponse(price)
 
@@ -47,7 +49,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "iso4217:USD",
         "100",
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP31
+        SEP31,
       )
     printResponse(postQuote)
 
@@ -60,7 +62,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "100",
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         SEP31,
-        expireAfter = expireAfter
+        expireAfter = expireAfter,
       )
     printResponse(postQuote)
 
@@ -72,7 +74,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
   }
 
   @Test
-  fun `test selling over asset limit throws an exception`() {
+  fun `test selling over asset limit for SEP-31 throws an exception`() {
     printRequest("Calling GET /price")
 
     assertThrows<SepException> {
@@ -80,7 +82,39 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "iso4217:USD",
         "10000000000",
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP31
+        SEP31,
+      )
+    }
+
+    assertThrows<SepException> {
+      sep38Client.postQuote(
+        "iso4217:USD",
+        "10000000000",
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        SEP31,
+      )
+    }
+  }
+
+  @Test
+  fun `test selling over asset limit for SEP-6 does throws an exception`() {
+    printRequest("Calling GET /price")
+
+    assertDoesNotThrow {
+      sep38Client.getPrice(
+        "iso4217:USD",
+        "10000000000",
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        SEP6,
+      )
+    }
+
+    assertDoesNotThrow {
+      sep38Client.postQuote(
+        "iso4217:USD",
+        "10000000000",
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        SEP6,
       )
     }
   }


### PR DESCRIPTION
### Description

This disables send limit checks when the SEP-38 context is not SEP-31.

### Context

This is to unblock the SEP-6 exchange flows.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

