### PR TITLE
[ANCHOR-717] Remove deprecated SEP-6 KYC fields

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/platform/PlatformTransactionData.java
@@ -107,14 +107,6 @@ public class PlatformTransactionData {
   @SerializedName("required_info_updates")
   List<String> requiredInfoUpdates;
 
-  @Deprecated
-  @SerializedName("required_customer_info_message")
-  String requiredCustomerInfoMessage;
-
-  @Deprecated
-  @SerializedName("required_customer_info_updates")
-  List<String> requiredCustomerInfoUpdates;
-
   Map<String, InstructionField> instructions;
 
   public enum Sep {

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RequestCustomerInfoUpdateRequest.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.api.rpc.method;
 
 import com.google.gson.annotations.SerializedName;
 import java.time.Instant;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,14 +14,6 @@ import org.stellar.anchor.api.rpc.method.features.SupportsUserActionRequiredBy;
 @EqualsAndHashCode(callSuper = false)
 public class RequestCustomerInfoUpdateRequest extends RpcMethodParamsRequest
     implements SupportsUserActionRequiredBy {
-
-  @Deprecated
-  @SerializedName("required_customer_info_message")
-  private String requiredCustomerInfoMessage;
-
-  @Deprecated
-  @SerializedName("required_customer_info_updates")
-  private List<String> requiredCustomerInfoUpdates;
 
   @SerializedName("user_action_required_by")
   Instant userActionRequiredBy;

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/Sep6TransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/Sep6TransactionResponse.java
@@ -89,13 +89,5 @@ public class Sep6TransactionResponse {
   @SerializedName("required_info_updates")
   List<String> requiredInfoUpdates;
 
-  @Deprecated
-  @SerializedName("required_customer_info_message")
-  String requiredCustomerInfoMessage;
-
-  @Deprecated
-  @SerializedName("required_customer_info_updates")
-  List<String> requiredCustomerInfoUpdates;
-
   Map<String, InstructionField> instructions;
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Transaction.java
@@ -344,26 +344,6 @@ public interface Sep6Transaction extends SepTransaction {
   void setRequiredInfoUpdates(List<String> requiredInfoUpdates);
 
   /**
-   * A human-readable message indicating why the SEP-12 information provided by the user is not
-   * sufficient to complete the transaction.
-   *
-   * @return the required customer info message.
-   */
-  String getRequiredCustomerInfoMessage();
-
-  void setRequiredCustomerInfoMessage(String requiredCustomerInfoMessage);
-
-  /**
-   * A set of SEP-9 fields that require update from the user via SEP-12. This field is only relevant
-   * when `status` is `pending_customer_info_update`.
-   *
-   * @return the required customer info updates.
-   */
-  List<String> getRequiredCustomerInfoUpdates();
-
-  void setRequiredCustomerInfoUpdates(List<String> requiredCustomerInfoUpdates);
-
-  /**
    * Describes how to complete the off-chain deposit.
    *
    * @return the deposit instructions.

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionBuilder.java
@@ -189,17 +189,6 @@ public class Sep6TransactionBuilder {
     return this;
   }
 
-  public Sep6TransactionBuilder requiredCustomerInfoMessage(String requiredCustomerInfoMessage) {
-    txn.setRequiredCustomerInfoMessage(requiredCustomerInfoMessage);
-    return this;
-  }
-
-  public Sep6TransactionBuilder requiredCustomerInfoUpdates(
-      List<String> requiredCustomerInfoUpdates) {
-    txn.setRequiredCustomerInfoUpdates(requiredCustomerInfoUpdates);
-    return this;
-  }
-
   public Sep6TransactionBuilder instructions(Map<String, InstructionField> instructions) {
     txn.setInstructions(instructions);
     return this;

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
@@ -65,8 +65,6 @@ public class Sep6TransactionUtils {
             .refunds(refunds)
             .requiredInfoMessage(txn.getRequiredInfoMessage())
             .requiredInfoUpdates(txn.getRequiredInfoUpdates())
-            .requiredCustomerInfoMessage(txn.getRequiredCustomerInfoMessage())
-            .requiredCustomerInfoUpdates(txn.getRequiredCustomerInfoUpdates())
             .instructions(txn.getInstructions());
 
     if (Sep6Transaction.Kind.valueOf(txn.getKind().toUpperCase().replace("-", "_")).isDeposit()) {

--- a/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionHelper.java
@@ -163,8 +163,6 @@ public class TransactionHelper {
         .refundMemoType(txn.getRefundMemoType())
         .requiredInfoMessage(txn.getRequiredInfoMessage())
         .requiredInfoUpdates(txn.getRequiredInfoUpdates())
-        .requiredCustomerInfoMessage(txn.getRequiredCustomerInfoMessage())
-        .requiredCustomerInfoUpdates(txn.getRequiredCustomerInfoUpdates())
         .instructions(txn.getInstructions())
         .customers(Customers.builder().sender(customer).receiver(customer).build())
         .build();

--- a/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep6/PojoSep6Transaction.java
@@ -47,8 +47,6 @@ public class PojoSep6Transaction implements Sep6Transaction {
   String refundMemoType;
   String requiredInfoMessage;
   List<String> requiredInfoUpdates;
-  String requiredCustomerInfoMessage;
-  List<String> requiredCustomerInfoUpdates;
   Map<String, InstructionField> instructions;
   List<FeeDescription> feeDetailsList;
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
@@ -96,11 +96,6 @@ class Sep6TransactionUtilsTest {
           "required_info_updates": [
               "some_field"
           ],
-          "required_customer_info_message": "need more customer info",
-          "required_customer_info_updates": [
-              "first_name",
-              "last_name"
-          ],
           "instructions": {
               "key": {
                   "value": "1234",
@@ -192,8 +187,6 @@ class Sep6TransactionUtilsTest {
         refundMemoType = "text"
         requiredInfoMessage = "need more info"
         requiredInfoUpdates = listOf("some_field")
-        requiredCustomerInfoMessage = "need more customer info"
-        requiredCustomerInfoUpdates = listOf("first_name", "last_name")
         instructions = mapOf("key" to InstructionField("1234", "Bank account number"))
       }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
@@ -846,8 +846,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
             "jsonrpc": "2.0",
             "params": {
               "transaction_id": "TX_ID",
-              "message": "test message 1",
-              "required_customer_info_updates": ["first_name", "last_name"]
+              "message": "test message 1"
             }
           },
           {
@@ -956,8 +955,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "1"
           },
@@ -991,8 +989,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "2"
           },
@@ -1028,8 +1025,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "3"
           },
@@ -1065,8 +1061,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "4"
           },
@@ -1102,8 +1097,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "5"
           },
@@ -1157,8 +1151,7 @@ class PlatformApiTests : AbstractIntegrationTests(TestConfig()) {
                 "receiver": {
                   "account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
                 }
-              },
-              "required_customer_info_updates": ["first_name", "last_name"]
+              }
             },
             "id": "6"
           }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Data.kt
@@ -90,10 +90,7 @@ data class RequestOnchainFundsRequest(
 @Serializable
 data class RequestCustomerInfoUpdateHandler(
   @SerialName("transaction_id") override val transactionId: String,
-  override val message: String?,
-  @SerialName("required_customer_info_message") val requiredCustomerInfoMessage: String? = null,
-  @SerialName("required_customer_info_updates")
-  val requiredCustomerInfoUpdates: List<String>? = null,
+  override val message: String?
 ) : RpcActionParamsRequest()
 
 @Serializable

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6Transaction.java
@@ -133,15 +133,6 @@ public class JdbcSep6Transaction extends JdbcSepTransaction implements Sep6Trans
   @Type(type = "json")
   List<String> requiredInfoUpdates;
 
-  @SerializedName("required_customer_info_message")
-  @Column(name = "required_customer_info_message")
-  String requiredCustomerInfoMessage;
-
-  @SerializedName("required_customer_info_updates")
-  @Column(name = "required_customer_info_updates")
-  @Type(type = "json")
-  List<String> requiredCustomerInfoUpdates;
-
   @Column(name = "instructions")
   @Type(type = "json")
   Map<String, InstructionField> instructions;

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandler.java
@@ -20,7 +20,6 @@ import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
-import org.stellar.anchor.sep6.Sep6Transaction;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
 
 public class RequestCustomerInfoUpdateHandler
@@ -77,16 +76,6 @@ public class RequestCustomerInfoUpdateHandler
   @Override
   protected void updateTransactionWithRpcRequest(
       JdbcSepTransaction txn, RequestCustomerInfoUpdateRequest request) {
-    if (Sep.from(txn.getProtocol()) == SEP_6) {
-      Sep6Transaction txn6 = (Sep6Transaction) txn;
-
-      if (request.getRequiredCustomerInfoMessage() != null) {
-        txn6.setRequiredCustomerInfoMessage(request.getRequiredCustomerInfoMessage());
-      }
-
-      if (request.getRequiredCustomerInfoUpdates() != null) {
-        txn6.setRequiredCustomerInfoUpdates(request.getRequiredCustomerInfoUpdates());
-      }
-    }
+    return;
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -395,8 +395,6 @@ public class TransactionService {
         JdbcSep6Transaction sep6Txn = (JdbcSep6Transaction) txn;
         txnUpdated = updateField(patch, sep6Txn, "requiredInfoMessage", txnUpdated);
         txnUpdated = updateField(patch, sep6Txn, "requiredInfoUpdates", txnUpdated);
-        txnUpdated = updateField(patch, sep6Txn, "requiredCustomerInfoMessage", txnUpdated);
-        txnUpdated = updateField(patch, sep6Txn, "requiredCustomerInfoUpdates", txnUpdated);
         txnUpdated = updateField(patch, sep6Txn, "instructions", txnUpdated);
         if (feeDetails != null) {
           sep6Txn.setFeeDetails(feeDetails);

--- a/platform/src/main/resources/db/migration/V18__sep6_remove_deprecated_kyc_fields.sql
+++ b/platform/src/main/resources/db/migration/V18__sep6_remove_deprecated_kyc_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sep6_transaction DROP COLUMN required_customer_info_message;
+ALTER TABLE sep6_transaction DROP COLUMN required_customer_info_updates;

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestCustomerInfoUpdateHandlerTest.kt
@@ -227,11 +227,7 @@ class RequestCustomerInfoUpdateHandlerTest {
 
   @Test
   fun test_handle_sep6_unsupportedStatus() {
-    val request =
-      RequestCustomerInfoUpdateRequest.builder()
-        .transactionId(TX_ID)
-        .requiredCustomerInfoUpdates(listOf("email_address", "family_name", "given_name"))
-        .build()
+    val request = RequestCustomerInfoUpdateRequest.builder().transactionId(TX_ID).build()
     val txn6 = JdbcSep6Transaction()
     txn6.status = PENDING_USR_TRANSFER_START.toString()
     txn6.kind = DEPOSIT.toString()
@@ -271,11 +267,7 @@ class RequestCustomerInfoUpdateHandlerTest {
       ]
   )
   fun test_handle_sep6_ok(kind: String, status: String) {
-    val request =
-      RequestCustomerInfoUpdateRequest.builder()
-        .transactionId(TX_ID)
-        .requiredCustomerInfoUpdates(listOf("email_address", "family_name", "given_name"))
-        .build()
+    val request = RequestCustomerInfoUpdateRequest.builder().transactionId(TX_ID).build()
     val txn6 = JdbcSep6Transaction()
     txn6.status = status
     txn6.kind = kind
@@ -301,8 +293,6 @@ class RequestCustomerInfoUpdateHandlerTest {
     expectedSep6Txn.kind = kind
     expectedSep6Txn.status = PENDING_CUSTOMER_INFO_UPDATE.toString()
     expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedSep6Txn.requiredCustomerInfoUpdates =
-      listOf("email_address", "family_name", "given_name")
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -317,8 +307,6 @@ class RequestCustomerInfoUpdateHandlerTest {
     expectedResponse.amountExpected = Amount(null, "")
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
-    expectedResponse.requiredCustomerInfoUpdates =
-      listOf("email_address", "family_name", "given_name")
 
     JSONAssert.assertEquals(
       gson.toJson(expectedResponse),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/TransactionServiceTest.kt
@@ -714,14 +714,6 @@ class TransactionServiceTest {
         "completed_at": "2023-10-31T21:16:44.652008Z",
         "stellar_transaction_id": "a8b7f7ba67a5c63975512aa113c5a177e675c5e195a2e15920b39f5a5a91f306",
         "message": "Funds sent to user",
-        "required_customer_info_updates": [
-          "id_type",
-          "id_country_code",
-          "id_issue_date",
-          "id_expiration_date",
-          "id_number",
-          "address"
-        ],
         "instructions": {
           "organization.bank_number": {
             "value": "121122676",
@@ -1077,14 +1069,6 @@ class TransactionServiceTest {
         "completed_at": "2023-10-31T21:16:44.652008Z",
         "message": "Funds sent to user",
         "customers": { "sender": {}, "receiver": {} },
-        "required_customer_info_updates": [
-          "id_type",
-          "id_country_code",
-          "id_issue_date",
-          "id_expiration_date",
-          "id_number",
-          "address"
-        ],
         "instructions": {
           "organization.bank_number": {
             "value": "121122676",


### PR DESCRIPTION
### Description

This removes the deprecated `required_customer_info_updates` and `required_customer_info_message` fields.

### Context

These fields have been deprecated in favor of transactional SEP-12 APIs.

### Testing

- `./gradlew test`

### Documentation

I will create PR to remove the fields from the docs.

### Known limitations

N/A

