### PR TITLE
[ANCHOR-734] Fix wrong secret used to sign headers

### DIFF
--- a/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
@@ -8,7 +8,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.http.HttpStatus;
 import org.stellar.anchor.api.exception.*;
-import org.stellar.anchor.auth.AuthHelper;
 import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.GsonUtils;
 
@@ -22,7 +21,6 @@ public abstract class BaseApiClient {
           .writeTimeout(10, TimeUnit.MINUTES)
           .callTimeout(10, TimeUnit.MINUTES)
           .build();
-  final AuthHelper authHelper;
   final String endpoint;
 
   /**
@@ -31,8 +29,7 @@ public abstract class BaseApiClient {
    * @param authHelper the AuthHelper to use for authentication.
    * @param endpoint the API endpoint.
    */
-  protected BaseApiClient(AuthHelper authHelper, String endpoint) {
-    this.authHelper = authHelper;
+  protected BaseApiClient(String endpoint) {
     this.endpoint = endpoint;
   }
 
@@ -55,9 +52,11 @@ public abstract class BaseApiClient {
     Request.Builder requestBuilder =
         new Request.Builder().header("Content-Type", "application/json");
 
-    AuthHeader<String, String> authHeader = authHelper.createPlatformServerAuthHeader();
+    AuthHeader<String, String> authHeader = createAuthHeader();
     return authHeader == null
         ? requestBuilder
         : requestBuilder.header(authHeader.getName(), authHeader.getValue());
   }
+
+  abstract AuthHeader<String, String> createAuthHeader() throws InvalidConfigException;
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
@@ -11,6 +11,7 @@ import org.stellar.anchor.api.callback.SendEventResponse;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.auth.AuthHelper;
+import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.OkHttpUtil;
 
@@ -18,6 +19,7 @@ import org.stellar.anchor.util.OkHttpUtil;
 public class CallbackApiClient extends BaseApiClient {
   static final Gson gson = GsonUtils.getInstance();
   final HttpUrl url;
+  private final AuthHelper authHelper;
 
   /**
    * Creates a new CallbackApiClient.
@@ -27,7 +29,8 @@ public class CallbackApiClient extends BaseApiClient {
    * @throws InvalidConfigException if the endpoint is invalid.
    */
   public CallbackApiClient(AuthHelper authHelper, String endpoint) throws InvalidConfigException {
-    super(authHelper, endpoint);
+    super(endpoint);
+    this.authHelper = authHelper;
     HttpUrl endpointUrl = HttpUrl.parse(endpoint);
     if (endpointUrl == null)
       throw new InvalidConfigException(
@@ -58,5 +61,10 @@ public class CallbackApiClient extends BaseApiClient {
         gson.fromJson(handleResponse(response), SendEventResponse.class);
     sendEventResponse.setCode(response.code());
     return sendEventResponse;
+  }
+
+  @Override
+  AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
+    return authHelper.createCallbackAuthHeader();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/PlatformApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/PlatformApiClient.java
@@ -31,15 +31,17 @@ import org.stellar.anchor.api.rpc.method.NotifyTransactionErrorRequest;
 import org.stellar.anchor.api.rpc.method.RpcMethod;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.auth.AuthHelper;
+import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.OkHttpUtil;
 
 /** The client for the PlatformAPI endpoints. */
 public class PlatformApiClient extends BaseApiClient {
-
+  private final AuthHelper authHelper;
   public static final String JSON_RPC_VERSION = "2.0";
 
   public PlatformApiClient(AuthHelper authHelper, String endpoint) {
-    super(authHelper, endpoint);
+    super(endpoint);
+    this.authHelper = authHelper;
   }
 
   /**
@@ -225,5 +227,10 @@ public class PlatformApiClient extends BaseApiClient {
     if (val != null) {
       builder.addQueryParameter(name, f.apply(val));
     }
+  }
+
+  @Override
+  AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
+    return authHelper.createPlatformServerAuthHeader();
   }
 }


### PR DESCRIPTION
### Description

Fixed bug described in #1406 

### Context

CallbackApiClient (derived from BaseApiClient) was using wrong method for JWT signature (it was hardcoded to be `authHelper.createPlatformServerAuthHeader`), which in turn raised an error because platform JWT secret wasn't defined in the scope of that particular AuthHelper   

### Testing

- `./gradlew test`


### Documentation

N/A

### Known limitations

N/A
