### PR TITLE
[Anchor-734] AuthHelper refactoring

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/UnauthorizedException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package org.stellar.anchor.api.exception;
+
+import lombok.EqualsAndHashCode;
+
+/** Thrown when the client request is unauthorized. */
+@EqualsAndHashCode(callSuper = false)
+public class UnauthorizedException extends AnchorException {
+  public UnauthorizedException(String message, Exception cause) {
+    super(message, cause);
+  }
+
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
@@ -8,6 +8,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.http.HttpStatus;
 import org.stellar.anchor.api.exception.*;
+import org.stellar.anchor.auth.AuthHelper;
 import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.GsonUtils;
 
@@ -22,6 +23,7 @@ public abstract class BaseApiClient {
           .callTimeout(10, TimeUnit.MINUTES)
           .build();
   final String endpoint;
+  private final AuthHelper authHelper;
 
   /**
    * Creates a new BaseApiClient.
@@ -29,7 +31,8 @@ public abstract class BaseApiClient {
    * @param authHelper the AuthHelper to use for authentication.
    * @param endpoint the API endpoint.
    */
-  protected BaseApiClient(String endpoint) {
+  protected BaseApiClient(AuthHelper authHelper, String endpoint) {
+    this.authHelper = authHelper;
     this.endpoint = endpoint;
   }
 
@@ -52,11 +55,9 @@ public abstract class BaseApiClient {
     Request.Builder requestBuilder =
         new Request.Builder().header("Content-Type", "application/json");
 
-    AuthHeader<String, String> authHeader = createAuthHeader();
+    AuthHeader<String, String> authHeader = authHelper.createAuthHeader();
     return authHeader == null
         ? requestBuilder
         : requestBuilder.header(authHeader.getName(), authHeader.getValue());
   }
-
-  abstract AuthHeader<String, String> createAuthHeader() throws InvalidConfigException;
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
@@ -11,7 +11,6 @@ import org.stellar.anchor.api.callback.SendEventResponse;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.auth.AuthHelper;
-import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.OkHttpUtil;
 
@@ -29,7 +28,7 @@ public class CallbackApiClient extends BaseApiClient {
    * @throws InvalidConfigException if the endpoint is invalid.
    */
   public CallbackApiClient(AuthHelper authHelper, String endpoint) throws InvalidConfigException {
-    super(endpoint);
+    super(authHelper, endpoint);
     this.authHelper = authHelper;
     HttpUrl endpointUrl = HttpUrl.parse(endpoint);
     if (endpointUrl == null)
@@ -61,10 +60,5 @@ public class CallbackApiClient extends BaseApiClient {
         gson.fromJson(handleResponse(response), SendEventResponse.class);
     sendEventResponse.setCode(response.code());
     return sendEventResponse;
-  }
-
-  @Override
-  AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
-    return authHelper.createCallbackAuthHeader();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/PlatformApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/PlatformApiClient.java
@@ -31,17 +31,14 @@ import org.stellar.anchor.api.rpc.method.NotifyTransactionErrorRequest;
 import org.stellar.anchor.api.rpc.method.RpcMethod;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.auth.AuthHelper;
-import org.stellar.anchor.util.AuthHeader;
 import org.stellar.anchor.util.OkHttpUtil;
 
 /** The client for the PlatformAPI endpoints. */
 public class PlatformApiClient extends BaseApiClient {
-  private final AuthHelper authHelper;
   public static final String JSON_RPC_VERSION = "2.0";
 
   public PlatformApiClient(AuthHelper authHelper, String endpoint) {
-    super(endpoint);
-    this.authHelper = authHelper;
+    super(authHelper, endpoint);
   }
 
   /**
@@ -227,10 +224,5 @@ public class PlatformApiClient extends BaseApiClient {
     if (val != null) {
       builder.addQueryParameter(name, f.apply(val));
     }
-  }
-
-  @Override
-  AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
-    return authHelper.createPlatformServerAuthHeader();
   }
 }

--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -1,7 +1,8 @@
 package org.stellar.anchor.auth;
 
 import static java.util.Date.from;
-import static org.stellar.anchor.auth.AuthHelper.jwtsBuilder;
+import static org.stellar.anchor.util.JwtUtil.jwtsBuilder;
+import static org.stellar.anchor.util.JwtUtil.jwtsParser;
 
 import io.jsonwebtoken.*;
 import java.lang.reflect.InvocationTargetException;
@@ -198,11 +199,7 @@ public class JwtService {
           String.format("The Jwt class:[%s] is not supported", cls.getName()));
     }
 
-    Jwt jwt =
-        AuthHelper.jwtsParser()
-            .verifyWith(KeyUtil.toSecretKeySpecOrNull(secret))
-            .build()
-            .parse(cipher);
+    Jwt jwt = jwtsParser().verifyWith(KeyUtil.toSecretKeySpecOrNull(secret)).build().parse(cipher);
 
     if (cls.equals(Sep6MoreInfoUrlJwt.class)) {
       return (T) Sep6MoreInfoUrlJwt.class.getConstructor(Jwt.class).newInstance(jwt);
@@ -232,7 +229,7 @@ public class JwtService {
     var jcaPublicKey = factory.generatePublic(x509KeySpec);
 
     try {
-      return AuthHelper.jwtsParser().verifyWith(jcaPublicKey).build().parseSignedClaims(cipher);
+      return jwtsParser().verifyWith(jcaPublicKey).build().parseSignedClaims(cipher);
     } catch (Exception e) {
       Log.debugF("Invalid header signature {}", e.getMessage());
       throw new SepValidationException("Invalid header signature");

--- a/core/src/main/java/org/stellar/anchor/util/JwtUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/JwtUtil.java
@@ -1,0 +1,17 @@
+package org.stellar.anchor.util;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.JwtParserBuilder;
+import io.jsonwebtoken.Jwts;
+import org.stellar.anchor.auth.JwtsGsonDeserializer;
+import org.stellar.anchor.auth.JwtsGsonSerializer;
+
+public final class JwtUtil {
+  public static JwtBuilder jwtsBuilder() {
+    return Jwts.builder().json(JwtsGsonSerializer.newInstance());
+  }
+
+  public static JwtParserBuilder jwtsParser() {
+    return Jwts.parser().json(JwtsGsonDeserializer.newInstance());
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/AuthHelperTest.kt
@@ -72,9 +72,14 @@ class AuthHelperTest {
               .platformAuthSecret("secret__________________________________")
               .build()
           var authHelper =
-            AuthHelper.forJwtToken(headerName, jwtService, JWT_EXPIRATION_MILLISECONDS)
+            AuthHelper.forJwtToken(
+              headerName,
+              jwtService,
+              JWT_EXPIRATION_MILLISECONDS,
+              PlatformAuthJwt::class.java
+            )
 
-          val gotPlatformAuthHeader = authHelper.createPlatformServerAuthHeader()
+          val gotPlatformAuthHeader = authHelper.createAuthHeader()
           val wantPlatformAuthHeader =
             AuthHeader(headerName, "Bearer ${jwtService.encode(wantPlatformJwt)}")
           assertEquals(wantPlatformAuthHeader, gotPlatformAuthHeader)
@@ -83,8 +88,14 @@ class AuthHelperTest {
             JwtService.builder()
               .callbackAuthSecret("secret__________________________________")
               .build()
-          authHelper = AuthHelper.forJwtToken(headerName, jwtService, JWT_EXPIRATION_MILLISECONDS)
-          val gotCallbackAuthHeader = authHelper.createCallbackAuthHeader()
+          authHelper =
+            AuthHelper.forJwtToken(
+              headerName,
+              jwtService,
+              JWT_EXPIRATION_MILLISECONDS,
+              CallbackAuthJwt::class.java
+            )
+          val gotCallbackAuthHeader = authHelper.createAuthHeader()
           val wantCallbackAuthHeader =
             AuthHeader(headerName, "Bearer ${jwtService.encode(wantCallbackJwt)}")
           assertEquals(wantCallbackAuthHeader, gotCallbackAuthHeader)
@@ -93,32 +104,28 @@ class AuthHelperTest {
             JwtService.builder()
               .custodyAuthSecret("secret__________________________________")
               .build()
-          authHelper = AuthHelper.forJwtToken(headerName, jwtService, JWT_EXPIRATION_MILLISECONDS)
-          val gotCustodyAuthHeader = authHelper.createCustodyAuthHeader()
+          authHelper =
+            AuthHelper.forJwtToken(
+              headerName,
+              jwtService,
+              JWT_EXPIRATION_MILLISECONDS,
+              CustodyAuthJwt::class.java
+            )
+          val gotCustodyAuthHeader = authHelper.createAuthHeader()
           val wantCustodyAuthHeader =
             AuthHeader(headerName, "Bearer ${jwtService.encode(wantCustodyJwt)}")
           assertEquals(wantCustodyAuthHeader, gotCustodyAuthHeader)
         }
         API_KEY -> {
           val authHelper = AuthHelper.forApiKey("X-Api-Key", "secret")
-          val gotPlatformAuthHeader = authHelper.createPlatformServerAuthHeader()
+          val gotPlatformAuthHeader = authHelper.createAuthHeader()
           val wantPlatformAuthHeader = AuthHeader("X-Api-Key", "secret")
           assertEquals(wantPlatformAuthHeader, gotPlatformAuthHeader)
-          val gotCallbackAuthHeader = authHelper.createCallbackAuthHeader()
-          val wantCallbackAuthHeader = AuthHeader("X-Api-Key", "secret")
-          assertEquals(wantCallbackAuthHeader, gotCallbackAuthHeader)
-          val gotCustodyAuthHeader = authHelper.createCustodyAuthHeader()
-          val wantCustodyAuthHeader = AuthHeader("X-Api-Key", "secret")
-          assertEquals(wantCustodyAuthHeader, gotCustodyAuthHeader)
         }
         NONE -> {
           val authHelper = AuthHelper.forNone()
-          val platformAuthHeader = authHelper.createPlatformServerAuthHeader()
+          val platformAuthHeader = authHelper.createAuthHeader()
           assertNull(platformAuthHeader)
-          val callbackAuthHeader = authHelper.createCallbackAuthHeader()
-          assertNull(callbackAuthHeader)
-          val custodyAuthHeader = authHelper.createCustodyAuthHeader()
-          assertNull(custodyAuthHeader)
         }
         else -> {
           throw Exception("Unsupported new AuthType!!!")

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
@@ -18,6 +18,7 @@ import org.stellar.anchor.api.callback.GetFeeRequest
 import org.stellar.anchor.api.callback.GetRateRequest
 import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
+import org.stellar.anchor.auth.ApiAuthJwt.CallbackAuthJwt
 import org.stellar.anchor.auth.AuthHelper
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.client.Sep12Client
@@ -63,7 +64,12 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
     )
 
   private val authHelper =
-    AuthHelper.forJwtToken("Authorization", platformToAnchorJwtService, JWT_EXPIRATION_MILLISECONDS)
+    AuthHelper.forJwtToken(
+      "Authorization",
+      platformToAnchorJwtService,
+      JWT_EXPIRATION_MILLISECONDS,
+      CallbackAuthJwt::class.java
+    )
 
   private val gson: Gson = GsonUtils.getInstance()
 

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/AbstractAuthIntegrationTest.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/AbstractAuthIntegrationTest.kt
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.extendedtest.auth
 
+import org.stellar.anchor.auth.ApiAuthJwt.CustodyAuthJwt
+import org.stellar.anchor.auth.ApiAuthJwt.PlatformAuthJwt
 import org.stellar.anchor.auth.AuthHelper
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.platform.TestProfileExecutor
@@ -42,9 +44,19 @@ abstract class AbstractAuthIntegrationTest {
         (PLATFORM_TO_CUSTODY_SECRET + "bad")
       )
 
-    internal val jwtAuthHelper = AuthHelper.forJwtToken(jwtService, 10000)
-    internal val jwtWrongKeyAuthHelper = AuthHelper.forJwtToken(jwtWrongKeyService, 10000)
-    internal val jwtExpiredAuthHelper = AuthHelper.forJwtToken(jwtService, 0)
+    internal val platformJwtAuthHelper =
+      AuthHelper.forJwtToken(jwtService, 10000, PlatformAuthJwt::class.java)
+    internal val platformJwtWrongKeyAuthHelper =
+      AuthHelper.forJwtToken(jwtWrongKeyService, 10000, PlatformAuthJwt::class.java)
+    internal val platformJwtExpiredAuthHelper =
+      AuthHelper.forJwtToken(jwtService, 0, PlatformAuthJwt::class.java)
+
+    internal val custodyJwtAuthHelper =
+      AuthHelper.forJwtToken(jwtService, 10000, CustodyAuthJwt::class.java)
+    internal val custodyJwtWrongKeyAuthHelper =
+      AuthHelper.forJwtToken(jwtWrongKeyService, 10000, CustodyAuthJwt::class.java)
+    internal val custodyJwtExpiredAuthHelper =
+      AuthHelper.forJwtToken(jwtService, 0, CustodyAuthJwt::class.java)
     internal lateinit var testProfileRunner: TestProfileExecutor
   }
 }

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/custody/AuthJwtCustodyTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/custody/AuthJwtCustodyTests.kt
@@ -30,11 +30,11 @@ internal class AuthJwtCustodyTests : AbstractAuthIntegrationTest() {
     CustodyApiConfig(PropertyCustodySecretConfig()).apply { baseUrl = "http://localhost:8086" }
 
   private val jwtCustodyClient: CustodyApiClient =
-    CustodyApiClient(httpClient, jwtAuthHelper, custodyApiConfig)
+    CustodyApiClient(httpClient, custodyJwtAuthHelper, custodyApiConfig)
   private val jwtWrongKeyCustodyClient: CustodyApiClient =
-    CustodyApiClient(httpClient, jwtWrongKeyAuthHelper, custodyApiConfig)
+    CustodyApiClient(httpClient, custodyJwtWrongKeyAuthHelper, custodyApiConfig)
   private val jwtExpiredTokenCustodyClient: CustodyApiClient =
-    CustodyApiClient(httpClient, jwtExpiredAuthHelper, custodyApiConfig)
+    CustodyApiClient(httpClient, custodyJwtExpiredAuthHelper, custodyApiConfig)
 
   @Test
   fun `test the custody endpoints with JWT auth`() {

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
@@ -98,7 +98,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         gson
       )
     // Assert the request does not throw a 403.
-    assertThrows<NotFoundException> {
+    assertThrows<UnauthorizedException> {
       rci.getCustomer(GetCustomerRequest.builder().id("1").build())
     }
   }
@@ -113,7 +113,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         gson
       )
     // Assert the request does not throw a 403.
-    assertThrows<BadRequestException> { rri.getRate(GetRateRequest.builder().build()) }
+    assertThrows<UnauthorizedException> { rri.getRate(GetRateRequest.builder().build()) }
   }
 
   @Test
@@ -126,7 +126,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         gson
       )
     // Assert the request does not throw a 403.
-    assertThrows<BadRequestException> { rfi.getFee(GetFeeRequest.builder().build()) }
+    assertThrows<UnauthorizedException> { rfi.getFee(GetFeeRequest.builder().build()) }
   }
 
   @Test
@@ -138,7 +138,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtWrongKeyAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> {
+    assertThrows<UnauthorizedException> {
       badTokenClient.getCustomer(GetCustomerRequest.builder().id("1").build())
     }
 
@@ -149,7 +149,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtWrongKeyAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> {
+    assertThrows<UnauthorizedException> {
       expiredTokenClient.getCustomer(GetCustomerRequest.builder().id("1").build())
     }
   }
@@ -163,7 +163,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtWrongKeyAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> { badTokenClient.getRate(GetRateRequest.builder().build()) }
+    assertThrows<UnauthorizedException> { badTokenClient.getRate(GetRateRequest.builder().build()) }
 
     val expiredTokenClient =
       RestRateIntegration(
@@ -172,7 +172,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtExpiredAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> {
+    assertThrows<UnauthorizedException> {
       expiredTokenClient.getRate(GetRateRequest.builder().build())
     }
   }
@@ -186,7 +186,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtWrongKeyAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> { badTokenClient.getFee(GetFeeRequest.builder().build()) }
+    assertThrows<UnauthorizedException> { badTokenClient.getFee(GetFeeRequest.builder().build()) }
 
     val expiredTokenClient =
       RestFeeIntegration(
@@ -195,7 +195,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         platformJwtExpiredAuthHelper,
         gson
       )
-    assertThrows<ServerErrorException> {
+    assertThrows<UnauthorizedException> {
       expiredTokenClient.getFee(GetFeeRequest.builder().build())
     }
   }

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
@@ -30,11 +30,11 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       .build()
 
   private val jwtPlatformClient: PlatformApiClient =
-    PlatformApiClient(jwtAuthHelper, "http://localhost:8085")
+    PlatformApiClient(platformJwtAuthHelper, "http://localhost:8085")
   private val jwtWrongKeyPlatformClient: PlatformApiClient =
-    PlatformApiClient(jwtWrongKeyAuthHelper, "http://localhost:8085")
+    PlatformApiClient(platformJwtWrongKeyAuthHelper, "http://localhost:8085")
   private val jwtExpiredTokenPlatformClient: PlatformApiClient =
-    PlatformApiClient(jwtExpiredAuthHelper, "http://localhost:8085")
+    PlatformApiClient(platformJwtExpiredAuthHelper, "http://localhost:8085")
 
   @ParameterizedTest
   @CsvSource(
@@ -94,7 +94,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestCustomerIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtAuthHelper,
+        platformJwtAuthHelper,
         gson
       )
     // Assert the request does not throw a 403.
@@ -109,7 +109,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestRateIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtAuthHelper,
+        platformJwtAuthHelper,
         gson
       )
     // Assert the request does not throw a 403.
@@ -122,7 +122,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestFeeIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtAuthHelper,
+        platformJwtAuthHelper,
         gson
       )
     // Assert the request does not throw a 403.
@@ -135,7 +135,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestCustomerIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtWrongKeyAuthHelper,
+        platformJwtWrongKeyAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> {
@@ -146,7 +146,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestCustomerIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtWrongKeyAuthHelper,
+        platformJwtWrongKeyAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> {
@@ -160,7 +160,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestRateIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtWrongKeyAuthHelper,
+        platformJwtWrongKeyAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> { badTokenClient.getRate(GetRateRequest.builder().build()) }
@@ -169,7 +169,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestRateIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtExpiredAuthHelper,
+        platformJwtExpiredAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> {
@@ -183,7 +183,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestFeeIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtWrongKeyAuthHelper,
+        platformJwtWrongKeyAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> { badTokenClient.getFee(GetFeeRequest.builder().build()) }
@@ -192,7 +192,7 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
       RestFeeIntegration(
         "http://localhost:${REFERENCE_SERVER_PORT}",
         httpClient,
-        jwtExpiredAuthHelper,
+        platformJwtExpiredAuthHelper,
         gson
       )
     assertThrows<ServerErrorException> {

--- a/platform/src/main/java/org/stellar/anchor/platform/apiclient/CustodyApiClient.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/apiclient/CustodyApiClient.java
@@ -98,7 +98,7 @@ public class CustodyApiClient {
 
   private Request.Builder getRequestBuilder() throws InvalidConfigException {
     Request.Builder requestBuilder = new Request.Builder();
-    AuthHeader<String, String> authHeader = authHelper.createCustodyAuthHeader();
+    AuthHeader<String, String> authHeader = authHelper.createAuthHeader();
     return authHeader == null
         ? requestBuilder
         : requestBuilder.header(authHeader.getName(), authHeader.getValue());

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -46,7 +46,8 @@ public class PlatformIntegrationHelper {
     }
   }
 
-  public static AnchorException httpError(String responseContent, int responseCode, Gson gson) {
+  public static AnchorException httpError(String responseContent, int responseCode, Gson gson)
+      throws AnchorException {
     Log.infoF(
         "Error returned from the Anchor Backend.\nresponseCode={}\nContent={}",
         responseCode,
@@ -67,6 +68,8 @@ public class PlatformIntegrationHelper {
                 : HttpStatus.valueOf(responseCode).getReasonPhrase();
 
     switch (HttpStatus.valueOf(responseCode)) {
+      case UNAUTHORIZED: // 401
+        throw new UnauthorizedException(errorMessage);
       case UNPROCESSABLE_ENTITY: // 422
       case BAD_REQUEST: // 400
         return new BadRequestException(errorMessage);

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -19,7 +19,7 @@ public class PlatformIntegrationHelper {
     Request.Builder requestBuilder =
         new Request.Builder().header("Content-Type", "application/json");
 
-    AuthHeader<String, String> authHeader = authHelper.createCallbackAuthHeader();
+    AuthHeader<String, String> authHeader = authHelper.createAuthHeader();
     return authHeader == null
         ? requestBuilder
         : requestBuilder.header(authHeader.getName(), authHeader.getValue());

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/CustodyApiBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/CustodyApiBeans.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.auth.ApiAuthJwt;
 import org.stellar.anchor.auth.AuthHelper;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.platform.apiclient.CustodyApiClient;
@@ -40,7 +41,8 @@ public class CustodyApiBeans {
         return AuthHelper.forJwtToken(
             custodyApiConfig.getAuth().getJwt().getHttpHeader(),
             JwtService.builder().custodyAuthSecret(authSecret).build(),
-            Long.parseLong(custodyApiConfig.getAuth().getJwt().getExpirationMilliseconds()));
+            Long.parseLong(custodyApiConfig.getAuth().getJwt().getExpirationMilliseconds()),
+            ApiAuthJwt.CustodyAuthJwt.class);
       case API_KEY:
         return AuthHelper.forApiKey(
             custodyApiConfig.getAuth().getApiKey().getHttpHeader(), authSecret);

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/PlatformApiClientBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/PlatformApiClientBeans.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.component.share;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.stellar.anchor.apiclient.PlatformApiClient;
+import org.stellar.anchor.auth.ApiAuthJwt;
 import org.stellar.anchor.auth.AuthHelper;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.platform.config.PlatformApiConfig;
@@ -22,7 +23,8 @@ public class PlatformApiClientBeans {
         return AuthHelper.forJwtToken(
             platformApiConfig.getAuth().getJwt().getHttpHeader(),
             JwtService.builder().platformAuthSecret(secret).build(),
-            Long.parseLong(platformApiConfig.getAuth().getJwt().getExpirationMilliseconds()));
+            Long.parseLong(platformApiConfig.getAuth().getJwt().getExpirationMilliseconds()),
+            ApiAuthJwt.PlatformAuthJwt.class);
       case API_KEY:
         return AuthHelper.forApiKey(
             platformApiConfig.getAuth().getApiKey().getHttpHeader(), secret);

--- a/platform/src/main/java/org/stellar/anchor/platform/config/CallbackApiConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/CallbackApiConfig.java
@@ -7,10 +7,7 @@ import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-import org.stellar.anchor.auth.AuthConfig;
-import org.stellar.anchor.auth.AuthHelper;
-import org.stellar.anchor.auth.AuthType;
-import org.stellar.anchor.auth.JwtService;
+import org.stellar.anchor.auth.*;
 import org.stellar.anchor.util.KeyUtil;
 import org.stellar.anchor.util.NetUtil;
 
@@ -89,7 +86,8 @@ public class CallbackApiConfig implements Validator {
         return AuthHelper.forJwtToken(
             getAuth().getJwt().getHttpHeader(),
             JwtService.builder().callbackAuthSecret(secret).build(),
-            Long.parseLong(getAuth().getJwt().getExpirationMilliseconds()));
+            Long.parseLong(getAuth().getJwt().getExpirationMilliseconds()),
+            ApiAuthJwt.CallbackAuthJwt.class);
       case API_KEY:
         return AuthHelper.forApiKey(getAuth().getApiKey().getHttpHeader(), secret);
       default:

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
@@ -42,7 +42,7 @@ public abstract class AbstractControllerExceptionHandler {
   }
 
   @ResponseStatus(HttpStatus.FORBIDDEN)
-  @ExceptionHandler({SepNotAuthorizedException.class})
+  @ExceptionHandler({SepNotAuthorizedException.class, UnauthorizedException.class})
   public SepExceptionResponse handleAuthError(SepException ex) {
     infoF("SEP-10 authorization failure: {}", ex.getMessage());
     return new SepExceptionResponse(ex.getMessage());

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksApiClient.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksApiClient.java
@@ -1,6 +1,6 @@
 package org.stellar.anchor.platform.custody.fireblocks;
 
-import static org.stellar.anchor.auth.AuthHelper.jwtsBuilder;
+import static org.stellar.anchor.util.JwtUtil.jwtsBuilder;
 import static org.stellar.anchor.util.OkHttpUtil.TYPE_JSON;
 
 import io.jsonwebtoken.SignatureAlgorithm;

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/PlatformIntegrationHelperTest.kt
@@ -49,7 +49,12 @@ class PlatformIntegrationHelperTest {
             .platformAuthSecret("secret__________________________________")
             .custodyAuthSecret("secret__________________________________")
             .build()
-        val authHelper = AuthHelper.forJwtToken(jwtService, JWT_EXPIRATION_MILLISECONDS)
+        val authHelper =
+          AuthHelper.forJwtToken(
+            jwtService,
+            JWT_EXPIRATION_MILLISECONDS,
+            PlatformAuthJwt::class.java
+          )
 
         val gotRequestBuilder = PlatformIntegrationHelper.getRequestBuilder(authHelper)
         val gotRequest = gotRequestBuilder.url(TEST_HOME_DOMAIN).get().build()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyApiClientTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyApiClientTest.kt
@@ -50,7 +50,7 @@ class CustodyApiClientTest {
     MockKAnnotations.init(this, relaxUnitFun = true)
 
     val authHeader = AuthHeader(AUTH_HEADER_NAME, AUTH_HEADER_VALUE)
-    every { authHelper.createCustodyAuthHeader() } returns authHeader
+    every { authHelper.createAuthHeader() } returns authHeader
     every { custodyApiConfig.baseUrl } returns BASE_URL
 
     custodyApiClient = CustodyApiClient(httpClient, authHelper, custodyApiConfig)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksApiClientTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksApiClientTest.kt
@@ -25,10 +25,10 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.exception.FireblocksException
 import org.stellar.anchor.api.exception.InvalidConfigException
-import org.stellar.anchor.auth.AuthHelper
 import org.stellar.anchor.config.CustodySecretConfig
 import org.stellar.anchor.platform.config.FireblocksConfig
 import org.stellar.anchor.util.FileUtil.getResourceFileAsString
+import org.stellar.anchor.util.JwtUtil.jwtsParser
 
 class FireblocksApiClientTest {
 
@@ -231,7 +231,7 @@ class FireblocksApiClientTest {
     Assertions.assertTrue(token.startsWith("Bearer "))
 
     val claims =
-      AuthHelper.jwtsParser()
+      jwtsParser()
         .verifyWith(getPublicKey())
         .build()
         .parseSignedClaims(StringUtils.substringAfter(token, "Bearer "))


### PR DESCRIPTION
### Description

Refactoring of AuthHelper splitting it into different helper types (JWT/ApiKey/None)

### Context

Previous structure was bug-prone and not very flexible: you can generate wrong header type by accident. With this change there's only one method that will generate header for correct type and correct JWT type (in case of JWT) -- all of this is determined on object creation time 

### Testing

- `./gradlew test`
- 
### Documentation

N/A

### Known limitations

N/A
