### PR TITLE
[ANCHOR-477] Remove `withdraw_anchor_account` on SEP-24 txn

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -216,10 +216,6 @@ public class Sep24Service {
             .clientDomain(token.getClientDomain())
             .clientName(clientFinder.getClientName(token));
 
-    if (!isEmpty(asset.getDistributionAccount())) {
-      builder.withdrawAnchorAccount(asset.getDistributionAccount());
-    }
-
     if (memo != null) {
       debug("transaction memo detected.", memo);
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -214,6 +214,7 @@ internal class Sep24ServiceTest {
     assertEquals(TEST_AMOUNT, slotTxn.captured.amountExpected)
     assertEquals(TEST_OFFCHAIN_ASSET, slotTxn.captured.amountOutAsset)
     assertNull(slotTxn.captured.amountInAsset)
+    assertNull(slotTxn.captured.withdrawAnchorAccount)
 
     val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
     val tokenStrings = params.filter { pair -> pair.name.equals("token") }
@@ -264,6 +265,7 @@ internal class Sep24ServiceTest {
     assertEquals(TEST_ACCOUNT, slotTxn.captured.fromAccount)
     assertEquals(TEST_CLIENT_DOMAIN, slotTxn.captured.clientDomain)
     assertEquals(TEST_CLIENT_NAME, slotTxn.captured.clientName)
+    assertNull(slotTxn.captured.withdrawAnchorAccount)
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ spotbugs-annotations = "4.8.6"
 spring-context = "6.1.11"
 spring-kafka = "3.2.1"
 spring-retry = "2.0.6"
-stellar-wallet-sdk = "1.7.0"
+stellar-wallet-sdk = "1.7.1"
 
 # Plugin versions
 spotless = "6.25.0"

--- a/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/TransactionService.java
@@ -415,6 +415,7 @@ public class TransactionService {
             && Kind.WITHDRAWAL.getKind().equals(sep24Txn.getKind())
             && sep24Txn.getStatus().equals(PENDING_USR_TRANSFER_START.toString())) {
           SepDepositInfo sep24DepositInfo = sep24DepositInfoGenerator.generate(sep24Txn);
+          sep24Txn.setWithdrawAnchorAccount(sep24DepositInfo.getStellarAddress());
           sep24Txn.setMemo(sep24DepositInfo.getMemo());
           sep24Txn.setMemoType(sep24DepositInfo.getMemoType());
         }


### PR DESCRIPTION
### Description

This PR unsets the `withdraw_anchor_account` on SEP-24 withdraw transaction creation. It is later when the transaction moves into `pending_user_transfer_start`.

### Context

The deposit address can be something other than the asset distribution account. It should not be set when the transaction is created.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

