### PR TITLE
[ANCHOR-441] Remove `TRANSACTION_ERROR` event type

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/SendEventRequestPayload.java
@@ -31,8 +31,6 @@ public class SendEventRequestPayload {
         payload.setQuote(event.getQuote());
       case TRANSACTION_CREATED:
         payload.setTransaction(event.getTransaction());
-      case TRANSACTION_ERROR:
-        payload.setTransaction(event.getTransaction());
       case TRANSACTION_STATUS_CHANGED:
         payload.setTransaction(event.getTransaction());
     }

--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -30,8 +30,6 @@ public class AnchorEvent {
     TRANSACTION_CREATED("transaction_created"),
     @SerializedName("transaction_status_changed")
     TRANSACTION_STATUS_CHANGED("transaction_status_changed"),
-    @SerializedName("transaction_error")
-    TRANSACTION_ERROR("transaction_error"),
     @SerializedName("quote_created")
     QUOTE_CREATED("quote_created"),
     @SerializedName("customer_updated")

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/AnchorEventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/AnchorEventProcessor.kt
@@ -21,10 +21,6 @@ class AnchorEventProcessor(
           log.info { "Received transaction status changed event" }
           processor.onTransactionStatusChanged(event)
         }
-        AnchorEvent.Type.TRANSACTION_ERROR.type -> {
-          log.info { "Received transaction error event" }
-          processor.onTransactionError(event)
-        }
         AnchorEvent.Type.CUSTOMER_UPDATED.type -> {
           log.info { "Received customer updated event" }
           // Only SEP-6 listens to this event

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/NoOpEventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/NoOpEventProcessor.kt
@@ -7,8 +7,6 @@ class NoOpEventProcessor : SepAnchorEventProcessor {
 
   override suspend fun onTransactionCreated(event: SendEventRequest) {}
 
-  override suspend fun onTransactionError(event: SendEventRequest) {}
-
   override suspend fun onTransactionStatusChanged(event: SendEventRequest) {}
 
   override suspend fun onCustomerUpdated(event: SendEventRequest) {}

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -66,10 +66,6 @@ class Sep6EventProcessor(
     }
   }
 
-  override suspend fun onTransactionError(event: SendEventRequest) {
-    log.warn { "Received transaction error event: $event" }
-  }
-
   override suspend fun onTransactionStatusChanged(event: SendEventRequest) {
     when (val kind = event.payload.transaction!!.kind) {
       Kind.DEPOSIT,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/SepAnchorEventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/SepAnchorEventProcessor.kt
@@ -7,8 +7,6 @@ interface SepAnchorEventProcessor {
 
   suspend fun onTransactionCreated(event: SendEventRequest)
 
-  suspend fun onTransactionError(event: SendEventRequest)
-
   suspend fun onTransactionStatusChanged(event: SendEventRequest)
 
   suspend fun onCustomerUpdated(event: SendEventRequest)


### PR DESCRIPTION
### Description

This PR removes the `TRANSACTION_ERROR` event type.

### Context

The `TRANSACTION_STATUS_CHANGED` type already covers transaction errors.

### Testing

- `./gradlew test`

### Documentation

https://github.com/stellar/stellar-docs/pull/819/

### Known limitations

N/A

