### PR TITLE
[ANCHOR-451] Merge `send` into `sep31` in assets config

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
@@ -50,7 +50,7 @@ public class AssetInfo {
 
   DepositOperation deposit;
   WithdrawOperation withdraw;
-  SendOperation send;
+  @Deprecated SendOperation send;
   Sep31Operation sep31;
   Sep38Operation sep38;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
@@ -50,7 +50,6 @@ public class AssetInfo {
 
   DepositOperation deposit;
   WithdrawOperation withdraw;
-  @Deprecated SendOperation send;
   Sep31Operation sep31;
   Sep38Operation sep38;
 
@@ -106,21 +105,6 @@ public class AssetInfo {
   @Data
   public static class WithdrawOperation extends AssetOperation {
     List<String> methods;
-  }
-
-  @Data
-  public static class SendOperation {
-    @SerializedName("fee_fixed")
-    Integer feeFixed;
-
-    @SerializedName("fee_percent")
-    Integer feePercent;
-
-    @SerializedName("min_amount")
-    Long minAmount;
-
-    @SerializedName("max_amount")
-    Long maxAmount;
   }
 
   @Data

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
@@ -7,17 +7,7 @@ import org.stellar.anchor.api.sep.AssetInfo;
 
 @Data
 public class Sep31Operation {
-  @SerializedName("fee_fixed")
-  Integer feeFixed;
-
-  @SerializedName("fee_percent")
-  Integer feePercent;
-
-  @SerializedName("min_amount")
-  Long minAmount;
-
-  @SerializedName("max_amount")
-  Long maxAmount;
+  SendOperation send;
 
   @SerializedName("quotes_supported")
   boolean quotesSupported;
@@ -27,6 +17,21 @@ public class Sep31Operation {
 
   Sep12Operation sep12;
   Fields fields;
+
+  @Data
+  public static class SendOperation {
+    @SerializedName("fee_fixed")
+    Integer feeFixed;
+
+    @SerializedName("fee_percent")
+    Integer feePercent;
+
+    @SerializedName("min_amount")
+    Long minAmount;
+
+    @SerializedName("max_amount")
+    Long maxAmount;
+  }
 
   @Data
   public static class Fields {

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
@@ -7,6 +7,18 @@ import org.stellar.anchor.api.sep.AssetInfo;
 
 @Data
 public class Sep31Operation {
+  @SerializedName("fee_fixed")
+  Integer feeFixed;
+
+  @SerializedName("fee_percent")
+  Integer feePercent;
+
+  @SerializedName("min_amount")
+  Long minAmount;
+
+  @SerializedName("max_amount")
+  Long maxAmount;
+
   @SerializedName("quotes_supported")
   boolean quotesSupported;
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -54,7 +54,6 @@ public class Sep12Service {
         assetService.listAllAssets().stream()
             .filter(x -> x.getSep31() != null && x.getSep31().getSep12() != null)
             .flatMap(x -> x.getSep31().getSep12().getReceiver().getTypes().keySet().stream());
-
     Stream<String> senderTypes =
         assetService.listAllAssets().stream()
             .filter(x -> x.getSep31() != null && x.getSep31().getSep12() != null)

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -52,11 +52,12 @@ public class Sep12Service {
     this.customerIntegration = customerIntegration;
     Stream<String> receiverTypes =
         assetService.listAllAssets().stream()
-            .filter(x -> x.getSep31() != null)
+            .filter(x -> x.getSep31() != null && x.getSep31().getSep12() != null)
             .flatMap(x -> x.getSep31().getSep12().getReceiver().getTypes().keySet().stream());
+
     Stream<String> senderTypes =
         assetService.listAllAssets().stream()
-            .filter(x -> x.getSep31() != null)
+            .filter(x -> x.getSep31() != null && x.getSep31().getSep12() != null)
             .flatMap(x -> x.getSep31().getSep12().getSender().getTypes().keySet().stream());
     this.knownTypes = Stream.concat(receiverTypes, senderTypes).collect(Collectors.toSet());
     this.platformApiClient = platformApiClient;

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -145,8 +145,8 @@ public class Sep31Service {
     validateAmountLimit(
         "sell_",
         request.getAmount(),
-        assetInfo.getSep31().getMinAmount(),
-        assetInfo.getSep31().getMaxAmount());
+        assetInfo.getSep31().getSend().getMinAmount(),
+        assetInfo.getSep31().getSend().getMaxAmount());
     validateLanguage(appConfig, request.getLang());
 
     /*
@@ -719,10 +719,10 @@ public class Sep31Service {
         AssetResponse assetResponse = new AssetResponse();
         assetResponse.setQuotesSupported(isQuotesSupported);
         assetResponse.setQuotesRequired(isQuotesRequired);
-        assetResponse.setFeeFixed(assetInfo.getSep31().getFeeFixed());
-        assetResponse.setFeePercent(assetInfo.getSep31().getFeePercent());
-        assetResponse.setMinAmount(assetInfo.getSep31().getMinAmount());
-        assetResponse.setMaxAmount(assetInfo.getSep31().getMaxAmount());
+        assetResponse.setFeeFixed(assetInfo.getSep31().getSend().getFeeFixed());
+        assetResponse.setFeePercent(assetInfo.getSep31().getSend().getFeePercent());
+        assetResponse.setMinAmount(assetInfo.getSep31().getSend().getMinAmount());
+        assetResponse.setMaxAmount(assetInfo.getSep31().getSend().getMaxAmount());
         assetResponse.setFields(assetInfo.getSep31().getFields());
         assetResponse.setSep12(assetInfo.getSep31().getSep12());
         response.getReceive().put(assetInfo.getCode(), assetResponse);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -64,6 +64,7 @@ import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep38.Sep38Quote;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
+import org.stellar.anchor.util.AssetHelper;
 import org.stellar.anchor.util.CustodyUtils;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.TransactionHelper;
@@ -145,8 +146,8 @@ public class Sep31Service {
     validateAmountLimit(
         "sell_",
         request.getAmount(),
-        assetInfo.getSend().getMinAmount(),
-        assetInfo.getSend().getMaxAmount());
+        AssetHelper.getSep31SendMinAmount(assetInfo),
+        AssetHelper.getSep31SendMaxAmount(assetInfo));
     validateLanguage(appConfig, request.getLang());
 
     /*
@@ -719,10 +720,10 @@ public class Sep31Service {
         AssetResponse assetResponse = new AssetResponse();
         assetResponse.setQuotesSupported(isQuotesSupported);
         assetResponse.setQuotesRequired(isQuotesRequired);
-        assetResponse.setFeeFixed(assetInfo.getSend().getFeeFixed());
-        assetResponse.setFeePercent(assetInfo.getSend().getFeePercent());
-        assetResponse.setMinAmount(assetInfo.getSend().getMinAmount());
-        assetResponse.setMaxAmount(assetInfo.getSend().getMaxAmount());
+        assetResponse.setFeeFixed(AssetHelper.getSep31SendFeeFixed(assetInfo));
+        assetResponse.setFeePercent(AssetHelper.getSep31SendFeePercent(assetInfo));
+        assetResponse.setMinAmount(AssetHelper.getSep31SendMinAmount(assetInfo));
+        assetResponse.setMaxAmount(AssetHelper.getSep31SendMaxAmount(assetInfo));
         assetResponse.setFields(assetInfo.getSep31().getFields());
         assetResponse.setSep12(assetInfo.getSep31().getSep12());
         response.getReceive().put(assetInfo.getCode(), assetResponse);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -64,7 +64,6 @@ import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep38.Sep38Quote;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
-import org.stellar.anchor.util.AssetHelper;
 import org.stellar.anchor.util.CustodyUtils;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.TransactionHelper;
@@ -146,8 +145,8 @@ public class Sep31Service {
     validateAmountLimit(
         "sell_",
         request.getAmount(),
-        AssetHelper.getSep31SendMinAmount(assetInfo),
-        AssetHelper.getSep31SendMaxAmount(assetInfo));
+        assetInfo.getSep31().getMinAmount(),
+        assetInfo.getSep31().getMaxAmount());
     validateLanguage(appConfig, request.getLang());
 
     /*
@@ -720,10 +719,10 @@ public class Sep31Service {
         AssetResponse assetResponse = new AssetResponse();
         assetResponse.setQuotesSupported(isQuotesSupported);
         assetResponse.setQuotesRequired(isQuotesRequired);
-        assetResponse.setFeeFixed(AssetHelper.getSep31SendFeeFixed(assetInfo));
-        assetResponse.setFeePercent(AssetHelper.getSep31SendFeePercent(assetInfo));
-        assetResponse.setMinAmount(AssetHelper.getSep31SendMinAmount(assetInfo));
-        assetResponse.setMaxAmount(AssetHelper.getSep31SendMaxAmount(assetInfo));
+        assetResponse.setFeeFixed(assetInfo.getSep31().getFeeFixed());
+        assetResponse.setFeePercent(assetInfo.getSep31().getFeePercent());
+        assetResponse.setMinAmount(assetInfo.getSep31().getMinAmount());
+        assetResponse.setMaxAmount(assetInfo.getSep31().getMaxAmount());
         assetResponse.setFields(assetInfo.getSep31().getFields());
         assetResponse.setSep12(assetInfo.getSep31().getSep12());
         response.getReceive().put(assetInfo.getCode(), assetResponse);

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -34,6 +34,7 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.config.Sep38Config;
 import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.util.AssetHelper;
 import org.stellar.anchor.util.Log;
 
 public class Sep38Service {
@@ -207,8 +208,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSend().getMinAmount();
-      Long sendMaxLimit = asset.getSend().getMaxAmount();
+      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
+      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
 
       // When sell_amount is specified
       if (sellAmount != null) {
@@ -241,8 +242,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSend().getMinAmount();
-      Long sendMaxLimit = asset.getSend().getMaxAmount();
+      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
+      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
 
       validateAmountLimit("sell_", rate.getSellAmount(), sendMinLimit, sendMaxLimit);
     }
@@ -354,8 +355,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSend().getMinAmount();
-      Long sendMaxLimit = asset.getSend().getMaxAmount();
+      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
+      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
 
       // When sell_amount is specified
       if (request.getSellAmount() != null) {
@@ -414,8 +415,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSend().getMinAmount();
-      Long sendMaxLimit = asset.getSend().getMaxAmount();
+      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
+      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
 
       validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
     }

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -207,8 +207,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSep31().getMinAmount();
-      Long sendMaxLimit = asset.getSep31().getMaxAmount();
+      Long sendMinLimit = asset.getSep31().getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getSend().getMaxAmount();
 
       // When sell_amount is specified
       if (sellAmount != null) {
@@ -241,8 +241,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSep31().getMinAmount();
-      Long sendMaxLimit = asset.getSep31().getMaxAmount();
+      Long sendMinLimit = asset.getSep31().getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getSend().getMaxAmount();
 
       validateAmountLimit("sell_", rate.getSellAmount(), sendMinLimit, sendMaxLimit);
     }
@@ -354,8 +354,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSep31().getMinAmount();
-      Long sendMaxLimit = asset.getSep31().getMaxAmount();
+      Long sendMinLimit = asset.getSep31().getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getSend().getMaxAmount();
 
       // When sell_amount is specified
       if (request.getSellAmount() != null) {
@@ -414,8 +414,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = asset.getSep31().getMinAmount();
-      Long sendMaxLimit = asset.getSep31().getMaxAmount();
+      Long sendMinLimit = asset.getSep31().getSend().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getSend().getMaxAmount();
 
       validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
     }

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -34,7 +34,6 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.config.Sep38Config;
 import org.stellar.anchor.event.EventService;
-import org.stellar.anchor.util.AssetHelper;
 import org.stellar.anchor.util.Log;
 
 public class Sep38Service {
@@ -208,8 +207,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
-      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
+      Long sendMinLimit = asset.getSep31().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getMaxAmount();
 
       // When sell_amount is specified
       if (sellAmount != null) {
@@ -242,8 +241,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
-      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
+      Long sendMinLimit = asset.getSep31().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getMaxAmount();
 
       validateAmountLimit("sell_", rate.getSellAmount(), sendMinLimit, sendMaxLimit);
     }
@@ -355,8 +354,8 @@ public class Sep38Service {
       }
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
-      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
+      Long sendMinLimit = asset.getSep31().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getMaxAmount();
 
       // When sell_amount is specified
       if (request.getSellAmount() != null) {
@@ -415,8 +414,8 @@ public class Sep38Service {
     if (context == SEP31 && isNotEmpty(buyAmount)) {
       String[] assetCode = sellAsset.getAsset().split(":");
       AssetInfo asset = assetService.getAsset(assetCode[1]);
-      Long sendMinLimit = AssetHelper.getSep31SendMinAmount(asset);
-      Long sendMaxLimit = AssetHelper.getSep31SendMaxAmount(asset);
+      Long sendMinLimit = asset.getSep31().getMinAmount();
+      Long sendMaxLimit = asset.getSep31().getMaxAmount();
 
       validateAmountLimit("sell_", sellAmount, sendMinLimit, sendMaxLimit);
     }

--- a/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.util;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import java.util.Currency;
+import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.sdk.KeyPair;
 
 public class AssetHelper {
@@ -68,5 +69,33 @@ public class AssetHelper {
    */
   public static String getAssetIssuer(String asset) {
     return asset.split(":").length >= 3 ? asset.split(":")[2] : null;
+  }
+
+  /**
+   * The following functions are for merging SendOperation and Sep31Operation only. They will be
+   * removed once the migration is complete.
+   */
+  public static Integer getSep31SendFeeFixed(AssetInfo asset) {
+    return asset.getSep31() != null && asset.getSep31().getFeeFixed() != null
+        ? asset.getSep31().getFeeFixed()
+        : asset.getSend() != null ? asset.getSend().getFeeFixed() : null;
+  }
+
+  public static Integer getSep31SendFeePercent(AssetInfo asset) {
+    return asset.getSep31() != null && asset.getSep31().getFeePercent() != null
+        ? asset.getSep31().getFeePercent()
+        : asset.getSend() != null ? asset.getSend().getFeePercent() : null;
+  }
+
+  public static Long getSep31SendMinAmount(AssetInfo asset) {
+    return asset.getSep31() != null && asset.getSep31().getMinAmount() != null
+        ? asset.getSep31().getMinAmount()
+        : asset.getSend() != null ? asset.getSend().getMinAmount() : null;
+  }
+
+  public static Long getSep31SendMaxAmount(AssetInfo asset) {
+    return asset.getSep31() != null && asset.getSep31().getMaxAmount() != null
+        ? asset.getSep31().getMaxAmount()
+        : asset.getSend() != null ? asset.getSend().getMaxAmount() : null;
   }
 }

--- a/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
@@ -3,7 +3,6 @@ package org.stellar.anchor.util;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import java.util.Currency;
-import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.sdk.KeyPair;
 
 public class AssetHelper {
@@ -69,33 +68,5 @@ public class AssetHelper {
    */
   public static String getAssetIssuer(String asset) {
     return asset.split(":").length >= 3 ? asset.split(":")[2] : null;
-  }
-
-  /**
-   * The following functions are for merging SendOperation and Sep31Operation only. They will be
-   * removed once the migration is complete.
-   */
-  public static Integer getSep31SendFeeFixed(AssetInfo asset) {
-    return asset.getSep31() != null && asset.getSep31().getFeeFixed() != null
-        ? asset.getSep31().getFeeFixed()
-        : asset.getSend() != null ? asset.getSend().getFeeFixed() : null;
-  }
-
-  public static Integer getSep31SendFeePercent(AssetInfo asset) {
-    return asset.getSep31() != null && asset.getSep31().getFeePercent() != null
-        ? asset.getSep31().getFeePercent()
-        : asset.getSend() != null ? asset.getSend().getFeePercent() : null;
-  }
-
-  public static Long getSep31SendMinAmount(AssetInfo asset) {
-    return asset.getSep31() != null && asset.getSep31().getMinAmount() != null
-        ? asset.getSep31().getMinAmount()
-        : asset.getSend() != null ? asset.getSend().getMinAmount() : null;
-  }
-
-  public static Long getSep31SendMaxAmount(AssetInfo asset) {
-    return asset.getSep31() != null && asset.getSep31().getMaxAmount() != null
-        ? asset.getSep31().getMaxAmount()
-        : asset.getSend() != null ? asset.getSend().getMaxAmount() : null;
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -125,10 +125,12 @@ internal class DefaultAssetServiceTest {
               ]
             },
             "sep31": {
-              "fee_fixed": 0,
-              "fee_percent": 0,
-              "min_amount": 1,
-              "max_amount": 1000000,
+              "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 1000000
+              },
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {
@@ -207,10 +209,12 @@ internal class DefaultAssetServiceTest {
               "max_amount": 1000000
             },
             "sep31": {
-              "fee_fixed": 0,
-              "fee_percent": 0,
-              "min_amount": 1,
-              "max_amount": 1000000,
+              "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 1000000
+              },
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {
@@ -276,10 +280,12 @@ internal class DefaultAssetServiceTest {
               "max_amount": 1000000
             },
             "sep31": {
-              "fee_fixed": 0,
-              "fee_percent": 0,
-              "min_amount": 1,
-              "max_amount": 1000000
+              "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 1000000
+              }
             },
             "sep38": {
               "exchangeable_assets": [
@@ -323,10 +329,12 @@ internal class DefaultAssetServiceTest {
               "max_amount": 1000000
             },
             "sep31": {
-              "fee_fixed": 0,
-              "fee_percent": 0,
-              "min_amount": 1,
-              "max_amount": 1000000,
+              "send": {
+                "fee_fixed": 0,
+                "fee_percent": 0,
+                "min_amount": 1,
+                "max_amount": 1000000
+              },
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -124,13 +124,11 @@ internal class DefaultAssetServiceTest {
                 "cash"
               ]
             },
-            "send": {
+            "sep31": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
+              "max_amount": 1000000,
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {
@@ -208,13 +206,11 @@ internal class DefaultAssetServiceTest {
               "min_amount": 1,
               "max_amount": 1000000
             },
-            "send": {
+            "sep31": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
+              "max_amount": 1000000,
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {
@@ -279,7 +275,7 @@ internal class DefaultAssetServiceTest {
               "min_amount": 1,
               "max_amount": 1000000
             },
-            "send": {
+            "sep31": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
@@ -326,13 +322,11 @@ internal class DefaultAssetServiceTest {
               "min_amount": 1,
               "max_amount": 1000000
             },
-            "send": {
+            "sep31": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
+              "max_amount": 1000000,
               "quotes_supported": true,
               "quotes_required": true,
               "sep12": {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -112,10 +112,12 @@ class Sep31ServiceTest {
                 "max_amount": 1000000
               },
               "sep31": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000,
+                "send": {
+                  "fee_fixed": 0,
+                  "fee_percent": 0,
+                  "min_amount": 1,
+                  "max_amount": 1000000
+                },
                 "quotes_supported": true,
                 "quotes_required": true,
                 "sep12": {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -111,13 +111,11 @@ class Sep31ServiceTest {
                 "min_amount": 1,
                 "max_amount": 1000000
               },
-              "send": {
+              "sep31": {
                 "fee_fixed": 0,
                 "fee_percent": 0,
                 "min_amount": 1,
-                "max_amount": 1000000
-              },
-              "sep31": {
+                "max_amount": 1000000,
                 "quotes_supported": true,
                 "quotes_required": true,
                 "sep12": {

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -24,13 +24,11 @@
           "cash"
         ]
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "sep31": {
+        "max_amount": 1000000,
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -108,13 +106,11 @@
         "min_amount": 1,
         "max_amount": 1000000
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "sep31": {
+        "max_amount": 1000000,
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -179,7 +175,7 @@
         "min_amount": 1,
         "max_amount": 1000000
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
@@ -226,13 +222,11 @@
         "min_amount": 1,
         "max_amount": 1000000
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "sep31": {
+        "max_amount": 1000000,
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -25,10 +25,12 @@
         ]
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000,
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -107,10 +109,12 @@
         "max_amount": 1000000
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000,
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -176,10 +180,12 @@
         "max_amount": 1000000
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        }
       },
       "sep38": {
         "exchangeable_assets": [
@@ -223,10 +229,12 @@
         "max_amount": 1000000
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000,
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {

--- a/core/src/test/resources/test_assets.json.quotes_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_not_supported
@@ -20,13 +20,11 @@
         "min_amount": 1,
         "max_amount": 10000
       },
-      "send": {
+      "sep31" : {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "sep31" : {
+        "max_amount": 1000000,
         "quotes_supported": false,
         "quotes_required": false,
         "fields": {

--- a/core/src/test/resources/test_assets.json.quotes_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_not_supported
@@ -21,10 +21,12 @@
         "max_amount": 10000
       },
       "sep31" : {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000,
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
         "quotes_supported": false,
         "quotes_required": false,
         "fields": {

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -19,10 +19,11 @@ assets:
         - bank_account
         - cash
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -79,10 +80,11 @@ assets:
       min_amount: 1
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -128,10 +130,11 @@ assets:
       min_amount: 1
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
     sep38:
       exchangeable_assets:
         - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
@@ -161,10 +164,11 @@ assets:
       min_amount: 1
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: true
       sep12:

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -18,12 +18,11 @@ assets:
       methods:
         - bank_account
         - cash
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -79,12 +78,11 @@ assets:
       enabled: false
       min_amount: 1
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -129,7 +127,7 @@ assets:
       enabled: false
       min_amount: 1
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1
@@ -162,12 +160,11 @@ assets:
       enabled: true
       min_amount: 1
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: true
       sep12:

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -200,9 +200,10 @@ assets_config: |
         - bank_account
         - cash
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -254,10 +255,11 @@ assets_config: |
       min_amount: 1
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -303,10 +305,10 @@ assets_config: |
       enabled: true
     withdraw:
       enabled: true
-    send:
-      fee_fixed: 0
-      fee_percent: 0
     sep31:
+      send:
+        fee_fixed: 0
+        fee_percent: 0
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -356,10 +358,11 @@ assets_config: |
       min_amount: 0
       max_amount: 10000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 0
+        max_amount: 10000
     sep38:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
@@ -388,9 +391,10 @@ assets_config: |
       enabled: true
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: true
       sep12:

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -199,11 +199,10 @@ assets_config: |
       methods:
         - bank_account
         - cash
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -254,12 +253,11 @@ assets_config: |
       enabled: true
       min_amount: 1
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -357,7 +355,7 @@ assets_config: |
       enabled: true
       min_amount: 0
       max_amount: 10000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 0
@@ -389,11 +387,10 @@ assets_config: |
     withdraw:
       enabled: true
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       max_amount: 1000000
-    sep31:
       quotes_supported: true
       quotes_required: true
       sep12:

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -139,10 +139,12 @@ assets:
             "max_amount": 1000000
           },
           "sep31": {
-            "fee_fixed": 0,
-            "fee_percent": 0,
-            "min_amount": 1,
-            "max_amount": 1000000,
+            "send": {
+              "fee_fixed": 0,
+              "fee_percent": 0,
+              "min_amount": 1,
+              "max_amount": 1000000
+            },
             "quotes_supported": true,
             "quotes_required": false,
             "sep12": {
@@ -218,10 +220,12 @@ assets:
             "max_amount": 1000000
           },
           "sep31": {
-            "fee_fixed": 0,
-            "fee_percent": 0,
-            "min_amount": 1,
-            "max_amount": 1000000,
+            "send": {
+              "fee_fixed": 0,
+              "fee_percent": 0,
+              "min_amount": 1,
+              "max_amount": 1000000
+            },
             "quotes_supported": true,
             "quotes_required": false,
             "sep12": {
@@ -294,10 +298,12 @@ assets:
             "max_amount": 10000
           },
           "sep31": {
-            "fee_fixed": 0,
-            "fee_percent": 0,
-            "min_amount": 0,
-            "max_amount": 10000
+            "send": {
+              "fee_fixed": 0,
+              "fee_percent": 0,
+              "min_amount": 1,
+              "max_amount": 1000000
+            },
           },
           "sep38": {
             "exchangeable_assets": [

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -138,13 +138,11 @@ assets:
             "min_amount": 1,
             "max_amount": 1000000
           },
-          "send": {
+          "sep31": {
             "fee_fixed": 0,
             "fee_percent": 0,
             "min_amount": 1,
-            "max_amount": 1000000
-          },
-          "sep31": {
+            "max_amount": 1000000,
             "quotes_supported": true,
             "quotes_required": false,
             "sep12": {
@@ -219,13 +217,11 @@ assets:
             "min_amount": 1,
             "max_amount": 1000000
           },
-          "send": {
+          "sep31": {
             "fee_fixed": 0,
             "fee_percent": 0,
             "min_amount": 1,
-            "max_amount": 1000000
-          },
-          "sep31": {
+            "max_amount": 1000000,
             "quotes_supported": true,
             "quotes_required": false,
             "sep12": {
@@ -297,7 +293,7 @@ assets:
             "min_amount": 0,
             "max_amount": 10000
           },
-          "send": {
+          "sep31": {
             "fee_fixed": 0,
             "fee_percent": 0,
             "min_amount": 0,

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -21,10 +21,12 @@
         "max_amount": 10000
       },
       "sep31" : {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 0,
-        "max_amount": 10000,
+        "send" : {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 0,
+          "max_amount": 10000
+        },
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -99,10 +101,12 @@
         "max_amount": 1000000
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 0,
+          "max_amount": 10000
+        }
       },
       "sep38": {
         "exchangeable_assets": [

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -20,13 +20,11 @@
         "min_amount": 0,
         "max_amount": 10000
       },
-      "send": {
+      "sep31" : {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 0,
-        "max_amount": 10000
-      },
-      "sep31" : {
+        "max_amount": 10000,
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {
@@ -100,7 +98,7 @@
         "min_amount": 1,
         "max_amount": 1000000
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -16,12 +16,11 @@ assets:
       fee_percent: 0
       min_amount: 0
       max_amount: 10000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 0
       max_amount: 10000
-    sep31:
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -73,7 +72,7 @@ assets:
       fee_percent: 0
       min_amount: 1
       max_amount: 1000000
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 1

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -17,10 +17,11 @@ assets:
       min_amount: 0
       max_amount: 10000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 0
+        max_amount: 10000
       quotes_supported: true
       quotes_required: true
       sep12:
@@ -73,10 +74,11 @@ assets:
       min_amount: 1
       max_amount: 1000000
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 1
+        max_amount: 1000000
     sep38:
       exchangeable_assets:
         - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -23,13 +23,11 @@
           "cash"
         ]
       },
-      "send": {
+      "sep31": {
         "fee_fixed": 0,
         "fee_percent": 0,
         "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "sep31": {
+        "max_amount": 1000000,
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -24,10 +24,12 @@
         ]
       },
       "sep31": {
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000,
+        "send": {
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
         "quotes_supported": true,
         "quotes_required": true,
         "sep12": {

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -19,10 +19,6 @@ assets:
       methods:
         - bank_account
         - cash
-    send: # (Deprecated) All fields should be incorporated into `sep31`.
-      fee_fixed: 0
-      fee_percent: 0
-      max_amount: 1000000
     sep31:
       fee_fixed: 0
       fee_percent: 0
@@ -192,9 +188,6 @@ assets:
   - schema: iso4217
     code: USD
     significant_decimals: 7
-    send: # (Deprecated) All fields should be incorporated into `sep31`.
-      min_amount: 0
-      max_amount: 1000000
     sep31:
       min_amount: 0
       max_amount: 1000000

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -19,11 +19,14 @@ assets:
       methods:
         - bank_account
         - cash
-    send:
+    send: # (Deprecated) All fields should be incorporated into `sep31`.
       fee_fixed: 0
       fee_percent: 0
       max_amount: 1000000
     sep31:
+      fee_fixed: 0
+      fee_percent: 0
+      max_amount: 1000000
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -75,12 +78,11 @@ assets:
       enabled: true
       min_amount: 0
       max_amount: 10
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
       min_amount: 0
       max_amount: 10
-    sep31:
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -127,10 +129,9 @@ assets:
       enabled: false
     withdraw:
       enabled: false
-    send:
+    sep31:
       fee_fixed: 0
       fee_percent: 0
-    sep31:
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -191,7 +192,10 @@ assets:
   - schema: iso4217
     code: USD
     significant_decimals: 7
-    send:
+    send: # (Deprecated) All fields should be incorporated into `sep31`.
+      min_amount: 0
+      max_amount: 1000000
+    sep31:
       min_amount: 0
       max_amount: 1000000
     sep38:
@@ -211,7 +215,7 @@ assets:
   - schema: iso4217
     code: CAD
     significant_decimals: 7
-    send:
+    sep31:
       min_amount: 0
       max_amount: 1000000
     sep38:

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -20,9 +20,10 @@ assets:
         - bank_account
         - cash
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      max_amount: 1000000
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        max_amount: 1000000
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -75,10 +76,11 @@ assets:
       min_amount: 0
       max_amount: 10
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10
+      send:
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 0
+        max_amount: 10
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -126,8 +128,9 @@ assets:
     withdraw:
       enabled: false
     sep31:
-      fee_fixed: 0
-      fee_percent: 0
+      send:
+        fee_fixed: 0
+        fee_percent: 0
       quotes_supported: true
       quotes_required: false
       sep12:
@@ -189,8 +192,9 @@ assets:
     code: USD
     significant_decimals: 7
     sep31:
-      min_amount: 0
-      max_amount: 1000000
+      send:
+        min_amount: 0
+        max_amount: 1000000
     sep38:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
@@ -209,8 +213,9 @@ assets:
     code: CAD
     significant_decimals: 7
     sep31:
-      min_amount: 0
-      max_amount: 1000000
+      send:
+        min_amount: 0
+        max_amount: 1000000
     sep38:
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP


### PR DESCRIPTION
### Description

- remove the `send` field in assets config 
- Merge all fields under `send` into `sep31`

### Context

There is no reason to have separate object for sep31 and send, as they describe the same service.

### Testing

- `./gradlew test` All tests should pass

