### PR TITLE
1438: Fix NPE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,7 +161,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.8.3"
+  version = "2.8.4"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.8.3/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.8.3)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.8.4/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.8.4)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -236,8 +236,9 @@ public class PropertySep10Config implements Sep10Config, Validator {
 
     // If clientAllowList is defined, only the clients in the allow list are allowed.
     return clientAllowList.stream()
-        .filter(domain -> clientsConfig.getClientConfigByName(domain) != null)
-        .flatMap(domain -> clientsConfig.getClientConfigByName(domain).getDomains().stream())
+        .filter(name -> clientsConfig.getClientConfigByName(name) != null)
+        .filter(name -> clientsConfig.getClientConfigByName(name).getDomains() != null)
+        .flatMap(name -> clientsConfig.getClientConfigByName(name).getDomains().stream())
         .filter(StringHelper::isNotEmpty)
         .collect(Collectors.toList());
   }

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=2.8.3
+version=2.8.4


### PR DESCRIPTION
### Description

Fixed #1438 

### Context

If there's a custodial wallet in clients with clientAllowList enabled, it will result to NPE because domains is null for custodial wallet
 
### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A
