### PR TITLE
[ANCHOR-733] Remove SEP-31 send limit checks in SEP-38

### DIFF
--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -293,6 +293,8 @@ class Sep38ServiceTest {
   @Test
   fun `test GET price failure`() {
     var getPriceRequestBuilder = Sep38GetPriceRequest.builder()
+    every { mockRateIntegration.getRate(any()) } returns
+      GetRateResponse.indicativePrice("1.02", "103", "100", mockSellAssetFee(fiatUSD))
 
     // empty rateIntegration should throw an error
     var ex: AnchorException = assertThrows {
@@ -401,27 +403,6 @@ class Sep38ServiceTest {
     ex = assertThrows { sep38Service.getPrice(null, getPriceRequestBuilder.build()) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported context. Should be one of [sep6, sep31].", ex.message)
-
-    // sell_amount should be within limit
-    getPriceRequestBuilder = getPriceRequestBuilder.context(SEP31).sellAmount("100000000")
-    ex = assertThrows { sep38Service.getPrice(null, getPriceRequestBuilder.build()) }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount exceeds max limit", ex.message)
-
-    // sell_amount should be positive
-    getPriceRequestBuilder = getPriceRequestBuilder.context(SEP31).sellAmount("0.5")
-    ex = assertThrows { sep38Service.getPrice(null, getPriceRequestBuilder.build()) }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount less than min limit", ex.message)
-
-    // buy_amount specified, but resulting sell_amount should be within limit
-    getPriceRequestBuilder = getPriceRequestBuilder.sellAmount(null)
-    getPriceRequestBuilder = getPriceRequestBuilder.buyAssetName(stellarUSDC).buyAmount("100000000")
-    every { mockRateIntegration.getRate(any()) } returns
-      GetRateResponse.indicativePrice("1.02", "102000000", "100000000", mockSellAssetFee(fiatUSD))
-    ex = assertThrows { sep38Service.getPrice(null, getPriceRequestBuilder.build()) }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount exceeds max limit", ex.message)
   }
 
   private fun mockSellAssetFee(sellAsset: String?): FeeDetails {
@@ -592,6 +573,8 @@ class Sep38ServiceTest {
   fun `test POST quote failures`() {
     // empty rateIntegration should throw an error
     this.sep38Service = Sep38Service(sep38Config, assetService, null, mockQuoteStore, eventService)
+    every { mockRateIntegration.getRate(any()) } returns
+      GetRateResponse.indicativePrice("1.02", "103", "100", mockSellAssetFee(fiatUSD))
 
     var ex: AnchorException = assertThrows {
       sep38Service.postQuote(null, Sep38PostQuoteRequest.builder().build())
@@ -833,59 +816,6 @@ class Sep38ServiceTest {
     }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("Unsupported context. Should be one of [sep6, sep24, sep31].", ex.message)
-
-    // sell_amount should be within limit
-    ex = assertThrows {
-      sep38Service.postQuote(
-        token,
-        Sep38PostQuoteRequest.builder()
-          .sellAssetName(fiatUSD)
-          .sellAmount("100000000")
-          .sellDeliveryMethod("WIRE")
-          .context(SEP31)
-          .buyAssetName(stellarUSDC)
-          .countryCode("USA")
-          .build()
-      )
-    }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount exceeds max limit", ex.message)
-
-    // sell_amount should be positive
-    ex = assertThrows {
-      sep38Service.postQuote(
-        token,
-        Sep38PostQuoteRequest.builder()
-          .sellAssetName(fiatUSD)
-          .sellAmount("0.5")
-          .sellDeliveryMethod("WIRE")
-          .context(SEP31)
-          .buyAssetName(stellarUSDC)
-          .countryCode("USA")
-          .build()
-      )
-    }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount less than min limit", ex.message)
-
-    // buy_amount specified, but resulting sell_amount should be within limit
-    every { mockRateIntegration.getRate(any()) } returns
-      GetRateResponse.indicativePrice("1.02", "102000000", "100000000", mockSellAssetFee(fiatUSD))
-    ex = assertThrows {
-      sep38Service.postQuote(
-        token,
-        Sep38PostQuoteRequest.builder()
-          .sellAssetName(fiatUSD)
-          .sellDeliveryMethod("WIRE")
-          .context(SEP31)
-          .buyAssetName(stellarUSDC)
-          .buyAmount("100000000")
-          .countryCode("USA")
-          .build()
-      )
-    }
-    assertInstanceOf(BadRequestException::class.java, ex)
-    assertEquals("sell_amount exceeds max limit", ex.message)
   }
 
   @Test

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
@@ -4,11 +4,7 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
-import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
-import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP6
 import org.stellar.anchor.client.Sep38Client
 import org.stellar.anchor.platform.AbstractIntegrationTests
 import org.stellar.anchor.platform.TestConfig
@@ -71,51 +67,5 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
     val getQuote = sep38Client.getQuote(postQuote.id)
     printResponse(getQuote)
     assertEquals(postQuote, getQuote)
-  }
-
-  @Test
-  fun `test selling over asset limit for SEP-31 throws an exception`() {
-    printRequest("Calling GET /price")
-
-    assertThrows<SepException> {
-      sep38Client.getPrice(
-        "iso4217:USD",
-        "10000000000",
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP31,
-      )
-    }
-
-    assertThrows<SepException> {
-      sep38Client.postQuote(
-        "iso4217:USD",
-        "10000000000",
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP31,
-      )
-    }
-  }
-
-  @Test
-  fun `test selling over asset limit for SEP-6 does throws an exception`() {
-    printRequest("Calling GET /price")
-
-    assertDoesNotThrow {
-      sep38Client.getPrice(
-        "iso4217:USD",
-        "10000000000",
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP6,
-      )
-    }
-
-    assertDoesNotThrow {
-      sep38Client.postQuote(
-        "iso4217:USD",
-        "10000000000",
-        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-        SEP6,
-      )
-    }
   }
 }


### PR DESCRIPTION
### Description

This commit removes SEP-31 send limit checks in the SEP-38 POST /quote and GET /price APIs.

### Context

This is safe to remove since the send limits are checked at the SEP-31 transaction creation time. If the quote exceeds the send limit when created, SEP-31 will validate that the requested amount matches the quote's `sell_amount`.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

