### PR TITLE
Fix RequestOnchainFunds incorrect hash memo

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -252,7 +252,7 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
         if (sep6DepositInfoGenerator instanceof Sep6DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), request.getMemoType());
           if (memo != null) {
-            txn6.setMemo(memo.toString());
+            txn6.setMemo(request.getMemo());
             txn6.setMemoType(memoTypeString(memoType(memo)));
           }
           txn6.setWithdrawAnchorAccount(request.getDestinationAccount());
@@ -286,7 +286,7 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
         if (sep24DepositInfoGenerator instanceof Sep24DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), request.getMemoType());
           if (memo != null) {
-            txn24.setMemo(memo.toString());
+            txn24.setMemo(request.getMemo());
             txn24.setMemoType(memoTypeString(memoType(memo)));
           }
           txn24.setWithdrawAnchorAccount(request.getDestinationAccount());

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -65,7 +65,6 @@ class RequestOnchainFundsHandlerTest {
     private const val STELLAR_USDC_ISSUER =
       "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
     private const val TEXT_MEMO = "testMemo"
-    private const val TEXT_MEMO_2 = "testMemo2"
     private const val HASH_MEMO = "YWYwOTk2M2QtNzU3Mi00NGQ4LWE5MDktMmY2YzMzNTY="
     private const val TEXT_MEMO_TYPE = "text"
     private const val HASH_MEMO_TYPE = "hash"
@@ -558,8 +557,8 @@ class RequestOnchainFundsHandlerTest {
         .amountOut(AmountAssetRequest("0.9", FIAT_USD))
         .feeDetails(Amount("0.1", STELLAR_USDC).toRate())
         .amountExpected(AmountRequest("1"))
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
         .destinationAccount(DESTINATION_ACCOUNT)
         .build()
     val txn24 = JdbcSep24Transaction()
@@ -603,8 +602,8 @@ class RequestOnchainFundsHandlerTest {
     expectedSep24Txn.amountFee = "0.1"
     expectedSep24Txn.amountFeeAsset = STELLAR_USDC
     expectedSep24Txn.amountExpected = "1"
-    expectedSep24Txn.memo = TEXT_MEMO
-    expectedSep24Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep24Txn.memo = HASH_MEMO
+    expectedSep24Txn.memoType = HASH_MEMO_TYPE
     expectedSep24Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep24Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
@@ -624,8 +623,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
-    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -685,7 +684,7 @@ class RequestOnchainFundsHandlerTest {
     txn24.requestAssetIssuer = STELLAR_USDC_ISSUER
     val sep24TxnCapture = slot<JdbcSep24Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
-    val depositInfo = SepDepositInfo(DESTINATION_ACCOUNT_2, TEXT_MEMO_2, TEXT_MEMO_TYPE)
+    val depositInfo = SepDepositInfo(DESTINATION_ACCOUNT_2, TEXT_MEMO, TEXT_MEMO_TYPE)
 
     every { txn6Store.findByTransactionId(any()) } returns null
     every { txn24Store.findByTransactionId(TX_ID) } returns txn24
@@ -721,7 +720,7 @@ class RequestOnchainFundsHandlerTest {
     expectedSep24Txn.amountFee = "0.1"
     expectedSep24Txn.amountFeeAsset = STELLAR_USDC
     expectedSep24Txn.amountExpected = "1"
-    expectedSep24Txn.memo = TEXT_MEMO_2
+    expectedSep24Txn.memo = TEXT_MEMO
     expectedSep24Txn.memoType = TEXT_MEMO_TYPE
     expectedSep24Txn.toAccount = DESTINATION_ACCOUNT_2
     expectedSep24Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT_2
@@ -742,7 +741,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO_2
+    expectedResponse.memo = TEXT_MEMO
     expectedResponse.memoType = TEXT_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT_2
 
@@ -888,8 +887,8 @@ class RequestOnchainFundsHandlerTest {
         .amountIn(AmountAssetRequest("1", STELLAR_USDC))
         .amountOut(AmountAssetRequest("0.9", FIAT_USD))
         .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
         .destinationAccount(DESTINATION_ACCOUNT)
         .userActionRequiredBy(actionRequiredBy)
         .build()
@@ -933,8 +932,8 @@ class RequestOnchainFundsHandlerTest {
     expectedSep24Txn.amountFee = "0.1"
     expectedSep24Txn.amountFeeAsset = STELLAR_USDC
     expectedSep24Txn.amountExpected = "1"
-    expectedSep24Txn.memo = TEXT_MEMO
-    expectedSep24Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep24Txn.memo = HASH_MEMO
+    expectedSep24Txn.memoType = HASH_MEMO_TYPE
     expectedSep24Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep24Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
     expectedSep24Txn.userActionRequiredBy = actionRequiredBy
@@ -955,8 +954,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
-    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.userActionRequiredBy = actionRequiredBy
 
@@ -989,8 +988,8 @@ class RequestOnchainFundsHandlerTest {
     val request =
       RequestOnchainFundsRequest.builder()
         .transactionId(TX_ID)
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
         .destinationAccount(DESTINATION_ACCOUNT)
         .build()
     val txn24 = JdbcSep24Transaction()
@@ -1040,8 +1039,8 @@ class RequestOnchainFundsHandlerTest {
     expectedSep24Txn.amountFee = "0.1"
     expectedSep24Txn.amountFeeAsset = STELLAR_USDC
     expectedSep24Txn.amountExpected = "1"
-    expectedSep24Txn.memo = TEXT_MEMO
-    expectedSep24Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep24Txn.memo = HASH_MEMO
+    expectedSep24Txn.memoType = HASH_MEMO_TYPE
     expectedSep24Txn.toAccount = DESTINATION_ACCOUNT
     expectedSep24Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
@@ -1061,8 +1060,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep24TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
-    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
     expectedResponse.destinationAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -1223,8 +1222,8 @@ class RequestOnchainFundsHandlerTest {
         .amountOut(AmountAssetRequest("0.9", FIAT_USD))
         .feeDetails(Amount("0.1", STELLAR_USDC).toRate())
         .amountExpected(AmountRequest("1"))
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
         .destinationAccount(DESTINATION_ACCOUNT)
         .build()
     val txn6 = JdbcSep6Transaction()
@@ -1269,8 +1268,8 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.memo = TEXT_MEMO
-    expectedSep6Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep6Txn.memo = HASH_MEMO
+    expectedSep6Txn.memoType = HASH_MEMO_TYPE
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -1295,8 +1294,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
-    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(
@@ -1357,7 +1356,7 @@ class RequestOnchainFundsHandlerTest {
     txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
     val sep6TxnCapture = slot<JdbcSep6Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
-    val depositInfo = SepDepositInfo(DESTINATION_ACCOUNT_2, TEXT_MEMO_2, TEXT_MEMO_TYPE)
+    val depositInfo = SepDepositInfo(DESTINATION_ACCOUNT_2, TEXT_MEMO, TEXT_MEMO_TYPE)
 
     every { txn6Store.findByTransactionId(TX_ID) } returns txn6
     every { txn24Store.findByTransactionId(any()) } returns null
@@ -1392,107 +1391,9 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.memo = TEXT_MEMO_2
-    expectedSep6Txn.memoType = TEXT_MEMO_TYPE
-    expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT_2
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedSep6Txn),
-      gson.toJson(sep6TxnCapture.captured),
-      JSONCompareMode.STRICT
-    )
-
-    val expectedResponse = GetTransactionResponse()
-    expectedResponse.sep = SEP_6
-    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
-    expectedResponse.status = PENDING_USR_TRANSFER_START
-    expectedResponse.amountIn = Amount("1", STELLAR_USDC)
-    expectedResponse.amountOut = Amount("0.9", FIAT_USD)
-    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
-    expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
-    expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
-    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO_2
-    expectedResponse.memoType = TEXT_MEMO_TYPE
-    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedResponse),
-      gson.toJson(response),
-      JSONCompareMode.STRICT
-    )
-
-    val expectedEvent =
-      AnchorEvent.builder()
-        .id(anchorEventCapture.captured.id)
-        .sep(SEP_6.sep.toString())
-        .type(TRANSACTION_STATUS_CHANGED)
-        .transaction(expectedResponse)
-        .build()
-
-    JSONAssert.assertEquals(
-      gson.toJson(expectedEvent),
-      gson.toJson(anchorEventCapture.captured),
-      JSONCompareMode.STRICT
-    )
-
-    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
-    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
-  }
-
-  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
-  @ParameterizedTest
-  fun test_handle_sep6_ok_withoutAmountExpected(kind: String) {
-    val request =
-      RequestOnchainFundsRequest.builder()
-        .transactionId(TX_ID)
-        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
-        .amountOut(AmountAssetRequest("0.9", FIAT_USD))
-        .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
-        .destinationAccount(DESTINATION_ACCOUNT)
-        .build()
-    val txn6 = JdbcSep6Transaction()
-    txn6.status = INCOMPLETE.toString()
-    txn6.kind = kind
-    txn6.requestAssetCode = STELLAR_USDC_CODE
-    txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
-    val sep6TxnCapture = slot<JdbcSep6Transaction>()
-    val anchorEventCapture = slot<AnchorEvent>()
-
-    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
-    every { txn24Store.findByTransactionId(any()) } returns null
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
-    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
-    every { metricsService.counter(AnchorMetrics.PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
-      sepTransactionCounter
-
-    val startDate = Instant.now()
-    val response = handler.handle(request)
-    val endDate = Instant.now()
-
-    verify(exactly = 0) { txn24Store.save(any()) }
-    verify(exactly = 0) { txn31Store.save(any()) }
-    verify(exactly = 1) { sepTransactionCounter.increment() }
-
-    val expectedSep6Txn = JdbcSep6Transaction()
-    expectedSep6Txn.kind = kind
-    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
-    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedSep6Txn.requestAssetCode = STELLAR_USDC_CODE
-    expectedSep6Txn.requestAssetIssuer = STELLAR_USDC_ISSUER
-    expectedSep6Txn.amountIn = "1"
-    expectedSep6Txn.amountInAsset = STELLAR_USDC
-    expectedSep6Txn.amountOut = "0.9"
-    expectedSep6Txn.amountOutAsset = FIAT_USD
-    expectedSep6Txn.amountFee = "0.1"
-    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
-    expectedSep6Txn.amountExpected = "1"
     expectedSep6Txn.memo = TEXT_MEMO
     expectedSep6Txn.memoType = TEXT_MEMO_TYPE
-    expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
+    expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT_2
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1540,12 +1441,110 @@ class RequestOnchainFundsHandlerTest {
 
   @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
   @ParameterizedTest
+  fun test_handle_sep6_ok_withoutAmountExpected(kind: String) {
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("0.9", FIAT_USD))
+        .amountFee(AmountAssetRequest("0.1", STELLAR_USDC))
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
+        .destinationAccount(DESTINATION_ACCOUNT)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = kind
+    txn6.requestAssetCode = STELLAR_USDC_CODE
+    txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
+    val sep6TxnCapture = slot<JdbcSep6Transaction>()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn6Store.save(capture(sep6TxnCapture)) } returns null
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+    every { metricsService.counter(AnchorMetrics.PLATFORM_RPC_TRANSACTION, "SEP", "sep6") } returns
+      sepTransactionCounter
+
+    val startDate = Instant.now()
+    val response = handler.handle(request)
+    val endDate = Instant.now()
+
+    verify(exactly = 0) { txn24Store.save(any()) }
+    verify(exactly = 0) { txn31Store.save(any()) }
+    verify(exactly = 1) { sepTransactionCounter.increment() }
+
+    val expectedSep6Txn = JdbcSep6Transaction()
+    expectedSep6Txn.kind = kind
+    expectedSep6Txn.status = PENDING_USR_TRANSFER_START.toString()
+    expectedSep6Txn.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedSep6Txn.requestAssetCode = STELLAR_USDC_CODE
+    expectedSep6Txn.requestAssetIssuer = STELLAR_USDC_ISSUER
+    expectedSep6Txn.amountIn = "1"
+    expectedSep6Txn.amountInAsset = STELLAR_USDC
+    expectedSep6Txn.amountOut = "0.9"
+    expectedSep6Txn.amountOutAsset = FIAT_USD
+    expectedSep6Txn.amountFee = "0.1"
+    expectedSep6Txn.amountFeeAsset = STELLAR_USDC
+    expectedSep6Txn.amountExpected = "1"
+    expectedSep6Txn.memo = HASH_MEMO
+    expectedSep6Txn.memoType = HASH_MEMO_TYPE
+    expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedSep6Txn),
+      gson.toJson(sep6TxnCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = SEP_6
+    expectedResponse.kind = PlatformTransactionData.Kind.from(kind)
+    expectedResponse.status = PENDING_USR_TRANSFER_START
+    expectedResponse.amountIn = Amount("1", STELLAR_USDC)
+    expectedResponse.amountOut = Amount("0.9", FIAT_USD)
+    expectedResponse.amountFee = Amount("0.1", STELLAR_USDC)
+    expectedResponse.feeDetails = Amount("0.1", STELLAR_USDC).toRate()
+    expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
+    expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
+    expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+
+    val expectedEvent =
+      AnchorEvent.builder()
+        .id(anchorEventCapture.captured.id)
+        .sep(SEP_6.sep.toString())
+        .type(TRANSACTION_STATUS_CHANGED)
+        .transaction(expectedResponse)
+        .build()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedEvent),
+      gson.toJson(anchorEventCapture.captured),
+      JSONCompareMode.STRICT
+    )
+
+    assertTrue(sep6TxnCapture.captured.updatedAt >= startDate)
+    assertTrue(sep6TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @CsvSource(value = ["withdrawal", "withdrawal-exchange"])
+  @ParameterizedTest
   fun test_handle_sep6_ok_withoutAmounts_amountsPresent(kind: String) {
     val request =
       RequestOnchainFundsRequest.builder()
         .transactionId(TX_ID)
-        .memo(TEXT_MEMO)
-        .memoType(TEXT_MEMO_TYPE)
+        .memo(HASH_MEMO)
+        .memoType(HASH_MEMO_TYPE)
         .destinationAccount(DESTINATION_ACCOUNT)
         .build()
     val txn6 = JdbcSep6Transaction()
@@ -1593,8 +1592,8 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.amountFee = "0.1"
     expectedSep6Txn.amountFeeAsset = STELLAR_USDC
     expectedSep6Txn.amountExpected = "1"
-    expectedSep6Txn.memo = TEXT_MEMO
-    expectedSep6Txn.memoType = TEXT_MEMO_TYPE
+    expectedSep6Txn.memo = HASH_MEMO
+    expectedSep6Txn.memoType = HASH_MEMO_TYPE
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
@@ -1613,8 +1612,8 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.feeDetails = expectedResponse.amountFee.toRate()
     expectedResponse.amountExpected = Amount("1", STELLAR_USDC)
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
-    expectedResponse.memo = TEXT_MEMO
-    expectedResponse.memoType = TEXT_MEMO_TYPE
+    expectedResponse.memo = HASH_MEMO
+    expectedResponse.memoType = HASH_MEMO_TYPE
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
 
     JSONAssert.assertEquals(


### PR DESCRIPTION
### Description

This sets the `memo` value to the request `memo` value.

### Context

 `memo.toString()` returns the hex value of the memo but the `memo` in the Payment object is in Base64 format, so the observer will never find the transaction in the database.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

