### PR TITLE
Use docker compose v2

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Pull Stellar Validation Tests Docker Image
         run: docker pull stellar/anchor-tests:latest &
 
-      - name: Run Kafka, Postgres, and Sep24 UI with docker-compose
+      - name: Run Kafka, Postgres, and Sep24 UI with docker compose
         env:
           TEST_PROFILE_NAME: default
-        run: docker-compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
+        run: docker compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
 
       - name: Run sep server, platform server, observer, and reference servers for integration tests
         env:

--- a/.github/workflows/sub_extended_tests.yml
+++ b/.github/workflows/sub_extended_tests.yml
@@ -46,8 +46,8 @@ jobs:
 
       #############################################
 
-      - name: Run Kafka, Postgres, and Sep24 UI with docker-compose
-        run: docker-compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
+      - name: Run Kafka, Postgres, and Sep24 UI with docker compose
+        run: docker compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
 
       # `custody` Tests
       - name: Start `custody` configuration

--- a/docs/01 - Contributing/A - Development Environment.md
+++ b/docs/01 - Contributing/A - Development Environment.md
@@ -11,7 +11,7 @@
         * [Clean](#clean)
         * [Build](#build)
         * [Running Unit Tests](#running-unit-tests)
-        * [Running `docker-compose` up for development](#running-docker-compose-up-for-development)
+        * [Running `docker compose` up for development](#running-docker-compose-up-for-development)
         * [Starting all servers](#starting-all-servers)
     * [Set up the Git Hooks](#set-up-the-git-hooks)
 * [Set up the Development Environment with IntelliJ IDEA](#set-up-the-development-environment-with-intellij-idea)
@@ -111,11 +111,11 @@ Run all tests: `./gradlew test`
 
 Run subproject tests: `./gradlew :[subproject]:test`
 
-### Running `docker-compose start` for Kafka, Postgres, and SEP24 Reference UI
+### Running `docker compose start` for Kafka, Postgres, and SEP24 Reference UI
 
 `./gradlew dockerComposeStart`
 
-### Running `docker-compose stop` to shutdown Kafka, Postgres, and SEP24 Reference UI
+### Running `docker compose stop` to shutdown Kafka, Postgres, and SEP24 Reference UI
 
 `./gradlew dockerComposeStop`
 
@@ -218,7 +218,7 @@ the `service-runner/src/main/resources/profiles` folder.
 
 If you would like to debug the Platform server, you can do so by running the
 
-- Make sure `docker` and `docker-compose` is available on your local machine.
+- Make sure `docker` is available on your local machine.
 - Check if there are previous docker containers running on your machine. If there are, please stop and delete them.
 - Run `Docker - Run Dev Stack - Kafka, Postgres, SEP24 Reference UI` to start the development stack.
 - Debug `Sep Server: default` to start the SEP server.
@@ -229,7 +229,7 @@ If you would like to debug the unit tests or the end-to-end tests, there are two
 
 #### Option 1: Run the servers from IntelliJ
 
-- Make sure `docker` and `docker-compose` is available on your local machine.
+- Make sure `docker` is available on your local machine.
 - Check if there are previous docker containers running on your machine. If there are, please stop and delete them.
 - Run `Docker - Run Dev Stack - Kafka, Postgres, SEP24 Reference UI` to start the development stack.
 - Run `Test Profile: default` to run the servers with the `default` profile.
@@ -237,7 +237,7 @@ If you would like to debug the unit tests or the end-to-end tests, there are two
 
 ### Option 2: Run the servers and tests from Gradle
 
-- Make sure `docker` and `docker-compose` is available on your local machine.
+- Make sure `docker` is available on your local machine.
 - Check if there are previous docker containers running on your machine. If there are, please stop and delete them.
 - Navigate to the directory to the project folder
 - `./gradlew dockerComposeStart` to start the development stack.

--- a/service-runner/build.gradle.kts
+++ b/service-runner/build.gradle.kts
@@ -61,9 +61,9 @@ tasks.register<JavaExec>("startServersWithTestProfile") {
   mainClass.set("org.stellar.anchor.platform.run_profiles.RunTestProfile")
 }
 
-/** Run docker-compose up to start Postgres, Kafka, etc. */
+/** Run docker compose up to start Postgres, Kafka, etc. */
 tasks.register<JavaExec>("dockerComposeStart") {
-  println("Running docker-compose to start Postgres, Kafka ,etc.")
+  println("Running docker compose to start Postgres, Kafka ,etc.")
   group = "application"
   classpath = sourceSets["main"].runtimeClasspath
   mainClass.set("org.stellar.anchor.platform.run_profiles.RunDockerDevStackNoWait")

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunDockerDevStackNoWait.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/run_profiles/RunDockerDevStackNoWait.kt
@@ -8,7 +8,7 @@ import org.stellar.anchor.platform.*
 fun main() = runBlocking {
   testProfileExecutor = TestProfileExecutor(TestConfig())
   // The "registerShutdownHook(testProfileExecutor)" is commented out to avoid shutting down the
-  // docker-compose stack when the JVM is shutdown.
+  // docker compose stack when the JVM is shutdown.
   testProfileExecutor.start(true) {
     it.env[RUN_DOCKER] = "true"
     it.env[RUN_ALL_SERVERS] = "false"


### PR DESCRIPTION
### Description

Replaces usages of `docker-compose` with `docker compose`.

### Context

`docker-compose` is deprecated and the GH action workflows will not run without upgrading.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

