### PR TITLE
[ANCHOR-748] Add quote_id to GET /transaction responses

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/TransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/TransactionResponse.java
@@ -43,6 +43,9 @@ public class TransactionResponse {
   @SerializedName("fee_details")
   FeeDetails feeDetails;
 
+  @SerializedName("quote_id")
+  String quoteId;
+
   @SerializedName("started_at")
   Instant startedAt;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
@@ -51,6 +51,9 @@ public class Sep31GetTransactionResponse {
     @SerializedName("fee_details")
     FeeDetails feeDetails;
 
+    @SerializedName("quote_id")
+    String quoteId;
+
     @SerializedName("amount_fee_asset")
     String amountFeeAsset;
 

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
@@ -25,6 +25,7 @@ public class Sep24Helper {
     if (txn.getToAccount() != null) txnR.setTo(txn.getToAccount());
     if (txn.getStartedAt() != null) txnR.setStartedAt(txn.getStartedAt());
     if (txn.getCompletedAt() != null) txnR.setCompletedAt(txn.getCompletedAt());
+    if (txn.getQuoteId() != null) txnR.setQuoteId(txn.getQuoteId());
     if (txn.getUserActionRequiredBy() != null)
       txnR.setUserActionRequiredBy(txn.getUserActionRequiredBy());
   }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
@@ -146,6 +146,7 @@ public interface Sep31Transaction extends SepTransaction {
                 .amountFee(getAmountFee())
                 .amountFeeAsset(getAmountFeeAsset())
                 .feeDetails(getFeeDetails())
+                .quoteId(getQuoteId())
                 .stellarAccountId(getStellarAccountId())
                 .stellarMemo(getStellarMemo())
                 .stellarMemoType(getStellarMemoType())

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionUtils.java
@@ -52,6 +52,7 @@ public class Sep6TransactionUtils {
             .amountFee(txn.getAmountFee())
             .amountFeeAsset(txn.getAmountFeeAsset())
             .feeDetails(txn.getFeeDetails())
+            .quoteId(txn.getQuoteId())
             .startedAt(txn.getStartedAt().toString())
             .updatedAt(txn.getUpdatedAt().toString())
             .completedAt(txn.getCompletedAt() != null ? txn.getCompletedAt().toString() : null)

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -25,15 +25,12 @@ import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_NAME
 import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestConstants.Companion.TEST_OFFCHAIN_ASSET
+import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_TRANSACTION_ID_0
 import org.stellar.anchor.TestConstants.Companion.TEST_TRANSACTION_ID_1
 import org.stellar.anchor.TestHelper
 import org.stellar.anchor.api.callback.FeeIntegration
-import org.stellar.anchor.api.exception.BadRequestException
-import org.stellar.anchor.api.exception.SepException
-import org.stellar.anchor.api.exception.SepNotAuthorizedException
-import org.stellar.anchor.api.exception.SepNotFoundException
-import org.stellar.anchor.api.exception.SepValidationException
+import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.sep.sep24.GetTransactionRequest
 import org.stellar.anchor.api.sep.sep24.GetTransactionsRequest
 import org.stellar.anchor.asset.AssetService
@@ -563,12 +560,14 @@ internal class Sep24ServiceTest {
     assertEquals(response.transactions[0].kind, kind)
     assertEquals(response.transactions[0].startedAt, TEST_STARTED_AT)
     assertEquals(response.transactions[0].completedAt, TEST_COMPLETED_AT)
+    assertEquals(response.transactions[0].quoteId, TEST_QUOTE_ID)
 
     assertEquals(response.transactions[1].id, TEST_TRANSACTION_ID_1)
     assertEquals(response.transactions[1].status, "completed")
     assertEquals(response.transactions[1].kind, kind)
     assertEquals(response.transactions[1].startedAt, TEST_STARTED_AT)
     assertEquals(response.transactions[1].completedAt, TEST_COMPLETED_AT)
+    assertEquals(response.transactions[1].quoteId, TEST_QUOTE_ID)
   }
 
   @ParameterizedTest

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTestHelper.kt
@@ -6,6 +6,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_AMOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_OFFCHAIN_ASSET
+import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
 
 fun createTestTransactionRequest(quoteID: String? = null): MutableMap<String, String> {
   val request =
@@ -67,6 +68,7 @@ fun createTestTransactions(kind: String): MutableList<Sep24Transaction> {
   txn.protocol = "sep24"
   txn.amountIn = "321.4"
   txn.amountOut = "321.4"
+  txn.quoteId = TEST_QUOTE_ID
   txns.add(txn)
 
   txn = PojoSep24Transaction()
@@ -85,6 +87,7 @@ fun createTestTransactions(kind: String): MutableList<Sep24Transaction> {
   txn.protocol = "sep24"
   txn.amountIn = "456.7"
   txn.amountOut = "456.7"
+  txn.quoteId = TEST_QUOTE_ID
   txns.add(txn)
 
   return txns

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -495,6 +495,7 @@ class Sep31ServiceTest {
           .amountFee("2")
           .amountFeeAsset("USDC")
           .feeDetails(FeeDetails("2", "USDC"))
+          .quoteId("quote_id")
           .stellarAccountId("GAYR3FVW2PCXTNHHWHEAFOCKZQV4PEY2ZKGIKB47EKPJ3GSBYA52XJBY")
           .stellarMemo("123456")
           .stellarMemoType("text")

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -158,6 +158,7 @@ class Sep31TransactionTest {
             .amountFee("2.0000")
             .amountFeeAsset(fiatUSD)
             .feeDetails(FeeDetails("2.0000", fiatUSD))
+            .quoteId("quote-id")
             .stellarAccountId(TEST_ACCOUNT)
             .stellarMemo(TEST_MEMO)
             .stellarMemoType("text")

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6TransactionUtilsTest.kt
@@ -49,6 +49,7 @@ class Sep6TransactionUtilsTest {
             "total": "1.00",
             "asset": "USD"
           },
+          "quote_id": "quote-id",
           "from": "1234",
           "to": "$TEST_ASSET_ISSUER_ACCOUNT_ID",
           "deposit_memo_type": "text",


### PR DESCRIPTION
### Description

This adds `quote_id` to the GET /transaction response.

### Context

This is currently missing.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A