### PR TITLE
[ANCHOR-752] Remove amount_out requirement in RequestOnchainFunds

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.SepException;
@@ -87,12 +88,10 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
 
     // If none of the accepted combinations of input parameters satisfies -> throw an exception
     if (!((request.getAmountIn() == null
-            && request.getAmountOut() == null
             && request.getAmountFee() == null
             && request.getFeeDetails() == null
             && request.getAmountExpected() == null)
         || (request.getAmountIn() != null
-            && request.getAmountOut() != null
             && (request.getAmountFee() != null || request.getFeeDetails() != null)))) {
       throw new InvalidParamsException(
           "All (amount_out is optional) or none of the amount_in, amount_out, and (fee_details or amount_fee) should be set");
@@ -139,6 +138,28 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
 
     if (request.getAmountIn() == null && txn.getAmountIn() == null) {
       throw new InvalidParamsException("amount_in is required");
+    }
+    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
+      if (SEP_6 == Sep.from(txn.getProtocol())) {
+        JdbcSep6Transaction txn6 = (JdbcSep6Transaction) txn;
+        if (txn6.getQuoteId() != null) {
+          throw new InvalidParamsException(
+              "amount_out is required for transactions with firm quotes");
+        }
+        if (StringUtils.equals(txn6.getAmountInAsset(), txn6.getAmountOutAsset())) {
+          throw new InvalidParamsException("amount_out is required for non-exchange transactions");
+        }
+      }
+      if (SEP_24 == Sep.from(txn.getProtocol())) {
+        JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
+        if (txn24.getQuoteId() != null) {
+          throw new InvalidParamsException(
+              "amount_out is required for transactions with firm quotes");
+        }
+        if (StringUtils.equals(txn24.getAmountInAsset(), txn24.getAmountOutAsset())) {
+          throw new InvalidParamsException("amount_out is required for non-exchange transactions");
+        }
+      }
     }
     if (request.getAmountFee() == null
         && request.getFeeDetails() == null

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -95,7 +95,7 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
             && request.getAmountOut() != null
             && (request.getAmountFee() != null || request.getFeeDetails() != null)))) {
       throw new InvalidParamsException(
-          "All or none of the amount_in, amount_out, and (fee_details or amount_fee) should be set");
+          "All (amount_out is optional) or none of the amount_in, amount_out, and (fee_details or amount_fee) should be set");
     }
 
     // In case 2nd predicate in previous IF statement was TRUE
@@ -139,9 +139,6 @@ public class RequestOnchainFundsHandler extends RpcMethodHandler<RequestOnchainF
 
     if (request.getAmountIn() == null && txn.getAmountIn() == null) {
       throw new InvalidParamsException("amount_in is required");
-    }
-    if (request.getAmountOut() == null && txn.getAmountOut() == null) {
-      throw new InvalidParamsException("amount_out is required");
     }
     if (request.getAmountFee() == null
         && request.getFeeDetails() == null


### PR DESCRIPTION
### Description

`amount_out` is not set if a transaction has an associated indicative quote but has not yet received funds.

### Context

N/A

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A