### PR TITLE
[ANCHOR-425] Deprecate platform API

### DIFF
--- a/api-schema/build.gradle.kts
+++ b/api-schema/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(libs.jakarta.annotation.api)
   implementation(libs.jakarta.validation.api)
   implementation(libs.google.gson)
+  implementation(libs.spring.data.commons)
 
   annotationProcessor(libs.lombok)
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/GetTransactionRpcRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/GetTransactionRpcRequest.java
@@ -1,0 +1,12 @@
+package org.stellar.anchor.api.rpc.method;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class GetTransactionRpcRequest extends RpcMethodParamsRequest {}

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/GetTransactionsRpcRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/GetTransactionsRpcRequest.java
@@ -1,0 +1,35 @@
+package org.stellar.anchor.api.rpc.method;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.domain.Sort;
+import org.stellar.anchor.api.platform.TransactionsOrderBy;
+import org.stellar.anchor.api.platform.TransactionsSeps;
+import org.stellar.anchor.api.sep.SepTransactionStatus;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class GetTransactionsRpcRequest extends RpcMethodParamsRequest {
+
+  @NotNull private TransactionsSeps sep;
+
+  @SerializedName("order_by")
+  private TransactionsOrderBy orderBy;
+
+  private Sort.Direction order;
+
+  private List<SepTransactionStatus> statuses;
+
+  @SerializedName("page_number")
+  private Integer pageNumber;
+
+  @SerializedName("page_size")
+  private Integer pageSize;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/method/RpcMethod.java
@@ -69,7 +69,13 @@ public enum RpcMethod {
   NOTIFY_TRANSACTION_RECOVERY("notify_transaction_recovery"),
 
   @SerializedName("notify_transaction_on_hold")
-  NOTIFY_TRANSACTION_ON_HOLD("notify_transaction_on_hold");
+  NOTIFY_TRANSACTION_ON_HOLD("notify_transaction_on_hold"),
+
+  @SerializedName("get_transaction")
+  GET_TRANSACTION("get_transaction"),
+
+  @SerializedName("get_transactions")
+  GET_TRANSACTIONS("get_transactions");
 
   private final String method;
 

--- a/core/src/main/java/org/stellar/anchor/util/RpcHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/RpcHelper.java
@@ -1,0 +1,38 @@
+package org.stellar.anchor.util;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import okhttp3.Response;
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
+import org.stellar.anchor.api.rpc.RpcResponse;
+
+public class RpcHelper {
+  static final Gson gson = GsonUtils.getInstance();
+
+  /**
+   * Retrieves the result field from an RPC response.
+   *
+   * @param rpcResponse The Response object containing the JSON response body from an RPC call.
+   * @return object populated with the data from the JSON response.
+   * @throws IllegalArgumentException if the JSON response body does not contain any items in the
+   *     list.
+   */
+  public static Object getResultFromRpcResponse(Response rpcResponse)
+      throws InvalidRequestException, IOException {
+    if (rpcResponse.body() == null) throw new InvalidRequestException("Empty response");
+    String responseBody = rpcResponse.body().string();
+
+    // List<RpcResponse> type token is needed due to rpcResponse is always wrapped in an array, e.g.
+    // [{"jsonrpc":"2.0","result":{"id":"31c02..."}}]
+    Type listType = new TypeToken<List<RpcResponse>>() {}.getType();
+    List<RpcResponse> responseList = gson.fromJson(responseBody, listType);
+    RpcResponse response = responseList.get(0);
+    if (response.getError() != null) {
+      throw new InvalidRequestException("Invalid JSON-RPC request");
+    }
+    return response.getResult();
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/util/SepHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepHelper.java
@@ -4,7 +4,7 @@ import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 import static org.stellar.anchor.util.MathHelper.decimal;
 
 import java.math.BigDecimal;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -172,24 +172,49 @@ public class SepHelper {
     }
   }
 
-  static final List<SepTransactionStatus> sep24Statuses =
-      List.of(
-          INCOMPLETE,
-          PENDING_USR_TRANSFER_START,
-          PENDING_USR_TRANSFER_COMPLETE,
+  public static final Set<SepTransactionStatus> sep6Statuses =
+      Set.of(
           PENDING_EXTERNAL,
           PENDING_ANCHOR,
+          ON_HOLD,
           PENDING_STELLAR,
           PENDING_TRUST,
           PENDING_USER,
+          PENDING_USR_TRANSFER_START,
+          PENDING_USR_TRANSFER_COMPLETE,
+          PENDING_CUSTOMER_INFO_UPDATE,
+          PENDING_TRANSACTION_INFO_UPDATE,
           COMPLETED,
+          INCOMPLETE,
+          EXPIRED,
           NO_MARKET,
           TOO_SMALL,
           TOO_LARGE,
-          ERROR);
+          ERROR,
+          REFUNDED);
 
-  static final List<SepTransactionStatus> sep31Statuses =
-      List.of(
+  public static final Set<SepTransactionStatus> sep24Statuses =
+      Set.of(
+          PENDING_EXTERNAL,
+          PENDING_ANCHOR,
+          ON_HOLD,
+          PENDING_STELLAR,
+          PENDING_TRUST,
+          PENDING_USER,
+          PENDING_USR_TRANSFER_START,
+          PENDING_USR_TRANSFER_COMPLETE,
+          PENDING_TRANSACTION_INFO_UPDATE,
+          COMPLETED,
+          INCOMPLETE,
+          EXPIRED,
+          NO_MARKET,
+          TOO_SMALL,
+          TOO_LARGE,
+          ERROR,
+          REFUNDED);
+
+  public static final Set<SepTransactionStatus> sep31Statuses =
+      Set.of(
           PENDING_SENDER,
           PENDING_STELLAR,
           PENDING_CUSTOMER_INFO_UPDATE,
@@ -198,5 +223,6 @@ public class SepHelper {
           PENDING_EXTERNAL,
           COMPLETED,
           EXPIRED,
-          ERROR);
+          ERROR,
+          REFUNDED);
 }

--- a/core/src/main/java/org/stellar/anchor/util/TransactionsParams.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionsParams.java
@@ -11,7 +11,7 @@ import org.stellar.anchor.api.sep.SepTransactionStatus;
 @Data
 @AllArgsConstructor
 public class TransactionsParams {
-  TransactionsOrderBy order_by;
+  TransactionsOrderBy orderBy;
   Sort.Direction order;
   @Nullable List<SepTransactionStatus> statuses;
   Integer pageNumber;

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -80,6 +80,44 @@ public class RpcActionBeans {
   }
 
   @Bean
+  GetTransactionHandler getTransactionHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    return new GetTransactionHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
+  }
+
+  @Bean
+  GetTransactionsHandler getTransactionsHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    return new GetTransactionsHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService);
+  }
+
+  @Bean
   NotifyAmountsUpdatedHandler notifyAmountsUpdatedHandler(
       Sep6TransactionStore txn6Store,
       Sep24TransactionStore txn24Store,

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/PlatformController.java
@@ -14,12 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.stellar.anchor.api.custody.CreateTransactionPaymentResponse;
 import org.stellar.anchor.api.exception.AnchorException;
-import org.stellar.anchor.api.platform.GetTransactionResponse;
-import org.stellar.anchor.api.platform.GetTransactionsResponse;
-import org.stellar.anchor.api.platform.PatchTransactionsRequest;
-import org.stellar.anchor.api.platform.PatchTransactionsResponse;
-import org.stellar.anchor.api.platform.TransactionsOrderBy;
-import org.stellar.anchor.api.platform.TransactionsSeps;
+import org.stellar.anchor.api.platform.*;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.custody.CustodyService;
 import org.stellar.anchor.platform.service.TransactionService;
@@ -36,6 +31,7 @@ public class PlatformController {
     this.custodyService = custodyService;
   }
 
+  @Deprecated // ANCHOR-641 Use Rpc method GET_TRANSACTION instead
   @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
@@ -47,6 +43,7 @@ public class PlatformController {
     return transactionService.findTransaction(txnId);
   }
 
+  @Deprecated // ANCHOR-641
   @CrossOrigin(origins = "*")
   @RequestMapping(
       value = "/transactions/{id}/payments",
@@ -59,6 +56,7 @@ public class PlatformController {
     return custodyService.createTransactionPayment(txnId, requestBody);
   }
 
+  @Deprecated // ANCHOR-641 Use corresponding Rpc method to update transaction/**/
   @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
@@ -71,6 +69,7 @@ public class PlatformController {
     return transactionService.patchTransactions(request);
   }
 
+  @Deprecated // ANCHOR-641 Use Rpc method GET_TRANSACTIONS instead
   @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
@@ -80,14 +79,14 @@ public class PlatformController {
   public GetTransactionsResponse getTransactions(
       @RequestParam(value = "sep") TransactionsSeps sep,
       @RequestParam(required = false, value = "order_by", defaultValue = "created_at")
-          TransactionsOrderBy order_by,
+          TransactionsOrderBy orderBy,
       @RequestParam(required = false, value = "order", defaultValue = "asc") Sort.Direction order,
       @RequestParam(required = false, value = "statuses") List<SepTransactionStatus> statuses,
       @RequestParam(required = false, value = "page_number", defaultValue = "0") Integer pageNumber,
       @RequestParam(required = false, value = "page_size", defaultValue = "20") Integer pageSize)
       throws AnchorException {
     TransactionsParams params =
-        new TransactionsParams(order_by, order, statuses, pageNumber, pageSize);
+        new TransactionsParams(orderBy, order, statuses, pageNumber, pageSize);
     return transactionService.findTransactions(sep, params);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
@@ -38,7 +38,7 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
             "SELECT * FROM %s t %s ORDER BY %s %s NULLS LAST, id ASC LIMIT %d OFFSET %d",
             table.name(),
             statuses == null ? "" : " WHERE t.status in (" + mergeStatusesList(statuses, "'") + ")",
-            params.getOrder_by().getTableName(),
+            params.getOrderBy().getTableName(),
             params.getOrder().name(),
             params.getPageSize(),
             params.getPageNumber() * params.getPageSize());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/GetTransactionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/GetTransactionHandler.java
@@ -1,0 +1,94 @@
+package org.stellar.anchor.platform.rpc;
+
+import static org.stellar.anchor.api.rpc.method.RpcMethod.GET_TRANSACTION;
+import static org.stellar.anchor.platform.utils.PlatformTransactionHelper.toGetTransactionResponse;
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
+import java.util.Set;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
+import org.stellar.anchor.api.platform.PlatformTransactionData.Sep;
+import org.stellar.anchor.api.rpc.method.GetTransactionRpcRequest;
+import org.stellar.anchor.api.rpc.method.RpcMethod;
+import org.stellar.anchor.api.sep.SepTransactionStatus;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSepTransaction;
+import org.stellar.anchor.platform.validator.RequestValidator;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
+import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
+import org.stellar.anchor.util.Log;
+import org.stellar.anchor.util.SepHelper;
+
+public class GetTransactionHandler extends RpcMethodHandler<GetTransactionRpcRequest> {
+  public GetTransactionHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    super(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService,
+        GetTransactionRpcRequest.class);
+  }
+
+  @Override
+  public Object handle(Object requestParams) throws AnchorException {
+    GetTransactionRpcRequest request =
+        gson.fromJson(gson.toJson(requestParams), GetTransactionRpcRequest.class);
+    if (isEmpty(request.getTransactionId())) {
+      Log.info("Rejecting GET /transaction/:id because the id is empty.");
+      throw new InvalidParamsException("transaction id cannot be empty");
+    }
+
+    Log.infoF("Processing RPC request {}", request);
+    JdbcSepTransaction txn = getTransaction(request.getTransactionId());
+    if (txn == null) {
+      throw new InvalidRequestException(
+          String.format("Transaction with id[%s] is not found", request.getTransactionId()));
+    }
+
+    return toGetTransactionResponse(txn, assetService);
+  }
+
+  @Override
+  public RpcMethod getRpcMethod() {
+    return GET_TRANSACTION;
+  }
+
+  @Override
+  protected SepTransactionStatus getNextStatus(
+      JdbcSepTransaction txn, GetTransactionRpcRequest request)
+      throws InvalidRequestException, InvalidParamsException {
+    return null;
+  }
+
+  @Override
+  protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
+    switch (Sep.from((txn.getProtocol()))) {
+      case SEP_6:
+        return SepHelper.sep6Statuses;
+      case SEP_24:
+        return SepHelper.sep24Statuses;
+      case SEP_31:
+        return SepHelper.sep31Statuses;
+      default:
+        throw new IllegalStateException("Unsupported protocol: " + txn.getProtocol());
+    }
+  }
+
+  @Override
+  protected void updateTransactionWithRpcRequest(
+      JdbcSepTransaction txn, GetTransactionRpcRequest request) throws AnchorException {}
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/GetTransactionsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/GetTransactionsHandler.java
@@ -1,0 +1,108 @@
+package org.stellar.anchor.platform.rpc;
+
+import static org.stellar.anchor.api.rpc.method.RpcMethod.GET_TRANSACTIONS;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.BadRequestException;
+import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
+import org.stellar.anchor.api.platform.GetTransactionsResponse;
+import org.stellar.anchor.api.platform.TransactionsSeps;
+import org.stellar.anchor.api.rpc.method.GetTransactionsRpcRequest;
+import org.stellar.anchor.api.rpc.method.RpcMethod;
+import org.stellar.anchor.api.sep.SepTransactionStatus;
+import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSepTransaction;
+import org.stellar.anchor.platform.utils.PlatformTransactionHelper;
+import org.stellar.anchor.platform.validator.RequestValidator;
+import org.stellar.anchor.sep24.Sep24TransactionStore;
+import org.stellar.anchor.sep31.Sep31TransactionStore;
+import org.stellar.anchor.sep6.Sep6TransactionStore;
+import org.stellar.anchor.util.TransactionsParams;
+
+public class GetTransactionsHandler extends RpcMethodHandler<GetTransactionsRpcRequest> {
+
+  public GetTransactionsHandler(
+      Sep6TransactionStore txn6Store,
+      Sep24TransactionStore txn24Store,
+      Sep31TransactionStore txn31Store,
+      RequestValidator requestValidator,
+      AssetService assetService,
+      EventService eventService,
+      MetricsService metricsService) {
+    super(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService,
+        GetTransactionsRpcRequest.class);
+  }
+
+  @Override
+  public Object handle(Object requestParams) throws AnchorException {
+    GetTransactionsRpcRequest request =
+        gson.fromJson(gson.toJson(requestParams), GetTransactionsRpcRequest.class);
+    TransactionsParams params =
+        new TransactionsParams(
+            request.getOrderBy(),
+            request.getOrder(),
+            request.getStatuses(),
+            request.getPageNumber(),
+            request.getPageSize());
+    return findTransactions(request.getSep(), params);
+  }
+
+  @Override
+  public RpcMethod getRpcMethod() {
+    return GET_TRANSACTIONS;
+  }
+
+  @Override
+  protected SepTransactionStatus getNextStatus(
+      JdbcSepTransaction txn, GetTransactionsRpcRequest request)
+      throws InvalidRequestException, InvalidParamsException {
+    return null;
+  }
+
+  @Override
+  protected Set<SepTransactionStatus> getSupportedStatuses(JdbcSepTransaction txn) {
+    return null;
+  }
+
+  @Override
+  protected void updateTransactionWithRpcRequest(
+      JdbcSepTransaction txn, GetTransactionsRpcRequest request) throws AnchorException {}
+
+  private GetTransactionsResponse findTransactions(TransactionsSeps sep, TransactionsParams params)
+      throws AnchorException {
+    List<?> txn;
+    switch (sep) {
+      case SEP_6:
+        txn = txn6Store.findTransactions(params);
+        break;
+      case SEP_24:
+        txn = txn24Store.findTransactions(params);
+        break;
+      case SEP_31:
+        txn = txn31Store.findTransactions(params);
+        break;
+      default:
+        throw new BadRequestException("SEP not supported");
+    }
+    return new GetTransactionsResponse(
+        txn.stream()
+            .map(
+                t ->
+                    PlatformTransactionHelper.toGetTransactionResponse(
+                        (JdbcSepTransaction) t, assetService))
+            .collect(Collectors.toList()));
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcMethodHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcMethodHandler.java
@@ -45,7 +45,7 @@ import org.stellar.anchor.util.Log;
 
 public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
 
-  private static final Gson gson = GsonUtils.getInstance();
+  protected static final Gson gson = GsonUtils.getInstance();
 
   protected final Sep6TransactionStore txn6Store;
   protected final Sep24TransactionStore txn24Store;
@@ -75,7 +75,7 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
   }
 
-  public GetTransactionResponse handle(Object requestParams) throws AnchorException {
+  public Object handle(Object requestParams) throws AnchorException {
     T request = gson.fromJson(gson.toJson(requestParams), requestType);
     Log.infoF("Processing RPC request {}", request);
     JdbcSepTransaction txn = getTransaction(request.getTransactionId());
@@ -122,7 +122,7 @@ public abstract class RpcMethodHandler<T extends RpcMethodParamsRequest> {
             .transaction(txResponse)
             .build());
 
-    return toGetTransactionResponse(txn, assetService);
+    return txResponse;
   }
 
   public abstract RpcMethod getRpcMethod();

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/GetTransactionHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/GetTransactionHandlerTest.kt
@@ -1,0 +1,127 @@
+package org.stellar.anchor.platform.rpc
+
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import java.time.Instant
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.api.exception.rpc.InvalidParamsException
+import org.stellar.anchor.api.exception.rpc.InvalidRequestException
+import org.stellar.anchor.api.platform.GetTransactionResponse
+import org.stellar.anchor.api.platform.PlatformTransactionData
+import org.stellar.anchor.api.rpc.method.GetTransactionRpcRequest
+import org.stellar.anchor.api.sep.SepTransactionStatus
+import org.stellar.anchor.api.shared.Amount
+import org.stellar.anchor.api.shared.Customers
+import org.stellar.anchor.api.shared.StellarId
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.event.EventService
+import org.stellar.anchor.metrics.MetricsService
+import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.validator.RequestValidator
+import org.stellar.anchor.sep24.Sep24TransactionStore
+import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
+import org.stellar.anchor.util.GsonUtils
+
+class GetTransactionHandlerTest {
+  companion object {
+    private val gson = GsonUtils.getInstance()
+    private const val TX_ID = "testId"
+    private const val INVALID_ID = "invalidId"
+    private const val EMPTY_ID_ERROR_MESSAGE = "transaction id cannot be empty"
+    private const val TRANSACTION_NOT_FOUND = "Transaction with id[invalidId] is not found"
+  }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn31Store: Sep31TransactionStore
+
+  @MockK(relaxed = true) private lateinit var requestValidator: RequestValidator
+
+  @MockK(relaxed = true) private lateinit var assetService: AssetService
+
+  @MockK(relaxed = true) private lateinit var eventService: EventService
+
+  @MockK(relaxed = true) private lateinit var metricsService: MetricsService
+
+  @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
+
+  private lateinit var handler: GetTransactionHandler
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    every { eventService.createSession(any(), EventService.EventQueue.TRANSACTION) } returns
+      eventSession
+    this.handler =
+      GetTransactionHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService
+      )
+  }
+
+  @Test
+  fun test_get_Sep31Txn_byId() {
+    val request = GetTransactionRpcRequest.builder().transactionId(TX_ID).build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = SepTransactionStatus.PENDING_SENDER.toString()
+    txn31.updatedAt = Instant.now()
+    val anchorEventCapture = slot<AnchorEvent>()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { eventSession.publish(capture(anchorEventCapture)) } just Runs
+
+    val response = handler.handle(request)
+    verify(exactly = 0) { txn6Store.findByTransactionId(any()) }
+    verify(exactly = 0) { txn24Store.findByTransactionId(any()) }
+    verify(exactly = 1) { txn31Store.findByTransactionId(any()) }
+    verify(exactly = 0) { eventSession.publish(any()) }
+
+    val expectedResponse = GetTransactionResponse()
+    expectedResponse.sep = PlatformTransactionData.Sep.SEP_31
+    expectedResponse.kind = PlatformTransactionData.Kind.RECEIVE
+    expectedResponse.status = SepTransactionStatus.PENDING_SENDER
+    expectedResponse.amountIn = Amount()
+    expectedResponse.amountOut = Amount()
+    expectedResponse.amountExpected = Amount()
+    expectedResponse.updatedAt = txn31.updatedAt
+    expectedResponse.customers = Customers(StellarId(), StellarId())
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+  }
+
+  @Test
+  fun test_handle_emptyId() {
+    val request = GetTransactionRpcRequest.builder().transactionId("").build()
+    val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
+    assertEquals(EMPTY_ID_ERROR_MESSAGE, ex.message?.trimIndent())
+  }
+
+  @Test
+  fun test_handle_invalidId() {
+    val request = GetTransactionRpcRequest.builder().transactionId(INVALID_ID).build()
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(INVALID_ID) } returns null
+    val ex = assertThrows<InvalidRequestException> { handler.handle(request) }
+    assertEquals(TRANSACTION_NOT_FOUND, ex.message?.trimIndent())
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/GetTransactionsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/GetTransactionsHandlerTest.kt
@@ -1,0 +1,106 @@
+package org.stellar.anchor.platform.rpc
+
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import java.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.api.platform.GetTransactionsResponse
+import org.stellar.anchor.api.platform.TransactionsSeps
+import org.stellar.anchor.api.rpc.method.GetTransactionsRpcRequest
+import org.stellar.anchor.api.sep.SepTransactionStatus
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.event.EventService
+import org.stellar.anchor.metrics.MetricsService
+import org.stellar.anchor.platform.data.JdbcSep31Transaction
+import org.stellar.anchor.platform.utils.PlatformTransactionHelper
+import org.stellar.anchor.platform.validator.RequestValidator
+import org.stellar.anchor.sep24.Sep24TransactionStore
+import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
+import org.stellar.anchor.util.GsonUtils
+
+class GetTransactionsHandlerTest {
+  companion object {
+    private val gson = GsonUtils.getInstance()
+  }
+
+  @MockK(relaxed = true) private lateinit var txn6Store: Sep6TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn24Store: Sep24TransactionStore
+
+  @MockK(relaxed = true) private lateinit var txn31Store: Sep31TransactionStore
+
+  @MockK(relaxed = true) private lateinit var requestValidator: RequestValidator
+
+  @MockK(relaxed = true) private lateinit var assetService: AssetService
+
+  @MockK(relaxed = true) private lateinit var eventService: EventService
+
+  @MockK(relaxed = true) private lateinit var metricsService: MetricsService
+
+  @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
+
+  private lateinit var handler: GetTransactionsHandler
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    every { eventService.createSession(any(), EventService.EventQueue.TRANSACTION) } returns
+      eventSession
+    this.handler =
+      GetTransactionsHandler(
+        txn6Store,
+        txn24Store,
+        txn31Store,
+        requestValidator,
+        assetService,
+        eventService,
+        metricsService
+      )
+  }
+
+  @Test
+  fun test_get_Sep31Txns() {
+    val request = GetTransactionsRpcRequest.builder().sep(TransactionsSeps.SEP_31).build()
+
+    val txn1 = JdbcSep31Transaction()
+    txn1.status = SepTransactionStatus.PENDING_SENDER.toString()
+    txn1.updatedAt = Instant.now()
+    val anchorEventCapture1 = slot<AnchorEvent>()
+
+    val txn2 = JdbcSep31Transaction()
+    txn2.status = SepTransactionStatus.COMPLETED.toString()
+    txn2.updatedAt = Instant.now()
+    val anchorEventCapture2 = slot<AnchorEvent>()
+
+    val allTxns = listOf(txn1, txn2)
+
+    every { txn6Store.findTransactions(any()) } returns null
+    every { txn24Store.findTransactions(any()) } returns null
+    every { txn31Store.findTransactions(any()) } returns allTxns
+    every { eventSession.publish(capture(anchorEventCapture1)) } just Runs
+    every { eventSession.publish(capture(anchorEventCapture2)) } just Runs
+
+    val response = handler.handle(request)
+    verify(exactly = 0) { txn6Store.findByTransactionId(any()) }
+    verify(exactly = 0) { txn24Store.findByTransactionId(any()) }
+    verify(exactly = 1) { txn31Store.findTransactions(any()) }
+    verify(exactly = 0) { eventSession.publish(any()) }
+
+    val expectedResponse = GetTransactionsResponse()
+    expectedResponse.records =
+      allTxns
+        .map { txn -> PlatformTransactionHelper.toGetTransactionResponse(txn, assetService) }
+        .toList()
+
+    JSONAssert.assertEquals(
+      gson.toJson(expectedResponse),
+      gson.toJson(response),
+      JSONCompareMode.STRICT
+    )
+  }
+}


### PR DESCRIPTION
### Description
1. Add rpc method for `/transactions/id` and `/transactions`
2. Annotate deprecated endpoints and services used for these endpoints.

### Testing

- `./gradlew test`

### Documentation

1. Add rpc method`/transactions/id` and `/transactions` to stellar doc
2. Remove https://github.com/stellar/stellar-docs/blob/main/openapi/anchor-platform/Platform%20API.yml (No longer available on the website)


