### PR TITLE
[ANCHOR-732] Add SEP-6 SEP-24 as top-level field in Assets config

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/asset/StellarAssetInfo.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/asset/StellarAssetInfo.java
@@ -1,0 +1,14 @@
+package org.stellar.anchor.api.asset;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import org.stellar.anchor.api.sep.AssetInfo;
+
+@Data
+public class StellarAssetInfo extends AssetInfo {
+
+  String issuer;
+
+  @SerializedName("distribution_account")
+  String distributionAccount;
+}

--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/Sep31MissingFieldException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/Sep31MissingFieldException.java
@@ -1,17 +1,17 @@
 package org.stellar.anchor.api.exception;
 
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 
 /** Thrown when a SEP-31 transaction is missing required fields. */
 public class Sep31MissingFieldException extends AnchorException {
-  private final Sep31Operation.Fields missingFields;
+  private final Sep31Info.Fields missingFields;
 
-  public Sep31MissingFieldException(Sep31Operation.Fields missingFields) {
+  public Sep31MissingFieldException(Sep31Info.Fields missingFields) {
     super();
     this.missingFields = missingFields;
   }
 
-  public Sep31Operation.Fields getMissingFields() {
+  public Sep31Info.Fields getMissingFields() {
     return missingFields;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/AssetInfo.java
@@ -3,16 +3,33 @@ package org.stellar.anchor.api.sep;
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import lombok.*;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
-import org.stellar.anchor.api.sep.operation.Sep38Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
+import org.stellar.anchor.api.sep.operation.Sep38Info;
 
 @SuppressWarnings("unused")
 @Data
 public class AssetInfo {
   public static String NATIVE_ASSET_CODE = "native";
 
+  Schema schema;
+
   String code;
+
   String issuer;
+
+  @SerializedName("distribution_account")
+  String distributionAccount;
+
+  @SerializedName("significant_decimals")
+  Integer significantDecimals;
+
+  DepositWithdrawInfo sep6;
+
+  DepositWithdrawInfo sep24;
+
+  Sep31Info sep31;
+
+  Sep38Info sep38;
 
   /**
    * Returns the SEP-38 asset name, which is the SEP-11 asset name prefixed with the schema.
@@ -40,31 +57,6 @@ public class AssetInfo {
     }
   }
 
-  @SerializedName("distribution_account")
-  String distributionAccount;
-
-  Schema schema;
-
-  @SerializedName("significant_decimals")
-  Integer significantDecimals;
-
-  DepositOperation deposit;
-  WithdrawOperation withdraw;
-  Sep31Operation sep31;
-  Sep38Operation sep38;
-
-  @SerializedName("sep6_enabled")
-  Boolean sep6Enabled = false;
-
-  @SerializedName("sep24_enabled")
-  Boolean sep24Enabled = false;
-
-  @SerializedName("sep31_enabled")
-  Boolean sep31Enabled = false;
-
-  @SerializedName("sep38_enabled")
-  Boolean sep38Enabled = false;
-
   public enum Schema {
     @SerializedName("stellar")
     STELLAR("stellar"),
@@ -85,25 +77,22 @@ public class AssetInfo {
   }
 
   @Data
-  public static class AssetOperation {
-    Boolean enabled;
+  public static class DepositWithdrawInfo {
+    Boolean enabled = false;
+    DepositWithdrawOperation deposit;
+    DepositWithdrawOperation withdraw;
+  }
+
+  @Data
+  public static class DepositWithdrawOperation {
+    Boolean enabled = false;
 
     @SerializedName("min_amount")
     Long minAmount;
 
     @SerializedName("max_amount")
     Long maxAmount;
-  }
 
-  @EqualsAndHashCode(callSuper = true)
-  @Data
-  public static class DepositOperation extends AssetOperation {
-    List<String> methods;
-  }
-
-  @EqualsAndHashCode(callSuper = true)
-  @Data
-  public static class WithdrawOperation extends AssetOperation {
     List<String> methods;
   }
 
@@ -115,5 +104,30 @@ public class AssetInfo {
     String description;
     List<String> choices;
     boolean optional;
+  }
+
+  /**
+   * Determines if deposit or withdraw service is enabled in SEP-6 or SEP-24.
+   *
+   * @param info The DepositWithdrawInfo containing the service details.
+   * @param service The operation to check, either "deposit" or "withdraw" (case-insensitive).
+   * @return true if the specified operation is enabled; false otherwise.
+   */
+  public boolean getIsServiceEnabled(DepositWithdrawInfo info, String service) {
+    if (info == null || !info.getEnabled()) {
+      return false;
+    }
+    DepositWithdrawOperation operation;
+    switch (service.toLowerCase()) {
+      case "deposit":
+        operation = info.getDeposit();
+        break;
+      case "withdraw":
+        operation = info.getWithdraw();
+        break;
+      default:
+        return false;
+    }
+    return operation != null && operation.getEnabled();
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Info.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Info.java
@@ -6,7 +6,9 @@ import lombok.Data;
 import org.stellar.anchor.api.sep.AssetInfo;
 
 @Data
-public class Sep31Operation {
+public class Sep31Info {
+  Boolean enabled = false;
+
   SendOperation send;
 
   @SerializedName("quotes_supported")
@@ -16,6 +18,7 @@ public class Sep31Operation {
   boolean quotesRequired;
 
   Sep12Operation sep12;
+
   Fields fields;
 
   @Data

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Info.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Info.java
@@ -9,7 +9,7 @@ import org.stellar.anchor.api.sep.AssetInfo;
 public class Sep31Info {
   Boolean enabled = false;
 
-  SendOperation send;
+  ReceiveOperation receive;
 
   @SerializedName("quotes_supported")
   boolean quotesSupported;
@@ -22,7 +22,7 @@ public class Sep31Info {
   Fields fields;
 
   @Data
-  public static class SendOperation {
+  public static class ReceiveOperation {
     @SerializedName("fee_fixed")
     Integer feeFixed;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep38Info.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep38Info.java
@@ -5,20 +5,22 @@ import java.util.List;
 import lombok.Data;
 
 @Data
-public class Sep38Operation {
+public class Sep38Info {
+  Boolean enabled = false;
+
   @SerializedName("exchangeable_assets")
   List<String> exchangeableAssets;
 
   @SerializedName("country_codes")
   List<String> countryCodes;
 
+  Integer decimals;
+
   @SerializedName("sell_delivery_methods")
   List<DeliveryMethod> sellDeliveryMethods;
 
   @SerializedName("buy_delivery_methods")
   List<DeliveryMethod> buyDeliveryMethods;
-
-  Integer decimals;
 
   @Data
   public static class DeliveryMethod {

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep24/InfoResponse.java
@@ -1,6 +1,6 @@
 package org.stellar.anchor.api.sep.sep24;
 
-import static org.stellar.anchor.api.sep.AssetInfo.AssetOperation;
+import static org.stellar.anchor.api.sep.AssetInfo.DepositWithdrawOperation;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.Map;
@@ -27,7 +27,7 @@ public class InfoResponse {
     @SerializedName("max_amount")
     Long maxAmount;
 
-    public static OperationResponse fromAssetOperation(AssetOperation operation) {
+    public static OperationResponse fromAssetOperation(DepositWithdrawOperation operation) {
       return OperationResponse.builder()
           .enabled(operation.getEnabled())
           .minAmount(operation.getMinAmount())

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31GetTransactionResponse.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 import org.stellar.anchor.api.shared.FeeDetails;
 
 /**
@@ -82,7 +82,7 @@ public class Sep31GetTransactionResponse {
     String requiredInfoMessage;
 
     @SerializedName("required_info_updates")
-    Sep31Operation.Fields requiredInfoUpdates;
+    Sep31Info.Fields requiredInfoUpdates;
   }
 
   @Data

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31InfoResponse.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 import lombok.Data;
 import org.stellar.anchor.api.sep.operation.Sep12Operation;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 
 /**
  * The response body of the /info endpoint of the SEP-31.
@@ -40,6 +40,6 @@ public class Sep31InfoResponse {
     Long maxAmount;
 
     Sep12Operation sep12;
-    Sep31Operation.Fields fields;
+    Sep31Info.Fields fields;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.Data;
 import org.stellar.anchor.api.sep.AssetInfo;
-import org.stellar.anchor.api.sep.operation.Sep38Operation;
+import org.stellar.anchor.api.sep.operation.Sep38Info;
 
 /**
  * The response body of the GET /info endpoint of SEP-38.
@@ -21,7 +21,7 @@ public class InfoResponse {
 
   public InfoResponse(List<AssetInfo> assetInfoList) {
     for (AssetInfo assetInfo : assetInfoList) {
-      if (!assetInfo.getSep38Enabled()) continue;
+      if (!assetInfo.getSep38().getEnabled()) continue;
       Asset newAsset = new Asset();
       String assetName = assetInfo.getSchema().toString() + ":" + assetInfo.getCode();
       if (!Objects.toString(assetInfo.getIssuer(), "").isEmpty()) {
@@ -29,7 +29,7 @@ public class InfoResponse {
       }
       newAsset.setAsset(assetName);
 
-      Sep38Operation sep38Info = assetInfo.getSep38();
+      Sep38Info sep38Info = assetInfo.getSep38();
       newAsset.setCountryCodes(sep38Info.getCountryCodes());
       newAsset.setSellDeliveryMethods(sep38Info.getSellDeliveryMethods());
       newAsset.setBuyDeliveryMethods(sep38Info.getBuyDeliveryMethods());
@@ -53,10 +53,10 @@ public class InfoResponse {
     private List<String> countryCodes;
 
     @SerializedName("sell_delivery_methods")
-    private List<Sep38Operation.DeliveryMethod> sellDeliveryMethods;
+    private List<Sep38Info.DeliveryMethod> sellDeliveryMethods;
 
     @SerializedName("buy_delivery_methods")
-    private List<Sep38Operation.DeliveryMethod> buyDeliveryMethods;
+    private List<Sep38Info.DeliveryMethod> buyDeliveryMethods;
 
     private transient List<String> exchangeableAssetNames;
 
@@ -73,7 +73,7 @@ public class InfoResponse {
     }
 
     private boolean supportsDeliveryMethod(
-        List<Sep38Operation.DeliveryMethod> deliveryMethods, String method) {
+        List<Sep38Info.DeliveryMethod> deliveryMethods, String method) {
       boolean noneIsAvailable = deliveryMethods == null || deliveryMethods.size() == 0;
       boolean noneIsProvided = method == null || method.equals("");
       if (noneIsAvailable && noneIsProvided) {
@@ -88,7 +88,7 @@ public class InfoResponse {
         return true;
       }
 
-      Sep38Operation.DeliveryMethod foundMethod =
+      Sep38Info.DeliveryMethod foundMethod =
           deliveryMethods.stream()
               .filter(dMethod -> dMethod.getName().equals(method))
               .findFirst()

--- a/core/src/main/java/org/stellar/anchor/asset/AssetServiceValidator.java
+++ b/core/src/main/java/org/stellar/anchor/asset/AssetServiceValidator.java
@@ -36,25 +36,23 @@ public class AssetServiceValidator {
 
   private static void validateWithdraw(AssetInfo assetInfo) throws InvalidConfigException {
     // Validate withdraw fields
-    if (assetInfo.getSep6Enabled()) {
-      if (assetInfo.getWithdraw() != null && assetInfo.getWithdraw().getEnabled()) {
+    AssetInfo.DepositWithdrawInfo sep6Info = assetInfo.getSep6();
+    if (assetInfo.getIsServiceEnabled(sep6Info, "withdraw")) {
+      // Check for missing SEP-6 withdrawal types
+      if (isEmpty(sep6Info.getWithdraw().getMethods())) {
+        throw new InvalidConfigException(
+            "Withdraw types not defined for asset " + assetInfo.getSep38AssetName());
+      }
 
-        // Check for missing SEP-6 withdrawal types
-        if (isEmpty(assetInfo.getWithdraw().getMethods())) {
+      // Check for duplicate SEP-6 withdrawal types
+      Set<String> existingWithdrawTypes = new HashSet<>();
+      for (String type : sep6Info.getWithdraw().getMethods()) {
+        if (!existingWithdrawTypes.add(type)) {
           throw new InvalidConfigException(
-              "Withdraw types not defined for asset " + assetInfo.getSep38AssetName());
-        }
-
-        // Check for duplicate SEP-6 withdrawal types
-        Set<String> existingWithdrawTypes = new HashSet<>();
-        for (String type : assetInfo.getWithdraw().getMethods()) {
-          if (!existingWithdrawTypes.add(type)) {
-            throw new InvalidConfigException(
-                "Duplicate withdraw types defined for asset "
-                    + assetInfo.getSep38AssetName()
-                    + ". Type = "
-                    + type);
-          }
+              "Duplicate withdraw types defined for asset "
+                  + assetInfo.getSep38AssetName()
+                  + ". Type = "
+                  + type);
         }
       }
     }
@@ -62,25 +60,23 @@ public class AssetServiceValidator {
 
   private static void validateDeposit(AssetInfo assetInfo) throws InvalidConfigException {
     // Validate deposit fields
-    if (assetInfo.getSep6Enabled()) {
-      if (assetInfo.getDeposit() != null && assetInfo.getDeposit().getEnabled()) {
+    AssetInfo.DepositWithdrawInfo sep6Info = assetInfo.getSep6();
+    if (assetInfo.getIsServiceEnabled(sep6Info, "deposit")) {
+      // Check for missing SEP-6 deposit types
+      if (isEmpty(sep6Info.getDeposit().getMethods())) {
+        throw new InvalidConfigException(
+            "Deposit types not defined for asset " + assetInfo.getSep38AssetName());
+      }
 
-        // Check for missing SEP-6 deposit types
-        if (isEmpty(assetInfo.getDeposit().getMethods())) {
+      // Check for duplicate SEP-6 deposit types
+      Set<String> existingDepositTypes = new HashSet<>();
+      for (String type : sep6Info.getDeposit().getMethods()) {
+        if (!existingDepositTypes.add(type)) {
           throw new InvalidConfigException(
-              "Deposit types not defined for asset " + assetInfo.getSep38AssetName());
-        }
-
-        // Check for duplicate SEP-6 deposit types
-        Set<String> existingDepositTypes = new HashSet<>();
-        for (String type : assetInfo.getDeposit().getMethods()) {
-          if (!existingDepositTypes.add(type)) {
-            throw new InvalidConfigException(
-                "Duplicate deposit types defined for asset "
-                    + assetInfo.getSep38AssetName()
-                    + ". Type = "
-                    + type);
-          }
+              "Duplicate deposit types defined for asset "
+                  + assetInfo.getSep38AssetName()
+                  + ". Type = "
+                  + type);
         }
       }
     }

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -156,13 +156,14 @@ public class Sep24Service {
     // Verify that the asset code exists in our database, with withdraw enabled.
     AssetInfo asset = assetService.getAsset(assetCode, assetIssuer);
     debugF("Asset: {}", asset);
-    if (asset == null || !asset.getWithdraw().getEnabled() || !asset.getSep24Enabled()) {
+    if (asset == null || !asset.getIsServiceEnabled(asset.getSep24(), "withdraw")) {
       infoF("invalid operation for asset {}", assetCode);
       throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
     }
 
     // Validate min amount
-    Long minAmount = asset.getWithdraw().getMinAmount();
+    AssetInfo.DepositWithdrawOperation sep24WithdrawInfo = asset.getSep24().getWithdraw();
+    Long minAmount = sep24WithdrawInfo.getMinAmount();
     if (strAmount != null && minAmount != null) {
       if (decimal(strAmount).compareTo(decimal(minAmount)) < 0) {
         infoF("invalid amount {}", strAmount);
@@ -172,7 +173,7 @@ public class Sep24Service {
     }
 
     // Validate max amount
-    Long maxAmount = asset.getWithdraw().getMaxAmount();
+    Long maxAmount = sep24WithdrawInfo.getMaxAmount();
     if (strAmount != null && maxAmount != null) {
       if (decimal(strAmount).compareTo(decimal(maxAmount)) > 0) {
         infoF("invalid amount {}", strAmount);
@@ -351,13 +352,14 @@ public class Sep24Service {
 
     // Verify that the asset code exists in our database, with deposit enabled.
     AssetInfo asset = assetService.getAsset(assetCode, assetIssuer);
-    if (asset == null || !asset.getDeposit().getEnabled() || !asset.getSep24Enabled()) {
+    if (asset == null || !asset.getIsServiceEnabled(asset.getSep24(), "deposit")) {
       infoF("invalid operation for asset {}", assetCode);
       throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
     }
 
     // Validate min amount
-    Long minAmount = asset.getDeposit().getMinAmount();
+    AssetInfo.DepositWithdrawOperation sep24DepositInfo = asset.getSep24().getDeposit();
+    Long minAmount = sep24DepositInfo.getMinAmount();
     if (strAmount != null && minAmount != null) {
       if (decimal(strAmount).compareTo(decimal(minAmount)) < 0) {
         infoF("invalid amount {}", strAmount);
@@ -367,7 +369,7 @@ public class Sep24Service {
     }
 
     // Validate max amount
-    Long maxAmount = asset.getDeposit().getMaxAmount();
+    Long maxAmount = sep24DepositInfo.getMaxAmount();
     if (strAmount != null && maxAmount != null) {
       if (decimal(strAmount).compareTo(decimal(maxAmount)) > 0) {
         infoF("invalid amount {}", strAmount);
@@ -570,14 +572,14 @@ public class Sep24Service {
     for (AssetInfo asset : assets) {
       // iso4217 assets do not have deposit/withdraw configurations
       if (asset.getSchema().equals(AssetInfo.Schema.STELLAR)) {
-        if (asset.getDeposit().getEnabled())
+        if (asset.getIsServiceEnabled(asset.getSep24(), "deposit"))
           depositMap.put(
               asset.getCode(),
-              InfoResponse.OperationResponse.fromAssetOperation(asset.getDeposit()));
-        if (asset.getWithdraw().getEnabled())
+              InfoResponse.OperationResponse.fromAssetOperation(asset.getSep24().getDeposit()));
+        if (asset.getIsServiceEnabled(asset.getSep24(), "withdraw"))
           withdrawMap.put(
               asset.getCode(),
-              InfoResponse.OperationResponse.fromAssetOperation(asset.getWithdraw()));
+              InfoResponse.OperationResponse.fromAssetOperation(asset.getSep24().getWithdraw()));
       }
     }
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -39,7 +39,7 @@ import org.stellar.anchor.api.exception.SepValidationException;
 import org.stellar.anchor.api.exception.ServerErrorException;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
-import org.stellar.anchor.api.sep.operation.Sep31Operation.Fields;
+import org.stellar.anchor.api.sep.operation.Sep31Info.Fields;
 import org.stellar.anchor.api.sep.sep31.Sep31GetTransactionResponse;
 import org.stellar.anchor.api.sep.sep31.Sep31InfoResponse;
 import org.stellar.anchor.api.sep.sep31.Sep31PatchTransactionRequest;
@@ -647,7 +647,7 @@ public class Sep31Service {
     Sep31InfoResponse response = new Sep31InfoResponse();
     response.setReceive(new HashMap<>());
     for (AssetInfo assetInfo : assetInfos) {
-      if (assetInfo.getSep31Enabled()) {
+      if (assetInfo.getSep31() != null && assetInfo.getSep31().getEnabled()) {
         boolean isQuotesSupported = assetInfo.getSep31().isQuotesSupported();
         boolean isQuotesRequired = assetInfo.getSep31().isQuotesRequired();
         if (isQuotesRequired && !isQuotesSupported) {

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -142,8 +142,8 @@ public class Sep31Service {
     validateAmountLimit(
         "sell_",
         request.getAmount(),
-        assetInfo.getSep31().getSend().getMinAmount(),
-        assetInfo.getSep31().getSend().getMaxAmount());
+        assetInfo.getSep31().getReceive().getMinAmount(),
+        assetInfo.getSep31().getReceive().getMaxAmount());
     validateLanguage(appConfig, request.getLang());
 
     /*
@@ -657,10 +657,10 @@ public class Sep31Service {
         AssetResponse assetResponse = new AssetResponse();
         assetResponse.setQuotesSupported(isQuotesSupported);
         assetResponse.setQuotesRequired(isQuotesRequired);
-        assetResponse.setFeeFixed(assetInfo.getSep31().getSend().getFeeFixed());
-        assetResponse.setFeePercent(assetInfo.getSep31().getSend().getFeePercent());
-        assetResponse.setMinAmount(assetInfo.getSep31().getSend().getMinAmount());
-        assetResponse.setMaxAmount(assetInfo.getSep31().getSend().getMaxAmount());
+        assetResponse.setFeeFixed(assetInfo.getSep31().getReceive().getFeeFixed());
+        assetResponse.setFeePercent(assetInfo.getSep31().getReceive().getFeePercent());
+        assetResponse.setMinAmount(assetInfo.getSep31().getReceive().getMinAmount());
+        assetResponse.setMaxAmount(assetInfo.getSep31().getReceive().getMaxAmount());
         assetResponse.setFields(assetInfo.getSep31().getFields());
         assetResponse.setSep12(assetInfo.getSep31().getSep12());
         response.getReceive().put(assetInfo.getCode(), assetResponse);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.stellar.anchor.SepTransaction;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 import org.stellar.anchor.api.sep.sep31.Sep31GetTransactionResponse;
 import org.stellar.anchor.api.shared.*;
 
@@ -80,9 +80,9 @@ public interface Sep31Transaction extends SepTransaction {
 
   void setFields(Map<String, String> fields);
 
-  Sep31Operation.Fields getRequiredInfoUpdates();
+  Sep31Info.Fields getRequiredInfoUpdates();
 
-  void setRequiredInfoUpdates(Sep31Operation.Fields requiredInfoUpdates);
+  void setRequiredInfoUpdates(Sep31Info.Fields requiredInfoUpdates);
 
   String getQuoteId();
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
@@ -3,7 +3,7 @@ package org.stellar.anchor.sep31;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.api.shared.StellarTransaction;
@@ -136,7 +136,7 @@ public class Sep31TransactionBuilder {
     return this;
   }
 
-  public Sep31TransactionBuilder requiredInfoUpdates(Sep31Operation.Fields requiredInfoUpdates) {
+  public Sep31TransactionBuilder requiredInfoUpdates(Sep31Info.Fields requiredInfoUpdates) {
     txn.setRequiredInfoUpdates(requiredInfoUpdates);
     return this;
   }

--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -23,7 +23,7 @@ public class RequestValidator {
    */
   public AssetInfo getDepositAsset(String assetCode) throws SepValidationException {
     AssetInfo asset = assetService.getAsset(assetCode);
-    if (asset == null || !asset.getSep6Enabled() || !asset.getDeposit().getEnabled()) {
+    if (asset == null || !asset.getIsServiceEnabled(asset.getSep6(), "deposit")) {
       throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
     }
     return asset;
@@ -38,7 +38,7 @@ public class RequestValidator {
    */
   public AssetInfo getWithdrawAsset(String assetCode) throws SepValidationException {
     AssetInfo asset = assetService.getAsset(assetCode);
-    if (asset == null || !asset.getSep6Enabled() || !asset.getWithdraw().getEnabled()) {
+    if (asset == null || !asset.getIsServiceEnabled(asset.getSep6(), "withdraw")) {
       throw new SepValidationException(String.format("invalid operation for asset %s", assetCode));
     }
     return asset;

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 import org.stellar.anchor.api.shared.FeeDescription;
 import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.api.shared.StellarId;
@@ -35,7 +35,7 @@ public class PojoSep31Transaction implements Sep31Transaction {
   String quoteId;
   String clientDomain;
   String clientName;
-  Sep31Operation.Fields requiredInfoUpdates;
+  Sep31Info.Fields requiredInfoUpdates;
   Map<String, String> fields;
   Boolean refunded;
   PojoSep31Refunds refunds;

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -150,7 +150,7 @@ internal class DefaultAssetServiceTest {
                 },
                 "sep31": {
                   "enabled": true,
-                  "send": {
+                  "receive": {
                     "fee_fixed": 0,
                     "fee_percent": 0,
                     "min_amount": 1,
@@ -239,7 +239,7 @@ internal class DefaultAssetServiceTest {
           
                 "sep31": {
                   "enabled": true,
-                  "send": {
+                  "receive": {
                     "fee_fixed": 0,
                     "fee_percent": 0,
                     "min_amount": 1,
@@ -298,7 +298,7 @@ internal class DefaultAssetServiceTest {
                 "significant_decimals": 2,
                 "sep31": {
                   "enabled": false,
-                  "send": {
+                  "receive": {
                     "fee_fixed": 0,
                     "fee_percent": 0,
                     "min_amount": 1,
@@ -351,7 +351,7 @@ internal class DefaultAssetServiceTest {
                 },
                 "sep31": {
                   "enabled": true,
-                  "send": {
+                  "receive": {
                     "fee_fixed": 0,
                     "fee_percent": 0,
                     "min_amount": 1,

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -99,300 +99,319 @@ internal class DefaultAssetServiceTest {
   private val expectedAssetsJson =
     """
       {
-        "assets": [
-          {
-            "schema": "stellar",
-            "code": "USDC",
-            "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-            "distribution_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
-            "significant_decimals": 2,
-            "deposit": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 10000,
-              "methods": [
-                "SEPA",
-                "SWIFT"
-              ]
-            },
-            "withdraw": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 10000,
-              "methods": [
-                "bank_account",
-                "cash"
-              ]
-            },
-            "sep31": {
-              "send": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-              },
-              "quotes_supported": true,
-              "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-                    },
-                    "sep31-large-sender": {
-                      "description": "U.S. citizens that do not have sending limits"
-                    },
-                    "sep31-foreign-sender": {
-                      "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-                    }
-                  }
-                },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "U.S. citizens receiving USD"
-                    },
-                    "sep31-foreign-receiver": {
-                      "description": "non-U.S. citizens receiving USD"
-                    }
-                  }
-                }
-              },
-              "fields": {
-                "transaction": {
-                  "receiver_routing_number": {
-                    "description": "routing number of the destination bank account",
-                    "optional": false
-                  },
-                  "receiver_account_number": {
-                    "description": "bank account number of the destination",
-                    "optional": false
-                  },
-                  "receiver_phone_number": {
-                    "description": "phone number of the receiver",
-                    "optional": true
-                  },
-                  "type": {
-                    "description": "type of deposit to make",
-                    "choices": [
+  "assets": [
+              {
+                "schema": "stellar",
+                "code": "USDC",
+                "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+                "distribution_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
+                "significant_decimals": 2,
+                "sep6": {
+                  "enabled": true,
+                  "deposit": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "methods": [
                       "SEPA",
                       "SWIFT"
                     ]
-                  }
-                }
-              }
-            },
-            "sep38": {
-              "exchangeable_assets": [
-                "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-                "iso4217:USD"
-              ]
-            },
-            "sep6_enabled": true,
-            "sep24_enabled": true,
-            "sep31_enabled": true,
-            "sep38_enabled": true
-          },
-          {
-            "schema": "stellar",
-            "code": "JPYC",
-            "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-            "significant_decimals": 2,
-            "deposit": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "withdraw": {
-              "enabled": false,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
-              "send": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-              },
-              "quotes_supported": true,
-              "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "Japanese citizens"
-                    }
-                  }
-                },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "Japanese citizens receiving USD"
-                    }
-                  }
-                }
-              },
-              "fields": {
-                "transaction": {
-                  "receiver_routing_number": {
-                    "description": "routing number of the destination bank account",
-                    "optional": false
                   },
-                  "receiver_account_number": {
-                    "description": "bank account number of the destination",
-                    "optional": false
-                  },
-                  "type": {
-                    "description": "type of deposit to make",
-                    "choices": [
-                      "ACH",
-                      "SWIFT",
-                      "WIRE"
+                  "withdraw": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "methods": [
+                      "bank_account",
+                      "cash"
                     ]
                   }
-                }
-              }
-            },
-            "sep38": {
-              "exchangeable_assets": [
-                "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-                "iso4217:USD"
-              ]
-            },
-            "sep6_enabled": false,
-            "sep24_enabled": true,
-            "sep31_enabled": true,
-            "sep38_enabled": true
-          },
-          {
-            "schema": "iso4217",
-            "code": "USD",
-            "significant_decimals": 2,
-            "deposit": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "withdraw": {
-              "enabled": false,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
-              "send": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-              }
-            },
-            "sep38": {
-              "exchangeable_assets": [
-                "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-                "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              ],
-              "country_codes": [
-                "USA"
-              ],
-              "decimals": 4,
-              "sell_delivery_methods": [
-                {
-                  "name": "WIRE",
-                  "description": "Send USD directly to the Anchor's bank account."
-                }
-              ],
-              "buy_delivery_methods": [
-                {
-                  "name": "WIRE",
-                  "description": "Have USD sent directly to your bank account."
-                }
-              ]
-            },
-            "sep6_enabled": false,
-            "sep24_enabled": true,
-            "sep31_enabled": false,
-            "sep38_enabled": true
-          },
-          {
-            "schema": "stellar",
-            "code": "native",
-            "significant_decimals": 7,
-            "deposit": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "withdraw": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep31": {
-              "send": {
-                "fee_fixed": 0,
-                "fee_percent": 0,
-                "min_amount": 1,
-                "max_amount": 1000000
-              },
-              "quotes_supported": true,
-              "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-                    },
-                    "sep31-large-sender": {
-                      "description": "U.S. citizens that do not have sending limits"
-                    },
-                    "sep31-foreign-sender": {
-                      "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-                    }
-                  }
                 },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "U.S. citizens receiving USD"
-                    },
-                    "sep31-foreign-receiver": {
-                      "description": "non-U.S. citizens receiving USD"
-                    }
-                  }
-                }
-              },
-              "fields": {
-                "transaction": {
-                  "receiver_routing_number": {
-                    "description": "routing number of the destination bank account"
-                  },
-                  "receiver_account_number": {
-                    "description": "bank account number of the destination"
-                  },
-                  "type": {
-                    "description": "type of deposit to make",
-                    "choices": [
+                "sep24": {
+                  "enabled": true,
+                  "deposit": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "methods": [
                       "SEPA",
                       "SWIFT"
                     ]
+                  },
+                  "withdraw": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 10000,
+                    "methods": [
+                      "bank_account",
+                      "cash"
+                    ]
                   }
+                },
+                "sep31": {
+                  "enabled": true,
+                  "send": {
+                    "fee_fixed": 0,
+                    "fee_percent": 0,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  },
+                  "quotes_supported": true,
+                  "quotes_required": true,
+                  "sep12": {
+                    "sender": {
+                      "types": {
+                        "sep31-sender": {
+                          "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
+                        },
+                        "sep31-large-sender": {
+                          "description": "U.S. citizens that do not have sending limits"
+                        },
+                        "sep31-foreign-sender": {
+                          "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
+                        }
+                      }
+                    },
+                    "receiver": {
+                      "types": {
+                        "sep31-receiver": {
+                          "description": "U.S. citizens receiving USD"
+                        },
+                        "sep31-foreign-receiver": {
+                          "description": "non-U.S. citizens receiving USD"
+                        }
+                      }
+                    }
+                  },
+                  "fields": {
+                    "transaction": {
+                      "receiver_routing_number": {
+                        "description": "routing number of the destination bank account",
+                        "optional": false
+                      },
+                      "receiver_account_number": {
+                        "description": "bank account number of the destination",
+                        "optional": false
+                      },
+                      "receiver_phone_number": {
+                        "description": "phone number of the receiver",
+                        "optional": true
+                      },
+                      "type": {
+                        "description": "type of deposit to make",
+                        "choices": [
+                          "SEPA",
+                          "SWIFT"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "sep38": {
+                  "enabled": true,
+                  "exchangeable_assets": [
+                    "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                    "iso4217:USD"
+                  ]
+                }
+              },
+              {
+                "schema": "stellar",
+                "code": "JPYC",
+                "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                "significant_decimals": 2,
+                "sep6" : {
+                  "enabled": false
+                },
+                "sep24": {
+                  "enabled": true,
+                  "deposit": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  },
+                  "withdraw": {
+                    "enabled": false,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  }
+                },
+          
+                "sep31": {
+                  "enabled": true,
+                  "send": {
+                    "fee_fixed": 0,
+                    "fee_percent": 0,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  },
+                  "quotes_supported": true,
+                  "quotes_required": true,
+                  "sep12": {
+                    "sender": {
+                      "types": {
+                        "sep31-sender": {
+                          "description": "Japanese citizens"
+                        }
+                      }
+                    },
+                    "receiver": {
+                      "types": {
+                        "sep31-receiver": {
+                          "description": "Japanese citizens receiving USD"
+                        }
+                      }
+                    }
+                  },
+                  "fields": {
+                    "transaction": {
+                      "receiver_routing_number": {
+                        "description": "routing number of the destination bank account",
+                        "optional": false
+                      },
+                      "receiver_account_number": {
+                        "description": "bank account number of the destination",
+                        "optional": false
+                      },
+                      "type": {
+                        "description": "type of deposit to make",
+                        "choices": [
+                          "ACH",
+                          "SWIFT",
+                          "WIRE"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "sep38": {
+                  "enabled": true,
+                  "exchangeable_assets": [
+                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+                    "iso4217:USD"
+                  ]
+                }
+              },
+              {
+                "schema": "iso4217",
+                "code": "USD",
+                "significant_decimals": 2,
+                "sep31": {
+                  "enabled": false,
+                  "send": {
+                    "fee_fixed": 0,
+                    "fee_percent": 0,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  }
+                },
+                "sep38": {
+                  "enabled": true,
+                  "exchangeable_assets": [
+                    "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+                  ],
+                  "country_codes": [
+                    "USA"
+                  ],
+                  "decimals": 4,
+                  "sell_delivery_methods": [
+                    {
+                      "name": "WIRE",
+                      "description": "Send USD directly to the Anchor's bank account."
+                    }
+                  ],
+                  "buy_delivery_methods": [
+                    {
+                      "name": "WIRE",
+                      "description": "Have USD sent directly to your bank account."
+                    }
+                  ]
+                }
+              },
+              {
+                "schema": "stellar",
+                "code": "native",
+                "significant_decimals": 7,
+                "sep6": {
+                  "enabled": false
+                },
+                "sep24": {
+                  "enabled": true,
+                  "deposit": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  },
+                  "withdraw": {
+                    "enabled": true,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  }
+                },
+                "sep31": {
+                  "enabled": true,
+                  "send": {
+                    "fee_fixed": 0,
+                    "fee_percent": 0,
+                    "min_amount": 1,
+                    "max_amount": 1000000
+                  },
+                  "quotes_supported": true,
+                  "quotes_required": true,
+                  "sep12": {
+                    "sender": {
+                      "types": {
+                        "sep31-sender": {
+                          "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
+                        },
+                        "sep31-large-sender": {
+                          "description": "U.S. citizens that do not have sending limits"
+                        },
+                        "sep31-foreign-sender": {
+                          "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
+                        }
+                      }
+                    },
+                    "receiver": {
+                      "types": {
+                        "sep31-receiver": {
+                          "description": "U.S. citizens receiving USD"
+                        },
+                        "sep31-foreign-receiver": {
+                          "description": "non-U.S. citizens receiving USD"
+                        }
+                      }
+                    }
+                  },
+                  "fields": {
+                    "transaction": {
+                      "receiver_routing_number": {
+                        "description": "routing number of the destination bank account"
+                      },
+                      "receiver_account_number": {
+                        "description": "bank account number of the destination"
+                      },
+                      "type": {
+                        "description": "type of deposit to make",
+                        "choices": [
+                          "SEPA",
+                          "SWIFT"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "sep38": {
+                  "enabled": true,
+                  "exchangeable_assets": [
+                    "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+                  ],
+                  "decimals": 7
                 }
               }
-            },
-            "sep38": {
-              "exchangeable_assets": [
-                "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-              ],
-              "decimals": 7
-            },
-            "sep6_enabled": false,
-            "sep24_enabled": true,
-            "sep31_enabled": true,
-            "sep38_enabled": true
+            ]
           }
-        ]
-      }
     """
       .trimIndent()
 }

--- a/core/src/test/kotlin/org/stellar/anchor/dto/sep38/InfoResponseTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/dto/sep38/InfoResponseTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.sep.AssetInfo
-import org.stellar.anchor.api.sep.operation.Sep38Operation
+import org.stellar.anchor.api.sep.operation.Sep38Info
 import org.stellar.anchor.api.sep.sep38.InfoResponse
 import org.stellar.anchor.asset.DefaultAssetService
 
@@ -53,10 +53,10 @@ class InfoResponseTest {
     assertNotNull(fiatUSD)
     assertEquals(listOf("USA"), fiatUSD!!.countryCodes)
     val wantSellDeliveryMethod =
-      Sep38Operation.DeliveryMethod("WIRE", "Send USD directly to the Anchor's bank account.")
+      Sep38Info.DeliveryMethod("WIRE", "Send USD directly to the Anchor's bank account.")
     assertEquals(listOf(wantSellDeliveryMethod), fiatUSD.sellDeliveryMethods)
     val wantBuyDeliveryMethod =
-      Sep38Operation.DeliveryMethod("WIRE", "Have USD sent directly to your bank account.")
+      Sep38Info.DeliveryMethod("WIRE", "Have USD sent directly to your bank account.")
     assertEquals(listOf(wantBuyDeliveryMethod), fiatUSD.buyDeliveryMethods)
     wantAssets =
       listOf(

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -112,7 +112,7 @@ class Sep31ServiceTest {
                 "max_amount": 1000000
               },
               "sep31": {
-                "send": {
+                "receive": {
                   "fee_fixed": 0,
                   "fee_percent": 0,
                   "min_amount": 1,

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -25,7 +25,7 @@ import org.stellar.anchor.api.callback.*
 import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.sep.AssetInfo
 import org.stellar.anchor.api.sep.AssetInfo.Field
-import org.stellar.anchor.api.sep.operation.Sep31Operation
+import org.stellar.anchor.api.sep.operation.Sep31Info
 import org.stellar.anchor.api.sep.sep12.Sep12Status
 import org.stellar.anchor.api.sep.sep31.*
 import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest.Sep31TxnFields
@@ -478,7 +478,7 @@ class Sep31ServiceTest {
         )
         .build()
 
-    val wantRequiredInfoUpdates = Sep31Operation.Fields()
+    val wantRequiredInfoUpdates = Sep31Info.Fields()
     wantRequiredInfoUpdates.transaction =
       mapOf("type" to Field("type of deposit to make", listOf("SEPA", "SWIFT"), false))
 
@@ -960,7 +960,7 @@ class Sep31ServiceTest {
 
     Context.get().transactionFields = mapOf()
     val ex4 = assertThrows<Sep31MissingFieldException> { sep31Service.validateRequiredFields() }
-    val wantMissingFields = Sep31Operation.Fields()
+    val wantMissingFields = Sep31Info.Fields()
     wantMissingFields.transaction =
       mapOf(
         "receiver_account_number" to Field("bank account number of the destination", null, false),

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31TransactionTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.sep.AssetInfo.Field
 import org.stellar.anchor.api.sep.SepTransactionStatus
-import org.stellar.anchor.api.sep.operation.Sep31Operation
+import org.stellar.anchor.api.sep.operation.Sep31Info
 import org.stellar.anchor.api.sep.sep31.Sep31GetTransactionResponse
 import org.stellar.anchor.api.sep.sep31.Sep31GetTransactionResponse.Sep31RefundPayment
 import org.stellar.anchor.api.shared.*
@@ -64,7 +64,7 @@ class Sep31TransactionTest {
         .build()
 
     // mock missing SEP-31 "transaction.fields"
-    val mockMissingFields = Sep31Operation.Fields()
+    val mockMissingFields = Sep31Info.Fields()
     mockMissingFields.transaction =
       mapOf(
         "receiver_account_number" to Field("bank account number of the destination", null, false),
@@ -138,7 +138,7 @@ class Sep31TransactionTest {
         )
         .build()
 
-    val requiredInfoUpdates = Sep31Operation.Fields()
+    val requiredInfoUpdates = Sep31Info.Fields()
     requiredInfoUpdates.transaction =
       mapOf(
         "receiver_account_number" to Field("bank account number of the destination", null, false)

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -22,7 +22,7 @@ import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.exception.ServerErrorException
 import org.stellar.anchor.api.platform.GetQuoteResponse
-import org.stellar.anchor.api.sep.operation.Sep38Operation
+import org.stellar.anchor.api.sep.operation.Sep38Info
 import org.stellar.anchor.api.sep.sep38.*
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP6
@@ -122,10 +122,10 @@ class Sep38ServiceTest {
     assertNotNull(fiatUSD)
     assertEquals(listOf("USA"), fiatUSD!!.countryCodes)
     val wantSellDeliveryMethod =
-      Sep38Operation.DeliveryMethod("WIRE", "Send USD directly to the Anchor's bank account.")
+      Sep38Info.DeliveryMethod("WIRE", "Send USD directly to the Anchor's bank account.")
     assertEquals(listOf(wantSellDeliveryMethod), fiatUSD.sellDeliveryMethods)
     val wantBuyDeliveryMethod =
-      Sep38Operation.DeliveryMethod("WIRE", "Have USD sent directly to your bank account.")
+      Sep38Info.DeliveryMethod("WIRE", "Have USD sent directly to your bank account.")
     assertEquals(listOf(wantBuyDeliveryMethod), fiatUSD.buyDeliveryMethods)
     wantAssets =
       listOf("stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", stellarUSDC)

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -26,10 +26,12 @@ class RequestValidatorTest {
 
   @Test
   fun `test getDepositAsset`() {
-    val asset = mockk<AssetInfo>()
-    val deposit = mockk<AssetInfo.DepositOperation>()
-    every { asset.sep6Enabled } returns true
-    every { asset.deposit } returns deposit
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    val deposit = mockk<AssetInfo.DepositWithdrawOperation>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns true
+    every { sep6Info.deposit } returns deposit
     every { deposit.enabled } returns true
     every { assetService.getAsset(TEST_ASSET) } returns asset
     requestValidator.getDepositAsset(TEST_ASSET)
@@ -43,10 +45,12 @@ class RequestValidatorTest {
 
   @Test
   fun `test getDepositAsset with deposit disabled asset`() {
-    val asset = mockk<AssetInfo>()
-    val deposit = mockk<AssetInfo.DepositOperation>()
-    every { asset.sep6Enabled } returns true
-    every { asset.deposit } returns deposit
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    val deposit = mockk<AssetInfo.DepositWithdrawOperation>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns true
+    every { sep6Info.deposit } returns deposit
     every { deposit.enabled } returns false
     every { assetService.getAsset(TEST_ASSET) } returns asset
     assertThrows<SepValidationException> { requestValidator.getDepositAsset(TEST_ASSET) }
@@ -54,18 +58,22 @@ class RequestValidatorTest {
 
   @Test
   fun `test getDepositAsset with sep6 disabled asset`() {
-    val asset = mockk<AssetInfo>()
-    every { asset.sep6Enabled } returns false
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns false
     every { assetService.getAsset(TEST_ASSET) } returns asset
     assertThrows<SepValidationException> { requestValidator.getDepositAsset(TEST_ASSET) }
   }
 
   @Test
   fun `test getWithdrawAsset`() {
-    val asset = mockk<AssetInfo>()
-    val withdraw = mockk<AssetInfo.WithdrawOperation>()
-    every { asset.sep6Enabled } returns true
-    every { asset.withdraw } returns withdraw
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    val withdraw = mockk<AssetInfo.DepositWithdrawOperation>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns true
+    every { sep6Info.withdraw } returns withdraw
     every { withdraw.enabled } returns true
     every { assetService.getAsset(TEST_ASSET) } returns asset
     requestValidator.getWithdrawAsset(TEST_ASSET)
@@ -79,10 +87,12 @@ class RequestValidatorTest {
 
   @Test
   fun `test getWithdrawAsset with withdraw disabled asset`() {
-    val asset = mockk<AssetInfo>()
-    val withdraw = mockk<AssetInfo.WithdrawOperation>()
-    every { asset.sep6Enabled } returns true
-    every { asset.withdraw } returns withdraw
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    val withdraw = mockk<AssetInfo.DepositWithdrawOperation>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns true
+    every { sep6Info.withdraw } returns withdraw
     every { withdraw.enabled } returns false
     every { assetService.getAsset(TEST_ASSET) } returns asset
     assertThrows<SepValidationException> { requestValidator.getWithdrawAsset(TEST_ASSET) }
@@ -90,8 +100,10 @@ class RequestValidatorTest {
 
   @Test
   fun `test getWithdrawAsset with sep6 disabled asset`() {
-    val asset = mockk<AssetInfo>()
-    every { asset.sep6Enabled } returns false
+    val asset = AssetInfo()
+    val sep6Info = mockk<AssetInfo.DepositWithdrawInfo>()
+    asset.sep6 = sep6Info
+    every { sep6Info.enabled } returns false
     every { assetService.getAsset(TEST_ASSET) } returns asset
     assertThrows<SepValidationException> { requestValidator.getWithdrawAsset(TEST_ASSET) }
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -118,15 +118,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.deposit.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -257,7 +257,7 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes(unsupportedType, TEST_ASSET, asset.deposit.methods)
+      requestValidator.validateTypes(unsupportedType, TEST_ASSET, asset.sep6.deposit.methods)
     }
 
     // Verify effects
@@ -283,15 +283,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", TEST_ASSET, asset.deposit.methods)
+      requestValidator.validateTypes("bank_account", TEST_ASSET, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         badAmount,
         TEST_ASSET,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
 
@@ -320,15 +320,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.deposit.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -375,15 +375,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("SWIFT", asset.code, asset.deposit.methods)
+      requestValidator.validateTypes("SWIFT", asset.code, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -456,15 +456,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("SWIFT", asset.code, asset.deposit.methods)
+      requestValidator.validateTypes("SWIFT", asset.code, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -563,7 +563,7 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes(unsupportedType, TEST_ASSET, asset.deposit.methods)
+      requestValidator.validateTypes(unsupportedType, TEST_ASSET, asset.sep6.deposit.methods)
     }
 
     // Verify effects
@@ -594,15 +594,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("SWIFT", TEST_ASSET, asset.deposit.methods)
+      requestValidator.validateTypes("SWIFT", TEST_ASSET, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         badAmount,
         TEST_ASSET,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
 
@@ -632,15 +632,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("SWIFT", asset.code, asset.deposit.methods)
+      requestValidator.validateTypes("SWIFT", asset.code, asset.sep6.deposit.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.deposit.minAmount,
-        asset.deposit.maxAmount,
+        asset.sep6.deposit.minAmount,
+        asset.sep6.deposit.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -674,15 +674,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -846,7 +846,7 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes(unsupportedType, asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes(unsupportedType, asset.code, asset.sep6.withdraw.methods)
     }
 
     // Verify effects
@@ -871,15 +871,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         badAmount,
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
 
@@ -907,15 +907,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -960,15 +960,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -1034,15 +1034,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
@@ -1179,7 +1179,7 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes(unsupportedType, asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes(unsupportedType, asset.code, asset.sep6.withdraw.methods)
     }
 
     // Verify effects
@@ -1208,15 +1208,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         badAmount,
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
 
@@ -1248,15 +1248,15 @@ class Sep6ServiceTest {
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
     verify(exactly = 1) {
-      requestValidator.validateTypes("bank_account", asset.code, asset.withdraw.methods)
+      requestValidator.validateTypes("bank_account", asset.code, asset.sep6.withdraw.methods)
     }
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
         asset.code,
         asset.significantDecimals,
-        asset.withdraw.minAmount,
-        asset.withdraw.maxAmount,
+        asset.sep6.withdraw.minAmount,
+        asset.sep6.withdraw.maxAmount,
       )
     }
     verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }

--- a/core/src/test/kotlin/org/stellar/anchor/util/TransactionMapperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/TransactionMapperTest.kt
@@ -11,7 +11,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 import org.stellar.anchor.api.platform.PlatformTransactionData
 import org.stellar.anchor.api.sep.AssetInfo
 import org.stellar.anchor.api.sep.SepTransactionStatus
-import org.stellar.anchor.api.sep.operation.Sep31Operation
+import org.stellar.anchor.api.sep.operation.Sep31Info
 import org.stellar.anchor.api.shared.*
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.sep24.PojoSep24RefundPayment
@@ -82,7 +82,7 @@ class TransactionMapperTest {
         externalTransactionId = "externalTransactionId"
         requiredInfoMessage = "requiredInfoMessage"
         requiredInfoUpdates =
-          Sep31Operation.Fields().apply {
+          Sep31Info.Fields().apply {
             transaction = mapOf("field" to AssetInfo.Field("description", null, false))
           }
         quoteId = "quoteId"

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -50,7 +50,7 @@
       },
       "sep31": {
         "enabled": true,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,
@@ -139,7 +139,7 @@
 
       "sep31": {
         "enabled": true,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,
@@ -198,7 +198,7 @@
       "significant_decimals": 2,
       "sep31": {
         "enabled": false,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,
@@ -251,7 +251,7 @@
       },
       "sep31": {
         "enabled": true,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -6,25 +6,50 @@
       "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
       "distribution_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
       "significant_decimals": 2,
-      "deposit": {
+      "sep6": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 10000,
-        "methods": [
-          "SEPA",
-          "SWIFT"
-        ]
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
+        },
+        "withdraw": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "bank_account",
+            "cash"
+          ]
+        }
       },
-      "withdraw": {
+      "sep24": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 10000,
-        "methods": [
-          "bank_account",
-          "cash"
-        ]
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
+        },
+        "withdraw": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "bank_account",
+            "cash"
+          ]
+        }
       },
       "sep31": {
+        "enabled": true,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -83,32 +108,37 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           "iso4217:USD"
         ]
-      },
-      "sep6_enabled": true,
-      "sep24_enabled": true,
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      }
     },
     {
       "schema": "stellar",
       "code": "JPYC",
       "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
       "significant_decimals": 2,
-      "deposit": {
+      "sep6" : {
+        "enabled": false
+      },
+      "sep24": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 1000000
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
+        "withdraw": {
+          "enabled": false,
+          "min_amount": 1,
+          "max_amount": 1000000
+        }
       },
-      "withdraw": {
-        "enabled": false,
-        "min_amount": 1,
-        "max_amount": 1000000
-      },
+
       "sep31": {
+        "enabled": true,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -155,31 +185,19 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
           "iso4217:USD"
         ]
-      },
-      "sep6_enabled": false,
-      "sep24_enabled": true,
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      }
     },
     {
       "schema": "iso4217",
       "code": "USD",
       "significant_decimals": 2,
-      "deposit": {
-        "enabled": true,
-        "min_amount": 1,
-        "max_amount": 1000000
-      },
-      "withdraw": {
-        "enabled": false,
-        "min_amount": 1,
-        "max_amount": 1000000
-      },
       "sep31": {
+        "enabled": false,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -188,6 +206,7 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
@@ -208,27 +227,30 @@
             "description": "Have USD sent directly to your bank account."
           }
         ]
-      },
-      "sep6_enabled": false,
-      "sep24_enabled": true,
-      "sep31_enabled": false,
-      "sep38_enabled": true
+      }
     },
     {
       "schema": "stellar",
       "code": "native",
       "significant_decimals": 7,
-      "deposit": {
-        "enabled": true,
-        "min_amount": 1,
-        "max_amount": 1000000
+      "sep6": {
+        "enabled": false
       },
-      "withdraw": {
+      "sep24": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 1000000
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
+        "withdraw": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 1000000
+        }
       },
       "sep31": {
+        "enabled": true,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -281,15 +303,12 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
         ],
         "decimals": 7
-      },
-      "sep6_enabled": false,
-      "sep24_enabled": true,
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      }
     }
   ]
 }

--- a/core/src/test/resources/test_assets.json.quotes_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_not_supported
@@ -42,7 +42,7 @@
       },
       "sep31" : {
         "enabled": true,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,

--- a/core/src/test/resources/test_assets.json.quotes_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_not_supported
@@ -6,21 +6,42 @@
       "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
       "distribution_account": "GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I",
       "significant_decimals": 2,
-      "deposit" : {
-        "enabled": true,
-        "fee_minimum": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 10000
+      "sep6":{
+        "enabled": false,
+        "deposit" : {
+          "enabled": true,
+          "fee_minimum": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 10000
+        },
+        "withdraw": {
+          "enabled": true,
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 10000
+        }
       },
-      "withdraw": {
-        "enabled": true,
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 10000
+      "sep24":{
+        "enabled": false,
+        "deposit" : {
+          "enabled": true,
+          "fee_minimum": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 10000
+        },
+        "withdraw": {
+          "enabled": true,
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 10000
+        }
       },
       "sep31" : {
+        "enabled": true,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -39,10 +60,9 @@
           }
         }
       },
-      "sep6_enabled": false,
-      "sep24_enabled": false,
-      "sep31_enabled": true,
-      "sep38_enabled": false
+      "sep38": {
+        "enabled": false
+      }
     }
   ]
 }

--- a/core/src/test/resources/test_assets.json.quotes_required_but_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_required_but_not_supported
@@ -4,14 +4,20 @@
       "schema": "stellar",
       "code": "USDC",
       "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      "sep6": {
+        "enabled": false
+      },
+      "sep24": {
+        "enabled": false
+      },
       "sep31" : {
+        "enabled": true,
         "quotes_supported": false,
         "quotes_required": true
       },
-      "sep6_enabled": false,
-      "sep24_enabled": false,
-      "sep31_enabled": true,
-      "sep38_enabled": false
+      "sep38": {
+        "enabled": false
+      }
     }
   ]
 }

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -4,21 +4,40 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - bank_account
+          - cash
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - bank_account
-        - cash
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - bank_account
+          - cash
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -60,26 +79,28 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - iso4217:USD
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: stellar
     code: JPYC
     issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
     significant_decimals: 2
-    deposit:
-      enabled: true
-      min_amount: 1
-      max_amount: 1000000
-    withdraw:
+    sep6:
       enabled: false
-      min_amount: 1
-      max_amount: 1000000
+    sep24:
+      enabled: true
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 1000000
+      withdraw:
+        enabled: false
+        min_amount: 1
+        max_amount: 1000000
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -111,31 +132,22 @@ assets:
               - SWIFT
               - WIRE
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - iso4217:USD
-    sep6_enabled: false
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: iso4217
     code: USD
     significant_decimals: 2
-    deposit:
-      enabled: true
-      min_amount: 1
-      max_amount: 1000000
-    withdraw:
-      enabled: false
-      min_amount: 1
-      max_amount: 1000000
     sep31:
+      enabled: false
       send:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
         max_amount: 1000000
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
@@ -148,22 +160,23 @@ assets:
       buy_delivery_methods:
         - name: WIRE
           description: Have USD sent directly to your bank account.
-    sep6_enabled: false
-    sep24_enabled: true
-    sep31_enabled: false
-    sep38_enabled: true
   - schema: stellar
     code: native
     significant_decimals: 7
-    deposit:
+    sep6:
+      enabled: false
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 1000000
-    withdraw:
-      enabled: true
-      min_amount: 1
-      max_amount: 1000000
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 1000000
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 1000000
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -201,10 +214,7 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       decimals: 7
-    sep6_enabled: false
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -38,7 +38,7 @@ assets:
           - cash
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
@@ -101,7 +101,7 @@ assets:
         max_amount: 1000000
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
@@ -141,7 +141,7 @@ assets:
     significant_decimals: 2
     sep31:
       enabled: false
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
@@ -177,7 +177,7 @@ assets:
         max_amount: 1000000
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1

--- a/core/src/test/resources/test_assets_duplicate_deposit_type.yaml
+++ b/core/src/test/resources/test_assets_duplicate_deposit_type.yaml
@@ -4,22 +4,41 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      types:
-        - SEPA
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        types:
+          - SEPA
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        types:
+          - cash
+          - bank_account
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      types:
-        - cash
-        - bank_account
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: false
-    sep38_enabled: false
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        types:
+          - SEPA
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        types:
+          - cash
+          - bank_account
+    sep31:
+      enabled: false
+    sep38:
+      enabled: false

--- a/core/src/test/resources/test_assets_duplicate_withdraw_type.yaml
+++ b/core/src/test/resources/test_assets_duplicate_withdraw_type.yaml
@@ -4,22 +4,41 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - cash
+          - cash
+          - bank_account
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - cash
-        - cash
-        - bank_account
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: false
-    sep38_enabled: false
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - cash
+          - cash
+          - bank_account
+    sep31:
+      enabled: false
+    sep38:
+      enabled: false

--- a/core/src/test/resources/test_assets_missing_deposit_type.yaml
+++ b/core/src/test/resources/test_assets_missing_deposit_type.yaml
@@ -4,18 +4,33 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - cash
+          - bank_account
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - cash
-        - bank_account
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: false
-    sep38_enabled: false
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - cash
+          - bank_account
+    sep31:
+      enabled: false
+    sep38:
+      enabled: false

--- a/core/src/test/resources/test_assets_missing_withdraw_type.yaml
+++ b/core/src/test/resources/test_assets_missing_withdraw_type.yaml
@@ -4,18 +4,33 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-      methods:
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 10000
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: false
-    sep38_enabled: false
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 10000
+    sep31:
+      enabled: false
+    sep38:
+      enabled: false

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -54,7 +54,7 @@ class Sep31Tests : AbstractIntegrationTests(TestConfig()) {
   fun `test info endpoint`() {
     printRequest("Calling GET /info")
     val info = sep31Client.getInfo()
-    JSONAssert.assertEquals(gson.toJson(info), expectedSep31Info, JSONCompareMode.STRICT)
+    JSONAssert.assertEquals(expectedSep31Info, gson.toJson(info), JSONCompareMode.STRICT)
   }
 
   @Test

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -200,7 +200,7 @@ assets_config: |
         - bank_account
         - cash
     sep31:
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         max_amount: 1000000
@@ -255,7 +255,7 @@ assets_config: |
       min_amount: 1
       max_amount: 1000000
     sep31:
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
@@ -306,7 +306,7 @@ assets_config: |
     withdraw:
       enabled: true
     sep31:
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
       quotes_supported: true
@@ -358,7 +358,7 @@ assets_config: |
       min_amount: 0
       max_amount: 10000
     sep31:
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 0
@@ -391,7 +391,7 @@ assets_config: |
       enabled: true
       max_amount: 1000000
     sep31:
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         max_amount: 1000000

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.Sep31CustomerInfoNeededException;
 import org.stellar.anchor.api.exception.Sep31MissingFieldException;
-import org.stellar.anchor.api.sep.operation.Sep31Operation.Fields;
+import org.stellar.anchor.api.sep.operation.Sep31Info.Fields;
 import org.stellar.anchor.api.sep.sep31.*;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.platform.condition.ConditionalOnAllSepsEnabled;

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import org.springframework.beans.BeanUtils;
 import org.stellar.anchor.SepTransaction;
-import org.stellar.anchor.api.sep.operation.Sep31Operation;
+import org.stellar.anchor.api.sep.operation.Sep31Info;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.sep31.Sep31Refunds;
 import org.stellar.anchor.sep31.Sep31Transaction;
@@ -96,7 +96,7 @@ public class JdbcSep31Transaction extends JdbcSepTransaction
   // Ignored by JPA and Gson
   @SerializedName("required_info_updates")
   @Transient
-  Sep31Operation.Fields requiredInfoUpdates;
+  Sep31Info.Fields requiredInfoUpdates;
 
   @Access(AccessType.PROPERTY)
   @Column(name = "requiredInfoUpdates")
@@ -106,8 +106,7 @@ public class JdbcSep31Transaction extends JdbcSepTransaction
 
   public void setRequiredInfoUpdatesJson(String requiredInfoUpdatesJson) {
     if (requiredInfoUpdatesJson != null) {
-      this.requiredInfoUpdates =
-          gson.fromJson(requiredInfoUpdatesJson, Sep31Operation.Fields.class);
+      this.requiredInfoUpdates = gson.fromJson(requiredInfoUpdatesJson, Sep31Info.Fields.class);
     }
   }
 

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -139,7 +139,7 @@ assets:
             "max_amount": 1000000
           },
           "sep31": {
-            "send": {
+            "receive": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
@@ -220,7 +220,7 @@ assets:
             "max_amount": 1000000
           },
           "sep31": {
-            "send": {
+            "receive": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,
@@ -298,7 +298,7 @@ assets:
             "max_amount": 10000
           },
           "sep31": {
-            "send": {
+            "receive": {
               "fee_fixed": 0,
               "fee_percent": 0,
               "min_amount": 1,

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -6,21 +6,25 @@
       "issuer": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
       "distribution_account": "GBJDTHT4562X2H37JMOE6IUTZZSDU6RYGYUNFYCHVFG3J4MYJIMU33HK",
       "significant_decimals": 2,
-      "deposit" : {
+      "sep24": {
         "enabled": true,
-        "fee_minimum": 0,
-        "fee_percent": 0,
-        "min_amount": 0,
-        "max_amount": 10000
-      },
-      "withdraw": {
-        "enabled": true,
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 0,
-        "max_amount": 10000
+        "send": {
+          "enabled": true,
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        },
+        "receive": {
+          "enabled": true,
+          "fee_fixed": 0,
+          "fee_percent": 0,
+          "min_amount": 1,
+          "max_amount": 1000000
+        }
       },
       "sep31" : {
+        "enabled": true,
         "send" : {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -73,34 +77,19 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           "iso4217:USD"
         ]
-      },
-      "sep24_enabled": true,
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      }
     },
     {
       "schema": "iso4217",
       "code": "USD",
-      "deposit" : {
-        "enabled": true,
-        "fee_minimum": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000
-      },
       "significant_decimals": 2,
-      "withdraw": {
-        "enabled": false,
-        "fee_fixed": 0,
-        "fee_percent": 0,
-        "min_amount": 1,
-        "max_amount": 1000000
-      },
       "sep31": {
+        "enabled": false,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -109,6 +98,7 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
@@ -127,9 +117,7 @@
             "description": "Have USD sent directly to your bank account."
           }
         ]
-      },
-      "sep31_enabled": false,
-      "sep38_enabled": true
+      }
     }
   ]
 }

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -8,7 +8,7 @@
       "significant_decimals": 2,
       "sep24": {
         "enabled": true,
-        "send": {
+        "receive": {
           "enabled": true,
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -25,7 +25,7 @@
       },
       "sep31" : {
         "enabled": true,
-        "send" : {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 0,
@@ -90,7 +90,7 @@
       "significant_decimals": 2,
       "sep31": {
         "enabled": false,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 0,

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -8,14 +8,14 @@
       "significant_decimals": 2,
       "sep24": {
         "enabled": true,
-        "receive": {
+        "deposit": {
           "enabled": true,
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,
           "max_amount": 1000000
         },
-        "receive": {
+        "withdraw": {
           "enabled": true,
           "fee_fixed": 0,
           "fee_percent": 0,

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -4,19 +4,22 @@ assets:
     issuer: GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
     distribution_account: GBJDTHT4562X2H37JMOE6IUTZZSDU6RYGYUNFYCHVFG3J4MYJIMU33HK
     significant_decimals: 2
-    deposit:
+    sep24:
       enabled: true
-      fee_minimum: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10000
-    withdraw:
-      enabled: true
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 0
-      max_amount: 10000
+      deposit:
+        enabled: true
+        fee_minimum: 0
+        fee_percent: 0
+        min_amount: 0
+        max_amount: 10000
+      withdraw:
+        enabled: true
+        fee_fixed: 0
+        fee_percent: 0
+        min_amount: 0
+        max_amount: 10000
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -53,33 +56,21 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - iso4217:USD
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: iso4217
     code: USD
-    deposit:
-      enabled: true
-      fee_minimum: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
-    withdraw:
-      enabled: false
-      fee_fixed: 0
-      fee_percent: 0
-      min_amount: 1
-      max_amount: 1000000
     sep31:
+      enabled: false
       send:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1
         max_amount: 1000000
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
@@ -92,5 +83,3 @@ assets:
       buy_delivery_methods:
         - name: WIRE
           description: Have USD sent directly to your bank account.
-    sep31_enabled: false
-    sep38_enabled: true

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -20,7 +20,7 @@ assets:
         max_amount: 10000
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 0
@@ -64,7 +64,7 @@ assets:
     code: USD
     sep31:
       enabled: false
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 1

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -49,7 +49,7 @@
       },
       "sep31": {
         "enabled": true,
-        "send": {
+        "receive": {
           "fee_fixed": 0,
           "fee_percent": 0,
           "min_amount": 1,

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -5,25 +5,50 @@
       "code": "USDC",
       "issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
       "significant_decimals": 2,
-      "deposit": {
+      "sep6": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 10000,
-        "methods": [
-          "SEPA",
-          "SWIFT"
-        ]
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
+        },
+        "withdraw": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "bank_account",
+            "cash"
+          ]
+        }
       },
-      "withdraw": {
+      "sep24": {
         "enabled": true,
-        "min_amount": 1,
-        "max_amount": 10000,
-        "methods": [
-          "bank_account",
-          "cash"
-        ]
+        "deposit": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
+        },
+        "withdraw": {
+          "enabled": true,
+          "min_amount": 1,
+          "max_amount": 10000,
+          "methods": [
+            "bank_account",
+            "cash"
+          ]
+        }
       },
       "sep31": {
+        "enabled": true,
         "send": {
           "fee_fixed": 0,
           "fee_percent": 0,
@@ -82,15 +107,12 @@
         }
       },
       "sep38": {
+        "enabled": true,
         "exchangeable_assets": [
           "stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
           "iso4217:USD"
         ]
-      },
-      "sep6_enabled": true,
-      "sep24_enabled": true,
-      "sep31_enabled": true,
-      "sep38_enabled": true
+      }
     }
   ]
 }

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -39,7 +39,7 @@ assets:
           - cash
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         max_amount: 1000000
@@ -95,7 +95,7 @@ assets:
         max_amount: 10
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 0
@@ -154,7 +154,7 @@ assets:
         enabled: false
     sep31:
       enabled: true
-      send:
+      receive:
         fee_fixed: 0
         fee_percent: 0
       quotes_supported: true
@@ -220,7 +220,7 @@ assets:
     significant_decimals: 7
     sep31:
       enabled: false
-      send:
+      receive:
         min_amount: 0
         max_amount: 1000000
     sep38:
@@ -241,7 +241,7 @@ assets:
     code: CAD
     significant_decimals: 7
     sep31:
-      send:
+      receive:
         min_amount: 0
         max_amount: 1000000
     sep38:

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -5,21 +5,40 @@ assets:
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 0
-      max_amount: 10
-      methods:
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+        methods:
+          - bank_account
+          - cash
+    sep24:
       enabled: true
-      min_amount: 0
-      max_amount: 10
-      methods:
-        - bank_account
-        - cash
+      deposit:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+        methods:
+          - bank_account
+          - cash
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -55,27 +74,27 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
         - iso4217:CAD
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: stellar
     code: USDC
     issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 2
-    deposit:
+    sep24:
       enabled: true
-      min_amount: 0
-      max_amount: 10
-    withdraw:
-      enabled: true
-      min_amount: 0
-      max_amount: 10
+      deposit:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+      withdraw:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -112,22 +131,29 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
         - iso4217:CAD
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: stellar
     code: JPYC
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 4
-    deposit:
+    sep6:
       enabled: false
-    withdraw:
+      deposit:
+        enabled: false
+      withdraw:
+        enabled: false
+    sep24:
       enabled: false
+      deposit:
+        enabled: false
+      withdraw:
+        enabled: false
     sep31:
+      enabled: true
       send:
         fee_fixed: 0
         fee_percent: 0
@@ -162,40 +188,43 @@ assets:
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
-    sep6_enabled: false
-    sep24_enabled: false
-    sep31_enabled: true
-    sep38_enabled: true
 
   # Native asset
   - schema: stellar
     code: native
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 7
-    deposit:
+    sep6:
+      enabled: false
+    sep24:
       enabled: true
-      min_amount: 0
-      max_amount: 10
-    withdraw:
-      enabled: true
-      min_amount: 0
-      max_amount: 10
-    sep6_enabled: false
-    sep31_enabled: false
-    sep38_enabled: false
-    sep24_enabled: true
+      deposit:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+      withdraw:
+        enabled: true
+        min_amount: 0
+        max_amount: 10
+    sep31:
+      enabled: false
+    sep38:
+      enabled: false
 
   # Fiat
   - schema: iso4217
     code: USD
     significant_decimals: 7
     sep31:
+      enabled: false
       send:
         min_amount: 0
         max_amount: 1000000
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
@@ -208,7 +237,6 @@ assets:
       buy_delivery_methods:
         - name: WIRE
           description: Have USD sent directly to your bank account.
-    sep38_enabled: true
   - schema: iso4217
     code: CAD
     significant_decimals: 7
@@ -217,6 +245,7 @@ assets:
         min_amount: 0
         max_amount: 1000000
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
@@ -229,4 +258,3 @@ assets:
       buy_delivery_methods:
         - name: WIRE
           description: Have CAD sent directly to your bank account.
-    sep38_enabled: true

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -219,7 +219,7 @@ assets:
     code: USD
     significant_decimals: 7
     sep31:
-      enabled: false
+      enabled: true
       receive:
         min_amount: 0
         max_amount: 1000000

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -219,7 +219,7 @@ assets:
     code: USD
     significant_decimals: 7
     sep31:
-      enabled: true
+      enabled: false
       receive:
         min_amount: 0
         max_amount: 1000000


### PR DESCRIPTION
### Description
This is part of the assets config refactor work

1. Unify the naming to `Sep#Info` for all sep attributions
2. Add `sep6` and `sep24` as top-level field, and move `deposit` and `withdraw` under each of them
3. Move the "sep#_enabled" under corresponding sep field
4. remove more `deposit` and `withdraw` from test fiat asset
5. rename `send` as `receive` for SEP-31 service

The new schema will be:
  shema:
  code:
  issuer:
  ...
  sep6:
    -- enabled:
    -- deposit:
    -- withdraw:
  sep24:
    -- enabled:
    -- deposit:
    -- withdraw:
  sep31:
    -- enabled:
    -- receive:
  sep38:
    -- enabled:



### Testing

- `./gradlew test`

