### PR TITLE
[ANCHOR-732] Remove sep12 from asset config

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/operation/Sep31Operation.java
@@ -15,7 +15,6 @@ public class Sep31Operation {
   @SerializedName("quotes_required")
   boolean quotesRequired;
 
-  Sep12Operation sep12;
   Fields fields;
 
   @Data

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -75,7 +75,6 @@ public class Sep31Service {
   private final ClientService clientService;
   private final AssetService assetService;
   private final RateIntegration rateIntegration;
-  private final CustomerIntegration customerIntegration;
   private final Sep31InfoResponse infoResponse;
   private final CustodyService custodyService;
   private final CustodyConfig custodyConfig;
@@ -93,7 +92,6 @@ public class Sep31Service {
       ClientService clientService,
       AssetService assetService,
       RateIntegration rateIntegration,
-      CustomerIntegration customerIntegration,
       EventService eventService,
       CustodyService custodyService,
       CustodyConfig custodyConfig) {
@@ -108,7 +106,6 @@ public class Sep31Service {
     this.clientService = clientService;
     this.assetService = assetService;
     this.rateIntegration = rateIntegration;
-    this.customerIntegration = customerIntegration;
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.infoResponse = sep31InfoResponseFromAssetInfoList(assetService.listAllAssets());
     this.custodyService = custodyService;
@@ -633,7 +630,7 @@ public class Sep31Service {
     Fields sep31MissingTxnFields = new Fields();
     sep31MissingTxnFields.setTransaction(missingFields);
 
-    if (missingFields.size() > 0) {
+    if (!missingFields.isEmpty()) {
       infoF(
           "Missing SEP-31 fields ({}) for request ({})",
           sep31MissingTxnFields,
@@ -662,7 +659,6 @@ public class Sep31Service {
         assetResponse.setMinAmount(assetInfo.getSep31().getSend().getMinAmount());
         assetResponse.setMaxAmount(assetInfo.getSep31().getSend().getMaxAmount());
         assetResponse.setFields(assetInfo.getSep31().getFields());
-        assetResponse.setSep12(assetInfo.getSep31().getSep12());
         response.getReceive().put(assetInfo.getCode(), assetResponse);
       }
     }

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -133,31 +133,6 @@ internal class DefaultAssetServiceTest {
               },
               "quotes_supported": true,
               "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-                    },
-                    "sep31-large-sender": {
-                      "description": "U.S. citizens that do not have sending limits"
-                    },
-                    "sep31-foreign-sender": {
-                      "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-                    }
-                  }
-                },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "U.S. citizens receiving USD"
-                    },
-                    "sep31-foreign-receiver": {
-                      "description": "non-U.S. citizens receiving USD"
-                    }
-                  }
-                }
-              },
               "fields": {
                 "transaction": {
                   "receiver_routing_number": {
@@ -217,22 +192,6 @@ internal class DefaultAssetServiceTest {
               },
               "quotes_supported": true,
               "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "Japanese citizens"
-                    }
-                  }
-                },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "Japanese citizens receiving USD"
-                    }
-                  }
-                }
-              },
               "fields": {
                 "transaction": {
                   "receiver_routing_number": {
@@ -337,31 +296,6 @@ internal class DefaultAssetServiceTest {
               },
               "quotes_supported": true,
               "quotes_required": true,
-              "sep12": {
-                "sender": {
-                  "types": {
-                    "sep31-sender": {
-                      "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-                    },
-                    "sep31-large-sender": {
-                      "description": "U.S. citizens that do not have sending limits"
-                    },
-                    "sep31-foreign-sender": {
-                      "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-                    }
-                  }
-                },
-                "receiver": {
-                  "types": {
-                    "sep31-receiver": {
-                      "description": "U.S. citizens receiving USD"
-                    },
-                    "sep31-foreign-receiver": {
-                      "description": "non-U.S. citizens receiving USD"
-                    }
-                  }
-                }
-              },
               "fields": {
                 "transaction": {
                   "receiver_routing_number": {

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -520,7 +520,6 @@ class Sep12ServiceTest {
     }
     assertInstanceOf(SepNotFoundException::class.java, ex)
     assertEquals("User not found.", ex.message)
-    // Verify getting customer for every existing type
     verify(exactly = 1) { customerIntegration.getCustomer(any()) }
     verify(exactly = 0) { customerIntegration.deleteCustomer(any()) }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -15,10 +15,7 @@ import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.platform.CustomerUpdatedResponse
 import org.stellar.anchor.api.platform.GetTransactionResponse
-import org.stellar.anchor.api.sep.sep12.Sep12CustomerRequestBase
-import org.stellar.anchor.api.sep.sep12.Sep12GetCustomerRequest
-import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
-import org.stellar.anchor.api.sep.sep12.Sep12Status
+import org.stellar.anchor.api.sep.sep12.*
 import org.stellar.anchor.api.shared.CustomerField
 import org.stellar.anchor.api.shared.Customers
 import org.stellar.anchor.api.shared.ProvidedCustomerField
@@ -102,7 +99,7 @@ class Sep12ServiceTest {
     every { assetService.listAllAssets() } returns assets
     every { eventService.createSession(any(), any()) } returns eventSession
 
-    sep12Service = Sep12Service(customerIntegration, assetService, platformApiClient, eventService)
+    sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService)
   }
 
   @Test
@@ -524,7 +521,7 @@ class Sep12ServiceTest {
     assertInstanceOf(SepNotFoundException::class.java, ex)
     assertEquals("User not found.", ex.message)
     // Verify getting customer for every existing type
-    verify(exactly = 5) { customerIntegration.getCustomer(any()) }
+    verify(exactly = 1) { customerIntegration.getCustomer(any()) }
     verify(exactly = 0) { customerIntegration.deleteCustomer(any()) }
 
     // customer deletion succeeds
@@ -532,9 +529,9 @@ class Sep12ServiceTest {
     mockValidCustomerFound.id = "customer-id"
     every { customerIntegration.getCustomer(any()) } returns mockValidCustomerFound
     assertDoesNotThrow { sep12Service.deleteCustomer(jwtToken, TEST_ACCOUNT, TEST_MEMO, null) }
-    verify(exactly = 10) { customerIntegration.getCustomer(any()) }
+    verify(exactly = 2) { customerIntegration.getCustomer(any()) }
     // callback API is called twice
-    verify(exactly = 5) { customerIntegration.deleteCustomer(any()) }
+    verify(exactly = 1) { customerIntegration.deleteCustomer(any()) }
     val wantDeleteCustomerId = "customer-id"
     assertEquals(wantDeleteCustomerId, deleteCustomerIdSlot.captured)
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -120,31 +120,6 @@ class Sep31ServiceTest {
                 },
                 "quotes_supported": true,
                 "quotes_required": true,
-                "sep12": {
-                  "sender": {
-                    "types": {
-                      "sep31-sender": {
-                        "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-                      },
-                      "sep31-large-sender": {
-                        "description": "U.S. citizens that do not have sending limits"
-                      },
-                      "sep31-foreign-sender": {
-                        "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-                      }
-                    }
-                  },
-                  "receiver": {
-                    "types": {
-                      "sep31-receiver": {
-                        "description": "U.S. citizens receiving USD"
-                      },
-                      "sep31-foreign-receiver": {
-                        "description": "non-U.S. citizens receiving USD"
-                      }
-                    }
-                  }
-                },
                 "fields": {
                   "transaction": {
                     "receiver_routing_number": {
@@ -919,13 +894,13 @@ class Sep31ServiceTest {
 
   private val jpycJson =
     """
-    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"Japanese citizens"}}},"receiver":{"types":{"sep31-receiver":{"description":"Japanese citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["ACH","SWIFT","WIRE"],"optional":false}}}}
+    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["ACH","SWIFT","WIRE"],"optional":false}}}}
   """
       .trimIndent()
 
   private val usdcJson =
     """
-    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"sep12":{"sender":{"types":{"sep31-sender":{"description":"U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"},"sep31-large-sender":{"description":"U.S. citizens that do not have sending limits"},"sep31-foreign-sender":{"description":"non-U.S. citizens sending payments of less than ${'$'}10,000 in value"}}},"receiver":{"types":{"sep31-receiver":{"description":"U.S. citizens receiving USD"},"sep31-foreign-receiver":{"description":"non-U.S. citizens receiving USD"}}}},"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false}, "receiver_phone_number": {"description": "phone number of the receiver", "optional": true},"type":{"description":"type of deposit to make","choices":["SEPA","SWIFT"],"optional":false}}}}
+    {"enabled":true,"quotes_supported":true,"quotes_required":true,"fee_fixed":0,"fee_percent":0,"min_amount":1,"max_amount":1000000,"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false}, "receiver_phone_number": {"description": "phone number of the receiver", "optional": true},"type":{"description":"type of deposit to make","choices":["SEPA","SWIFT"],"optional":false}}}}
   """
       .trimIndent()
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -322,7 +322,6 @@ class Sep31ServiceTest {
         clientService,
         assetService,
         rateIntegration,
-        customerIntegration,
         eventService,
         custodyService,
         custodyConfig
@@ -375,7 +374,6 @@ class Sep31ServiceTest {
         clientService,
         assetServiceQuotesNotSupported,
         rateIntegration,
-        customerIntegration,
         eventService,
         custodyService,
         custodyConfig
@@ -845,7 +843,6 @@ class Sep31ServiceTest {
         clientService,
         assetServiceQuotesNotSupported,
         rateIntegration,
-        customerIntegration,
         eventService,
         custodyService,
         custodyConfig

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -33,31 +33,6 @@
         },
         "quotes_supported": true,
         "quotes_required": true,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {
@@ -117,22 +92,6 @@
         },
         "quotes_supported": true,
         "quotes_required": true,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "Japanese citizens"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "Japanese citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {
@@ -237,31 +196,6 @@
         },
         "quotes_supported": true,
         "quotes_required": true,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -26,23 +26,6 @@ assets:
         max_amount: 1000000
       quotes_supported: true
       quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -87,15 +70,6 @@ assets:
         max_amount: 1000000
       quotes_supported: true
       quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: Japanese citizens
-        receiver:
-          types:
-            sep31-receiver:
-              description: Japanese citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -171,23 +145,6 @@ assets:
         max_amount: 1000000
       quotes_supported: true
       quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       # todo assume this is right for now
       fields:
         transaction:

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -429,29 +429,6 @@ private const val expectedSep31Info =
         "quotes_required": false,
         "fee_fixed": 0,
         "fee_percent": 0,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": { "description": "U.S. citizens receiving JPY" },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving JPY"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {
@@ -478,29 +455,6 @@ private const val expectedSep31Info =
         "fee_percent": 0,
         "min_amount": 0,
         "max_amount": 10,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than ${'$'}10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than ${'$'}10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": { "description": "U.S. citizens receiving USD" },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -206,23 +206,6 @@ assets_config: |
         max_amount: 1000000
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -262,23 +245,6 @@ assets_config: |
         max_amount: 1000000
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -311,23 +277,6 @@ assets_config: |
         fee_percent: 0
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving JPY
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving JPY
       fields:
         transaction:
           receiver_routing_number:
@@ -397,23 +346,6 @@ assets_config: |
         max_amount: 1000000
       quotes_supported: true
       quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       # todo assume this is right for now
       fields:
         transaction:

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -187,19 +187,36 @@ assets_config: |
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 2
-    deposit:
+    sep6:
       enabled: true
-      min_amount: 1
-      methods:
-        - SEPA
-        - SWIFT
-    withdraw:
+      deposit:
+        enabled: true
+        min_amount: 1
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        max_amount: 1000000
+        methods:
+          - bank_account
+          - cash
+    sep24:
       enabled: true
-      max_amount: 1000000
-      methods:
-        - bank_account
-        - cash
+      deposit:
+        enabled: true
+        min_amount: 1
+        methods:
+          - SEPA
+          - SWIFT
+      withdraw:
+        enabled: true
+        max_amount: 1000000
+        methods:
+          - bank_account
+          - cash
     sep31:
+      enabled: true
       receive:
         fee_fixed: 0
         fee_percent: 0
@@ -218,26 +235,26 @@ assets_config: |
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
-    sep6_enabled: true
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: stellar
     code: USDC
     issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 2
-    deposit:
+    sep24:
       enabled: true
-      min_amount: 1
-      max_amount: 1000000
-    withdraw:
-      enabled: true
-      min_amount: 1
-      max_amount: 1000000
+      deposit:
+        enabled: true
+        min_amount: 1
+        max_amount: 1000000
+      withdraw:
+        enabled: true
+        min_amount: 1
+        max_amount: 1000000
     sep31:
+      enabled: true
       receive:
         fee_fixed: 0
         fee_percent: 0
@@ -257,21 +274,24 @@ assets_config: |
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: stellar
     code: JPYC
     issuer: GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 4
-    deposit:
+    sep6:
+      enabled: false
+    sep24:
       enabled: true
-    withdraw:
-      enabled: true
+      deposit:
+        enabled: true
+      withdraw:
+        enabled: true
     sep31:
+      enabled: true
       receive:
         fee_fixed: 0
         fee_percent: 0
@@ -289,30 +309,21 @@ assets_config: |
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - iso4217:USD
-    sep6_enabled: false
-    sep24_enabled: true
-    sep31_enabled: true
-    sep38_enabled: true
   - schema: iso4217
     code: USD
     significant_decimals: 7
-    deposit:
-      enabled: true
-      min_amount: 0
-      max_amount: 10000
-    withdraw:
-      enabled: true
-      min_amount: 0
-      max_amount: 10000
     sep31:
+      enabled: false
       receive:
         fee_fixed: 0
         fee_percent: 0
         min_amount: 0
         max_amount: 10000
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
         - stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
@@ -325,28 +336,28 @@ assets_config: |
       buy_delivery_methods:
         - name: WIRE
           description: Have USD sent directly to your bank account.
-    sep6_enabled: false
-    sep24_enabled: false
-    sep31_enabled: false
-    sep38_enabled: true
   - schema: stellar
     code: native
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
     significant_decimals: 7
-    deposit:
+    sep6:
+      enabled: false
+    sep24:
       enabled: true
-      max_amount: 1000000
-    withdraw:
-      enabled: true
-      max_amount: 1000000
+      deposit:
+        enabled: true
+        max_amount: 1000000
+      withdraw:
+        enabled: true
+        max_amount: 1000000
     sep31:
+      enabled: true
       receive:
         fee_fixed: 0
         fee_percent: 0
         max_amount: 1000000
       quotes_supported: true
       quotes_required: true
-      # todo assume this is right for now
       fields:
         transaction:
           receiver_routing_number:
@@ -359,10 +370,7 @@ assets_config: |
               - SEPA
               - SWIFT
     sep38:
+      enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       decimals: 7
-    sep6_enabled: false
-    sep31_enabled: true
-    sep38_enabled: true
-    sep24_enabled: true

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -171,10 +171,9 @@ public class SepBeans {
   @ConditionalOnAllSepsEnabled(seps = {"sep12"})
   Sep12Service sep12Service(
       CustomerIntegration customerIntegration,
-      AssetService assetService,
       PlatformApiClient platformApiClient,
       EventService eventService) {
-    return new Sep12Service(customerIntegration, assetService, platformApiClient, eventService);
+    return new Sep12Service(customerIntegration, platformApiClient, eventService);
   }
 
   @Bean
@@ -256,7 +255,6 @@ public class SepBeans {
       ClientService clientService,
       AssetService assetService,
       RateIntegration rateIntegration,
-      CustomerIntegration customerIntegration,
       EventService eventService,
       CustodyService custodyService,
       CustodyConfig custodyConfig) {
@@ -270,7 +268,6 @@ public class SepBeans {
         clientService,
         assetService,
         rateIntegration,
-        customerIntegration,
         eventService,
         custodyService,
         custodyConfig);

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -147,31 +147,6 @@ assets:
             },
             "quotes_supported": true,
             "quotes_required": false,
-            "sep12": {
-              "sender": {
-                "types": {
-                  "sep31-sender": {
-                    "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-                  },
-                  "sep31-large-sender": {
-                    "description": "U.S. citizens that do not have sending limits"
-                  },
-                  "sep31-foreign-sender": {
-                    "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-                  }
-                }
-              },
-              "receiver": {
-                "types": {
-                  "sep31-receiver": {
-                    "description": "U.S. citizens receiving USD"
-                  },
-                  "sep31-foreign-receiver": {
-                    "description": "non-U.S. citizens receiving USD"
-                  }
-                }
-              }
-            },
             "fields": {
               "transaction": {
                 "receiver_routing_number": {
@@ -228,31 +203,6 @@ assets:
             },
             "quotes_supported": true,
             "quotes_required": false,
-            "sep12": {
-              "sender": {
-                "types": {
-                  "sep31-sender": {
-                    "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-                  },
-                  "sep31-large-sender": {
-                    "description": "U.S. citizens that do not have sending limits"
-                  },
-                  "sep31-foreign-sender": {
-                    "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-                  }
-                }
-              },
-              "receiver": {
-                "types": {
-                  "sep31-receiver": {
-                    "description": "U.S. citizens receiving JPY"
-                  },
-                  "sep31-foreign-receiver": {
-                    "description": "non-U.S. citizens receiving JPY"
-                  }
-                }
-              }
-            },
             "fields": {
               "transaction": {
                 "receiver_routing_number": {

--- a/platform/src/test/kotlin/org/stellar/anchor/sep31/Sep31DepositInfoGeneratorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/sep31/Sep31DepositInfoGeneratorTest.kt
@@ -84,7 +84,6 @@ class Sep31DepositInfoGeneratorTest {
         clientService,
         assetService,
         rateIntegration,
-        customerIntegration,
         eventPublishService,
         custodyService,
         custodyConfig
@@ -107,7 +106,6 @@ class Sep31DepositInfoGeneratorTest {
         clientService,
         assetService,
         rateIntegration,
-        customerIntegration,
         eventPublishService,
         custodyService,
         custodyConfig

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -29,31 +29,6 @@
         },
         "quotes_supported": true,
         "quotes_required": true,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -24,23 +24,6 @@ assets:
         max_amount: 10000
       quotes_supported: true
       quotes_required: true
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -32,31 +32,6 @@
         },
         "quotes_supported": true,
         "quotes_required": true,
-        "sep12": {
-          "sender": {
-            "types": {
-              "sep31-sender": {
-                "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-              },
-              "sep31-large-sender": {
-                "description": "U.S. citizens that do not have sending limits"
-              },
-              "sep31-foreign-sender": {
-                "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-              }
-            }
-          },
-          "receiver": {
-            "types": {
-              "sep31-receiver": {
-                "description": "U.S. citizens receiving USD"
-              },
-              "sep31-foreign-receiver": {
-                "description": "non-U.S. citizens receiving USD"
-              }
-            }
-          }
-        },
         "fields": {
           "transaction": {
             "receiver_routing_number": {

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -26,23 +26,6 @@ assets:
         max_amount: 1000000
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -83,23 +66,6 @@ assets:
         max_amount: 10
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving USD
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving USD
       fields:
         transaction:
           receiver_routing_number:
@@ -133,23 +99,6 @@ assets:
         fee_percent: 0
       quotes_supported: true
       quotes_required: false
-      sep12:
-        sender:
-          types:
-            sep31-sender:
-              description: U.S. citizens limited to sending payments of less than $10,000
-                in value
-            sep31-large-sender:
-              description: U.S. citizens that do not have sending limits
-            sep31-foreign-sender:
-              description: non-U.S. citizens sending payments of less than $10,000 in
-                value
-        receiver:
-          types:
-            sep31-receiver:
-              description: U.S. citizens receiving JPY
-            sep31-foreign-receiver:
-              description: non-U.S. citizens receiving JPY
       fields:
         transaction:
           receiver_routing_number:


### PR DESCRIPTION
### Description

As title.

Discussed with Jake that  a customer could only have one id with the anchor, and the customer type is only used for identify KYC info purposes, so we don't actually need to traverse all the customer type in DELETE /customer request.

### Testing

- `./gradlew test`

