### PR TITLE
[ANCHOR-764] Add callback URL validation for custodial clients

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -118,13 +118,8 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
           "client-signing-keys-conflict",
           "The client.signingKey and The client.signingKeys cannot coexist, please choose one to use");
     }
-    if (!isEmpty(clientConfig.getCallbackUrl())) {
-      try {
-        new URL(clientConfig.getCallbackUrl());
-      } catch (MalformedURLException e) {
-        errors.reject("client-invalid-callback_url", "The client.callbackUrl is invalid");
-      }
-    }
+
+    validateCallbackUrls(clientConfig, errors);
   }
 
   public void validateNonCustodialClient(ClientConfig clientConfig, Errors errors) {
@@ -141,17 +136,27 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
           "The client.domain and the client.domains cannot coexist, please choose one to use");
     }
 
+    validateCallbackUrls(clientConfig, errors);
+
+    if (clientConfig.getDestinationAccounts() != null) {
+      errors.reject(
+          "destination-accounts-noncustodial",
+          "Destination accounts list is not a valid configuration option for a non-custodial client");
+    }
+  }
+
+  void validateCallbackUrls(ClientConfig client, Errors errors) {
     ImmutableMap.of(
             "callback_url",
-            Optional.ofNullable(clientConfig.getCallbackUrl()).orElse(""),
+            Optional.ofNullable(client.getCallbackUrl()).orElse(""),
             "callback_url_sep6",
-            Optional.ofNullable(clientConfig.getCallbackUrlSep6()).orElse(""),
+            Optional.ofNullable(client.getCallbackUrlSep6()).orElse(""),
             "callback_url_sep24",
-            Optional.ofNullable(clientConfig.getCallbackUrlSep24()).orElse(""),
+            Optional.ofNullable(client.getCallbackUrlSep24()).orElse(""),
             "callback_url_sep31",
-            Optional.ofNullable(clientConfig.getCallbackUrlSep31()).orElse(""),
+            Optional.ofNullable(client.getCallbackUrlSep31()).orElse(""),
             "callback_url_sep12",
-            Optional.ofNullable(clientConfig.getCallbackUrlSep12()).orElse(""))
+            Optional.ofNullable(client.getCallbackUrlSep12()).orElse(""))
         .forEach(
             (key, value) -> {
               if (!isEmpty(value)) {
@@ -162,11 +167,5 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
                 }
               }
             });
-
-    if (clientConfig.getDestinationAccounts() != null) {
-      errors.reject(
-          "destination-accounts-noncustodial",
-          "Destination accounts list is not a valid configuration option for a non-custodial client");
-    }
   }
 }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -201,6 +201,10 @@ event_processor:
 #   If the type is `noncustodial`,
 #   - domains: (required) the domain of the client.
 #   - callback_url: (optional) the URL of the client's callback API endpoint
+#   - callback_url_sep6: (optional) the URL of the client's SEP-6 callback API endpoint.
+#   - callback_url_sep24: (optional) the URL of the client's SEP-24 callback API endpoint.
+#   - callback_url_sep31: (optional) the URL of the client's SEP-31 callback API endpoint.
+#   - callback_url_sep12: (optional) the URL of the client's SEP-12 callback API endpoint.
 #
 # Examples:
 #     - name: circle

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -129,11 +129,53 @@ class PropertyClientsConfigTest {
   }
 
   @Test
-  fun `test invalid non-custodial client with invalid callback URLs`() {
+  fun `test valid custodial client with all callback URLs set`() {
     val config = ClientConfig()
     config.name = "circle"
+    config.type = CUSTODIAL
+    config.signingKeys =
+      setOf(
+        "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2",
+        "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
+      )
+    config.callbackUrl = "https://callback.circle.com/api/v1/anchor/callback"
+    config.callbackUrlSep6 = "https://callback.circle.com/api/v1/anchor/callback/sep6"
+    config.callbackUrlSep24 = "https://callback.circle.com/api/v1/anchor/callback/sep24"
+    config.callbackUrlSep31 = "https://callback.circle.com/api/v1/anchor/callback/sep31"
+    config.callbackUrlSep12 = "https://callback.circle.com/api/v1/anchor/callback/sep12"
+    configs.clients.add(config)
+
+    configs.validate(configs, errors)
+    Assertions.assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test invalid non-custodial client with invalid callback URLs`() {
+    val config = ClientConfig()
+    config.name = "lobstr"
     config.type = NONCUSTODIAL
-    config.domains = setOf("circle.com")
+    config.domains = setOf("lobstr.co")
+    config.callbackUrl = "bad-url"
+    config.callbackUrlSep6 = "bad-url"
+    config.callbackUrlSep24 = "bad-url"
+    config.callbackUrlSep31 = "bad-url"
+    config.callbackUrlSep12 = "bad-url"
+    configs.clients.add(config)
+
+    configs.validate(configs, errors)
+    Assertions.assertEquals(5, errors.errorCount)
+  }
+
+  @Test
+  fun `test invalid custodial client with invalid callback URLs`() {
+    val config = ClientConfig()
+    config.name = "circle"
+    config.type = CUSTODIAL
+    config.signingKeys =
+      setOf(
+        "GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2",
+        "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
+      )
     config.callbackUrl = "bad-url"
     config.callbackUrlSep6 = "bad-url"
     config.callbackUrlSep24 = "bad-url"


### PR DESCRIPTION
### Description

This adds validation for callback URLs for custodial clients.

### Context

This was missed in the previous commit.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

