### PR TITLE
[ANCHOR-783] Remove amount_out requirement in RequestOffchainFunds

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -199,6 +199,7 @@ public class Sep6Service {
           exchangeAmountsCalculator.calculateFromQuote(
               request.getQuoteId(), sellAsset, request.getAmount());
     } else {
+      // TODO(philip): remove this
       // If a quote is not provided, set the fee and out amounts to 0.
       // The business server should use the request_offchain_funds RPC to update the amounts.
       amounts =
@@ -372,6 +373,7 @@ public class Sep6Service {
           exchangeAmountsCalculator.calculateFromQuote(
               request.getQuoteId(), sellAsset, request.getAmount());
     } else {
+      // TODO(philip): remove this
       // If a quote is not provided, set the fee and out amounts to 0.
       // The business server should use the request_onchain_funds RPC to update the amounts.
       amounts =


### PR DESCRIPTION
### Description

`amount_out` is not set if a transaction has an associated indicative quote but has not yet received funds.

### Context

This was fixed for `RequestOnchainFunds` already.

### Testing

- `./gradlew test`

### Documentation

Will update stellar-docs

### Known limitations

N/A

