### PR TITLE
Include doc release process in release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-a-new-version.md
+++ b/.github/ISSUE_TEMPLATE/release-a-new-version.md
@@ -27,3 +27,4 @@ assignees: ''
 - [ ] Create the pull request `release/2.2.x -> main`: this should require two approvals. DO NOT squash merge.
 - [ ] Create another pull request `release/2.2.x -> develop`: AFTER the release branch is merged with the `main` branch. DO NOT squash merge.
 - [ ] (Optional) Generate the new Anchor Platform documentation version in the stellar-docs repository if this is a new major or minor version.
+- [ ] (Optional) You'll need to manually publish a new version of the SDK to [Maven Central](https://search.maven.org/search?q=g:org.stellar.anchor-sdk) in the `legacy/release-1.0`.

--- a/.github/ISSUE_TEMPLATE/release-a-new-version.md
+++ b/.github/ISSUE_TEMPLATE/release-a-new-version.md
@@ -26,8 +26,4 @@ assignees: ''
 - [ ] If necessary, update the badges versions in [docs/00 - Stellar Anchor Platform.md].
 - [ ] Create the pull request `release/2.2.x -> main`: this should require two approvals. DO NOT squash merge.
 - [ ] Create another pull request `release/2.2.x -> develop`: AFTER the release branch is merged with the `main` branch. DO NOT squash merge.
-- [ ] Generate the new Anchor Platform documentation version in the stellar-docs repository.
-- [ ] (Optional) You'll need to manually publish a new version of the SDK to [Maven Central](https://search.maven.org/search?q=g:org.stellar.anchor-sdk).
-- [ ] (Optional) You'll need to manually upload the jar file from [Maven Central](https://search.maven.org/search?q=g:org.stellar.anchor-sdk) to the GH release.
-- [ ] (Optional) If necessary, open a PR for stellar/helm-charts and [update with the latest helm chart](https://docs.google.com/document/d/10ujUQZvBCMUyciObQPouxjtlnOdI5OpAz2Pk1LFdDDE) to publish
-- [ ] (Optional) Bump helm chart version.
+- [ ] (Optional) Generate the new Anchor Platform documentation version in the stellar-docs repository if this is a new major or minor version.

--- a/.github/ISSUE_TEMPLATE/release-a-new-version.md
+++ b/.github/ISSUE_TEMPLATE/release-a-new-version.md
@@ -26,6 +26,7 @@ assignees: ''
 - [ ] If necessary, update the badges versions in [docs/00 - Stellar Anchor Platform.md].
 - [ ] Create the pull request `release/2.2.x -> main`: this should require two approvals. DO NOT squash merge.
 - [ ] Create another pull request `release/2.2.x -> develop`: AFTER the release branch is merged with the `main` branch. DO NOT squash merge.
+- [ ] Generate the new Anchor Platform documentation version in the stellar-docs repository.
 - [ ] (Optional) You'll need to manually publish a new version of the SDK to [Maven Central](https://search.maven.org/search?q=g:org.stellar.anchor-sdk).
 - [ ] (Optional) You'll need to manually upload the jar file from [Maven Central](https://search.maven.org/search?q=g:org.stellar.anchor-sdk) to the GH release.
 - [ ] (Optional) If necessary, open a PR for stellar/helm-charts and [update with the latest helm chart](https://docs.google.com/document/d/10ujUQZvBCMUyciObQPouxjtlnOdI5OpAz2Pk1LFdDDE) to publish


### PR DESCRIPTION
### Description

Adds a checkbox for cutting a doc release.

### Context

We now have versioned docs.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

