### PR TITLE
Revert "Set default `container.imagePullPolicy` to `IfNotPresent` (#1467)"

### DIFF
--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: reference
           image: {{ .Values.container.image }}
           args: [ "--kotlin-reference-server" ]
-          imagePullPolicy: {{ .Values.container.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.container.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.services.ref.containerPort | default 8091 }}

--- a/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: event-processor
           image: {{ .Values.container.image }}
           args: [ "--event-processor" ]
-          imagePullPolicy: {{ .Values.container.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.container.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.services.sep.containerPort | default 8088 }}

--- a/helm-charts/sep-service/templates/observer-deployment.yaml
+++ b/helm-charts/sep-service/templates/observer-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: stellar-observer
           image: {{ .Values.container.image }}
           args: [ "--stellar-observer" ]
-          imagePullPolicy: {{ .Values.container.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.container.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.services.observer.containerPort | default 8083 }}

--- a/helm-charts/sep-service/templates/platform-deployment.yaml
+++ b/helm-charts/sep-service/templates/platform-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: platform
           image: {{ .Values.container.image }}
           args: [ "--platform-server" ]
-          imagePullPolicy: {{ .Values.container.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.container.imagePullPolicy}}
           ports:
             - name: http
               containerPort: {{ .Values.services.platform.containerPort | default 8085 }}

--- a/helm-charts/sep-service/templates/sepserver-deployment.yaml
+++ b/helm-charts/sep-service/templates/sepserver-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: sep-server
           image: {{ .Values.container.image }}
           args: [ "--sep-server" ]
-          imagePullPolicy: {{ .Values.container.imagePullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.container.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.services.sep.containerPort | default 8080 }}


### PR DESCRIPTION
### Description

This reverts commit fff3240ee9348d82748602254cdb3282b439cb34.

### Context

The previous change did not fix the deployments, causing the pods to be evicted continuously.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A
