### PR TITLE
[Bug] Fix the NPE thrown when the memo id is null

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -383,12 +383,14 @@ class Sep6EventProcessor(
           event.payload.transaction.id,
           missingFields,
         )
+        // We only use memoType "id" for reference server
+        val memoType = if (customer.memo != null) "id" else null
         val existingCustomer =
           customerService.getCustomer(
             GetCustomerRequest.builder()
               .account(customer.account)
               .memo(customer.memo)
-              .memoType("id")
+              .memoType(memoType)
               .build()
           )
         sepHelper.rpcAction(


### PR DESCRIPTION
### Description

The hard-coded "id" causes NPE if the `memo` is `null`

### Context

Bug

### Testing

- `./gradlew test`


### Documentation
N/A

### Known limitations
N/A
