### PR TITLE
[ANCHOR-755] Remove callback_url from client config

### DIFF
--- a/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
@@ -7,9 +7,6 @@ import org.apache.commons.lang3.StringUtils;
 public interface ClientConfig {
   String getName();
 
-  @Deprecated
-  String getCallbackUrl();
-
   CallbackUrls getCallbackUrls();
 
   @Data
@@ -27,11 +24,10 @@ public interface ClientConfig {
    * @return true if any of the callback URLs are set
    */
   default boolean isCallbackEnabled() {
-    return !StringUtils.isEmpty(getCallbackUrl())
-        || (getCallbackUrls() != null
-            && (!StringUtils.isEmpty(getCallbackUrls().getSep6())
-                || !StringUtils.isEmpty(getCallbackUrls().getSep24())
-                || !StringUtils.isEmpty(getCallbackUrls().getSep31())
-                || !StringUtils.isEmpty(getCallbackUrls().getSep12())));
+    return getCallbackUrls() != null
+        && (!StringUtils.isEmpty(getCallbackUrls().getSep6())
+            || !StringUtils.isEmpty(getCallbackUrls().getSep24())
+            || !StringUtils.isEmpty(getCallbackUrls().getSep31())
+            || !StringUtils.isEmpty(getCallbackUrls().getSep12()));
   }
 }

--- a/core/src/main/java/org/stellar/anchor/client/CustodialClientConfig.java
+++ b/core/src/main/java/org/stellar/anchor/client/CustodialClientConfig.java
@@ -20,15 +20,6 @@ public class CustodialClientConfig implements ClientConfig {
   Set<String> signingKeys;
 
   /**
-   * The endpoint URL to which the service can send callbacks, enabling real-time updates or
-   * actions. Optional due to some wallets may opt to poll instead, or may use polling first before
-   * implementing callbacks at a later stage.
-   */
-  @Deprecated
-  @SerializedName("callback_url")
-  String callbackUrl;
-
-  /**
    * The URLs to which the service can send callbacks for different SEP types. Optional due to some
    * wallets may opt to poll instead, or may use polling first before implementing callbacks at a
    * later stage.

--- a/core/src/main/java/org/stellar/anchor/client/NonCustodialClientConfig.java
+++ b/core/src/main/java/org/stellar/anchor/client/NonCustodialClientConfig.java
@@ -23,14 +23,6 @@ public class NonCustodialClientConfig implements ClientConfig {
   Set<String> domains;
 
   /**
-   * Similar to the custodial clients, this is the endpoint for callbacks, facilitating
-   * communication.
-   */
-  @Deprecated
-  @SerializedName("callback_url")
-  String callbackUrl;
-
-  /**
    * The URLs to which the service can send callbacks for different SEP types. Optional due to some
    * wallets may opt to poll instead, or may use polling first before implementing callbacks at a
    * later stage.

--- a/core/src/test/kotlin/org/stellar/anchor/client/DefaultClientServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/client/DefaultClientServiceTest.kt
@@ -52,7 +52,12 @@ class DefaultClientServiceTest {
         {
           "name": "reference",
           "domains": ["wallet-server:8092"],
-          "callback_url": "http://wallet-server:8092/callbacks"
+          "callback_urls": {
+            "sep6": "http://wallet-server:8092/sep6",
+            "sep24": "http://wallet-server:8092/sep24",
+            "sep31": "http://wallet-server:8092/sep31",
+            "sep12": "http://wallet-server:8092/sep12"
+          }
         }
       ]
     """

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -38,10 +38,7 @@ import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
-import org.stellar.anchor.client.ClientFinder
-import org.stellar.anchor.client.ClientService
-import org.stellar.anchor.client.CustodialClientConfig
-import org.stellar.anchor.client.NonCustodialClientConfig
+import org.stellar.anchor.client.*
 import org.stellar.anchor.config.*
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.sep38.PojoSep38Quote
@@ -151,7 +148,11 @@ internal class Sep24ServiceTest {
       NonCustodialClientConfig.builder()
         .name("reference")
         .domains(setOf("wallet-server:8092"))
-        .callbackUrl("http://wallet-server:8092/callbacks")
+        .callbackUrls(
+          ClientConfig.CallbackUrls.builder()
+            .sep24("http://wallet-server:8092/callbacks/sep24")
+            .build()
+        )
         .build()
     every { clientService.getClientConfigBySigningKey(any()) } returns
       CustodialClientConfig.builder()

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -36,6 +36,7 @@ import org.stellar.anchor.api.shared.SepDepositInfo
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.client.ClientConfig.CallbackUrls
 import org.stellar.anchor.client.ClientService
 import org.stellar.anchor.client.CustodialClientConfig
 import org.stellar.anchor.config.*
@@ -238,7 +239,9 @@ class Sep31ServiceTest {
       CustodialClientConfig.builder()
         .name("custodialClient")
         .signingKeys(setOf("GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEG"))
-        .callbackUrl("https://example.com/callback")
+        .callbackUrls(
+          CallbackUrls.builder().sep31("http://wallet-server:8092/callbacks/sep31").build()
+        )
         .allowAnyDestination(false)
         .destinationAccounts(emptySet())
         .build()

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
@@ -12,6 +12,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_MEMO
 import org.stellar.anchor.TestHelper
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
+import org.stellar.anchor.client.ClientConfig.CallbackUrls
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.client.ClientService
 import org.stellar.anchor.client.CustodialClientConfig
@@ -33,7 +34,14 @@ class ClientFinderTest {
       NonCustodialClientConfig.builder()
         .name("reference")
         .domains(setOf("wallet-server:8092"))
-        .callbackUrl("http://wallet-server:8092/callbacks")
+        .callbackUrls(
+          CallbackUrls.builder()
+            .sep6("https://wallet-server:8092/callbacks/sep6")
+            .sep24("https://wallet-server:8092/callbacks/sep24")
+            .sep31("https://wallet-server:8092/callbacks/sep31")
+            .sep12("https://wallet-server:8092/callbacks/sep12")
+            .build()
+        )
         .build()
   }
 

--- a/core/src/test/resources/test_clients.json
+++ b/core/src/test/resources/test_clients.json
@@ -13,7 +13,12 @@
     {
       "name": "reference",
       "domains": ["wallet-server:8092"],
-      "callback_url": "http://wallet-server:8092/callbacks"
+      "callback_urls": {
+        "sep6": "http://wallet-server:8092/sep6",
+        "sep24": "http://wallet-server:8092/sep24",
+        "sep31": "http://wallet-server:8092/sep31",
+        "sep12": "http://wallet-server:8092/sep12"
+      }
     }
   ]
 }

--- a/core/src/test/resources/test_clients.yaml
+++ b/core/src/test/resources/test_clients.yaml
@@ -9,4 +9,8 @@ noncustodial:
   - name: reference
     domains:
       - wallet-server:8092
-    callback_url: http://wallet-server:8092/callbacks
+    callback_urls:
+      sep6: http://wallet-server:8092/sep6
+      sep24: http://wallet-server:8092/sep24
+      sep31: http://wallet-server:8092/sep31
+      sep12: http://wallet-server:8092/sep12

--- a/core/src/test/resources/test_clients_file_format_not_valid.yaml.bad
+++ b/core/src/test/resources/test_clients_file_format_not_valid.yaml.bad
@@ -9,4 +9,3 @@ noncustodial:
   - name: reference
     domains:
       - wallet-server:8092
-    callback_url: http://wallet-server:8092/callbacks

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -87,21 +87,19 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
     for (ClientConfig client : clients) {
       debugF("Validating client {}", client);
       ImmutableMap.of(
-              "callback_url",
-              Optional.ofNullable(client.getCallbackUrl()).orElse(""),
-              "callback_url_sep6",
+              "callback_urls_sep6",
               Optional.ofNullable(client.getCallbackUrls())
                   .map(ClientConfig.CallbackUrls::getSep6)
                   .orElse(""),
-              "callback_url_sep24",
+              "callback_urls_sep24",
               Optional.ofNullable(client.getCallbackUrls())
                   .map(ClientConfig.CallbackUrls::getSep24)
                   .orElse(""),
-              "callback_url_sep31",
+              "callback_urls_sep31",
               Optional.ofNullable(client.getCallbackUrls())
                   .map(ClientConfig.CallbackUrls::getSep31)
                   .orElse(""),
-              "callback_url_sep12",
+              "callback_urls_sep12",
               Optional.ofNullable(client.getCallbackUrls())
                   .map(ClientConfig.CallbackUrls::getSep12)
                   .orElse(""))

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -106,8 +107,9 @@ public class ClientStatusCallbackHandler extends EventHandler {
     return buildHttpRequest(signer, payload, callbackUrl);
   }
 
+  @Nullable
   String getCallbackUrl(AnchorEvent event) throws InvalidConfigException {
-    String callbackUrl = clientConfig.getCallbackUrl();
+    String callbackUrl = null;
     if (event.getTransaction() != null) {
       switch (event.getTransaction().getSep()) {
         case SEP_6:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
@@ -74,7 +74,6 @@ class ClientsConfigTest {
             .sep12("https://example.com/api/v1/anchor/callback/sep12")
             .build()
         )
-        .callbackUrl("https://example.com/api/v1/anchor/callback")
         .build()
 
     config.setNoncustodial(listOf(nonCustodial))
@@ -101,7 +100,6 @@ class ClientsConfigTest {
             .sep12("https://example.com/api/v1/anchor/callback/sep12")
             .build()
         )
-        .callbackUrl("https://example.com/api/v1/anchor/callback")
         .build()
 
     config.setCustodial(listOf(custodial))
@@ -123,12 +121,11 @@ class ClientsConfigTest {
             .sep12("bad-url")
             .build()
         )
-        .callbackUrl("bad-url")
         .build()
 
     config.setNoncustodial(listOf(nonCustodial))
     config.validate(config, errors)
-    assertEquals(5, errors.errorCount)
+    assertEquals(4, errors.errorCount)
   }
 
   @Test
@@ -150,11 +147,10 @@ class ClientsConfigTest {
             .sep12("bad-url")
             .build()
         )
-        .callbackUrl("bad-url")
         .build()
 
     config.setCustodial(listOf(custodial))
     config.validate(config, errors)
-    assertEquals(5, errors.errorCount)
+    assertEquals(4, errors.errorCount)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/configurator/ConfigManagerTest.kt
@@ -33,15 +33,15 @@ class ConfigManagerTest {
     assertEquals(config.get("clients.noncustodial[0].name").value, "vibrant")
     assertEquals(config.get("clients.noncustodial[0].domains[0]").value, "vibrant.co")
     assertEquals(
-      config.get("clients.noncustodial[0].callback_url").value,
-      "https://callback.vibrant.com/api/v2/anchor/callback"
+      config.get("clients.noncustodial[0].callback_urls.sep24").value,
+      "https://callback.vibrant.com/api/v2/anchor/callback/sep24"
     )
 
     assertEquals(config.get("clients.noncustodial[1].name").value, "lobstr")
     assertEquals(config.get("clients.noncustodial[1].domains[0]").value, "lobstr.co")
     assertEquals(
-      config.get("clients.noncustodial[1].callback_url").value,
-      "https://callback.lobstr.co/api/v2/anchor/callback"
+      config.get("clients.noncustodial[1].callback_urls.sep6").value,
+      "https://callback.lobstr.co/api/v2/anchor/callback/sep6"
     )
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -61,8 +61,14 @@ class ClientStatusCallbackHandlerTest {
             "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F",
           )
         )
-        .callbackUrl("https://callback.circle.com/api/v1/anchor/callback")
-        .callbackUrls(CallbackUrls.builder().build())
+        .callbackUrls(
+          CallbackUrls.builder()
+            .sep6("https://callback.circle.com/api/v1/anchor/callback/sep6")
+            .sep24("https://callback.circle.com/api/v1/anchor/callback/sep24")
+            .sep31("https://callback.circle.com/api/v1/anchor/callback/sep31")
+            .sep12("https://callback.circle.com/api/v1/anchor/callback/sep12")
+            .build()
+        )
         .allowAnyDestination(false)
         .destinationAccounts(emptySet())
         .build()
@@ -116,7 +122,7 @@ class ClientStatusCallbackHandlerTest {
 
     val payload = json(event)
     val request =
-      ClientStatusCallbackHandler.buildHttpRequest(signer, payload, clientConfig.callbackUrl)
+      ClientStatusCallbackHandler.buildHttpRequest(signer, payload, clientConfig.callbackUrls.sep6)
     val requestHeader = request.headers["Signature"]
     val parsedSignature = requestHeader?.split(", ")?.get(1)?.substring(2)
     val decodedSignature = Base64.getDecoder().decode(parsedSignature)
@@ -127,14 +133,6 @@ class ClientStatusCallbackHandlerTest {
     val signatureToVerify = signer.sign(payloadToVerify.toByteArray())
 
     Assertions.assertArrayEquals(decodedSignature, signatureToVerify)
-  }
-
-  @Test
-  fun `test getCallbackUrl fallback`() {
-    clientConfig.callbackUrls.sep6 = null
-    val url = handler.getCallbackUrl(event)
-
-    Assertions.assertEquals(clientConfig.callbackUrl, url)
   }
 
   @Test
@@ -176,7 +174,6 @@ class ClientStatusCallbackHandlerTest {
 
   @Test
   fun `test buildHttpRequest with no callback URLs defined`() {
-    clientConfig.callbackUrl = null
     clientConfig.callbackUrls.sep6 = null
     clientConfig.callbackUrls.sep24 = null
     clientConfig.callbackUrls.sep31 = null

--- a/platform/src/test/resources/config/test_anchor_config.yaml
+++ b/platform/src/test/resources/config/test_anchor_config.yaml
@@ -8,9 +8,11 @@ clients:
     - name: vibrant
       domains:
         - vibrant.co
-      callback_url: https://callback.vibrant.com/api/v2/anchor/callback
+      callback_urls:
+        sep24: https://callback.vibrant.com/api/v2/anchor/callback/sep24
     - name: lobstr
       domains:
         - lobstr.co
-      callback_url: https://callback.lobstr.co/api/v2/anchor/callback
+      callback_urls:
+        sep6: https://callback.lobstr.co/api/v2/anchor/callback/sep6
 

--- a/platform/src/test/resources/config/test_anchor_config_missing_version.yaml
+++ b/platform/src/test/resources/config/test_anchor_config_missing_version.yaml
@@ -4,9 +4,7 @@ clients:
   - name: vibrant
     type: noncustodial
     domain: vibrant.co
-    callback_url: https://callback.vibrant.com/api/v2/anchor/callback
     signing_key: GA22WORKYRXB6AW7XR5GIOAOQUY4KKCENEAI34FN3KJNWHKDZTZSVLTU
   - name: lobstr
     type: noncustodial
     domain: lobstr.co
-    callback_url: https://callback.lobstr.co/api/v2/anchor/callback

--- a/platform/src/test/resources/test_clients.yaml
+++ b/platform/src/test/resources/test_clients.yaml
@@ -7,8 +7,17 @@ noncustodial:
     - name: lobstr
       domains:
         - lobstr.co
-      callback_url: https://callback.lobstr.co/api/v2/anchor/callback
+      callback_urls:
+        sep6: https://callback.lobstr.co/api/v2/anchor/callback/sep6
+        sep24: https://callback.lobstr.co/api/v2/anchor/callback/sep24
+        sep31: https://callback.lobstr.co/api/v2/anchor/callback/sep31
+        sep12: https://callback.lobstr.co/api/v2/anchor/callback/sep12
     - name: circle
       domains:
         - circle.com
-      callback_url: https://callback.circle.com/api/v2/anchor/callback
+      callback_urls:
+        sep6: https://callback.circle.com/api/v2/anchor/callback/sep6
+        sep24: https://callback.circle.com/api/v2/anchor/callback/sep24
+        sep31: https://callback.circle.com/api/v2/anchor/callback/sep31
+        sep12: https://callback.circle.com/api/v2/anchor/callback/sep12
+

--- a/service-runner/src/main/resources/config/clients.yaml
+++ b/service-runner/src/main/resources/config/clients.yaml
@@ -9,7 +9,6 @@ noncustodial:
   - name: reference
     domains:
       - wallet-server:8092
-    callback_url: http://wallet-server:8092/callbacks
     callback_urls:
       sep6: http://wallet-server:8092/callbacks/sep6
       sep24: http://wallet-server:8092/callbacks/sep24


### PR DESCRIPTION
### Description

This commit removes the `callback_url` field from the client config.

### Context

It was deprecated in favor of SEP-specific URLs.

### Testing

- `./gradlew test`

### Documentation

https://github.com/stellar/stellar-docs/pull/958

### Known limitations

N/A

