### PR TITLE
[ANCHOR-794] Remove sep38 decimals from asset definition

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/asset/Sep38Info.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/asset/Sep38Info.java
@@ -14,8 +14,6 @@ public class Sep38Info {
   @SerializedName("country_codes")
   List<String> countryCodes;
 
-  Integer decimals;
-
   @SerializedName("sell_delivery_methods")
   List<DeliveryMethod> sellDeliveryMethods;
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.api.asset.AssetInfo;
-import org.stellar.anchor.api.asset.FiatAssetInfo;
 import org.stellar.anchor.api.asset.Sep38Info;
 
 /**
@@ -24,22 +23,16 @@ public class InfoResponse {
       if (assetInfo.getSep38() == null
           || assetInfo.getSep38().getEnabled() == null
           || !assetInfo.getSep38().getEnabled()) continue;
-      Asset newAsset = new Asset();
       Sep38Info sep38Info = assetInfo.getSep38();
 
-      newAsset.setAsset(assetInfo.getId());
-      newAsset.setCountryCodes(sep38Info.getCountryCodes());
-      newAsset.setExchangeableAssetNames(sep38Info.getExchangeableAssets());
+      Asset assetResponse = new Asset();
 
-      int decimals = 7;
-      if (assetInfo instanceof FiatAssetInfo fiatAssetInfo) {
-        newAsset.setSellDeliveryMethods(fiatAssetInfo.getSep38().getSellDeliveryMethods());
-        newAsset.setBuyDeliveryMethods(fiatAssetInfo.getSep38().getBuyDeliveryMethods());
-        decimals = sep38Info.getDecimals() != null ? sep38Info.getDecimals() : 7;
-      }
+      assetResponse.setAsset(assetInfo.getId());
+      assetResponse.setCountryCodes(sep38Info.getCountryCodes());
+      assetResponse.setExchangeableAssetNames(sep38Info.getExchangeableAssets());
+      assetResponse.setDecimals(assetInfo.getSignificantDecimals());
 
-      newAsset.setDecimals(decimals);
-      assets.add(newAsset);
+      assets.add(assetResponse);
     }
   }
 

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep38/InfoResponse.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.stellar.anchor.api.asset.AssetInfo;
+import org.stellar.anchor.api.asset.FiatAssetInfo;
 import org.stellar.anchor.api.asset.Sep38Info;
 
 /**
@@ -26,6 +27,11 @@ public class InfoResponse {
       Sep38Info sep38Info = assetInfo.getSep38();
 
       Asset assetResponse = new Asset();
+
+      if (assetInfo instanceof FiatAssetInfo fiatAssetInfo) {
+        assetResponse.setSellDeliveryMethods(fiatAssetInfo.getSep38().getSellDeliveryMethods());
+        assetResponse.setBuyDeliveryMethods(fiatAssetInfo.getSep38().getBuyDeliveryMethods());
+      }
 
       assetResponse.setAsset(assetInfo.getId());
       assetResponse.setCountryCodes(sep38Info.getCountryCodes());

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -264,7 +264,6 @@ internal class DefaultAssetServiceTest {
                   "country_codes": [
                     "USA"
                   ],
-                  "decimals": 4,
                   "sell_delivery_methods": [
                     {
                       "name": "WIRE",
@@ -330,8 +329,7 @@ internal class DefaultAssetServiceTest {
                   "enabled": true,
                   "exchangeable_assets": [
                     "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-                  ],
-                  "decimals": 7
+                  ]
                 }
               }
             ]

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -222,8 +222,8 @@ class Sep38ServiceTest {
     var gotResponse: GetPricesResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrices(fiatUSD, "100", null, null, null) }
     val wantResponse = GetPricesResponse()
-    wantResponse.addAsset(stellarJPYC, 7, "1")
-    wantResponse.addAsset(stellarUSDC, 7, "2")
+    wantResponse.addAsset(stellarJPYC, 2, "1")
+    wantResponse.addAsset(stellarUSDC, 2, "2")
     assertEquals(wantResponse, gotResponse)
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -260,8 +260,8 @@ class Sep38ServiceTest {
     var gotResponse: GetPricesResponse? = null
     assertDoesNotThrow { gotResponse = sep38Service.getPrices(fiatUSD, "100", "WIRE", null, "USA") }
     val wantResponse = GetPricesResponse()
-    wantResponse.addAsset(stellarJPYC, 7, "1.1")
-    wantResponse.addAsset(stellarUSDC, 7, "2.1")
+    wantResponse.addAsset(stellarJPYC, 2, "1.1")
+    wantResponse.addAsset(stellarUSDC, 2, "2.1")
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -286,7 +286,7 @@ class Sep38ServiceTest {
       gotResponse = sep38Service.getPrices(stellarUSDC, "100", null, "WIRE", null)
     }
     val wantResponse = GetPricesResponse()
-    wantResponse.addAsset(fiatUSD, 4, "1")
+    wantResponse.addAsset(fiatUSD, 2, "1")
     assertEquals(wantResponse, gotResponse)
   }
 
@@ -1082,7 +1082,7 @@ class Sep38ServiceTest {
         .sellAsset(fiatUSD)
         .sellAmount("100")
         .buyAsset(stellarUSDC)
-        .buyAmount("97.0873786")
+        .buyAmount("97.09")
         .fee(mockFee)
         .build()
     assertEquals(wantResponse, gotResponse)
@@ -1098,7 +1098,7 @@ class Sep38ServiceTest {
     assertEquals("100", savedQuote.sellAmount)
     assertEquals("WIRE", savedQuote.sellDeliveryMethod)
     assertEquals(stellarUSDC, savedQuote.buyAsset)
-    assertEquals("97.0873786", savedQuote.buyAmount)
+    assertEquals("97.09", savedQuote.buyAmount)
     assertEquals(PUBLIC_KEY, savedQuote.creatorAccountId)
     assertNotNull(savedQuote.createdAt)
     assertEquals(mockFee, savedQuote.fee)
@@ -1114,7 +1114,7 @@ class Sep38ServiceTest {
     wantEvent.quote.sellAsset = fiatUSD
     wantEvent.quote.sellAmount = "100"
     wantEvent.quote.buyAsset = stellarUSDC
-    wantEvent.quote.buyAmount = "97.0873786"
+    wantEvent.quote.buyAmount = "97.09"
     wantEvent.quote.expiresAt = tomorrow
     wantEvent.quote.price = "1.02"
     wantEvent.quote.totalPrice = "1.0300000004"

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -128,7 +128,6 @@ assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       country_codes:
         - USA
-      decimals: 4
       sell_delivery_methods:
         - name: WIRE
           description: Send USD directly to the Anchor's bank account.
@@ -180,4 +179,3 @@ assets:
       enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-      decimals: 7

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -323,7 +323,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
           "status": "incomplete",
           "amount_in": "10",
           "amount_in_asset": "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
-          "amount_out": "8.57",
+          "amount_out": "8.5714",
           "amount_out_asset": "iso4217:USD",
           "fee_details": {
             "total": "1.00",

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -322,7 +322,6 @@ assets_config: |
         - stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
       country_codes:
         - USA
-      decimals: 4
       sell_delivery_methods:
         - name: WIRE
           description: Send USD directly to the Anchor's bank account.
@@ -365,4 +364,3 @@ assets_config: |
       enabled: true
       exchangeable_assets:
         - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-      decimals: 7

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -206,7 +206,6 @@ assets:
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
       country_codes:
         - USA
-      decimals: 2
       sell_delivery_methods:
         - name: WIRE
           description: Send USD directly to the Anchor's bank account.
@@ -227,7 +226,6 @@ assets:
         - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
       country_codes:
         - CAN
-      decimals: 2
       sell_delivery_methods:
         - name: WIRE
           description: Send CAD directly to the Anchor's bank account.


### PR DESCRIPTION
### Description

Remove sep38 decimals from asset definition

### Context

This part of the asset config refactoring.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations
N/A
