### PR TITLE
Hold inline yaml support for Clients Config

### DIFF
--- a/platform/src/main/resources/config/anchor-client-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-client-default-values.yaml
@@ -9,8 +9,8 @@ items:
     type: custodial
     # The public keys used for SEP-10 authentication.
     signing_keys:
-      - GDADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
-      - GDBDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+      - GDADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+      - GDBDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
     # The URLs to which the service can send callbacks for different SEP types. Optional due to some wallets may opt
     # to poll instead, or may use polling first before implementing callbacks at a later stage.
     callbackUrls:

--- a/platform/src/main/resources/config/anchor-client-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-client-default-values.yaml
@@ -1,0 +1,39 @@
+#
+# This file contains the configuration for the client. The values used here are for testing purposes only.
+#
+items:
+  # Custodial Client
+    # The unique name identifying the client. This should be a recognizable name that represents the client entity.
+  - name: Client1
+    # The type of the client. It can be either `custodial` or `noncustodial`.
+    type: custodial
+    # The public keys used for SEP-10 authentication.
+    signing_keys:
+      - GDADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+      - GDBDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+    # The URLs to which the service can send callbacks for different SEP types. Optional due to some wallets may opt
+    # to poll instead, or may use polling first before implementing callbacks at a later stage.
+    callbackUrls:
+      sep6: https://example.com/callbacks/sep6
+      sep24: https://example.com/callbacks/sep24
+      sep31: https://example.com/callbacks/sep31
+      sep12: https://example.com/callbacks/sep12
+    # A boolean flag that, when set to true, allows any destination for deposits. Defaults to false,
+    # which enforces that the destination account must be listed in the destination_accounts list.
+    allowAnyDestination: false
+    # List of accounts allowed to be used for the deposit. By default, only SEP-10 authenticated account can be used to
+    # deposit funds into. If allows_any_destinations set to true, this configuration option is ignored.
+    destinationAccounts:
+
+  # Noncustodial Client
+  - name: Client2
+    type: noncustodial
+    # The domains associated with the client, used for verifying the client's identity.
+    domains:
+      - wallet-server:8092
+    callback_urls:
+      sep6: http://wallet-server:8092/callbacks/sep6
+      sep24: http://wallet-server:8092/callbacks/sep24
+      sep31: http://wallet-server:8092/callbacks/sep31
+      sep12: http://wallet-server:8092/callbacks/sep12
+

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -662,7 +662,7 @@ events:
 # Assets Configuration
 #########################
 # Assets are empty by default.
-# Accepts file reference (eg. 'file:assets.yaml') or in-line definition.
+# Accepts file reference (e.g. 'file:assets.yaml') or in-line definition.
 assets:
   # Option 1: Use a file to provide the configuration.
   # Specify the type as 'file' and provide the file path in the value field.
@@ -692,7 +692,7 @@ assets:
 ##############################
 # The list of clients for the Anchor server to safely communicate with the outside wallet servers or clients.
 # The list is empty if not defined.
-# You can either use a file to provide the configuration or define it inline.
+# You can either use a file to provide the configuration or define it inline. See anchor-client-default-values.yaml for examples.
 # Use only one of the following combinations:
 clients:
   # Option 1: Use a file to provide the configuration.

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -664,11 +664,25 @@ events:
 # Assets are empty by default.
 # Accepts file reference (eg. 'file:assets.yaml') or in-line definition.
 assets:
-  # The type of the assets definition.
-  # `type` can be one of the following:
-  #     `json`: value field contains the content of the assets in JSON format
-  #     `yaml`: value field contains the content of the assets in YAML format
-  #     `file`: value field contains the path to the assets file. The file name can be *.json or *.yaml.
+  # Option 1: Use a file to provide the configuration.
+  # Specify the type as 'file' and provide the file path in the value field.
+  # The file can only be in .yaml or .json format.
+  # The file content should follow the format used in Option 2.
+  #
+  # type: file
+  # value: path/to/file.yaml
+  #
+  # Option 2: Define assets inline using a YAML string.
+  # Specify the type as 'yaml', and define your clients value in YAML string format.
+  #
+  # type: yaml
+  # value: "items:\n  - id: stellar:USDC:<Issuer>\n  - id: iso4217:USD"
+  #
+  # Option 3: Define assets inline using a JSON string.
+  # Specify the type as 'json', and define your clients value in JSON string format.
+  #
+  # type: json
+  # value: "{\n  \"items\": [\n    {\n      \"id\": \"stellar:<Issuer>\"\n    },\n    {\n      \"id\": \"iso4217:USD5\"\n    }\n]\n}"
   type: json
   # The value of the assets definition depending on the `type` field.
   value:
@@ -688,34 +702,20 @@ clients:
   #
   # type: file
   # value: path/to/file.yaml
-
-  # Option 2: Define clients inline.
-  # Specify the type as 'inline', and define your clients directly under items.
   #
-  # type: inline
-  # items:
-  #   - name: client1
-  #     type: custodial
-  #     signingKeys:
-  #       - singingKey1
-  #       - singingKey2
-  #     callbackUrls:
-  #       sep6: http://client1/sep6/callbacks
-  #       sep24: http://client1/sep24/callbacks
-  #       sep31: http://client1/sep31/callbacks
-  #       sep12: http://client1/sep12/callbacks
-  #     allowAnyDestination: false
-  #     destinationAccounts:
-  #       - GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
-  #   - name: client2
-  #     type: noncustodial
-  #     domains:
-  #       - client2.com
-  #     callbackUrls:
-  #       sep6: http://client2/sep6/callbacks
-  type: inline
+  # Option 2: Define clients inline using a YAML string.
+  # Specify the type as 'yaml', and define your clients value in YAML string format.
+  #
+  # type: yaml
+  # value: "items:\n  - name: client1\n    type: custodial\n  - name: client2"
+  #
+  # Option 3: Define clients inline using a JSON string.
+  # Specify the type as 'json', and define your clients value in JSON string format.
+  #
+  # type: json
+  # value: "{\n  \"items\": [\n    {\n      \"name\": \"referenceCustodial\",\n      \"type\": \"custodial\"\n    }\n]\n}"
+  type: json
   value:
-  items:
 
 ################################
 # Data Configuration


### PR DESCRIPTION
### Description

Inline yaml support for Clients Config will be hold until further discussion with data points. The functionality will be kept in codebase but not advertised to user.

Update the config examples in `anchor-config-default-values.yaml` 

### Testing

- `./gradlew test`
