### PR TITLE
[ANCHOR-810] Fix the rate response validation bug when there is no fee

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -29,6 +29,7 @@ import org.stellar.anchor.api.exception.ServerErrorException;
 import org.stellar.anchor.api.platform.GetQuoteResponse;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.sep38.*;
+import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.Sep10Jwt;
@@ -252,10 +253,15 @@ public class Sep38Service {
             decimal(rate.getSellAmount(), pricePrecision),
             decimal(rate.getBuyAmount(), pricePrecision));
 
+    FeeDetails feeDetails =
+        (rate.getFee() != null)
+            ? rate.getFee()
+            : new FeeDetails("0", sellAssetName, new ArrayList<>());
+
     return GetPriceResponse.builder()
         .price(rate.getPrice())
         .totalPrice(totalPrice)
-        .fee(rate.getFee())
+        .fee(feeDetails)
         .sellAmount(rate.getSellAmount())
         .buyAmount(rate.getBuyAmount())
         .build();

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
@@ -110,10 +110,6 @@ public class RestRateIntegration implements RateIntegration {
     }
 
     if (request.getType() == GetRateRequest.Type.FIRM) {
-      if (Objects.requireNonNull(rate).getFee() == null) {
-        logErrorAndThrow(
-            "'rate.fee' is missing in the GET /rate response", ServerErrorException.class);
-      }
       if (rate.getId() == null || rate.getExpiresAt() == null) {
         logErrorAndThrow(
             "'rate.id' or 'rate.expires_at' are missing in the GET /rate response. When the rate is firm, these fields are required",

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
@@ -255,7 +255,7 @@ public class RestRateIntegration implements RateIntegration {
       // when fee is not present, check that sell_amount ~= price * buy_amount
       BigDecimal expected =
           new BigDecimal(rate.getPrice()).multiply(new BigDecimal(rate.getBuyAmount()));
-      if (withinRoundingError(
+      if (!withinRoundingError(
           new BigDecimal(rate.getSellAmount()), expected, sellAsset.getSignificantDecimals())) {
         logErrorAndThrow(
             format(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
@@ -120,7 +120,7 @@ class RestRateIntegrationTest {
     rateResponseWithFee.rate.expiresAt = Instant.now()
 
     // The fee is in sell_asset
-    rateResponseWithFee.rate.fee.asset = usdcAssetInfo.sep38AssetName
+    rateResponseWithFee.rate.fee.asset = usdAssetInfo.sep38AssetName
     rateResponseWithFee.rate.sellAmount = "100.00"
     rateResponseWithFee.rate.buyAmount = "94.29"
     rateIntegration.validateRateResponse(request, rateResponseWithFee)


### PR DESCRIPTION
### Description

- Fix the rate response validation bug when there is no fee
- The `withinRoundingError` call was missing the `!` operator when there is no `fee` in the rate response.

### Context

Bub fix.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

