### PR TITLE
[ANCHOR-797] Clean up `GET /rate` by ID

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/callback/GetRateRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/callback/GetRateRequest.java
@@ -47,8 +47,6 @@ public class GetRateRequest {
   @SerializedName("client_id")
   String clientId;
 
-  String id;
-
   public enum Type {
     @SerializedName("indicative")
     INDICATIVE("indicative"),

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
@@ -3,10 +3,6 @@ package org.stellar.anchor.platform.integrationtest
 import com.google.gson.Gson
 import io.mockk.every
 import io.mockk.mockk
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
@@ -151,69 +147,5 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
     }"""
         .trimMargin()
     JSONAssert.assertEquals(wantBody, org.stellar.anchor.platform.gson.toJson(result), true)
-  }
-
-  @Disabled // ANCHOR-797
-  @Test
-  fun testRate_firm() {
-    val rate =
-      rriClient
-        .getRate(
-          GetRateRequest.builder()
-            .type(GetRateRequest.Type.FIRM)
-            .sellAsset(FIAT_USD)
-            .buyAsset(STELLAR_USD)
-            .buyAmount("100")
-            .build()
-        )
-        .rate
-    Assertions.assertNotNull(rate)
-
-    // check if id is a valid UUID
-    val id = rate.id
-    Assertions.assertDoesNotThrow { UUID.fromString(id) }
-    var gotExpiresAt: Instant? = null
-    val expiresAtStr = rate.expiresAt!!.toString()
-    Assertions.assertDoesNotThrow {
-      gotExpiresAt = DateTimeFormatter.ISO_INSTANT.parse(rate.expiresAt!!.toString(), Instant::from)
-    }
-
-    val wantExpiresAt =
-      ZonedDateTime.now(ZoneId.of("UTC"))
-        .plusDays(1)
-        .withHour(12)
-        .withMinute(0)
-        .withSecond(0)
-        .withNano(0)
-    assertEquals(wantExpiresAt.toInstant(), gotExpiresAt)
-
-    // check if rate was persisted by getting the rate with ID
-    val gotQuote = rriClient.getRate(GetRateRequest.builder().id(rate.id).build())
-    assertEquals(rate.id, gotQuote.rate.id)
-    assertEquals("1.02", gotQuote.rate.price)
-
-    val wantBody =
-      """{
-      "rate":{
-        "id": "$id",
-        "price":"1.02",
-        "sell_amount": "103",
-        "buy_amount": "100",
-        "expires_at": "$expiresAtStr",
-        "fee": {
-          "total": "1.00",
-          "asset": "$FIAT_USD",
-          "details": [
-            {
-              "name": "Sell fee",
-              "description": "Fee related to selling the asset.",
-              "amount": "1.00"
-            }
-          ]
-        }
-      }
-    }"""
-        .trimMargin()
-    JSONAssert.assertEquals(wantBody, org.stellar.anchor.platform.gson.toJson(gotQuote), true)
   }
 }


### PR DESCRIPTION
### Description

The `id` field and `testRate_firm` was cleaned up in https://github.com/stellar/java-stellar-anchor-sdk/pull/1456 due to lack of usage

### Testing

- `./gradlew test`

