### PR TITLE
[ANCHOR-799] Remove `platform_server.auth`

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -20,6 +20,7 @@ import org.stellar.anchor.filter.PlatformAuthJwtFilter;
 import org.stellar.anchor.horizon.Horizon;
 import org.stellar.anchor.platform.apiclient.CustodyApiClient;
 import org.stellar.anchor.platform.condition.ConditionalOnAnySepsEnabled;
+import org.stellar.anchor.platform.config.PlatformApiConfig;
 import org.stellar.anchor.platform.config.PlatformServerConfig;
 import org.stellar.anchor.platform.config.PropertyCustodyConfig;
 import org.stellar.anchor.platform.data.JdbcTransactionPendingTrustRepo;
@@ -43,19 +44,20 @@ public class PlatformServerBeans {
    * @return Spring Filter Registration Bean
    */
   @Bean
-  public FilterRegistrationBean<Filter> platformTokenFilter(PlatformServerConfig config) {
+  public FilterRegistrationBean<Filter> platformTokenFilter(
+      PlatformServerConfig serverConfig, PlatformApiConfig apiConfig) {
     Filter anchorToPlatformFilter;
-    String authSecret = config.getSecretConfig().getPlatformAuthSecret();
-    switch (config.getAuth().getType()) {
+    String authSecret = serverConfig.getSecretConfig().getPlatformAuthSecret();
+    switch (apiConfig.getAuth().getType()) {
       case JWT:
         JwtService jwtService = JwtService.builder().platformAuthSecret(authSecret).build();
         anchorToPlatformFilter =
-            new PlatformAuthJwtFilter(jwtService, config.getAuth().getJwt().getHttpHeader());
+            new PlatformAuthJwtFilter(jwtService, apiConfig.getAuth().getJwt().getHttpHeader());
         break;
 
       case API_KEY:
         anchorToPlatformFilter =
-            new ApiKeyFilter(authSecret, config.getAuth().getApiKey().getHttpHeader());
+            new ApiKeyFilter(authSecret, apiConfig.getAuth().getApiKey().getHttpHeader());
         break;
 
       default:

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PlatformServerConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PlatformServerConfig.java
@@ -1,12 +1,10 @@
 package org.stellar.anchor.platform.config;
 
 import lombok.Data;
-import org.stellar.anchor.auth.AuthConfig;
 
 @Data
 public class PlatformServerConfig {
   String contextPath;
-  AuthConfig auth;
   PropertySecretConfig secretConfig;
 
   public PlatformServerConfig(PropertySecretConfig secretConfig) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -50,7 +50,7 @@ callback_api:
   base_url: http://localhost:8081
   # If the flag is set to false, all certificates from the business servers will be trusted.
   check_certificate: false
-  # Authentication config the anchor platform server to safely communicate with the business server.
+  # This defines the authentication method used by the Anchor Platform to authenticate with the business server.
   auth:
     #
     # `type` can be one of: none, api_key, jwt
@@ -63,18 +63,14 @@ callback_api:
     # If the type is api_key, the secret will be used as the api_key.
     # If the type is jwt, the secret will be used as the jwt shared secret.
     #
-    # Secrets are shared on both sides (anchor platform and business server) and are used in `Callback API`
-    # requests (`Platform->Anchor`) so the business server can ensure the party making the request is the anchor
-    # platform server
-    #
     type: none
-    # The JWT authentication config, if the type is set to `jwt`
+    # The JWT authentication config when the type is set to `jwt`
     jwt:
       # The JWT expiration in milliseconds
       expiration_milliseconds: 30000
       # The HTTP header name of the JWT token
       http_header: Authorization
-    # The API key config, if the type is set to `api_key`
+    # The API key config when if the type is set to `api_key`
     api_key:
       # The HTTP header name of the API key
       http_header: X-Api-Key
@@ -87,7 +83,8 @@ platform_api:
   # the `Platform API.yml` spec.
   #
   base_url: http://localhost:8085
-  # Authentication config the anchor platform server to safely communicate with the business server.
+  # This defines the authentication method that should be used by the business server to authenticate with the
+  # Platform API server.
   auth:
     #
     # `type` can be one of: none, api_key, jwt
@@ -100,19 +97,14 @@ platform_api:
     # If the type is api_key, the secret will be used as the api_key.
     # If the type is jwt, the secret will be used as the jwt shared secret.
     #
-    #
-    # Secrets are shared on both sides (anchor platform and business server) and are used in `Platform API`
-    # requests (`business server -> anchor platform`) so the anchor platform can ensure the party making the request
-    # is the business server.
-    #
     type: none
-    # The JWT authentication config, if the type is set to `jwt`
+    # The JWT authentication config when the type is set to `jwt`
     jwt:
       # The JWT expiration in milliseconds
       expiration_milliseconds: 30000
       # The HTTP header name of the JWT token
       http_header: Authorization
-    # The API key config, if the type is set to `api_key`
+    # The API key config when the type is set to `api_key`
     api_key:
       # The HTTP header name of the API key
       http_header: X-Api-Key
@@ -185,32 +177,6 @@ platform_server:
   # The management_server_port is the port used by Spring actuator.
   # https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html
   management_server_port: 9085
-  # Defines the authentication requirements of the platform_api requests. This is used to ensure that the requests
-  # must satisfy the authentication requirements before they can be processed.
-  #
-  # supported_values: none, api_key, jwt
-  #     none: no authentication is used
-  #     api_key: The authentication is done using an API key added to the HTTP request header.
-  #     jwt: The authentication is done using a JWT token added to the `Authorization` header. This token is
-  #          generated from the secret key.
-  #
-  # If the type is `api_key` or `jwt`, the secret must be set by the environment variable `secret.platform_api.auth_secret`.
-  # If the type is api_key, the secret will be used as the api_key.
-  # If the type is jwt, the secret will be used as the jwt shared secret.
-  #
-  # Secrets are shared on both sides (Platform and Anchor) and are used in Platform API requests (`Anchor->Platform`)
-  # so the Platform server can ensure the party making the request is the Anchor
-  auth:
-    # The authentication type
-    type: none
-    # The JWT authentication config, if the type is set to `jwt`
-    jwt:
-      # The JWT expiration in milliseconds
-      http_header: Authorization
-    # The API key config, if the type is set to `api_key`
-    api_key:
-      # The HTTP header name of the API key
-      http_header: X-Api-Key
 
 ######################
 # SEP Server Configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -67,9 +67,6 @@ platform_api.auth.jwt.expiration_milliseconds:
 platform_api.auth.jwt.http_header:
 platform_api.auth.type:
 platform_api.base_url:
-platform_server.auth.api_key.http_header:
-platform_server.auth.jwt.http_header:
-platform_server.auth.type:
 platform_server.context_path:
 platform_server.management_server_port:
 platform_server.port:

--- a/service-runner/src/main/resources/profiles/auth-apikey-platform/config.env
+++ b/service-runner/src/main/resources/profiles/auth-apikey-platform/config.env
@@ -1,1 +1,1 @@
-platform_server.auth.type=api_key
+platform_api.auth.type=api_key

--- a/service-runner/src/main/resources/profiles/auth-jwt-platform/config.env
+++ b/service-runner/src/main/resources/profiles/auth-jwt-platform/config.env
@@ -3,7 +3,7 @@ run.platform.server=true
 run.kotlin.reference.server=true
 
 # Platform Server
-platform_server.auth.type=JWT
+platform_api.auth.type=JWT
 platformToAnchorSecret=myPlatformToAnchorSecret1234567890
 anchorToPlatformSecret=myAnchorToPlatformSecret1234567890
 expirationMilliseconds=10000


### PR DESCRIPTION
### Description

This PR simplifies the authentication configuration for the Platform API. Currently, this is configured in two places.

- `platform_server.auth`: This enables request authentication on the Platform server.
- `platform_api.auth`: This determines what is included in the HTTP header of the Platform API requests.

We are removing `platform_server.auth` in favor of using `platform_api.auth` on the server and request building sides.

### Context

These configurations are intertwined, making it confusing to configure auth. They will always need to be set to the same thing, and we should not duplicate it.

### Testing

- `./gradlew test`

### Documentation

Stellar docs PR will be created

### Known limitations

N/A
