### PR TITLE
[ANCHOR-827] Fix the NPE when deliver events to callback API returns empty string

### DIFF
--- a/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/BaseApiClient.java
@@ -59,4 +59,8 @@ public abstract class BaseApiClient {
   }
 
   abstract AuthHeader<String, String> createAuthHeader() throws InvalidConfigException;
+
+  OkHttpClient getClient() {
+    return client;
+  }
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.apiclient;
 
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
 import com.google.gson.Gson;
 import java.io.IOException;
 import okhttp3.HttpUrl;
@@ -56,15 +58,19 @@ public class CallbackApiClient extends BaseApiClient {
       throws AnchorException, IOException {
     RequestBody requestBody = OkHttpUtil.buildJsonRequestBody(gson.toJson(sendEventRequest));
     Request request = getRequestBuilder().url(url).post(requestBody).build();
-    Response response = client.newCall(request).execute();
-    SendEventResponse sendEventResponse =
-        gson.fromJson(handleResponse(response), SendEventResponse.class);
-    sendEventResponse.setCode(response.code());
-    return sendEventResponse;
+    Response response = getClient().newCall(request).execute();
+    String responseText = handleResponse(response);
+
+    return new SendEventResponse(response.code(), isEmpty(responseText) ? "" : responseText);
   }
 
   @Override
   AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
     return authHelper.createCallbackAuthHeader();
+  }
+
+  public static void main(String[] args) {
+    SendEventResponse response = gson.fromJson("", SendEventResponse.class);
+    System.out.println(response);
   }
 }

--- a/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
+++ b/core/src/main/java/org/stellar/anchor/apiclient/CallbackApiClient.java
@@ -68,9 +68,4 @@ public class CallbackApiClient extends BaseApiClient {
   AuthHeader<String, String> createAuthHeader() throws InvalidConfigException {
     return authHelper.createCallbackAuthHeader();
   }
-
-  public static void main(String[] args) {
-    SendEventResponse response = gson.fromJson("", SendEventResponse.class);
-    System.out.println(response);
-  }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/apiclient/CallbackApiClientTests.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/apiclient/CallbackApiClientTests.kt
@@ -1,0 +1,52 @@
+package org.stellar.anchor.apiclient
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.stellar.anchor.api.callback.SendEventRequest
+import org.stellar.anchor.api.callback.SendEventRequestPayload
+import org.stellar.anchor.auth.AuthHelper
+
+class CallbackApiClientTests {
+  lateinit var callbackApiClient: CallbackApiClient
+  @MockK(relaxed = true) lateinit var mockAuthHelper: AuthHelper
+  @MockK(relaxed = true) lateinit var mockResponseBody: ResponseBody
+  @MockK(relaxed = true) lateinit var mockResponse: okhttp3.Response
+  @MockK(relaxed = true) lateinit var mockCall: okhttp3.Call
+  @MockK(relaxed = true) lateinit var mockClient: OkHttpClient
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    callbackApiClient = spyk(CallbackApiClient(mockAuthHelper, "https://api.example.com"))
+
+    every { callbackApiClient.client } returns mockClient
+    every { callbackApiClient.createAuthHeader() } returns null
+    every { mockClient.newCall(any()) } returns mockCall
+    every { mockCall.execute() } returns mockResponse
+    every { mockResponse.body } returns mockResponseBody
+    every { mockResponse.code } returns 200
+    every { mockResponseBody.string() } returns ""
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+    strings =
+      ["", "{}", "non-json message is here", "{'message':'success'}", "{'status':'success'}"]
+  )
+  fun `test valid responses`(responseBodyString: String) {
+    every { mockResponseBody.string() } returns responseBodyString
+
+    val sendEventResponse =
+      callbackApiClient.sendEvent(
+        SendEventRequest("id", "timestamp", "type", SendEventRequestPayload())
+      )
+    assert(sendEventResponse.code == 200)
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/event/CallbackApiEventHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/CallbackApiEventHandler.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.*;
 
 import java.io.IOException;
 import org.stellar.anchor.api.callback.SendEventRequest;
+import org.stellar.anchor.api.callback.SendEventResponse;
 import org.stellar.anchor.api.event.AnchorEvent;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.InvalidConfigException;
@@ -24,7 +25,13 @@ public class CallbackApiEventHandler extends EventHandler {
     traceF("Sending event to callback API: {}", event);
 
     try {
-      callbackApiClient.sendEvent(SendEventRequest.from(event));
+      SendEventResponse sendEventResponse =
+          callbackApiClient.sendEvent(SendEventRequest.from(event));
+      debugF(
+          "Event {} sent to callback API. code: {}, message: {}",
+          event.getId(),
+          sendEventResponse.getCode(),
+          sendEventResponse.getMessage());
       return true;
     } catch (AnchorException e) {
       errorEx("Failed to send event to callback API. Error code: {}", e);


### PR DESCRIPTION
### Description

Fix the NPE when deliver events to callback API returns empty string

### Context

Bug fixes.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A


