### PR TITLE
[ANCHOR-828] Improve PropertyQueueConfig validations

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
@@ -86,7 +86,7 @@ fun Route.testSep24(
 
             val stellarAsset = asset.replace("stellar:", "")
 
-            // Run deposit processing asynchronously
+            // Run withdrawal processing asynchronously
             CoroutineScope(Dispatchers.Default).launch {
               withdrawalService.processWithdrawal(transactionId, amountExpected, stellarAsset)
             }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyEventConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyEventConfig.java
@@ -1,11 +1,10 @@
 package org.stellar.anchor.platform.config;
 
-import static org.stellar.anchor.util.StringHelper.isEmpty;
+import static org.springframework.validation.ValidationUtils.*;
 
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
 import org.stellar.anchor.config.event.EventConfig;
 
@@ -26,107 +25,8 @@ public class PropertyEventConfig implements EventConfig, Validator {
       return;
     }
 
-    validateConfig(config, errors);
-
-    switch (config.getQueue().getType()) {
-      case MSK:
-        validateMsk(config, errors);
-        break;
-      case KAFKA:
-        validateKafka(config, errors);
-        break;
-      case SQS:
-        validateSqs(config, errors);
-        break;
-      default:
-        errors.rejectValue(
-            "queue.type",
-            "invalidType-publisher-type",
-            "events.publisher.type must be one of 'KAFKA', 'SQS', or MSK");
-    }
-  }
-
-  void validateConfig(EventConfig config, Errors errors) {
-    if (config.getQueue() == null)
-      errors.rejectValue(
-          "queue.type",
-          "publisher-type-empty",
-          "events.publisher.type is not defined. Please specify the type: KAFKA, SQS, or MSK");
-  }
-
-  void validateSqs(PropertyEventConfig config, Errors errors) {
-    if (isEmpty(config.getQueue().getSqs().awsRegion)) {
-      errors.rejectValue(
-          "queue.sqs.awsRegion",
-          "sqs-aws-region-empty",
-          "events.publisher.sqs.aws_region must be defined");
-    }
-  }
-
-  void validateKafka(PropertyEventConfig config, Errors errors) {
-    ValidationUtils.rejectIfEmptyOrWhitespace(
-        errors, "queue.kafka.bootstrapServer", "kafka-bootstrap-server-empty");
-    if (config.queue.kafka.retries < 0) {
-      errors.rejectValue(
-          "queue.kafka.retries",
-          "kafka-retries-invalid",
-          "events.queue.kafka.retries must be greater than 0");
-    }
-
-    if (config.queue.kafka.lingerMs < 0) {
-      errors.rejectValue(
-          "queue.kafka.lingerMs",
-          "kafka-linger-ms-invalid",
-          "events.queue.kafka.linger_ms must be greater than 0");
-    }
-
-    if (config.queue.kafka.batchSize < 0) {
-      errors.rejectValue(
-          "queue.kafka.batchSize",
-          "kafka-batch-size-invalid",
-          "events.queue.kafka.batch_size must be greater than 0");
-    }
-
-    if (config.queue.kafka.securityProtocol == null) {
-      errors.rejectValue(
-          "queue.kafka.securityProtocol",
-          "kafka-security-protocol-empty",
-          "events.queue.kafka.security_protocol must be defined");
-    }
-
-    if (config.queue.kafka.securityProtocol == KafkaConfig.SecurityProtocol.SASL_PLAINTEXT) {
-      if (config.queue.kafka.saslMechanism == null) {
-        errors.rejectValue(
-            "queue.kafka.saslMechanism",
-            "kafka-sasl-mechanism-empty",
-            "events.queue.kafka.sasl_mechanism must be defined");
-      }
-    }
-  }
-
-  void validateMsk(PropertyEventConfig config, Errors errors) {
-    ValidationUtils.rejectIfEmptyOrWhitespace(
-        errors, "queue.msk.bootstrapServer", "msk-bootstrap-server-empty");
-
-    if (config.queue.msk.retries < 0) {
-      errors.rejectValue(
-          "queue.msk.retries",
-          "msk-retries-invalid",
-          "events.publisher.msk.retries must be greater than 0");
-    }
-
-    if (config.queue.msk.lingerMs < 0) {
-      errors.rejectValue(
-          "queue.msk.lingerMs",
-          "msk-linger-ms-invalid",
-          "events.publisher.msk.linger_ms must be greater than 0");
-    }
-
-    if (config.queue.msk.batchSize < 0) {
-      errors.rejectValue(
-          "queue.msk.batchSize",
-          "msk-batch-size-invalid",
-          "events.publisher.msk.batch_size must be greater than 0");
+    if (config.getQueue() != null) {
+      queue.validate(config.getQueue(), errors);
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
@@ -1,5 +1,8 @@
 package org.stellar.anchor.platform.config;
 
+import static java.lang.String.*;
+import static org.springframework.validation.ValidationUtils.rejectIfEmptyOrWhitespace;
+import static org.stellar.anchor.platform.utils.ResourceHelper.*;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import java.io.IOException;
@@ -8,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.stellar.anchor.config.event.*;
-import org.stellar.anchor.platform.utils.ResourceHelper;
 
 @Data
 public class PropertyQueueConfig implements QueueConfig, Validator {
@@ -26,8 +28,7 @@ public class PropertyQueueConfig implements QueueConfig, Validator {
   public void validate(@NotNull Object target, @NotNull Errors errors) {
     PropertyQueueConfig config = (PropertyQueueConfig) target;
     if (config.getType() == null) {
-      errors.rejectValue(
-          "type",
+      errors.reject(
           "queue-type-empty",
           "queue.type is not defined. Please specify the type: KAFKA, SQS, or MSK");
       return;
@@ -44,109 +45,116 @@ public class PropertyQueueConfig implements QueueConfig, Validator {
         validateMsk(config, errors);
         break;
       default:
-        errors.rejectValue(
-            "type", "invalidType-queue-type", "queue.type must be one of 'KAFKA', 'SQS', or MSK");
+        errors.reject("invalidType-queue-type", "queue.type must be one of 'KAFKA', 'SQS', or MSK");
     }
   }
 
-  private void validateMsk(PropertyQueueConfig ignoredConfig, Errors errors) {
-    errors.rejectValue(
-        "msk",
-        "queue-type-msk-not-implemented",
-        "MSK is not implemented. Please specify a different queue type.");
-  }
-
-  private void validateSqs(PropertyQueueConfig ignoredConfig, Errors errors) {
-    errors.rejectValue(
-        "sqs",
-        "queue-type-sqs-not-implemented",
-        "SQS is not implemented. Please specify a different queue type.");
-  }
-
-  private void validateKafka(PropertyQueueConfig config, Errors errors) {
+  void validateKafka(PropertyQueueConfig config, Errors errors) {
     if (config.getKafka() == null) {
-      errors.rejectValue(
-          "kafka",
+      errors.reject(
           "queue-kafka-empty",
           "queue.kafka is not defined. Please specify the Kafka configuration.");
     } else {
       KafkaConfig kafkaConfig = config.getKafka();
-      if (kafkaConfig.getBootstrapServer() == null) {
-        errors.rejectValue(
-            "kafka.bootstrapServer",
+      if (isEmpty(kafkaConfig.getBootstrapServer())) {
+        errors.reject(
             "kafka-bootstrap-server-empty",
             "queue.kafka.bootstrap_server is not defined. Please specify the Kafka bootstrap server.");
       }
       if (kafkaConfig.getRetries() < 0) {
-        errors.rejectValue(
-            "kafka.retries",
-            "kafka-retries-invalid",
-            "queue.kafka.retries must be greater than or equal to 0.");
+        errors.reject(
+            "kafka-retries-invalid", "queue.kafka.retries must be greater than or equal to 0.");
       }
 
       if (kafkaConfig.getLingerMs() < 0) {
-        errors.rejectValue(
-            "kafka.lingerMs",
-            "kafka-linger-ms-invalid",
-            "queue.kafka.linger_ms must be greater than or equal to 0.");
+        errors.reject(
+            "kafka-linger-ms-invalid", "queue.kafka.linger_ms must be greater than or equal to 0.");
       }
 
       if (kafkaConfig.getBatchSize() <= 0) {
-        errors.rejectValue(
-            "kafka.batchSize",
-            "kafka-batch-size-invalid",
-            "queue.kafka.batch_size must be greater than 0.");
+        errors.reject("kafka-batch-size-invalid", "queue.kafka.batch_size must be greater than 0.");
       }
 
       if (kafkaConfig.getPollTimeoutSeconds() <= 0) {
-        errors.rejectValue(
-            "kafka.pollTimeoutSeconds",
+        errors.reject(
             "kafka-poll-timeout-seconds-invalid",
             "queue.kafka.poll_timeout_seconds must be greater than 0.");
       }
 
-      if (kafkaConfig.getSecurityProtocol() != null
-          && kafkaConfig.getSecurityProtocol() != KafkaConfig.SecurityProtocol.PLAINTEXT) {
+      if (kafkaConfig.getSecurityProtocol() == null) {
+        errors.reject(
+            "kafka-security-protocol-empty", "queue.kafka.security_protocol must be defined.");
+      }
+
+      if (kafkaConfig.getSecurityProtocol() == KafkaConfig.SecurityProtocol.SASL_PLAINTEXT) {
         if (kafkaConfig.getSaslMechanism() == null) {
-          errors.rejectValue(
-              "kafka.saslMechanism",
+          errors.reject(
               "kafka-sasl-mechanism-empty",
-              "queue.kafka.sasl_mechanism must be defined if securityProtocol is not PLAINTEXT.");
+              "events.queue.kafka.sasl_mechanism must be defined when securityProtocol is SASL_PLAINTEXT.");
         }
       }
 
       if (kafkaConfig.getSecurityProtocol() == KafkaConfig.SecurityProtocol.SASL_SSL) {
+        if (kafkaConfig.getSaslMechanism() == null) {
+          errors.reject(
+              "kafka-sasl-mechanism-empty",
+              "events.queue.kafka.sasl_mechanism must be defined when securityProtocol is SASL_SSL.");
+        }
         if (isEmpty(kafkaConfig.getSslKeystoreLocation())) {
-          errors.rejectValue(
-              "kafka.sslKeystoreLocation",
+          errors.reject(
               "kafka-ssl-keystore-location-empty",
               "queue.kafka.ssl_keystore_location must be defined if securityProtocol is SASL_SSL.");
         } else {
           try {
-            ResourceHelper.findFileThenResource(kafkaConfig.getSslKeystoreLocation());
+            findFileThenResource(kafkaConfig.getSslKeystoreLocation());
           } catch (IOException e) {
-            errors.rejectValue(
-                "kafka.sslKeystoreLocation",
+            errors.reject(
                 "kafka-ssl-keystore-location-not-found",
-                "queue.kafka.ssl_keystore_location file not found.");
+                format(
+                    "queue.kafka.ssl_keystore_location file \"%s\" not found.",
+                    kafkaConfig.getSslKeystoreLocation()));
           }
         }
         if (isEmpty(kafkaConfig.getSslTruststoreLocation())) {
-          errors.rejectValue(
-              "kafka.sslTruststoreLocation",
+          errors.reject(
               "kafka-ssl-truststore-location-empty",
               "queue.kafka.ssl_truststore_location must be defined if securityProtocol is SASL_SSL.");
         } else {
           try {
-            ResourceHelper.findFileThenResource(kafkaConfig.getSslTruststoreLocation());
+            findFileThenResource(kafkaConfig.getSslTruststoreLocation());
           } catch (IOException e) {
-            errors.rejectValue(
-                "kafka.sslTruststoreLocation",
+            errors.reject(
                 "kafka-ssl-truststore-location-not-found",
-                "queue.kafka.ssl_truststore_location file not found.");
+                format(
+                    "queue.kafka.ssl_truststore_location file \"%s\" not found.",
+                    kafkaConfig.getSslTruststoreLocation()));
           }
         }
       }
+    }
+  }
+
+  void validateMsk(PropertyQueueConfig config, Errors errors) {
+    rejectIfEmptyOrWhitespace(errors, "msk.bootstrapServer", "msk-bootstrap-server-empty");
+
+    if (config.msk.retries < 0) {
+      errors.reject("msk-retries-invalid", "events.publisher.msk.retries must be greater than 0");
+    }
+
+    if (config.msk.lingerMs < 0) {
+      errors.reject(
+          "msk-linger-ms-invalid", "events.publisher.msk.linger_ms must be greater than 0");
+    }
+
+    if (config.msk.batchSize < 0) {
+      errors.reject(
+          "msk-batch-size-invalid", "events.publisher.msk.batch_size must be greater than 0");
+    }
+  }
+
+  void validateSqs(PropertyQueueConfig config, Errors errors) {
+    if (isEmpty(config.getSqs().awsRegion)) {
+      errors.reject("sqs-aws-region-empty", "events.publisher.sqs.aws_region must be defined");
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
@@ -90,7 +90,7 @@ public class PropertyQueueConfig implements QueueConfig, Validator {
         if (kafkaConfig.getSaslMechanism() == null) {
           errors.reject(
               "kafka-sasl-mechanism-empty",
-              "events.queue.kafka.sasl_mechanism must be defined when securityProtocol is SASL_PLAINTEXT.");
+              "events.queue.kafka.sasl_mechanism must be defined when queue.kafka.security_protocol is SASL_PLAINTEXT.");
         }
       }
 
@@ -98,12 +98,12 @@ public class PropertyQueueConfig implements QueueConfig, Validator {
         if (kafkaConfig.getSaslMechanism() == null) {
           errors.reject(
               "kafka-sasl-mechanism-empty",
-              "events.queue.kafka.sasl_mechanism must be defined when securityProtocol is SASL_SSL.");
+              "events.queue.kafka.sasl_mechanism must be defined when queue.kafka.security_protocol is SASL_SSL.");
         }
         if (isEmpty(kafkaConfig.getSslKeystoreLocation())) {
           errors.reject(
               "kafka-ssl-keystore-location-empty",
-              "queue.kafka.ssl_keystore_location must be defined if securityProtocol is SASL_SSL.");
+              "queue.kafka.ssl_keystore_location must be defined if queue.kafka.security_protocol is SASL_SSL.");
         } else {
           try {
             findFileThenResource(kafkaConfig.getSslKeystoreLocation());

--- a/platform/src/main/java/org/stellar/anchor/platform/event/KafkaSession.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/KafkaSession.java
@@ -232,7 +232,7 @@ public class KafkaSession implements EventService.Session {
           props.put(SSL_KEY_PASSWORD_CONFIG, secret(SECRET_SSL_KEY_PASSWORD));
         if (!isEmpty(secret(SECRET_SSL_TRUSTSTORE_PASSWORD)))
           props.put(SSL_TRUSTSTORE_PASSWORD_CONFIG, secret(SECRET_SSL_TRUSTSTORE_PASSWORD));
-
+        break;
       case PLAINTEXT:
         break;
       default:

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/ResourceHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/ResourceHelper.java
@@ -14,10 +14,11 @@ public class ResourceHelper {
   }
 
   public static File findResourceFile(Resource resource) throws IOException {
-    if (resource.exists()) {
-      return resource.getFile();
-    }
-    throw new IOException("Resource not found: " + resource.getFilename());
+    File resourceFile = null;
+    if (resource.exists()) resourceFile = resource.getFile();
+    if (resourceFile == null || !resourceFile.isFile())
+      throw new IOException("Resource not found: " + resource.getFilename());
+    return resourceFile;
   }
 
   /**

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
@@ -13,13 +13,10 @@ import org.stellar.anchor.config.event.QueueConfig.QueueType.*
 
 class EventConfigTest {
   lateinit var config: PropertyEventConfig
-  //  lateinit var errors: Errors
 
   @BeforeEach
   fun setUp() {
     config = PropertyEventConfig()
-
-    //    errors = BindException(config, "config")
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
@@ -8,23 +8,23 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.validation.BindException
-import org.springframework.validation.Errors
 import org.springframework.validation.ValidationUtils
 import org.stellar.anchor.config.event.QueueConfig.QueueType.*
 
 class EventConfigTest {
   lateinit var config: PropertyEventConfig
-  lateinit var errors: Errors
+  //  lateinit var errors: Errors
 
   @BeforeEach
   fun setUp() {
     config = PropertyEventConfig()
 
-    errors = BindException(config, "config")
+    //    errors = BindException(config, "config")
   }
 
   @Test
   fun `test enabled flag`() {
+    val errors = BindException(config, "config")
     config.isEnabled = false
     ValidationUtils.invokeValidator(config, config, errors)
     assertEquals(0, errors.errorCount)
@@ -37,7 +37,8 @@ class EventConfigTest {
     config.queue = PropertyQueueConfig()
     config.queue.type = KAFKA
     config.queue.kafka = kafkaConfig
-    config.validateKafka(config, errors)
+    val errors = BindException(config.queue, "config")
+    config.queue.validateKafka(config.queue, errors)
     assertEquals(errorCount, errors.errorCount)
     if (errorCount > 0) {
       assertEquals(errorCode, errors.allErrors[0].code)
@@ -51,7 +52,8 @@ class EventConfigTest {
     config.queue = PropertyQueueConfig()
     config.queue.type = SQS
     config.queue.sqs = sqsConfig
-    config.validateSqs(config, errors)
+    val errors = BindException(config.queue, "config")
+    config.queue.validateSqs(config.queue, errors)
     assertEquals(errorCount, errors.errorCount)
     if (errorCount > 0) {
       assertEquals(errorCode, errors.allErrors[0].code)
@@ -65,7 +67,8 @@ class EventConfigTest {
     config.queue = PropertyQueueConfig()
     config.queue.type = MSK
     config.queue.msk = mskConfig
-    config.validateMsk(config, errors)
+    val errors = BindException(config.queue, "config")
+    config.queue.validateMsk(config.queue, errors)
     assertEquals(errorCount, errors.errorCount)
     if (errorCount > 0) {
       assertEquals(errorCode, errors.allErrors[0].code)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyQueueConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyQueueConfigTest.kt
@@ -33,16 +33,6 @@ class PropertyQueueConfigTest {
     errors = BindException(configs, "config")
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = ["MSK", "SQS"])
-  fun `test MSK and SQS not supported`(type: QueueType) {
-    configs.type = type
-    configs.validate(configs, errors)
-
-    Assertions.assertEquals(1, errors.errorCount)
-    assertErrorCode(errors, "queue-type-${type.toString().lowercase()}-not-implemented")
-  }
-
   @Test
   fun `test invalid null type`() {
     configs.type = null


### PR DESCRIPTION
### Description

- Merge `PropertyEventConfig` and `PropertyQueueConfig` validations
- Bug: `PropertyQueueConfig` validation was not invoked.
- Improved the error message.
- Improved the `ssl_keystore_location` and `ssl_truststore_location` checks

### Context

- Validation bug fixes
- Validation error message improvements.

### Testing

- `./gradlew test`

### Documentation

N/A

- Attach stellar-docs pull request, documenting new feature
- If it's an urgent feature request, please create a ticket and attach ticket number to this PR

### Known limitations

 N/A

