### PR TITLE
[ANCHOR-833] Improve RestRateIntegration fee handling

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/PlatformIntegrationHelper.java
@@ -19,7 +19,8 @@ public class PlatformIntegrationHelper {
     Request.Builder requestBuilder =
         new Request.Builder().header("Content-Type", "application/json");
 
-    AuthHeader<String, String> authHeader = authHelper.createCallbackAuthHeader();
+    AuthHeader<String, String> authHeader =
+        (authHelper == null) ? null : authHelper.createCallbackAuthHeader();
     return authHeader == null
         ? requestBuilder
         : requestBuilder.header(authHeader.getName(), authHeader.getValue());

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
@@ -94,6 +94,12 @@ public class RestRateIntegration implements RateIntegration {
       }
 
       validateRateResponse(request, getRateResponse);
+
+      // If the rate.fee is not present, we need to set it to 0 so that the fee always exists
+      if (getRateResponse.getRate().getFee() == null) {
+        getRateResponse.getRate().setFee(new FeeDetails("0", request.getSellAsset()));
+      }
+
       return getRateResponse;
     }
   }
@@ -160,6 +166,14 @@ public class RestRateIntegration implements RateIntegration {
             "'rate.fee.total' is missing or a negative number in the GET /rate response",
             ServerErrorException.class);
       }
+
+      // if fee.total is zero, fee.details must be empty or non-existent
+      if (fee.getTotal().equals("0") && fee.getDetails() != null && !fee.getDetails().isEmpty()) {
+        logErrorAndThrow(
+            "'rate.fee.details' must be empty or not-existent when 'rate.fee.total' is zero in the GET /rate response",
+            ServerErrorException.class);
+      }
+
       // fee.asset is a valid asset
       AssetInfo feeAsset = assetService.getAssetByName(fee.getAsset());
       if (fee.getAsset() == null || feeAsset == null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
@@ -221,18 +221,18 @@ public class RestRateIntegration implements RateIntegration {
         for (FeeDescription feeDescription : fee.getDetails()) {
           if (!isPositiveNumber(feeDescription.getAmount())) {
             logErrorAndThrow(
-                "'rate.fee.details[?].description.amount' is missing or not a positive number in the GET /rate response",
+                "'rate.fee.details[?].amount' is missing or not a positive number in the GET /rate response",
                 ServerErrorException.class);
           }
           if (!hasProperSignificantDecimals(
               feeDescription.getAmount(), feeAsset.getSignificantDecimals())) {
             logErrorAndThrow(
-                "'rate.fee.details[?].description.amount' has incorrect number of significant decimals in the GET /rate response",
+                "'rate.fee.details[?].amount' has incorrect number of significant decimals in the GET /rate response",
                 ServerErrorException.class);
           }
           if (feeDescription.getName() == null) {
             logErrorAndThrow(
-                "'rate.fee.details.description[?].name' is missing in the GET /rate response",
+                "'rate.fee.details[?].name' is missing in the GET /rate response",
                 ServerErrorException.class);
           }
           totalFee = totalFee.add(new BigDecimal(feeDescription.getAmount()));

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
@@ -230,6 +230,7 @@ class RestRateIntegrationTest {
   )
   fun `test fee total`(total: String?, hasError: Boolean, errorMessage: String) {
     rateResponseWithFee.rate.fee.total = total
+    rateResponseWithFee.rate.fee.details = null
     if (hasError) {
       val ex =
         assertThrows<ServerErrorException> {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
@@ -266,7 +266,7 @@ class RestRateIntegrationTest {
         rateIntegration.validateRateResponse(request, rateResponseWithFee)
       }
     assertEquals(
-      "'rate.fee.details.description[?].name' is missing in the GET /rate response",
+      "'rate.fee.details[?].name' is missing in the GET /rate response",
       ex.message,
     )
 
@@ -277,7 +277,7 @@ class RestRateIntegrationTest {
         rateIntegration.validateRateResponse(request, rateResponseWithFee)
       }
     assertEquals(
-      "'rate.fee.details[?].description.amount' is missing or not a positive number in the GET /rate response",
+      "'rate.fee.details[?].amount' is missing or not a positive number in the GET /rate response",
       ex.message,
     )
 
@@ -327,7 +327,7 @@ class RestRateIntegrationTest {
         rateIntegration.validateRateResponse(request, rateResponseWithFee)
       }
     assertEquals(
-      "'rate.fee.details[?].description.amount' has incorrect number of significant decimals in the GET /rate response",
+      "'rate.fee.details[?].amount' has incorrect number of significant decimals in the GET /rate response",
       ex.message,
     )
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/callback/RestRateIntegrationTest.kt
@@ -3,10 +3,12 @@ package org.stellar.anchor.platform.callback
 import com.google.gson.Gson
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import java.math.BigDecimal
 import java.time.Instant
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -29,7 +31,8 @@ class RestRateIntegrationTest {
   private val gson: Gson = GsonUtils.getInstance()
   private var usdAssetInfo = AssetInfo()
   private var usdcAssetInfo = AssetInfo()
-  private val rateIntegration = RestRateIntegration("/", null, null, gson, assetService)
+  private val rateIntegration =
+    RestRateIntegration("http://localhost/callback", null, null, gson, assetService)
   private var request: GetRateRequest = GetRateRequest()
   private var rateResponseWithFee: GetRateResponse = GetRateResponse()
   private var rateResponseWithoutFee: GetRateResponse = GetRateResponse()
@@ -110,6 +113,22 @@ class RestRateIntegrationTest {
       """,
         GetRateResponse::class.java,
       )
+  }
+
+  @Test
+  fun `test getRate when the callback response does not provide a fee`() {
+    val mockResponse = mockk<Response>()
+    val mockResponseBody = mockk<ResponseBody>()
+    val spyRateIntegration = spyk(rateIntegration)
+    every { mockResponse.body } returns mockResponseBody
+    every { mockResponse.code } returns 200
+    every { mockResponse.close() } returns Unit
+    every { mockResponseBody.string() } returns gson.toJson(rateResponseWithoutFee)
+    every { spyRateIntegration.invokeGetRateRequest(any(), any()) } returns mockResponse
+
+    val rate = spyRateIntegration.getRate(request)
+    assertNotNull(rate.rate.fee)
+    assertEquals(BigDecimal(rate.rate.fee.total).compareTo(BigDecimal.ZERO), 0)
   }
 
   @ParameterizedTest
@@ -378,6 +397,21 @@ class RestRateIntegrationTest {
     assertEquals(
       shouldAllow.toBoolean(),
       withinRoundingError(BigDecimal(amount), BigDecimal(expected), scale.toInt()),
+    )
+  }
+
+  @Test
+  fun `test 0 fee with details`() {
+    rateResponseWithFee.rate.fee.total = "0.00"
+    rateResponseWithFee.rate.fee.details[0].amount = "0.00"
+    rateResponseWithFee.rate.fee.details[1].amount = "0.00"
+    val ex =
+      assertThrows<ServerErrorException> {
+        rateIntegration.validateRateResponse(request, rateResponseWithFee)
+      }
+    assertEquals(
+      "'rate.fee.details' must be empty or not-existent when 'rate.fee.total' is zero in the GET /rate response",
+      ex.message
     )
   }
 }


### PR DESCRIPTION
### Description

- Fix the the inaccurate validation error message.
- Populate the fee object with total=0 if the business server does not provide one. This is to avoid SEP-6 and SEP-31 validation errors when the business server does not provide a `rate.fee` object.

### Context

Bug fixes.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

