### PR TITLE
[ANCHOR-834] Add transaction_id to callback customer API when request provides it

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12CustomerRequestBase.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12CustomerRequestBase.java
@@ -1,21 +1,19 @@
 package org.stellar.anchor.api.sep.sep12;
 
-public interface Sep12CustomerRequestBase {
-  String getId();
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
-  String getAccount();
+@Data
+@SuperBuilder
+public class Sep12CustomerRequestBase {
+  String id;
+  String account;
+  String memo;
 
-  void setAccount(String account);
+  @SerializedName("memo_type")
+  String memoType;
 
-  String getMemo();
-
-  void setMemo(String memo);
-
-  String getMemoType();
-
-  void setMemoType(String memoType);
-
-  String getTransactionId();
-
-  void setTransactionId(String transactionId);
+  @SerializedName("transaction_id")
+  String transactionId;
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12GetCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12GetCustomerRequest.java
@@ -1,8 +1,7 @@
 package org.stellar.anchor.api.sep.sep12;
 
-import com.google.gson.annotations.SerializedName;
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 /**
  * The request body of the GET /customer endpoint of SEP-12.
@@ -12,18 +11,8 @@ import lombok.Data;
  *     to SEP-12</a>
  */
 @Data
-@Builder
-public class Sep12GetCustomerRequest implements Sep12CustomerRequestBase {
-  String id;
-  String account;
-  String memo;
-
-  @SerializedName("transaction_id")
-  String transactionId;
-
-  @SerializedName("memo_type")
-  String memoType;
-
+@SuperBuilder
+public class Sep12GetCustomerRequest extends Sep12CustomerRequestBase {
   String type;
   String lang;
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12PutCustomerRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep12/Sep12PutCustomerRequest.java
@@ -1,8 +1,8 @@
 package org.stellar.anchor.api.sep.sep12;
 
 import com.google.gson.annotations.SerializedName;
-import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
 /**
  * The request body of the PUT /customer endpoint of SEP-12.
@@ -12,18 +12,8 @@ import lombok.Data;
  *     to SEP-12</a>
  */
 @Data
-@Builder
-public class Sep12PutCustomerRequest implements Sep12CustomerRequestBase {
-  String id;
-  String account;
-  String memo;
-
-  @SerializedName("transaction_id")
-  String transactionId;
-
-  @SerializedName("memo_type")
-  String memoType;
-
+@SuperBuilder
+public class Sep12PutCustomerRequest extends Sep12CustomerRequestBase {
   String type;
 
   @SerializedName("first_name")

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_12
 import static org.stellar.anchor.util.Log.infoF;
 import static org.stellar.anchor.util.MetricConstants.*;
 import static org.stellar.anchor.util.MetricConstants.SEP12_CUSTOMER;
+import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
@@ -18,6 +19,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.stellar.anchor.api.callback.*;
+import org.stellar.anchor.api.callback.GetCustomerRequest.GetCustomerRequestBuilder;
 import org.stellar.anchor.api.event.AnchorEvent;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.platform.GetTransactionResponse;
@@ -66,9 +68,25 @@ public class Sep12Service {
     Log.info("Sep12Service initialized.");
   }
 
+  public void populateRequestFromTransactionId(Sep12CustomerRequestBase requestBase)
+      throws SepNotFoundException {
+    if (requestBase.getTransactionId() != null) {
+      try {
+        GetTransactionResponse txn =
+            platformApiClient.getTransaction(requestBase.getTransactionId());
+        requestBase.setAccount(txn.getCustomers().getSender().getAccount());
+        requestBase.setMemo(txn.getCustomers().getSender().getMemo());
+      } catch (Exception e) {
+        throw new SepNotFoundException("The transaction specified does not exist");
+      }
+    }
+  }
+
   public Sep12GetCustomerResponse getCustomer(Sep10Jwt token, Sep12GetCustomerRequest request)
       throws AnchorException {
-    validateGetOrPutRequest(request, token);
+    populateRequestFromTransactionId(request);
+
+    validateRequest(request, token);
     if (request.getId() == null && request.getAccount() == null && token.getAccount() != null) {
       request.setAccount(token.getAccount());
     }
@@ -84,7 +102,9 @@ public class Sep12Service {
 
   public Sep12PutCustomerResponse putCustomer(Sep10Jwt token, Sep12PutCustomerRequest request)
       throws AnchorException {
-    validateGetOrPutRequest(request, token);
+    populateRequestFromTransactionId(request);
+
+    validateRequest(request, token);
 
     if (request.getAccount() == null && token.getAccount() != null) {
       request.setAccount(token.getAccount());
@@ -108,8 +128,13 @@ public class Sep12Service {
 
     PutCustomerResponse response =
         customerIntegration.putCustomer(PutCustomerRequest.from(request));
-    GetCustomerResponse updatedCustomer =
-        customerIntegration.getCustomer(GetCustomerRequest.builder().id(response.getId()).build());
+    GetCustomerRequestBuilder gcrBuilder = GetCustomerRequest.builder().id(response.getId());
+
+    // Forward the transaction_id to the getCustomer call if it was provided in the request.
+    if (!isEmpty(request.getTransactionId())) {
+      gcrBuilder.transactionId(request.getTransactionId());
+    }
+    GetCustomerResponse updatedCustomer = customerIntegration.getCustomer(gcrBuilder.build());
 
     // Only publish event if the customer was updated.
     eventSession.publish(
@@ -173,21 +198,10 @@ public class Sep12Service {
     sep12DeleteCustomerCounter.increment();
   }
 
-  void validateGetOrPutRequest(Sep12CustomerRequestBase requestBase, Sep10Jwt token)
-      throws SepException {
-    if (requestBase.getTransactionId() != null) {
-      try {
-        GetTransactionResponse txn =
-            platformApiClient.getTransaction(requestBase.getTransactionId());
-        requestBase.setAccount(txn.getCustomers().getSender().getAccount());
-        requestBase.setMemo(txn.getCustomers().getSender().getMemo());
-      } catch (Exception e) {
-        throw new SepNotAuthorizedException("The transaction specified does not exist");
-      }
-    }
-    validateRequestAndTokenAccounts(requestBase, token);
-    validateRequestAndTokenMemos(requestBase, token);
-    updateRequestMemoAndMemoType(requestBase, token);
+  void validateRequest(Sep12CustomerRequestBase request, Sep10Jwt token) throws SepException {
+    validateRequestAndTokenAccounts(request, token);
+    validateRequestAndTokenMemos(request, token);
+    updateRequestMemoAndMemoType(request, token);
   }
 
   void validateRequestAndTokenAccounts(

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -190,13 +190,11 @@ class Sep12ServiceTest {
         )
         .build()
     every { platformApiClient.getTransaction(any()) } returns transaction
-    val jwtToken = createJwtToken(TEST_ACCOUNT)
 
-    val putRequestBase =
-      Sep12PutCustomerRequest.builder().transactionId(TEST_TRANSACTION_ID).build()
-    assertDoesNotThrow { sep12Service.populateRequestFromTransactionId(putRequestBase) }
-    assertEquals(TEST_ACCOUNT, putRequestBase.account)
-    assertEquals(TEST_MEMO, putRequestBase.memo)
+    val putRequest = Sep12PutCustomerRequest.builder().transactionId(TEST_TRANSACTION_ID).build()
+    assertDoesNotThrow { sep12Service.populateRequestFromTransactionId(putRequest) }
+    assertEquals(TEST_ACCOUNT, putRequest.account)
+    assertEquals(TEST_MEMO, putRequest.memo)
 
     val getRequestBase =
       Sep12GetCustomerRequest.builder().transactionId(TEST_TRANSACTION_ID).build()


### PR DESCRIPTION
### Description

-  Add transaction_id to callback customer API when request provides it

### Context

- When the business server only implements the `GET /custemer` with `transaction_id`, it is necessary for the SEP-12 to pass the `transaction_id`.

### Testing

- `./gradlew test`
Added more tests to `Sep12ServiceTest.kt`

### Documentation

N/A

### Known limitations

N/A

