### PR TITLE
[ANCHOR-842] Add `rate.buy/sell_amount` must match `request.buy/sell_amount` validations

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
@@ -40,7 +40,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         SEP31,
       )
-    printResponse(price)
+    assertEquals(price.sellAmount, "100")
 
     // POST {SEP38}/quote
     printRequest("Calling POST /quote")
@@ -51,7 +51,7 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         SEP31,
       )
-    printResponse(postQuote)
+    assertEquals(postQuote.sellAmount, "100")
 
     // POST {SEP38}/quote with `expires_after`
     printRequest("Calling POST /quote")
@@ -64,7 +64,12 @@ class Sep38Tests : AbstractIntegrationTests(TestConfig()) {
         SEP31,
         expireAfter = expireAfter,
       )
-    printResponse(postQuote)
+    assertEquals(postQuote.sellAmount, "100")
+    assertEquals(postQuote.sellAsset, "iso4217:USD")
+    assertEquals(
+      postQuote.buyAsset,
+      "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    )
 
     // GET {SEP38}/quote/{id}
     printRequest("Calling GET /quote")

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/jwt/platform/AuthJwtPlatformTests.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.callback.GetFeeRequest
 import org.stellar.anchor.api.callback.GetRateRequest
+import org.stellar.anchor.api.callback.GetRateRequest.Type.INDICATIVE
 import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.apiclient.PlatformApiClient
 import org.stellar.anchor.asset.AssetService
@@ -106,7 +107,11 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         mockk<AssetService>(),
       )
     // Assert the request does not throw a 403.
-    assertThrows<BadRequestException> { rri.getRate(GetRateRequest.builder().build()) }
+    assertThrows<BadRequestException> {
+      rri.getRate(
+        GetRateRequest.builder().type(INDICATIVE).sellAsset("iso4217:USD").sellAmount("1.0").build()
+      )
+    }
   }
 
   @Test
@@ -157,7 +162,11 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         gson,
         mockk<AssetService>(),
       )
-    assertThrows<ServerErrorException> { badTokenClient.getRate(GetRateRequest.builder().build()) }
+    assertThrows<ServerErrorException> {
+      badTokenClient.getRate(
+        GetRateRequest.builder().type(INDICATIVE).sellAsset("iso4217:USD").sellAmount("1.0").build()
+      )
+    }
 
     val expiredTokenClient =
       RestRateIntegration(
@@ -168,7 +177,9 @@ internal class AuthJwtPlatformTests : AbstractAuthIntegrationTest() {
         mockk<AssetService>(),
       )
     assertThrows<ServerErrorException> {
-      expiredTokenClient.getRate(GetRateRequest.builder().build())
+      expiredTokenClient.getRate(
+        GetRateRequest.builder().type(INDICATIVE).sellAsset("iso4217:USD").sellAmount("1.0").build()
+      )
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/callback/RestRateIntegration.java
@@ -149,8 +149,9 @@ public class RestRateIntegration implements RateIntegration {
     }
 
     // sell_amount has a proper number of significant decimals
-    if (!hasProperSignificantDecimals(
-        Objects.requireNonNull(rate).getSellAmount(), sellAsset.getSignificantDecimals())) {
+    if (sellAsset != null
+        && !hasProperSignificantDecimals(
+            Objects.requireNonNull(rate).getSellAmount(), sellAsset.getSignificantDecimals())) {
       logErrorAndThrow(
           format(
               "'rate.sell_amount' (%s) has incorrect number of significant decimals (expected: %d) in the GET /rate response",
@@ -159,8 +160,9 @@ public class RestRateIntegration implements RateIntegration {
     }
 
     // buy_amount has a proper number of significant decimals
-    if (!hasProperSignificantDecimals(
-        Objects.requireNonNull(rate).getBuyAmount(), buyAsset.getSignificantDecimals())) {
+    if (buyAsset != null
+        && !hasProperSignificantDecimals(
+            Objects.requireNonNull(rate).getBuyAmount(), buyAsset.getSignificantDecimals())) {
       logErrorAndThrow(
           format(
               "'rate.buy_amount' (%s) has incorrect number of significant decimals (expected: %d) in the GET /rate response",
@@ -245,8 +247,12 @@ public class RestRateIntegration implements RateIntegration {
             new BigDecimal(rate.getSellAmount()), expected, sellAsset.getSignificantDecimals())) {
           logErrorAndThrow(
               format(
-                  "'rate.sell_amount' (%s) is not within the rounding error of the expected (%s[=%s*%s]) ('price * buy_amount + fee') in the GET /rate response",
-                  rate.getSellAmount(), expected, rate.getPrice(), rate.getBuyAmount()),
+                  "'rate.sell_amount' (%s) is not within the rounding error of the expected (%s[=%s*%s+%s]) ('price * buy_amount + fee') in the GET /rate response",
+                  rate.getSellAmount(),
+                  expected,
+                  rate.getPrice(),
+                  rate.getBuyAmount(),
+                  rate.getFee().getTotal()),
               ServerErrorException.class);
         }
       } else {
@@ -259,8 +265,12 @@ public class RestRateIntegration implements RateIntegration {
             new BigDecimal(rate.getSellAmount()), expected, sellAsset.getSignificantDecimals())) {
           logErrorAndThrow(
               format(
-                  "'rate.sell_amount' (%s) is not within the rounding error of the expected (%s=[%s*%s]) ('price * (buy_amount + fee)') in the GET /rate response",
-                  rate.getSellAmount(), expected, rate.getPrice(), rate.getBuyAmount()),
+                  "'rate.sell_amount' (%s) is not within the rounding error of the expected (%s=[%s*%s+%s]) ('price * (buy_amount + fee)') in the GET /rate response",
+                  rate.getSellAmount(),
+                  expected,
+                  rate.getPrice(),
+                  rate.getBuyAmount(),
+                  rate.getFee().getTotal()),
               ServerErrorException.class);
         }
       }


### PR DESCRIPTION
### Description

- Add `rate.buy/sell_amount` must match `request.buy/sell_amount` validations
- Improve rounding error messages.
- Add amount matching tests to Sep38Tests (integration tests)

### Context

Validation improvements.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations
N/A
