### PR TITLE
[ANCHOR-836] Add configuration `event.queue.kafka.ssl_cert_verify` 

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/KafkaConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/KafkaConfig.java
@@ -1,12 +1,14 @@
 package org.stellar.anchor.platform.config;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class KafkaConfig {
   /**
    * A comma-separated list of host:port pairs that are the addresses of one or more brokers in a

--- a/platform/src/main/java/org/stellar/anchor/platform/config/KafkaConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/KafkaConfig.java
@@ -38,6 +38,9 @@ public class KafkaConfig {
   /** The SASL mechanism used for authentication. */
   SaslMechanism saslMechanism;
 
+  /** The certificate verification flag. */
+  Boolean sslVerifyCert = Boolean.TRUE;
+
   /** the SSL keystore location. */
   String sslKeystoreLocation;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/config/MskConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/MskConfig.java
@@ -20,6 +20,7 @@ public class MskConfig extends KafkaConfig {
       int pollTimeoutSeconds,
       SecurityProtocol securityProtocol,
       SaslMechanism saslMechanism,
+      Boolean sslVerifyCert,
       String sslKeystoreLocation,
       String sslTruststoreLocation) {
 
@@ -32,6 +33,7 @@ public class MskConfig extends KafkaConfig {
         pollTimeoutSeconds,
         securityProtocol,
         saslMechanism,
+        sslVerifyCert,
         sslKeystoreLocation,
         sslTruststoreLocation);
     this.useIAM = useIAM;

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyQueueConfig.java
@@ -94,7 +94,8 @@ public class PropertyQueueConfig implements QueueConfig, Validator {
         }
       }
 
-      if (kafkaConfig.getSecurityProtocol() == KafkaConfig.SecurityProtocol.SASL_SSL) {
+      if (kafkaConfig.getSecurityProtocol() == KafkaConfig.SecurityProtocol.SASL_SSL
+          && kafkaConfig.getSslVerifyCert()) {
         if (kafkaConfig.getSaslMechanism() == null) {
           errors.reject(
               "kafka-sasl-mechanism-empty",

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/TrustAllSslEngineFactory.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/TrustAllSslEngineFactory.java
@@ -1,0 +1,79 @@
+package org.stellar.anchor.platform.utils;
+
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.kafka.common.security.auth.SslEngineFactory;
+
+public class TrustAllSslEngineFactory implements SslEngineFactory {
+
+  private final TrustManager TRUST_ALL_MANAGER =
+      new X509TrustManager() {
+
+        public X509Certificate[] getAcceptedIssuers() {
+          return null;
+        }
+
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+          // empty
+        }
+
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+          // empty
+        }
+      };
+
+  @Override
+  public SSLEngine createClientSslEngine(
+      String peerHost, int peerPort, String endpointIdentification) {
+    TrustManager[] trustManagers = new TrustManager[] {TRUST_ALL_MANAGER};
+    try {
+      SSLContext sslContext = SSLContext.getInstance("SSL");
+      sslContext.init(null, trustManagers, new SecureRandom());
+      SSLEngine sslEngine = sslContext.createSSLEngine(peerHost, peerPort);
+      sslEngine.setUseClientMode(true);
+      return sslEngine;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public SSLEngine createServerSslEngine(String peerHost, int peerPort) {
+    return null;
+  }
+
+  @Override
+  public boolean shouldBeRebuilt(Map<String, Object> nextConfigs) {
+    return false;
+  }
+
+  @Override
+  public Set<String> reconfigurableConfigs() {
+    return null;
+  }
+
+  @Override
+  public KeyStore keystore() {
+    return null;
+  }
+
+  @Override
+  public KeyStore truststore() {
+    return null;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {}
+}

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -702,6 +702,10 @@ events:
       # `sasl_mechanism` can be one of the following supported mechanisms:
       #   `PLAIN`: PLAIN SASL mechanism
       sasl_mechanism: PLAIN
+      # The configuration to enable SSL certificate verification. If true, the SSL certificate will be verified.
+      # For dev and test environments, it can be used to disable SSL certificate verification.
+      # For production environments, it is strongly recommended to set to true to avoid man-in-the-middle attach
+      ssl_verify_cert: true
       # The SSL keystore location. The file path to the keystore file (jks).
       ssl_keystore_location:
       # The SSL truststore location. The file path to the truststore file (jks).

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -704,7 +704,7 @@ events:
       sasl_mechanism: PLAIN
       # The configuration to enable SSL certificate verification. If true, the SSL certificate will be verified.
       # For dev and test environments, it can be used to disable SSL certificate verification.
-      # For production environments, it is strongly recommended to set to true to avoid man-in-the-middle attach
+      # For production environments, it is strongly recommended to set to true to avoid man-in-the-middle attacks.
       ssl_verify_cert: true
       # The SSL keystore location. The file path to the keystore file (jks).
       ssl_keystore_location:

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -35,6 +35,7 @@ events.queue.kafka.security_protocol:
 events.queue.kafka.sasl_mechanism:
 events.queue.kafka.username:
 events.queue.kafka.password:
+events.queue.kafka.ssl_verify_cert:
 events.queue.kafka.ssl_keystore_location:
 events.queue.kafka.ssl_truststore_location:
 events.queue.msk.batch_size:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/EventConfigTest.kt
@@ -88,6 +88,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -104,6 +105,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -120,6 +122,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -136,6 +139,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -152,6 +156,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -168,6 +173,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -175,7 +181,7 @@ class EventConfigTest {
         Arguments.of(
           1,
           "kafka-security-protocol-empty",
-          KafkaConfig("localhost:29092", "client_id", 1, 10, 500, 10, null, null, null, null),
+          KafkaConfig("localhost:29092", "client_id", 1, 10, 500, 10, null, null, true, null, null),
         ),
         Arguments.of(
           1,
@@ -189,6 +195,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.SASL_PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -222,6 +229,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -239,6 +247,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -256,6 +265,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -273,6 +283,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -290,6 +301,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),
@@ -307,6 +319,7 @@ class EventConfigTest {
             10,
             KafkaConfig.SecurityProtocol.PLAINTEXT,
             null,
+            true,
             null,
             null
           ),

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/KafkaSessionTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/KafkaSessionTest.kt
@@ -1,0 +1,107 @@
+package org.stellar.anchor.platform.event
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
+import java.util.*
+import org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG
+import org.apache.kafka.common.config.SaslConfigs.SASL_MECHANISM
+import org.apache.kafka.common.config.SslConfigs.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.context.ConfigurableApplicationContext
+import org.stellar.anchor.LockAndMockStatic
+import org.stellar.anchor.LockAndMockTest
+import org.stellar.anchor.event.EventService.EventQueue
+import org.stellar.anchor.platform.config.KafkaConfig
+import org.stellar.anchor.platform.config.KafkaConfig.SecurityProtocol.PLAINTEXT
+import org.stellar.anchor.platform.config.PropertySecretConfig.SECRET_EVENTS_QUEUE_KAFKA_PASSWORD
+import org.stellar.anchor.platform.config.PropertySecretConfig.SECRET_EVENTS_QUEUE_KAFKA_USERNAME
+import org.stellar.anchor.platform.configurator.SecretManager
+import org.stellar.anchor.platform.utils.TrustAllSslEngineFactory
+
+@ExtendWith(LockAndMockTest::class)
+class KafkaSessionTest {
+  companion object {
+    const val TEST_USERNAME = "user"
+    const val TEST_PASSWORD = "password"
+  }
+
+  @MockK(relaxed = true) lateinit var kafkaConfig: KafkaConfig
+  @MockK(relaxed = true) lateinit var eventQueue: EventQueue
+  @MockK(relaxed = true) lateinit var appContext: ConfigurableApplicationContext
+  private lateinit var kafkaSession: KafkaSession
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    kafkaSession = spyk(KafkaSession(kafkaConfig, "test", eventQueue))
+  }
+
+  @Test
+  fun `test security-protocol PLAINTEXT `() {
+    val properties = Properties()
+    every { kafkaConfig.securityProtocol } returns PLAINTEXT
+    kafkaSession.configureAuth(properties)
+    assert(properties.size == 0)
+  }
+
+  @Test
+  @LockAndMockStatic([SecretManager::class])
+  fun `test security-protocol SASL_PLAINTEXT `() {
+    val properties = Properties()
+    every { kafkaConfig.securityProtocol } returns KafkaConfig.SecurityProtocol.SASL_PLAINTEXT
+    every { kafkaConfig.saslMechanism } returns KafkaConfig.SaslMechanism.PLAIN
+
+    every { SecretManager.secret(SECRET_EVENTS_QUEUE_KAFKA_USERNAME) } returns TEST_USERNAME
+    every { SecretManager.secret(SECRET_EVENTS_QUEUE_KAFKA_PASSWORD) } returns TEST_PASSWORD
+
+    kafkaSession.configureAuth(properties)
+    assert(properties.size == 3)
+    assert(properties.getProperty("security.protocol") == "SASL_PLAINTEXT")
+    assert(properties.getProperty("sasl.mechanism") == "PLAIN")
+    assert(
+      properties.getProperty("sasl.jaas.config") ==
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$TEST_USERNAME\" password=\"$TEST_PASSWORD\";"
+    )
+  }
+
+  @LockAndMockStatic([SecretManager::class])
+  @ParameterizedTest
+  @ValueSource(booleans = [true, false])
+  fun `test security-protocol SASL_SSL `(sslVerifyCert: Boolean) {
+    val properties = Properties()
+    every { kafkaConfig.securityProtocol } returns KafkaConfig.SecurityProtocol.SASL_SSL
+    every { kafkaConfig.saslMechanism } returns KafkaConfig.SaslMechanism.PLAIN
+    every { kafkaConfig.sslVerifyCert } returns sslVerifyCert
+    kafkaSession.sslKeystoreLocation = "keystore.jks"
+    kafkaSession.sslTruststoreLocation = "truststore.jks"
+
+    every { SecretManager.secret(SECRET_EVENTS_QUEUE_KAFKA_USERNAME) } returns TEST_USERNAME
+    every { SecretManager.secret(SECRET_EVENTS_QUEUE_KAFKA_PASSWORD) } returns TEST_PASSWORD
+
+    kafkaSession.configureAuth(properties)
+
+    assert(properties.size == 5)
+    assert(
+      properties.getProperty("sasl.jaas.config") ==
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$TEST_USERNAME\" password=\"$TEST_PASSWORD\";"
+    )
+    assertEquals("SASL_SSL", properties.getProperty(SECURITY_PROTOCOL_CONFIG))
+    assertEquals("PLAIN", properties.getProperty(SASL_MECHANISM))
+
+    if (sslVerifyCert) {
+      assertEquals("keystore.jks", properties.getProperty(SSL_KEYSTORE_LOCATION_CONFIG))
+      assertEquals("truststore.jks", properties.getProperty(SSL_TRUSTSTORE_LOCATION_CONFIG))
+    } else {
+      assertEquals("", properties.getProperty(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG))
+      val cls = properties.get(SSL_ENGINE_FACTORY_CLASS_CONFIG) as Class<TrustAllSslEngineFactory>
+      assertEquals("org.stellar.anchor.platform.utils.TrustAllSslEngineFactory", cls.name)
+    }
+  }
+}

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=2.10.2R
+version=2.10.2

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=2.10.2
+version=2.10.2R


### PR DESCRIPTION
### Description

- Add configuration `event.queue.kafka.ssl_cert_verify` 

### Context

This flag is for dev and test environment where a valid CA may not be present. 

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

