### PR TITLE
Add reference server ingress

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/WebAuthContractTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/WebAuthContractTests.kt
@@ -70,7 +70,7 @@ class WebAuthContractTests {
       it.auth.forEach { entryXdr ->
         val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
         Log.info("Unsigned auth entry: ${entry.toXdrBase64()}")
-        val validUntilLedgerSeq = simulationResponse.latestLedger + 1
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 100
 
         val signer =
           object : Sep10CClient.Companion.Signer {

--- a/helm-charts/reference-server/templates/ingress.yaml
+++ b/helm-charts/reference-server/templates/ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name}}
+  namespace: {{ .Values.namespace }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-ingress
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- if .Values.ingress.tls.host }}
+    - hosts:
+        - {{ .Values.ingress.tls.host }}
+    {{- end }}
+    {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.rules }}
+      {{- if .Values.ingress.rules.host }}
+      host: {{ .Values.ingress.rules.host }}
+      {{- end }}
+      {{- end }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+                port:
+                  number: {{ .Values.services.ref.servicePort | default 8091 }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -29,3 +29,9 @@ services:
         limits:
           memory: 1Gi
           cpu: 1
+
+ingress:
+  name: ingress-anchor-platform-ref
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep10CClient.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep10CClient.kt
@@ -59,7 +59,7 @@ class Sep10CClient(
         }
       }
 
-    val validUntilLedgerSeq = rpc.latestLedger.sequence + 1.toLong()
+    val validUntilLedgerSeq = rpc.latestLedger.sequence + 100.toLong()
     val signedEntry =
       authorizeEntry(authorizedEntry, signer, validUntilLedgerSeq, Network(rpc.network.passphrase))
 


### PR DESCRIPTION
Adds an ingress resource for the reference server. The reference server needs to be publicly reachable for the SEP-24 flows.