### PR TITLE
[FIX] Allow the clients config value to be left unset

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -38,12 +38,6 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
 
   @Override
   public void validate(@NotNull Object target, @NotNull Errors errors) {
-    // If type is FILE, value must be defined
-    // if type is INLINE, items can be left empty as this not a required config
-    if (this.getType() == ClientsConfigType.FILE && isEmpty(this.getValue())) {
-      errors.reject("invalid-no-value-defined", "clients.value is empty. Please define.");
-    }
-
     // Parse the file and validate the contents
     try {
       parseConfigIntoItemList();
@@ -119,9 +113,10 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   }
 
   private void parseConfigIntoItemList() throws InvalidConfigException {
-    if (this.getType().equals(ClientsConfigType.INLINE)) {
+    if (this.getType().equals(ClientsConfigType.INLINE) || isEmpty(this.getValue())) {
       return;
     }
+
     // 1. Parse the content into a map with "items" as the key and a List<Object> as the value.
     Map<String, List<Object>> contentMap = new HashMap<>();
     switch (this.getType()) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/ClientsConfigTest.kt
@@ -1,9 +1,10 @@
 package org.stellar.anchor.platform.config
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.validation.BindException
 import org.springframework.validation.Errors
 import org.stellar.anchor.client.ClientConfig.CallbackUrls
@@ -161,5 +162,22 @@ class ClientsConfigTest {
     config.setItems(listOf(custodial))
     config.validate(config, errors)
     assertEquals(4, errors.errorCount)
+  }
+
+  @ParameterizedTest
+  @EnumSource(ClientsConfig.ClientsConfigType::class, names = ["FILE", "JSON", "YAML"])
+  fun `test empty value for file, json, yaml config type`(
+    configType: ClientsConfig.ClientsConfigType
+  ) {
+    config.setType(configType)
+    assertTrue(config.getValue().isNullOrEmpty())
+    assertDoesNotThrow { config.validate(config, errors) }
+  }
+
+  @Test
+  fun `test empty value for inline config type`() {
+    config.setType(ClientsConfig.ClientsConfigType.INLINE)
+    assertTrue { config.getItems().isEmpty() }
+    assertDoesNotThrow { config.validate(config, errors) }
   }
 }


### PR DESCRIPTION
### Description

Allow clients config to be left entire empty since this is not a required config

