### PR TITLE
[ANCHOR-843] Allow PENDING_EXTERNAL state even if funds are not received in `notify_offchain_funds_received` method

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOffchainFundsReceivedHandler.java
@@ -148,9 +148,7 @@ public class NotifyOffchainFundsReceivedHandler
         if (ImmutableSet.of(DEPOSIT, DEPOSIT_EXCHANGE).contains(Kind.from(txn6.getKind()))) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
           supportedStatuses.add(ON_HOLD);
-          if (areFundsReceived(txn6)) {
-            supportedStatuses.add(PENDING_EXTERNAL);
-          }
+          supportedStatuses.add(PENDING_EXTERNAL);
         }
         break;
       case SEP_24:
@@ -158,9 +156,7 @@ public class NotifyOffchainFundsReceivedHandler
         if (DEPOSIT == Kind.from(txn24.getKind())) {
           supportedStatuses.add(PENDING_USR_TRANSFER_START);
           supportedStatuses.add(ON_HOLD);
-          if (areFundsReceived(txn24)) {
-            supportedStatuses.add(PENDING_EXTERNAL);
-          }
+          supportedStatuses.add(PENDING_EXTERNAL);
         }
         break;
       default:


### PR DESCRIPTION
### Description

- Allow PENDING_EXTERNAL state even if funds are not received in `notify_offchain_funds_received` method

### Context

- Bug fix

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

