### PR TITLE
[SEP-24] Raise deposit base units

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/service/SepHelper.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/service/SepHelper.kt
@@ -162,7 +162,7 @@ class SepHelper(private val cfg: Config) {
         // amount=
         SCVal.Builder()
           .discriminant(SCValType.SCV_I128)
-          .i128(Scv.toInt128(amount.toBigInteger()).i128)
+          .i128(Scv.toInt128((amount.times(BigDecimal.valueOf(10000000))).toBigInteger()).i128)
           .build(),
       )
 


### PR DESCRIPTION
The default unit is in (10^e-7). This needs to be raised so we don't send units less than a cent.