### PR TITLE
[ANCHOR-858] Do not require keystore and truststore if ssl_cert_verify is false

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/event/CallbackApiEventHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/CallbackApiEventHandler.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import org.stellar.anchor.api.callback.SendEventRequest;
 import org.stellar.anchor.api.callback.SendEventResponse;
 import org.stellar.anchor.api.event.AnchorEvent;
-import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.apiclient.CallbackApiClient;
 import org.stellar.anchor.platform.config.CallbackApiConfig;
@@ -33,7 +32,7 @@ public class CallbackApiEventHandler extends EventHandler {
           sendEventResponse.getCode(),
           sendEventResponse.getMessage());
       return true;
-    } catch (AnchorException e) {
+    } catch (Exception e) {
       errorEx("Failed to send event to callback API. Error code: {}", e);
       return false;
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/event/KafkaSession.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/KafkaSession.java
@@ -269,6 +269,6 @@ public class KafkaSession implements EventService.Session {
   }
 
   String find(String sslKeystoreLocation) throws IOException {
-    return findFileThenResource(kafkaConfig.getSslKeystoreLocation()).getAbsolutePath();
+    return findFileThenResource(sslKeystoreLocation).getAbsolutePath();
   }
 }


### PR DESCRIPTION
### Description

Do not search for the `keystore` and `truststore` files if `ssl_cert_verify` is to `false`. 

When ` ssl_cert_verify` is set to `false`, the `KafkaSession` still look for the file and cause IOException. 

### Context

Bug fix.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

