### PR TITLE
Bump version to 2.11.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,7 +222,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "2.11.1"
+  version = "2.11.2"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v2.11.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.11.1)
+[![Docker](https://badgen.net/badge/Latest%20Release/v2.11.2/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=2.11.2)
 ![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=2.11.1
+version=2.11.2


### PR DESCRIPTION
### Description

- Bump version to `2.11.2`

### Context

- Pre-release

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

