### PR TITLE
[ANCHOR-809][SEP-31] Add funding_method to SEP-31

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/asset/Sep31Info.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/asset/Sep31Info.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.api.asset;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 
@@ -23,6 +24,8 @@ public class Sep31Info {
 
     @SerializedName("max_amount")
     Long maxAmount;
+
+    List<String> methods;
   }
 
   @Data

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31InfoResponse.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.api.sep.sep31;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 
@@ -30,5 +31,8 @@ public class Sep31InfoResponse {
 
     @SerializedName("max_amount")
     Long maxAmount;
+
+    @SerializedName("funding_methods")
+    List<String> fundingMethods;
   }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31PostTransactionRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep31/Sep31PostTransactionRequest.java
@@ -34,8 +34,12 @@ public class Sep31PostTransactionRequest {
   @SerializedName("receiver_id")
   String receiverId;
 
-  Sep31TxnFields fields;
+  @Deprecated Sep31TxnFields fields;
+
   String lang;
+
+  @SerializedName("funding_method")
+  String fundingMethod;
 
   @Data
   @AllArgsConstructor

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -570,11 +570,13 @@ public class Sep31Service {
       if (assetInfo.getSep31() != null && assetInfo.getSep31().getEnabled()) {
         boolean isQuotesSupported = assetInfo.getSep31().isQuotesSupported();
         boolean isQuotesRequired = assetInfo.getSep31().isQuotesRequired();
+        List<String> methods = assetInfo.getSep31().getReceive().getMethods();
         AssetResponse assetResponse = new AssetResponse();
         assetResponse.setQuotesSupported(isQuotesSupported);
         assetResponse.setQuotesRequired(isQuotesRequired);
         assetResponse.setMinAmount(assetInfo.getSep31().getReceive().getMinAmount());
         assetResponse.setMaxAmount(assetInfo.getSep31().getReceive().getMaxAmount());
+        assetResponse.setFundingMethods(methods);
         response.getReceive().put(assetInfo.getCode(), assetResponse);
       }
     }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -13,10 +13,7 @@ import static org.stellar.anchor.util.MathHelper.decimal;
 import static org.stellar.anchor.util.MathHelper.formatAmount;
 import static org.stellar.anchor.util.MetricConstants.SEP31_TRANSACTION_CREATED;
 import static org.stellar.anchor.util.MetricConstants.SEP31_TRANSACTION_PATCHED;
-import static org.stellar.anchor.util.SepHelper.amountEquals;
-import static org.stellar.anchor.util.SepHelper.generateSepTransactionId;
-import static org.stellar.anchor.util.SepHelper.validateAmount;
-import static org.stellar.anchor.util.SepHelper.validateAmountLimit;
+import static org.stellar.anchor.util.SepHelper.*;
 import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
 import io.micrometer.core.instrument.Counter;
@@ -126,6 +123,10 @@ public class Sep31Service {
         request.getAmount(),
         assetInfo.getSep31().getReceive().getMinAmount(),
         assetInfo.getSep31().getReceive().getMaxAmount());
+    validateFundingMethod(
+        assetInfo.getId(),
+        request.getFundingMethod(),
+        assetInfo.getSep31().getReceive().getMethods());
     validateLanguage(appConfig, request.getLang());
 
     /*
@@ -173,6 +174,7 @@ public class Sep31Service {
         new Sep31TransactionBuilder(sep31TransactionStore)
             .id(generateSepTransactionId())
             .status(SepTransactionStatus.PENDING_RECEIVER.getStatus())
+            .fundingMethod(request.getFundingMethod())
             .statusEta(null)
             .feeDetails(feeDetails)
             .startedAt(now)

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Transaction.java
@@ -108,6 +108,10 @@ public interface Sep31Transaction extends SepTransaction {
 
   void setCreator(StellarId creator);
 
+  String getFundingMethod();
+
+  void setFundingMethod(String fundingMethod);
+
   default Customers getCustomers() {
     return new Customers(
         StellarId.builder().id(getSenderId()).build(),

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31TransactionBuilder.java
@@ -171,6 +171,11 @@ public class Sep31TransactionBuilder {
     return this;
   }
 
+  public Sep31TransactionBuilder fundingMethod(String fundingMethod) {
+    txn.setFundingMethod(fundingMethod);
+    return this;
+  }
+
   public Sep31Transaction build() {
     return txn;
   }

--- a/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
@@ -86,7 +86,7 @@ public class AssetValidator {
                 "if quotes_required is true, quotes_supported must also be true for asset: %s",
                 assetId));
 
-      // Validate SEP-31 `receive.min_amount` and `receive.max_amount` fields
+      // Validate SEP-31 `receive.min_amount`, `receive.max_amount`, and `receive.methods` fields
       ReceiveOperation receiveInfo = sep31Info.getReceive();
       if (receiveInfo != null) {
         if (receiveInfo.getMinAmount() < 0)
@@ -100,6 +100,19 @@ public class AssetValidator {
               format(
                   "Invalid max_amount defined for asset %s. sep31.receive.max_amount = %s",
                   assetId, receiveInfo.getMaxAmount()));
+        // Check for empty and duplicate receive methods
+        if (isEmpty(receiveInfo.getMethods())) {
+          throw new InvalidConfigException(
+              format("No receive methods defined for asset %s", assetId));
+        }
+        Set<String> existingReceiveMethods = new HashSet<>();
+        for (String method : receiveInfo.getMethods()) {
+          if (!existingReceiveMethods.add(method)) {
+            throw new InvalidConfigException(
+                format(
+                    "Duplicate receive method defined for asset %s. Type = %s", assetId, method));
+          }
+        }
       }
     }
   }

--- a/core/src/main/java/org/stellar/anchor/util/SepHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepHelper.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 import static org.stellar.anchor.util.MathHelper.decimal;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.stellar.anchor.api.exception.AnchorException;
@@ -134,6 +135,28 @@ public class SepHelper {
       if (sAmount.compareTo(bdMax) > 0) {
         throw new BadRequestException(String.format("%samount exceeds max limit", messagePrefix));
       }
+    }
+  }
+
+  /**
+   * Validates whether a specified funding method is supported for a given asset.
+   *
+   * @param assetID the unique id of the asset being validated.
+   * @param method the funding method to validate.
+   * @param supportedMethods a list of funding methods supported for the asset.
+   * @throws BadRequestException if the provided funding method is not in the list of supported
+   *     methods.
+   */
+  public static void validateFundingMethod(
+      String assetID, String method, List<String> supportedMethods) throws AnchorException {
+    if (StringHelper.isEmpty(method)) {
+      throw new BadRequestException("funding_method cannot be empty");
+    }
+    if (!supportedMethods.contains(method)) {
+      throw new BadRequestException(
+          String.format(
+              "invalid funding method %s for asset %s, supported types are %s",
+              method, assetID, supportedMethods));
     }
   }
 

--- a/core/src/main/java/org/stellar/anchor/util/SepHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepHelper.java
@@ -148,7 +148,7 @@ public class SepHelper {
    *     methods.
    */
   public static void validateFundingMethod(
-      String assetID, String method, List<String> supportedMethods) throws AnchorException {
+      String assetID, String method, List<String> supportedMethods) throws BadRequestException {
     if (StringHelper.isEmpty(method)) {
       throw new BadRequestException("funding_method cannot be empty");
     }

--- a/core/src/main/java/org/stellar/anchor/util/TransactionMapper.java
+++ b/core/src/main/java/org/stellar/anchor/util/TransactionMapper.java
@@ -95,6 +95,7 @@ public class TransactionMapper {
         .sep(PlatformTransactionData.Sep.SEP_31)
         .kind(RECEIVE)
         .status(SepTransactionStatus.from(txn.getStatus()))
+        .type(txn.getFundingMethod())
         .amountExpected(new Amount(txn.getAmountExpected(), txn.getAmountInAsset()))
         .amountIn(new Amount(txn.getAmountIn(), txn.getAmountInAsset()))
         .amountOut(new Amount(txn.getAmountOut(), txn.getAmountOutAsset()))

--- a/core/src/main/resources/config/anchor-asset-default-values.yaml
+++ b/core/src/main/resources/config/anchor-asset-default-values.yaml
@@ -97,6 +97,11 @@ items:
         # the maximum amount that the user can receive.
         min_amount: 0
         max_amount: 1000
+        # The list of methods supported by the anchor to receive assets.
+        # Example:
+        #   - SEPA
+        #   - SWIFT
+        methods: []
 
     # The configuration for the SEP-38 transactions.
     sep38:
@@ -122,6 +127,7 @@ items:
         # the maximum amount that the user can receive.
         min_amount: 0
         max_amount:
+        methods: []
       # `true` if the asset supports quotesinforesponse.java.
       quotes_supported: true
       # `true` if the asset requires quotes.

--- a/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
+++ b/core/src/test/java/org/stellar/anchor/sep31/PojoSep31Transaction.java
@@ -45,6 +45,7 @@ public class PojoSep31Transaction implements Sep31Transaction {
   String receiverId;
   String senderId;
   StellarId creator;
+  String fundingMethod;
   List<FeeDescription> feeDetailsList;
 
   public void setFeeDetails(FeeDetails feeDetails) {

--- a/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/asset/DefaultAssetServiceTest.kt
@@ -87,6 +87,20 @@ internal class DefaultAssetServiceTest {
   }
 
   @Test
+  fun `test invalid config with duplicate receive type when sep-31 enabled`() {
+    assertThrows<InvalidConfigException> {
+      DefaultAssetService.fromYamlResource("test_assets_duplicate_receive_methods.yaml")
+    }
+  }
+
+  @Test
+  fun `test invalid config with missing receive type when sep-31 enabled`() {
+    assertThrows<InvalidConfigException> {
+      DefaultAssetService.fromYamlResource("test_assets_missing_receive_method.yaml")
+    }
+  }
+
+  @Test
   fun `test trailing comma in JSON does not result in null element`() {
     val assetsService = DefaultAssetService.fromJsonContent(trailingCommaInAssets)
     assert(assetsService.stellarAssets.all { it != null })
@@ -146,7 +160,11 @@ internal class DefaultAssetServiceTest {
                   "enabled": true,
                   "receive": {
                     "min_amount": 1,
-                    "max_amount": 1000000
+                    "max_amount": 1000000,
+                    "methods": [
+                      "SEPA",
+                      "SWIFT"
+                    ]
                   },
                   "quotes_supported": true,
                   "quotes_required": true
@@ -183,7 +201,11 @@ internal class DefaultAssetServiceTest {
                   "enabled": true,
                   "receive": {
                     "min_amount": 1,
-                    "max_amount": 1000000
+                    "max_amount": 1000000,
+                    "methods": [
+                      "SEPA",
+                      "SWIFT"
+                    ]
                   },
                   "quotes_supported": true,
                   "quotes_required": true
@@ -203,7 +225,11 @@ internal class DefaultAssetServiceTest {
                   "enabled": false,
                   "receive": {
                     "min_amount": 1,
-                    "max_amount": 1000000
+                    "max_amount": 1000000,
+                    "methods": [
+                      "SEPA",
+                      "SWIFT"
+                    ]
                   }
                 },
                 "sep38": {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -100,30 +100,14 @@ class Sep31ServiceTest {
                 "enabled": true,
                 "receive": {
                   "min_amount": 1,
-                  "max_amount": 1000000
+                  "max_amount": 1000000,
+                  "methods": [
+                    "SEPA",
+                    "SWIFT"
+                  ]
                 },
                 "quotes_supported": true,
-                "quotes_required": true,
-                "fields": {
-                  "transaction": {
-                    "receiver_routing_number": {
-                      "description": "routing number of the destination bank account",
-                      "optional": false
-                    },
-                    "receiver_account_number": {
-                      "description": "bank account number of the destination",
-                      "optional": false
-                    },
-                    "type": {
-                      "description": "type of deposit to make",
-                      "choices": [
-                        "SEPA",
-                        "SWIFT"
-                      ],
-                      "optional": false
-                    }
-                  }
-                }
+                "quotes_required": true
               },
               "sep38": {
                 "enabled": true,
@@ -809,13 +793,13 @@ class Sep31ServiceTest {
 
   private val jpycJson =
     """
-    {"enabled":true,"quotes_supported":true,"quotes_required":true,"min_amount":1,"max_amount":1000000,"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false},"type":{"description":"type of deposit to make","choices":["ACH","SWIFT","WIRE"],"optional":false}}}}
-  """
+      {"enabled":true,"quotes_supported":true,"quotes_required":true,"min_amount":1,"max_amount":1000000,"funding_methods":["SEPA","SWIFT"]}
+    """
       .trimIndent()
 
   private val usdcJson =
     """
-    {"enabled":true,"quotes_supported":true,"quotes_required":true,"min_amount":1,"max_amount":1000000,"fields":{"transaction":{"receiver_routing_number":{"description":"routing number of the destination bank account","optional":false},"receiver_account_number":{"description":"bank account number of the destination","optional":false}, "receiver_phone_number": {"description": "phone number of the receiver", "optional": true},"type":{"description":"type of deposit to make","choices":["SEPA","SWIFT"],"optional":false}}}}
+    {"enabled":true,"quotes_supported":true,"quotes_required":true,"min_amount":1,"max_amount":1000000,"funding_methods":["SEPA","SWIFT"]}
   """
       .trimIndent()
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -523,10 +523,14 @@ class Sep31ServiceTest {
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("amount should be positive", ex.message)
 
-    // ----- QUOTE_ID IS USED ⬇️ -----
     postTxRequest.lang = "en"
     postTxRequest.amount = "1"
+    ex = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
+    assertInstanceOf(BadRequestException::class.java, ex)
+    assertEquals("funding_method cannot be empty", ex.message)
 
+    postTxRequest.fundingMethod = "SEPA"
+    // ----- QUOTE_ID IS USED ⬇️ -----
     // not found quote_id
     val fields =
       hashMapOf(
@@ -608,6 +612,7 @@ class Sep31ServiceTest {
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
     postTxRequest.quoteId = "my_quote_id"
+    postTxRequest.fundingMethod = "SEPA"
     postTxRequest.fields =
       Sep31TxnFields(
         hashMapOf(
@@ -664,6 +669,7 @@ class Sep31ServiceTest {
       """{
       "id": "$txId",
       "status": "pending_receiver",
+      "fundingMethod": "SEPA",
       "amountFee": "10",
       "amountFeeAsset": "$stellarUSDC",
       "startedAt": "$txStartedAt",
@@ -707,6 +713,7 @@ class Sep31ServiceTest {
     postTxRequest.assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
+    postTxRequest.fundingMethod = "SEPA"
     postTxRequest.fields =
       Sep31TxnFields(
         hashMapOf(
@@ -764,6 +771,7 @@ class Sep31ServiceTest {
     postTxRequest.assetIssuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
     postTxRequest.senderId = senderId
     postTxRequest.receiverId = receiverId
+    postTxRequest.fundingMethod = "SEPA"
     postTxRequest.fields =
       Sep31TxnFields(
         hashMapOf(

--- a/core/src/test/resources/test_assets.json
+++ b/core/src/test/resources/test_assets.json
@@ -50,7 +50,11 @@
         "enabled": true,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": true,
         "quotes_required": true,
@@ -117,30 +121,14 @@
         "enabled": true,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": true,
-        "quotes_required": true,
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account",
-              "optional": false
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination",
-              "optional": false
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "ACH",
-                "SWIFT",
-                "WIRE"
-              ]
-            }
-          }
-        }
+        "quotes_required": true
       },
       "sep38": {
         "enabled": true,
@@ -157,7 +145,11 @@
         "enabled": false,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+              "SEPA",
+              "SWIFT"
+          ]
         }
       },
       "sep38": {
@@ -215,27 +207,14 @@
         "enabled": true,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": true,
-        "quotes_required": true,
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account"
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination"
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ]
-            }
-          }
-        }
+        "quotes_required": true
       },
       "sep38": {
         "enabled": true,

--- a/core/src/test/resources/test_assets.json.quotes_not_supported
+++ b/core/src/test/resources/test_assets.json.quotes_not_supported
@@ -34,7 +34,11 @@
         "enabled": true,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": false,
         "quotes_required": false,

--- a/core/src/test/resources/test_assets.yaml
+++ b/core/src/test/resources/test_assets.yaml
@@ -39,24 +39,11 @@ items:
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: true
-      fields:
-        transaction:
-          receiver_routing_number:
-            description: routing number of the destination bank account
-            optional: false
-          receiver_account_number:
-            description: bank account number of the destination
-            optional: false
-          receiver_phone_number:
-            description: phone number of the receiver
-            optional: true
-          type:
-            description: type of deposit to make
-            choices:
-              - SEPA
-              - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:
@@ -87,22 +74,11 @@ items:
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: true
-      fields:
-        transaction:
-          receiver_routing_number:
-            description: routing number of the destination bank account
-            optional: false
-          receiver_account_number:
-            description: bank account number of the destination
-            optional: false
-          type:
-            description: type of deposit to make
-            choices:
-              - ACH
-              - SWIFT
-              - WIRE
     sep38:
       enabled: true
       exchangeable_assets:
@@ -115,6 +91,9 @@ items:
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:
@@ -153,6 +132,9 @@ items:
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: true
       # todo assume this is right for now

--- a/core/src/test/resources/test_assets_duplicate_receive_methods.yaml
+++ b/core/src/test/resources/test_assets_duplicate_receive_methods.yaml
@@ -1,0 +1,23 @@
+items:
+  - id: stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+    distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
+    significant_decimals: 2
+    sep6:
+      enabled: false
+    sep24:
+      enabled: false
+    sep31:
+      enabled: true
+      receive:
+        min_amount: 1
+        max_amount: 1000000
+        methods:
+          - SEPA
+          - SEPA
+      quotes_supported: true
+      quotes_required: true
+    sep38:
+      enabled: true
+      exchangeable_assets:
+        - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        - iso4217:USD

--- a/core/src/test/resources/test_assets_missing_receive_method.yaml
+++ b/core/src/test/resources/test_assets_missing_receive_method.yaml
@@ -1,0 +1,20 @@
+items:
+  - id: stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+    distribution_account: GA7FYRB5VREZKOBIIKHG5AVTPFGWUBPOBF7LTYG4GTMFVIOOD2DWAL7I
+    significant_decimals: 2
+    sep6:
+      enabled: false
+    sep24:
+      enabled: false
+    sep31:
+      enabled: true
+      receive:
+        min_amount: 1
+        max_amount: 1000000
+      quotes_supported: true
+      quotes_required: true
+    sep38:
+      enabled: true
+      exchangeable_assets:
+        - stellar:JPYC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        - iso4217:USD

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
@@ -116,6 +116,7 @@ open class Sep31End2EndTests : AbstractIntegrationTests(TestConfig()) {
     txnRequest.senderId = senderCustomer!!.id
     txnRequest.receiverId = receiverCustomer!!.id
     txnRequest.quoteId = quote.id
+    txnRequest.fundingMethod = "SWIFT"
     val postTxResponse = sep31Client.postTransaction(txnRequest)
     info("POST /transaction initiated ${postTxResponse.id}")
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformApiTests.kt
@@ -6566,6 +6566,7 @@ private val SEP_31_RECEIVE_FLOW_REQUEST =
   "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
   "receiver_id": "%RECEIVER_ID%",
   "sender_id": "%SENDER_ID%",
+  "funding_method": "SEPA",
   "fields": {
     "transaction": {
       "receiver_routing_number": "r0123",

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -421,15 +421,16 @@ private const val expectedSep31Info =
         "quotes_supported": true,
         "quotes_required": false,
         "min_amount": 0,
-        "max_amount": 1000000
+        "max_amount": 1000000,
+        "funding_methods": ["SEPA","SWIFT"]
       },
       "USDC": {
         "enabled": true,
         "quotes_supported": true,
         "quotes_required": false,
         "min_amount": 0,
-        "max_amount": 10
-        }
+        "max_amount": 10,
+        "funding_methods": ["SEPA","SWIFT"]
       }
     }
   }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31Tests.kt
@@ -386,6 +386,7 @@ private const val postTxnRequest =
     "asset_issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
     "receiver_id": "MOCK_RECEIVER_ID",
     "sender_id": "MOCK_SENDER_ID",
+    "funding_method": "SEPA",
     "fields": {
         "transaction": {
             "receiver_routing_number": "r0123",

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
@@ -1090,6 +1090,7 @@ private const val SEP_31_RECEIVE_FLOW_REQUEST =
   "asset_issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
   "receiver_id": "%RECEIVER_ID%",
   "sender_id": "%SENDER_ID%",
+  "funding_method": "SEPA",
   "fields": {
     "transaction": {
       "receiver_routing_number": "r0123",

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -220,6 +220,9 @@ assets_config: |
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
     sep38:
@@ -244,6 +247,9 @@ assets_config: |
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
     sep38:
@@ -264,6 +270,9 @@ assets_config: |
     sep31:
       enabled: true
       receive:
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
     sep38:
@@ -277,6 +286,9 @@ assets_config: |
       receive:
         min_amount: 0
         max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:
@@ -307,6 +319,9 @@ assets_config: |
       enabled: true
       receive:
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: true
     sep38:

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31Transaction.java
@@ -76,6 +76,10 @@ public class JdbcSep31Transaction extends JdbcSepTransaction
   @Column(length = 2047)
   StellarId creator;
 
+  @SerializedName("funding_method")
+  @Column(name = "funding_method")
+  String fundingMethod;
+
   // Ignored by JPA and Gson
   @SerializedName("fields")
   @Transient

--- a/platform/src/main/resources/db/migration/V20__sep31_add_funding_method.sql
+++ b/platform/src/main/resources/db/migration/V20__sep31_add_funding_method.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sep31_transaction ADD funding_method VARCHAR(255);

--- a/platform/src/main/resources/example.anchor-config.yaml
+++ b/platform/src/main/resources/example.anchor-config.yaml
@@ -139,27 +139,14 @@ assets:
             "enabled": true
             "receive": {
               "min_amount": 1,
-              "max_amount": 1000000
+              "max_amount": 1000000,
+              "methods": [
+                "SEPA",
+                "SWIFT"
+              ]
             },
             "quotes_supported": true,
-            "quotes_required": false,
-            "fields": {
-              "transaction": {
-                "receiver_routing_number": {
-                  "description": "routing number of the destination bank account"
-                },
-                "receiver_account_number": {
-                  "description": "bank account number of the destination"
-                },
-                "type": {
-                  "description": "type of deposit to make",
-                  "choices": [
-                    "SEPA",
-                    "SWIFT"
-                  ]
-                }
-              }
-            }
+            "quotes_required": false
           },
           "sep38": {
             "enabled": true,
@@ -189,27 +176,14 @@ assets:
             "enabled": true
             "receive": {
               "min_amount": 1,
-              "max_amount": 1000000
+              "max_amount": 1000000,
+              "methods": [
+                "SEPA",
+                "SWIFT"
+              ]
             },
             "quotes_supported": true,
-            "quotes_required": false,
-            "fields": {
-              "transaction": {
-                "receiver_routing_number": {
-                  "description": "routing number of the destination bank account"
-                },
-                "receiver_account_number": {
-                  "description": "bank account number of the destination"
-                },
-                "type": {
-                  "description": "type of deposit to make",
-                  "choices": [
-                    "SEPA",
-                    "SWIFT"
-                  ]
-                }
-              }
-            }
+            "quotes_required": false
           },
           "sep38": {
             "enabled": true,
@@ -225,6 +199,10 @@ assets:
             "receive": {
               "min_amount": 1,
               "max_amount": 1000000
+              "methods": [
+                "SEPA",
+                "SWIFT"
+              ]
             },
           },
           "sep38": {

--- a/platform/src/test/resources/test_assets.json
+++ b/platform/src/test/resources/test_assets.json
@@ -10,46 +10,33 @@
           "enabled": true,
           "min_amount": 1,
           "max_amount": 1000000,
-            "methods": [
-                "SEPA",
-                "SWIFT"
-            ]
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "withdraw": {
           "enabled": true,
           "min_amount": 1,
           "max_amount": 1000000,
-            "methods": [
-                "SEPA",
-                "SWIFT"
-            ]
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         }
       },
       "sep31" : {
         "enabled": true,
         "receive": {
           "min_amount": 0,
-          "max_amount": 10000
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": true,
-        "quotes_required": true,
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account"
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination"
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ]
-            }
-          }
-        }
+        "quotes_required": true
       },
       "sep38": {
         "enabled": true,
@@ -66,7 +53,11 @@
         "enabled": false,
         "receive": {
           "min_amount": 0,
-          "max_amount": 10000
+          "max_amount": 10000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         }
       },
       "sep38": {

--- a/platform/src/test/resources/test_assets.yaml
+++ b/platform/src/test/resources/test_assets.yaml
@@ -23,6 +23,9 @@ items:
       receive:
         min_amount: 0
         max_amount: 10000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: true
     sep38:
@@ -36,6 +39,9 @@ items:
       receive:
         min_amount: 1
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:

--- a/platform/src/test/resources/test_assets_missing_distribution_account.json
+++ b/platform/src/test/resources/test_assets_missing_distribution_account.json
@@ -49,33 +49,14 @@
         "enabled": true,
         "receive": {
           "min_amount": 1,
-          "max_amount": 1000000
+          "max_amount": 1000000,
+          "methods": [
+            "SEPA",
+            "SWIFT"
+          ]
         },
         "quotes_supported": true,
-        "quotes_required": true,
-        "fields": {
-          "transaction": {
-            "receiver_routing_number": {
-              "description": "routing number of the destination bank account",
-              "optional": false
-            },
-            "receiver_account_number": {
-              "description": "bank account number of the destination",
-              "optional": false
-            },
-            "receiver_phone_number": {
-              "description": "phone number of the receiver",
-              "optional": true
-            },
-            "type": {
-              "description": "type of deposit to make",
-              "choices": [
-                "SEPA",
-                "SWIFT"
-              ]
-            }
-          }
-        }
+        "quotes_required": true
       },
       "sep38": {
         "enabled": true,

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -40,6 +40,9 @@ items:
       receive:
         min_amount: 0
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
     sep38:
@@ -71,6 +74,9 @@ items:
       receive:
         min_amount: 0
         max_amount: 10
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
     sep38:
@@ -120,6 +126,9 @@ items:
         fee_percent: 0
         min_amount: 0
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
       quotes_supported: true
       quotes_required: false
 
@@ -163,6 +172,9 @@ items:
       receive:
         min_amount: 0
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:
@@ -183,6 +195,9 @@ items:
       receive:
         min_amount: 0
         max_amount: 1000000
+        methods:
+          - SEPA
+          - SWIFT
     sep38:
       enabled: true
       exchangeable_assets:


### PR DESCRIPTION
### Description

- Add `funding_methods` to `/info` response. This field is mandatory for the anchor. 
- Add `funding_method` to `POST /transaction` param. This field is mandatory for wallet.

### Context

SEP-31 changes scoped in https://github.com/stellar/stellar-protocol/pull/1567

### Testing

- `./gradlew test`

### Next
The SEP-6 change will be handled in a separate PR.

