### PR TITLE
[ANCHOR-809][SEP-6] Add funding_method to SEP-6

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/InfoResponse.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/InfoResponse.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.api.sep.sep6;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
@@ -77,13 +78,16 @@ public class InfoResponse {
     @SerializedName("max_amount")
     Long maxAmount;
 
+    @SerializedName("funding_methods")
+    List<String> fundingMethods;
+
     /**
      * The fields required to initiate a deposit.
      *
      * <p>The only field supported by the platform is <code>type</code>. Additional fields required
      * for KYC are supplied asynchronously through SEP-12 requests.
      */
-    Map<String, AssetInfo.Field> fields;
+    @Deprecated Map<String, AssetInfo.Field> fields;
   }
 
   /** Withdrawal configuration. */
@@ -109,6 +113,10 @@ public class InfoResponse {
     @SerializedName("max_amount")
     Long maxAmount;
 
+    /** The maximum amount that can be withdrawn. */
+    @SerializedName("funding_methods")
+    List<String> fundingMethods;
+
     /**
      * The types of withdrawal methods supported and their fields.
      *
@@ -116,7 +124,7 @@ public class InfoResponse {
      * account and KYC information is supplied asynchronously through PATCH requests and SEP-12
      * requests respectively.
      */
-    Map<String, WithdrawType> types;
+    @Deprecated Map<String, WithdrawType> types;
   }
 
   /** Withdrawal type configuration. */

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositExchangeRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositExchangeRequest.java
@@ -49,8 +49,12 @@ public class StartDepositExchangeRequest {
   /** The memo to use for the deposit. */
   String memo;
 
-  /** Type of deposit. */
-  @NonNull String type;
+  /** Deposit method used for the transaction. */
+  @SerializedName("funding_method")
+  String fundingMethod;
+
+  /** Type of deposit. Deprecated in favor of funding_method */
+  @Deprecated String type;
 
   /**
    * Defaults to en if not specified or if the specified language is not supported. Currently,

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartDepositRequest.java
@@ -32,8 +32,12 @@ public class StartDepositRequest {
   @SerializedName("email_address")
   String emailAddress;
 
-  /** Type of deposit. */
-  String type;
+  /** Deposit method used for the transaction. */
+  @SerializedName("funding_method")
+  String fundingMethod;
+
+  /** Type of deposit. Deprecated in favor of funding_method */
+  @Deprecated String type;
 
   /** Name of wallet to deposit to. Currently, ignored. */
   @SerializedName("wallet_name")

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawExchangeRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawExchangeRequest.java
@@ -39,8 +39,12 @@ public class StartWithdrawExchangeRequest {
   /** The amount of the source asset the user would like to withdraw. */
   @NonNull String amount;
 
-  /** The type of withdrawal to make. */
-  @NonNull String type;
+  /** Withdraw method used for the transaction. */
+  @SerializedName("funding_method")
+  String fundingMethod;
+
+  /** The type of withdrawal to make. Deprecated in favor of funding_method */
+  @Deprecated String type;
 
   /** The ISO 3166-1 alpha-3 code of the user's current address. */
   @SerializedName("country_code")

--- a/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/sep/sep6/StartWithdrawRequest.java
@@ -20,8 +20,12 @@ public class StartWithdrawRequest {
   @NonNull
   String assetCode;
 
-  /** Type of withdrawal. */
-  String type;
+  /** Withdraw method used for the transaction. */
+  @SerializedName("funding_method")
+  String fundingMethod;
+
+  /** Type of withdrawal. Deprecated in favor of funding_method */
+  @Deprecated String type;
 
   /** The account to withdraw from. */
   String account;

--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.stellar.anchor.api.asset.StellarAssetInfo;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.util.StringHelper;
 import org.stellar.sdk.KeyPair;
 
 /** SEP-6 request validations */
@@ -91,6 +92,12 @@ public class RequestValidator {
    */
   public void validateTypes(String requestType, String assetCode, List<String> validTypes)
       throws SepValidationException {
+    if (StringHelper.isEmpty(requestType)) {
+      throw new SepValidationException(
+          String.format(
+              "this field cannot be null or empty for asset %s, supported types are %s",
+              assetCode, validTypes));
+    }
     if (!validTypes.contains(requestType)) {
       throw new SepValidationException(
           String.format(

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -6,7 +6,6 @@ import static org.stellar.anchor.util.AssetHelper.isWithdrawEnabled;
 import static org.stellar.anchor.util.MemoHelper.*;
 import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
-import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.Counter;
 import java.time.Instant;
 import java.util.*;
@@ -542,7 +541,7 @@ public class Sep6Service {
                 .authenticationRequired(true)
                 .minAmount(asset.getSep6().getDeposit().getMinAmount())
                 .maxAmount(asset.getSep6().getDeposit().getMaxAmount())
-                .fields(ImmutableMap.of("type", type))
+                .fundingMethods(methods)
                 .build();
 
         response.getDeposit().put(asset.getCode(), deposit);
@@ -551,10 +550,6 @@ public class Sep6Service {
 
       if (isWithdrawEnabled(asset.getSep6())) {
         List<String> methods = asset.getSep6().getWithdraw().getMethods();
-        Map<String, WithdrawType> types = new HashMap<>();
-        for (String method : methods) {
-          types.put(method, WithdrawType.builder().fields(new HashMap<>()).build());
-        }
 
         WithdrawAssetResponse withdraw =
             WithdrawAssetResponse.builder()
@@ -562,7 +557,7 @@ public class Sep6Service {
                 .authenticationRequired(true)
                 .minAmount(asset.getSep6().getWithdraw().getMinAmount())
                 .maxAmount(asset.getSep6().getWithdraw().getMaxAmount())
-                .types(types)
+                .fundingMethods(methods)
                 .build();
 
         response.getWithdraw().put(asset.getCode(), withdraw);

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -106,10 +106,11 @@ public class Sep6Service {
     }
 
     StellarAssetInfo asset = requestValidator.getDepositAsset(request.getAssetCode());
-    if (request.getType() != null) {
-      requestValidator.validateTypes(
-          request.getType(), asset.getCode(), asset.getSep6().getDeposit().getMethods());
-    }
+    String fundingMethod =
+        request.getFundingMethod() != null ? request.getFundingMethod() : request.getMemoType();
+    requestValidator.validateTypes(
+        fundingMethod, asset.getCode(), asset.getSep6().getDeposit().getMethods());
+
     if (request.getAmount() != null) {
       requestValidator.validateAmount(
           request.getAmount(),
@@ -185,8 +186,10 @@ public class Sep6Service {
     }
 
     StellarAssetInfo buyAsset = requestValidator.getDepositAsset(request.getDestinationAsset());
+    String fundingMethod =
+        request.getFundingMethod() != null ? request.getFundingMethod() : request.getType();
     requestValidator.validateTypes(
-        request.getType(), buyAsset.getCode(), buyAsset.getSep6().getDeposit().getMethods());
+        fundingMethod, buyAsset.getCode(), buyAsset.getSep6().getDeposit().getMethods());
     requestValidator.validateAmount(
         request.getAmount(),
         buyAsset.getCode(),
@@ -280,10 +283,11 @@ public class Sep6Service {
     }
 
     StellarAssetInfo asset = requestValidator.getWithdrawAsset(request.getAssetCode());
-    if (request.getType() != null) {
-      requestValidator.validateTypes(
-          request.getType(), asset.getCode(), asset.getSep6().getWithdraw().getMethods());
-    }
+    String fundingMethod =
+        request.getFundingMethod() != null ? request.getFundingMethod() : request.getType();
+    requestValidator.validateTypes(
+        fundingMethod, asset.getCode(), asset.getSep6().getWithdraw().getMethods());
+
     if (request.getAmount() != null) {
       requestValidator.validateAmount(
           request.getAmount(),
@@ -356,8 +360,10 @@ public class Sep6Service {
     }
 
     StellarAssetInfo sellAsset = requestValidator.getWithdrawAsset(request.getSourceAsset());
+    String fundingMethod =
+        request.getFundingMethod() != null ? request.getFundingMethod() : request.getType();
     requestValidator.validateTypes(
-        request.getType(), sellAsset.getCode(), sellAsset.getSep6().getWithdraw().getMethods());
+        fundingMethod, sellAsset.getCode(), sellAsset.getSep6().getWithdraw().getMethods());
     requestValidator.validateAmount(
         request.getAmount(),
         sellAsset.getCode(),

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTestData.kt
@@ -11,16 +11,8 @@ class Sep6ServiceTestData {
                     "authentication_required": true,
                     "min_amount": 1,
                     "max_amount": 10000,
-                    "fields": {
-                        "type": {
-                            "description": "type of deposit to make",
-                            "choices": [
-                                "SEPA",
-                                "SWIFT"
-                            ],
-                            "optional": false
-                        }
-                    }
+                    "funding_methods": ["SEPA", "SWIFT"]
+       
                 }
             },
             "deposit-exchange": {
@@ -29,16 +21,7 @@ class Sep6ServiceTestData {
                     "authentication_required": true,
                     "min_amount": 1,
                     "max_amount": 10000,
-                    "fields": {
-                        "type": {
-                            "description": "type of deposit to make",
-                            "choices": [
-                                "SEPA",
-                                "SWIFT"
-                            ],
-                            "optional": false
-                        }
-                    }
+                    "funding_methods": ["SEPA", "SWIFT"]
                 }
             },
             "withdraw": {
@@ -47,14 +30,7 @@ class Sep6ServiceTestData {
                     "authentication_required": true,
                     "min_amount": 1,
                     "max_amount": 10000,
-                    "types": {
-                        "cash": {
-                            "fields": {}
-                        },
-                        "bank_account": {
-                            "fields": {}
-                        }
-                    }
+                    "funding_methods": ["bank_account", "cash"]
                 }
             },
             "withdraw-exchange": {
@@ -63,14 +39,7 @@ class Sep6ServiceTestData {
                     "authentication_required": true,
                     "min_amount": 1,
                     "max_amount": 10000,
-                    "types": {
-                        "cash": {
-                            "fields": {}
-                        },
-                        "bank_account": {
-                            "fields": {}
-                        }
-                    }
+                    "funding_methods": ["bank_account", "cash"]
                 }
             },
             "fee": {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -182,13 +182,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
             "authentication_required": true,
             "min_amount": 0,
             "max_amount": 10,
-            "fields": {
-              "type": {
-                "description": "type of deposit to make",
-                "choices": ["SEPA", "SWIFT"],
-                "optional": false
-              }
-            }
+            "funding_methods": ["SEPA", "SWIFT"]
           }
         },
         "deposit-exchange": {
@@ -197,13 +191,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
             "authentication_required": true,
             "min_amount": 0,
             "max_amount": 10,
-            "fields": {
-              "type": {
-                "description": "type of deposit to make",
-                "choices": ["SEPA", "SWIFT"],
-                "optional": false
-              }
-            }
+            "funding_methods": ["SEPA", "SWIFT"]
           }
         },
         "withdraw": {
@@ -212,7 +200,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
             "authentication_required": true,
             "min_amount": 0,
             "max_amount": 10,
-            "types": { "cash": { "fields": {} }, "bank_account": { "fields": {} } }
+            "funding_methods": ["bank_account", "cash"]
           }
         },
         "withdraw-exchange": {
@@ -221,7 +209,7 @@ class Sep6Tests : AbstractIntegrationTests(TestConfig()) {
             "authentication_required": true,
             "min_amount": 0,
             "max_amount": 10,
-            "types": { "cash": { "fields": {} }, "bank_account": { "fields": {} } }
+            "funding_methods": ["bank_account", "cash"]
           }
         },
         "fee": { "enabled": false, "description": "Fee endpoint is not supported." },

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -47,6 +47,7 @@ public class Sep6Controller {
       @RequestParam(value = "memo_type", required = false) String memoType,
       @RequestParam(value = "memo", required = false) String memo,
       @RequestParam(value = "email_address", required = false) String emailAddress,
+      @RequestParam(value = "funding_method", required = false) String fundingMethod,
       @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "wallet_name", required = false) String walletName,
       @RequestParam(value = "wallet_url", required = false) String walletUrl,
@@ -65,6 +66,7 @@ public class Sep6Controller {
             .memoType(memoType)
             .memo(memo)
             .emailAddress(emailAddress)
+            .fundingMethod(fundingMethod)
             .type(type)
             .walletName(walletName)
             .walletUrl(walletUrl)
@@ -90,7 +92,8 @@ public class Sep6Controller {
       @RequestParam(value = "account") String account,
       @RequestParam(value = "memo_type", required = false) String memoType,
       @RequestParam(value = "memo", required = false) String memo,
-      @RequestParam(value = "type") String type,
+      @RequestParam(value = "funding_method", required = false) String fundingMethod,
+      @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "lang", required = false) String lang,
       @RequestParam(value = "country_code", required = false) String countryCode,
       @RequestParam(value = "claimable_balances_supported", required = false)
@@ -107,6 +110,7 @@ public class Sep6Controller {
             .account(account)
             .memoType(memoType)
             .memo(memo)
+            .fundingMethod(fundingMethod)
             .type(type)
             .lang(lang)
             .countryCode(countryCode)
@@ -123,6 +127,7 @@ public class Sep6Controller {
   public StartWithdrawResponse withdraw(
       HttpServletRequest request,
       @RequestParam(value = "asset_code") String assetCode,
+      @RequestParam(value = "funding_method", required = false) String fundingMethod,
       @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "amount", required = false) String amount,
       @RequestParam(value = "country_code", required = false) String countryCode,
@@ -134,6 +139,7 @@ public class Sep6Controller {
     StartWithdrawRequest startWithdrawRequest =
         StartWithdrawRequest.builder()
             .assetCode(assetCode)
+            .fundingMethod(fundingMethod)
             .type(type)
             .amount(amount)
             .countryCode(countryCode)
@@ -154,7 +160,8 @@ public class Sep6Controller {
       @RequestParam(value = "destination_asset") String destinationAsset,
       @RequestParam(value = "quote_id", required = false) String quoteId,
       @RequestParam(value = "amount") String amount,
-      @RequestParam(value = "type") String type,
+      @RequestParam(value = "funding_method", required = false) String fundingMethod,
+      @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "country_code", required = false) String countryCode,
       @RequestParam(value = "refund_memo", required = false) String refundMemo,
       @RequestParam(value = "refund_memo_type", required = false) String refundMemoType)
@@ -167,6 +174,7 @@ public class Sep6Controller {
             .destinationAsset(destinationAsset)
             .quoteId(quoteId)
             .amount(amount)
+            .fundingMethod(fundingMethod)
             .type(type)
             .countryCode(countryCode)
             .refundMemo(refundMemo)


### PR DESCRIPTION
### Description

- In `/info` response, replace `fields`(in deposit) and `types`(in withdraw) with `funding_methods` 
- In all 4 transaction creation request, replace `type` with `funding_method`, and this param will be mandatory

### Context

SEP-31 changes scoped in https://github.com/stellar/stellar-protocol/pull/1567

### Testing

- `./gradlew test`