### PR TITLE
[ANCHOR-592] Add data.schema to configuration to `develop` branch

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v /home/runner/java-stellar-anchor-sdk/platform/src/test/resources://config stellar/anchor-tests:latest --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
+          docker run --network host -v /home/runner/java-stellar-anchor-sdk/platform/src/test/resources://config stellar/anchor-tests:v0.6.20 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
       - name: Upload Essential Tests report
         if: always()

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
@@ -181,9 +181,13 @@ public class DataConfigAdapter extends SpringConfigAdapter {
   }
 
   private String constructPostgressUrl(ConfigMap config) {
+    String schema = config.getString("data.schema");
+    if (isEmpty(schema)) {
+      schema = "public";
+    }
     return String.format(
-        "jdbc:postgresql://%s/%s",
-        config.getString("data.server"), config.getString("data.database"));
+            "jdbc:postgresql://%s/%s?currentSchema=%s",
+            config.getString("data.server"), config.getString("data.database"), schema);
   }
 
   private String constructSQLiteUrl(ConfigMap config) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -728,8 +728,17 @@ data:
   # The hostname and port of the database server.
   server:
 
-  # Name of the database.
+  # The name of the database.
+  # For `sqlite`, this is the path to the database file.
+  # For `postgres` and `aurora`, this is the name of the database.
   database:
+
+  # The schema of the database.
+  # For `postgres` and `aurora`, default is `public`
+  # For `sqlite`, this is ignored.
+  # Note： If the schema is specified other than the default value, the tables will be created in the new schema.
+  #        The previously created tables may need to be moved from the default to the new schema.
+  schema:
 
   # Initial number of connections
   # For `sqlite`, set this to 1 to avoid database file lock exception

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -20,6 +20,7 @@ data.flyway_location:
 data.initial_connection_pool_size:
 data.max_active_connections:
 data.server:
+data.schema:
 data.type:
 event_processor.callback_api_request.enabled:
 event_processor.client_status_callback.enabled:

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -27,6 +27,7 @@ custody_server.base_url=http://custody-server:8086
 data.type=postgres
 data.server=db:5432
 data.database=postgres
+data.schema=anchor-platform
 data.flyway_enabled=true
 # assets
 assets.type=file


### PR DESCRIPTION
### Description

[ANCHOR-592] Add data.schema to configuration 

### Context

Per anchor's request.

### Testing

- `./gradlew test`

### Documentation

Documented in `anchor-config-default-values.yaml`

### Known limitations

N/A



[ANCHOR-592]: https://stellarorg.atlassian.net/browse/ANCHOR-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ