### PR TITLE
[ANCHOR-707] Improve comments of `languages` in anchor config

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/DataConfigAdapter.java
@@ -186,8 +186,8 @@ public class DataConfigAdapter extends SpringConfigAdapter {
       schema = "public";
     }
     return String.format(
-            "jdbc:postgresql://%s/%s?currentSchema=%s",
-            config.getString("data.server"), config.getString("data.database"), schema);
+        "jdbc:postgresql://%s/%s?currentSchema=%s",
+        config.getString("data.server"), config.getString("data.database"), schema);
   }
 
   private String constructSQLiteUrl(ConfigMap config) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -11,7 +11,9 @@ version: 1
 ##############################
 
 #
-# The default language of the application
+# A list of languages supported by the anchor for localization content, such as the "moreInfoUrl" in a transaction response.
+# When constructing URLs or providing content, one of these languages may be selected based on user preference or availability.
+#
 # The supported languages defined by RFC4646 (https://datatracker.ietf.org/doc/html/rfc4646)
 #
 languages: en


### PR DESCRIPTION
### Description

Right now `languages` in yaml doc is misleading.
This property is the list of supported languages. 

### Testing

- `./gradlew test`