### PR TITLE
[ANCHOR-767] Implement SEP-6 deposit flows for contract accounts

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/RequestValidator.java
@@ -11,7 +11,9 @@ import org.stellar.anchor.api.asset.StellarAssetInfo;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.util.StringHelper;
-import org.stellar.sdk.KeyPair;
+import org.stellar.sdk.Address;
+import org.stellar.sdk.MuxedAccount;
+import org.stellar.sdk.scval.Scv;
 
 /** SEP-6 request validations */
 @RequiredArgsConstructor
@@ -113,10 +115,24 @@ public class RequestValidator {
    * @throws SepValidationException if the account is invalid
    */
   public void validateAccount(String account) throws AnchorException {
-    try {
-      KeyPair.fromAccountId(account);
-    } catch (IllegalArgumentException ex) {
-      throw new SepValidationException(String.format("invalid account %s", account));
+    switch (account.charAt(0)) {
+      case 'G':
+      case 'C':
+        try {
+          Address.fromSCAddress(Scv.fromAddress(Scv.toAddress(account)).toSCAddress());
+        } catch (RuntimeException ex) {
+          throw new SepValidationException(String.format("invalid account %s", account));
+        }
+        break;
+      case 'M':
+        try {
+          new MuxedAccount(account);
+        } catch (RuntimeException ex) {
+          throw new SepValidationException(String.format("invalid account %s", account));
+        }
+        break;
+      default:
+        throw new SepValidationException(String.format("invalid account %s", account));
     }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/RequestValidatorTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.stellar.anchor.TestConstants.Companion.TEST_ACCOUNT
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.api.asset.DepositWithdrawOperation
 import org.stellar.anchor.api.asset.Sep6Info
@@ -152,9 +151,17 @@ class RequestValidatorTest {
     }
   }
 
-  @Test
-  fun `test validateAccount`() {
-    requestValidator.validateAccount(TEST_ACCOUNT)
+  @ValueSource(
+    strings =
+      [
+        "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "MBFZNZTFSI6TWLVAID7VOLCIFX2PMUOS2X7U6H4TNK4PAPSHPWMMUAAAAAAAAAPCIA2IM",
+        "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX",
+      ]
+  )
+  @ParameterizedTest
+  fun `test validateAccount`(account: String) {
+    requestValidator.validateAccount(account)
   }
 
   @Test

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
@@ -21,6 +21,7 @@ data class AppSettings(
   val isTest: Boolean,
   val port: Int,
   val horizonEndpoint: String,
+  val rpcEndpoint: String,
   val platformApiEndpoint: String,
   val distributionWallet: String,
   val distributionWalletMemo: String,
@@ -40,7 +41,7 @@ data class AuthSettings(
   enum class Type {
     NONE,
     API_KEY,
-    JWT
+    JWT,
   }
 }
 
@@ -48,5 +49,5 @@ data class DataSettings(
   val url: String,
   val database: String,
   val user: String,
-  val password: String
+  val password: String,
 )

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/EventConsumerContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/EventConsumerContainer.kt
@@ -12,15 +12,12 @@ object EventConsumerContainer {
     Sep6EventProcessor(
       config,
       ServiceContainer.horizon,
+      ServiceContainer.rpc,
       ServiceContainer.platform,
       ServiceContainer.customerService,
       ServiceContainer.sepHelper,
     )
-  private val sep31EventProcessor =
-    Sep31EventProcessor(
-      config,
-      ServiceContainer.platform,
-    )
+  private val sep31EventProcessor = Sep31EventProcessor(config, ServiceContainer.platform)
   private val noOpEventProcessor = NoOpEventProcessor()
   private val processor =
     AnchorEventProcessor(sep6EventProcessor, sep31EventProcessor, noOpEventProcessor)

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ServiceContainer.kt
@@ -15,6 +15,7 @@ import org.stellar.reference.sep24.WithdrawalService
 import org.stellar.reference.service.SepHelper
 import org.stellar.reference.service.sep31.ReceiveService
 import org.stellar.sdk.Server
+import org.stellar.sdk.SorobanServer
 
 object ServiceContainer {
   private val config = ConfigContainer.getInstance().config
@@ -37,6 +38,7 @@ object ServiceContainer {
   val customerService = CustomerService(customerRepo, transactionKYCRepo, sepHelper)
   val rateService = RateService(quotesRepo)
   val horizon = Server(config.appSettings.horizonEndpoint)
+  val rpc = SorobanServer(config.appSettings.rpcEndpoint)
   val platform =
     PlatformClient(
       HttpClient {

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep12Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep12Client.kt
@@ -21,10 +21,17 @@ const val MULTIPART_FORM_DATA_CHARSET_UTF_8 = "multipart/form-data; charset=utf-
 val TYPE_MULTIPART_FORM_DATA = MULTIPART_FORM_DATA_CHARSET_UTF_8.toMediaType()
 
 class Sep12Client(private val endpoint: String, private val jwt: String) : SepClient() {
-  fun getCustomer(id: String, type: String? = null): Sep12GetCustomerResponse? {
+  fun getCustomer(
+    id: String,
+    type: String? = null,
+    transactionId: String? = null,
+  ): Sep12GetCustomerResponse? {
     var url = String.format(this.endpoint + "/customer?id=%s", id)
     if (type != null) {
       url += "&type=$type"
+    }
+    if (transactionId != null) {
+      url += "&transaction_id=$transactionId"
     }
     val responseBody = httpGet(url, jwt)
     return gson.fromJson(responseBody, Sep12GetCustomerResponse::class.java)
@@ -32,7 +39,7 @@ class Sep12Client(private val endpoint: String, private val jwt: String) : SepCl
 
   fun putCustomer(
     customerRequest: Sep12PutCustomerRequest,
-    mediaType: MediaType = TYPE_JSON
+    mediaType: MediaType = TYPE_JSON,
   ): Sep12PutCustomerResponse? {
     val body: RequestBody?
     when (mediaType) {

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep45Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep45Client.kt
@@ -38,7 +38,6 @@ class Sep45Client(
     val authEntries =
       SorobanAuthorizationEntryList.fromXdrBase64(challengeResponse.authorizationEntries)
         .authorizationEntryList
-    authEntries.forEach { println(it.toXdrBase64()) }
     val walletAuthEntry =
       authEntries.find {
         it.credentials.address.address.discriminant.equals(SCAddressType.SC_ADDRESS_TYPE_CONTRACT)

--- a/service-runner/src/main/resources/config/reference-config.yaml
+++ b/service-runner/src/main/resources/config/reference-config.yaml
@@ -6,6 +6,8 @@ app:
   port: 8091
   # The URL of the Stellar network to which the Anchor will connect.
   horizonEndpoint: https://horizon-testnet.stellar.org
+  # The URL of the Stellar RPC server to which the Anchor will connect.
+  rpcEndpoint: https://soroban-testnet.stellar.org
   # The URL of the platform server.
   platformApiEndpoint: http://platform:8085
   # The Stellar wallet to which the customer will send the Stellar assets.


### PR DESCRIPTION
### Description

This implements SEP-6 deposit + deposit exchange flows for contract accounts. The main change is to allow contract accounts as source and destination accounts for SEP-6 deposit requests. The bulk of this PR is adding test code.

### Context

Contract account support

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

SEP-45 does not support memos so we cannot create a new customer every time the test is run. Therefore, we cannot assert on the intermediate PENDING_CUSTOMER_INFO_UPDATE status since a previous run may have already created a customer with enough KYC.

