### PR TITLE
Remove message on Sentry initialization

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/SentryConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/SentryConfigAdapter.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.platform.configurator;
 
-import static io.sentry.Sentry.captureMessage;
 import static org.stellar.anchor.util.Log.*;
 import static org.stellar.anchor.util.StringHelper.*;
 
@@ -31,11 +30,6 @@ public class SentryConfigAdapter extends SpringConfigAdapter {
           options.setTracesSampleRate(1.0);
           options.setEnableUncaughtExceptionHandler(true);
         });
-
-    captureMessage(
-        String.format(
-            "Sentry agent initialized. release:%s, environment: %s, debug: %s",
-            config.getString("sentry.release"), sentryEnv, config.getBoolean("sentry.debug")));
   }
 
   String getAuthToken() {


### PR DESCRIPTION
### Description

This removes the message sent to Sentry on initialization.

### Context

This is creating a lot of noise. Now that we have Prometheus alerts on crashing pods, it is unnecessary.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

