### PR TITLE
[CHORE] Make extended_tests depends on essential_tests to avoid concurrent tests

### DIFF
--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/sub_essential_tests.yml
 
   extended_tests:
-    needs: [ gradle_build ]
+    needs: [ gradle_build, essential_tests ]
     uses: ./.github/workflows/sub_extended_tests.yml
 
   codeql_analysis:


### PR DESCRIPTION
### Description

- Make extended_tests depends on essential_tests to avoid concurrent tests

### Context

- Improve tests stability.
