### PR TITLE
[ANCHOR-1140] Fix `on_push_to_develop ` Github workflow

### DIFF
--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -48,6 +48,8 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
+          build-args: |
+            TARGETARCH=amd64
           tags: |
             stellar/anchor-platform:edge,stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
           # add build cache for faster rebuilds
@@ -91,6 +93,8 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/arm64
+          build-args: |
+            TARGETARCH=arm64
           tags: |
             stellar/anchor-platform:edge,stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
           # add build cache for faster rebuilds

--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -55,6 +55,8 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
+          build-args: |
+            TARGETARCH=amd64
           tags: |
             stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
             stellar/anchor-platform:latest
@@ -95,6 +97,8 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/arm64
+          build-args: |
+            TARGETARCH=arm64
           tags: |
             stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
             stellar/anchor-platform:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,12 @@ ARG JDK_VER=17.0.16_8
 ARG TEMURIN_RELEASE=jdk-17.0.16+8
 ARG TARGETARCH=amd64
 
-COPY --from=build /code/service-runner/build/libs/anchor-platform-runner*.jar /app/anchor-platform-runner.jar
-COPY --from=build /code/scripts/docker-start.sh /app/start.sh
+RUN bash -c 'echo "Building for arch: $TARGETARCH"'
 
 # Install curl and ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates tar unzip \
  && rm -rf /var/lib/apt/lists/*
-
-RUN bash -c 'echo "Building for arch: $TARGETARCH"'
 
 # ---- Install Temurin JDK 17.0.16+8 ----
 RUN case "$TARGETARCH" in \
@@ -42,5 +39,8 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Sanity check
 RUN java --version
+
+COPY --from=build /code/service-runner/build/libs/anchor-platform-runner*.jar /app/anchor-platform-runner.jar
+COPY --from=build /code/scripts/docker-start.sh /app/start.sh
 
 ENTRYPOINT ["/bin/bash", "/app/start.sh"]


### PR DESCRIPTION
### Description

- The `on_release_created_or_updated` is fixed but the `on_push_to_develop` is still on old work flow. 

### Context

- Workflow improvement. 
