### PR TITLE
[HotFix] Fix the InternalException thrown from notify_onchain_fund_sent in Sep24 deposit transaction

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/DepositService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/DepositService.kt
@@ -168,6 +168,10 @@ class DepositService(private val cfg: Config, private val paymentClient: Payment
             }
           }
           .collect {}
+      } else {
+        log.warn {
+          "Transaction ${transaction.id} is in unexpected status ${transaction.status}, skipping notify_onchain_funds_sent"
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

- Fix the InternalException thrown from the `notify_onchain_fund_sent` in Sep24 deposit transaction

### Context

- After submitting Sep24 deposit transaction from demo wallet, anchor platform keeps throwing exceptions. This is caused by the reference server calling the `notify_onchain_fund_sent` after the transaction is in `completed` status.

### Testing

- `./gradlew test`
