### PR TITLE
Fix: Wrap all RPC exceptions in try/catch in the observer

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
@@ -154,6 +154,10 @@ public abstract class AbstractPaymentObserver implements HealthCheckable {
     return this.getName().compareTo(other.getName());
   }
 
+  ObserverStatus getStatus() {
+    return this.status;
+  }
+
   void setStatus(ObserverStatus status) {
     if (this.status != status) {
       if (this.status.isSettable(status)) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -37,6 +37,7 @@ import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.Log;
 import org.stellar.sdk.MuxedAccount;
 import org.stellar.sdk.SorobanServer;
+import org.stellar.sdk.exception.NetworkException;
 import org.stellar.sdk.requests.sorobanrpc.EventFilterType;
 import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest;
 import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest.EventFilter;
@@ -114,7 +115,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
 
   ScheduledFuture<?> task;
 
-  private void fetchEvents() {
+  void fetchEvents() {
     String cursor = (this.cursor != null) ? this.cursor : loadStellarRpcCursor();
 
     try {
@@ -137,8 +138,10 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
     } catch (IOException ioex) {
       warnF(
           "Error fetching latest ledger: {}. ex={}. Wait for next retry.",
-          GsonUtils.getInstance().toJson(ioex),
+          ioex.toString(),
           ioex.getMessage());
+    } catch (NetworkException nex) {
+      warnF("Network error in RPC observer loop: {}. ex={}", nex.toString(), nex.getMessage());
     } catch (Throwable t) {
       errorEx("Unhandled error in RPC observer loop", t);
       setStatus(ObserverStatus.STREAM_ERROR);


### PR DESCRIPTION
### Description

This fixes the observer stalling when RPC returns a transient error.

### Context

Exceptions coming from the SDK are not mapped to IOExceptions so they are not handled, killing the thread. The RPC observer implementation does not set `lastActivityTime` or change the status so the health checks stay green.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

