### PR TITLE
update links to the dev docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ anchor, allowing businesses to focus on the core business logic necessary to pro
 
 ## Getting Started
 
-To get started, visit the [Anchor Platform documentation](https://developers.stellar.org/docs/category/anchor-platform).
+To get started, visit the [Anchor Platform documentation](https://developers.stellar.org/docs/platforms/anchor-platform).
 Release notes can be found on the
 project's [releases page](https://github.com/stellar/anchor-platform/releases).
 
@@ -51,7 +51,7 @@ contribute to this project.
 
 ## Quickstart
 
-Anchor Platform can be run locally using Docker Compose. 
+Anchor Platform can be run locally using Docker Compose.
 
 Run the Anchor Platform using Docker Compose:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ anchor, allowing businesses to focus on the core business logic necessary to pro
 
 ## Getting Started
 
-To get started, visit the [Anchor Platform documentation](https://developers.stellar.org/docs/category/anchor-platform).
+To get started, visit the [Anchor Platform documentation](https://developers.stellar.org/docs/platforms/anchor-platform).
 Release notes can be found on the
 project's [releases page](https://github.com/stellar/anchor-platform/releases).
 
@@ -51,7 +51,7 @@ contribute to this project.
 
 ## Quickstart
 
-Anchor Platform can be run locally using Docker Compose. 
+Anchor Platform can be run locally using Docker Compose.
 
 ### For version 2.x.x stable release
 ```shell

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/customer/CustomerRoute.kt
@@ -16,7 +16,7 @@ import org.stellar.reference.di.AUTH_CONFIG_ENDPOINT
 
 /**
  * Defines the routes related to the customer callback API. See
- * [Customer Callbacks](https://developers.stellar.org/api/anchor-platform/callbacks/customer/).
+ * [Customer Callbacks](https://developers.stellar.org/docs/platforms/anchor-platform/api-reference/callbacks/get-customer).
  *
  * @param customerService the [CustomerService] to use to process the requests.
  */

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateRoute.kt
@@ -11,7 +11,7 @@ import org.stellar.reference.di.AUTH_CONFIG_ENDPOINT
 
 /**
  * Defines the routes related to the rate callback API. See
- * [Rate Callbacks](https://developers.stellar.org/api/anchor-platform/callbacks/rate/).
+ * [Rate Callbacks](https://developers.stellar.org/docs/platforms/anchor-platform/api-reference/callbacks/get-rates).
  *
  * @param rateService the [RateService] to use to process the requests.
  */

--- a/soroban/README.md
+++ b/soroban/README.md
@@ -6,7 +6,7 @@ testing.
 ## Prerequisites
 
 - [Rust](https://www.rust-lang.org/tools/install)
-- [Stellar CLI](https://developers.stellar.org/docs/build/guides/cli)
+- [Stellar CLI](https://developers.stellar.org/docs/tools/cli/cookbook)
 
 This assumes that you have the Stellar CLI installed and configured with a
 testnet account `${MY_ACCOUNT}`.


### PR DESCRIPTION
### Description

Change Links to the developer documentation

### Context

I moved some of the platform docs around (with redirects), and wanted to update the source links, as well.

### Testing

N/A

### Documentation

Just some external links that are changed

### Known limitations

N/A

