### PR TITLE
Fix: Cast `rpcEnabled` to string in ref server chart

### DIFF
--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: APP.RPC_ENDPOINT
               value: {{ .Values.config.app.rpcEndpoint }}
             - name: APP.RPC_ENABLED
-              value: {{ .Values.config.app.rpcEnabled }}
+              value: {{ .Values.config.app.rpcEnabled | quote }}
             - name: DATA.URL
               value: {{ .Values.config.data.url }}
             - name: DATA.USER


### PR DESCRIPTION
### Description

This casts `rpcEnabled` to a string in the ref server chart. 

### Context

Fixes

```
  json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of
  type string
```

https://buildmeister-v3.stellar-ops.com/job/ProductEngineering/job/anchor-platform-testanchor/76/console

### Testing

- `helm template reference-server . --values values.yaml`

### Documentation

N/A

### Known limitations

N/A

