### PR TITLE
Fix: Add callback auth to observer deployment

### DIFF
--- a/helm-charts/sep-service/templates/observer-deployment.yaml
+++ b/helm-charts/sep-service/templates/observer-deployment.yaml
@@ -88,6 +88,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.fullName }}-secrets
                   key: SEP6_MORE_INFO_URL_JWT_SECRET
+            - name: SECRET_CALLBACK_API_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fullName }}-secrets
+                  key: CALLBACK_API_AUTH_SECRET
             - name: SECRET_PLATFORM_API_AUTH_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### Description

This adds the missing secret mapping to the observer auth.

### Context

A previous PR enabled auth between the reference server and the platform in the chart but the observer deployment was not correctly updated.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

