### PR TITLE
Fix: Request funds when customer info is updated

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/event/processor/Sep6EventProcessor.kt
@@ -162,6 +162,9 @@ class Sep6EventProcessor(
             message = "Funds received from user",
           ),
         )
+      PENDING_CUSTOMER_INFO_UPDATE -> {
+        requestCustomerFunds(transaction)
+      }
       COMPLETED -> {
         log.info { "Transaction ${transaction.id} completed" }
       }
@@ -226,6 +229,9 @@ class Sep6EventProcessor(
             ),
           )
         }
+      PENDING_CUSTOMER_INFO_UPDATE -> {
+        requestCustomerFunds(transaction)
+      }
       COMPLETED -> {
         log.info { "Transaction ${transaction.id} completed" }
       }


### PR DESCRIPTION
### Description

This fixes a bug where a SEP-6 transaction gets stuck in a `pending_customer_info_update` status even though the SEP-12 customer status is `ACCEPTED`. 

### Context

We are now checking transaction-level KYC. The transaction now enters `pending_customer_info_update` even if the account already has the fields.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

