### PR TITLE
[ANCHOR-1187] Fix `MEMO_ID` validation to support full Stellar uint64 range

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.sep10;
 
 import static java.lang.String.format;
 import static org.stellar.anchor.util.Log.*;
+import static org.stellar.anchor.util.MemoHelper.makeMemoId;
 import static org.stellar.anchor.util.MetricConstants.SEP10_CHALLENGE_CREATED;
 import static org.stellar.anchor.util.MetricConstants.SEP10_CHALLENGE_VALIDATED;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
@@ -199,15 +200,10 @@ public class Sep10Service implements ISep10Service {
 
   @Override
   public Memo validateChallengeRequestMemo(ChallengeRequest request) throws SepException {
-    // Validate memo. It should be 64-bit positive integer if not null.
+    // Validate memo. It should be a positive uint64 integer if not null.
     try {
       if (request.getMemo() != null) {
-        long memoLong = Long.parseUnsignedLong(request.getMemo());
-        if (memoLong <= 0) {
-          infoF("Invalid memo value: {}", request.getMemo());
-          throw new SepValidationException(format("Invalid memo value: %s", request.getMemo()));
-        }
-        return new MemoId(memoLong);
+        return makeMemoId(request.getMemo());
       } else {
         return null;
       }

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -106,11 +106,7 @@ public class MemoHelper {
    */
   public static MemoId makeMemoId(String memo) {
     try {
-      BigInteger memoId = new BigInteger(memo);
-      if (memoId.compareTo(BigInteger.ZERO) <= 0) {
-        throw new NumberFormatException("Memo ID must be greater than 0");
-      }
-      return new MemoId(memoId);
+      return new MemoId(new BigInteger(memo));
     } catch (IllegalArgumentException e) {
       NumberFormatException nfe = new NumberFormatException(e.getMessage());
       nfe.initCause(e);

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -3,6 +3,7 @@ package org.stellar.anchor.util;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 import static org.stellar.sdk.xdr.MemoType.*;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.apache.commons.codec.DecoderException;
@@ -78,7 +79,7 @@ public class MemoHelper {
     try {
       switch (memoType) {
         case MEMO_ID:
-          return new MemoId(Long.parseLong(memo));
+          return makeMemoId(memo);
         case MEMO_TEXT:
           return new MemoText(memo);
         case MEMO_HASH:
@@ -96,6 +97,22 @@ public class MemoHelper {
     } catch (NumberFormatException nfex) {
       throw new SepValidationException(
           String.format("Invalid memo %s of type: %s", memo, memoType), nfex);
+    }
+  }
+
+  /**
+   * Creates a MemoId from a string, supporting the full uint64 range (1 to
+   * 18,446,744,073,709,551,615) as defined by the Stellar protocol.
+   */
+  public static MemoId makeMemoId(String memo) {
+    try {
+      BigInteger memoId = new BigInteger(memo);
+      if (memoId.compareTo(BigInteger.ZERO) <= 0) {
+        throw new NumberFormatException("Memo ID must be greater than 0");
+      }
+      return new MemoId(memoId);
+    } catch (IllegalArgumentException e) {
+      throw new NumberFormatException(e.getMessage());
     }
   }
 
@@ -160,7 +177,7 @@ public class MemoHelper {
     return switch (memoXdr.getDiscriminant()) {
       case MEMO_NONE -> null; // No memo
       case MEMO_TEXT -> new String(memoXdr.getText().getBytes(), StandardCharsets.UTF_8);
-      case MEMO_ID -> String.valueOf(memoXdr.getId().getUint64().getNumber().longValue());
+      case MEMO_ID -> memoXdr.getId().getUint64().getNumber().toString();
       case MEMO_HASH, MEMO_RETURN ->
           Base64.getEncoder().encodeToString(memoXdr.getHash().getHash());
     };

--- a/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/MemoHelper.java
@@ -112,7 +112,9 @@ public class MemoHelper {
       }
       return new MemoId(memoId);
     } catch (IllegalArgumentException e) {
-      throw new NumberFormatException(e.getMessage());
+      NumberFormatException nfe = new NumberFormatException(e.getMessage());
+      nfe.initCause(e);
+      throw nfe;
     }
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -401,7 +401,7 @@ internal class Sep10ServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = ["ABC", "12AB", "-1", "0", Integer.MIN_VALUE.toString()])
+  @ValueSource(strings = ["ABC", "12AB", "-1", Integer.MIN_VALUE.toString()])
   fun `test createChallenge() with bad memo`(badMemo: String) {
     every { sep10Config.isClientAttributionRequired } returns false
     val cr =

--- a/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
@@ -64,6 +64,48 @@ internal class MemoHelperTest {
   }
 
   @Test
+  fun `test makeMemoId with valid uint64 values`() {
+    // Small value - should not throw
+    makeMemoId("1234")
+
+    // Max signed long - should not throw
+    makeMemoId("9223372036854775807")
+
+    // Above signed long max (valid uint64)
+    makeMemoId("11872666534918305457")
+
+    // Max uint64 - should not throw
+    makeMemoId("18446744073709551615")
+  }
+
+  @Test
+  fun `test makeMemoId with invalid values`() {
+    assertThrows<SepValidationException> { makeMemo("0", "id") }
+    assertThrows<SepValidationException> { makeMemo("-1", "id") }
+    assertThrows<SepValidationException> { makeMemo("18446744073709551616", "id") }
+    assertThrows<SepValidationException> { makeMemo("abc", "id") }
+  }
+
+  @Test
+  fun `test xdrMemoToString round-trip with uint64 memo ids`() {
+    // Round-trip: makeMemoId -> toXdr -> xdrMemoToString should preserve the original value
+    val testValues =
+      listOf("1234", "9223372036854775807", "11872666534918305457", "18446744073709551615")
+    for (value in testValues) {
+      val memo = makeMemoId(value)
+      val xdr = toXdr(memo)
+      assertEquals(value, xdrMemoToString(xdr))
+    }
+  }
+
+  @Test
+  fun `test xdrMemoToString with null and none`() {
+    assertEquals(null, xdrMemoToString(null))
+    val noneMemo = toXdr(null)
+    assertEquals(null, xdrMemoToString(noneMemo))
+  }
+
+  @Test
   fun `test toXdr()`() {
     val memoId: MemoId = makeMemo("123", MEMO_ID) as MemoId
     assertEquals("123", "${toXdr(memoId).id.uint64.number}")

--- a/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
@@ -80,7 +80,6 @@ internal class MemoHelperTest {
 
   @Test
   fun `test makeMemo rejects invalid memo id values`() {
-    assertThrows<SepValidationException> { makeMemo("0", "id") }
     assertThrows<SepValidationException> { makeMemo("-1", "id") }
     assertThrows<SepValidationException> { makeMemo("18446744073709551616", "id") }
     assertThrows<SepValidationException> { makeMemo("abc", "id") }

--- a/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/MemoHelperTest.kt
@@ -79,7 +79,7 @@ internal class MemoHelperTest {
   }
 
   @Test
-  fun `test makeMemoId with invalid values`() {
+  fun `test makeMemo rejects invalid memo id values`() {
     assertThrows<SepValidationException> { makeMemo("0", "id") }
     assertThrows<SepValidationException> { makeMemo("-1", "id") }
     assertThrows<SepValidationException> { makeMemo("18446744073709551616", "id") }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -149,7 +149,7 @@ public class DefaultPaymentListener implements PaymentListener {
         && accountType(ledgerPayment.getTo()) == Muxed) {
       MuxedAccount muxedAccount = new MuxedAccount(ledgerPayment.getTo());
       toAccount = muxedAccount.getAccountId();
-      memo = Memo.id(Objects.requireNonNull(muxedAccount.getMuxedId()).longValue());
+      memo = Memo.id(Objects.requireNonNull(muxedAccount.getMuxedId()));
     } else {
       toAccount = ledgerPayment.getTo();
       memo = Memo.fromXdr(ledgerTransaction.getMemo());


### PR DESCRIPTION
### Description

  - Fix MEMO_ID validation to support the full Stellar uint64 range (0 to 18,446,744,073,709,551,615)
  - Replace Long.parseLong and Long.longValue() with BigInteger for MEMO_ID parsing and conversion
  - Consolidate memo ID creation into a shared MemoHelper.makeMemoId() method   

### Context

Partner reported that SEP-24 requests with refund_memo 11872666534918305457 were rejected with "Invalid Memo"  due to this refund_memo value above Java's `Long.MAX_VALUE `(9,223,372,036,854,775,807) 

Stellar protocol defines `MEMO_ID` as uint64, but the platform was using Java's signed long for parsing, which only supports half the range.

The same issue existed in SEP-10 memo validation, `xdrMemoToString` (used by the payment observer for memo matching), and muxed account memo handling in `DefaultPaymentListener`

### Testing

  - ./gradlew test
  - Added new unit tests to cover all cases

### Documentation

N/A

### Known limitations

N/A

