### PR TITLE
[ANCHOR-1190] Fix Docker release to publish multi-arch images    

### DIFF
--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -51,7 +51,7 @@ jobs:
           build-args: |
             TARGETARCH=amd64
           tags: |
-            stellar/anchor-platform:edge,stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64
           # add build cache for faster rebuilds
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -86,7 +86,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images - AMD64
+      - name: Build and push Docker images - ARM64
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -96,14 +96,50 @@ jobs:
           build-args: |
             TARGETARCH=arm64
           tags: |
-            stellar/anchor-platform:edge,stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
           # add build cache for faster rebuilds
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  create_multi_arch_manifest:
+    name: Create Multi-Arch Manifest
+    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current date
+        id: get_date
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Calculate Github SHA
+        shell: bash
+        id: get_sha
+        run: echo "SHA=$(git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
+
+      - name: Login to DockerHub
+        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest for edge tag
+        run: |
+          docker manifest create stellar/anchor-platform:edge \
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64 \
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
+          docker manifest push stellar/anchor-platform:edge
+
+      - name: Create and push multi-arch manifest for dated tag
+        run: |
+          docker manifest create stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }} \
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64 \
+            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
+          docker manifest push stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
+
   complete:
     if: always()
-    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64 ]
+    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64, create_multi_arch_manifest ]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -10,6 +10,9 @@ on:
     # when commits are pushed or pull requests merged onto `develop` branch
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build_and_push_docker_image_amd64:
     name: Push to DockerHub - AMD64

--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -26,6 +26,7 @@ jobs:
 
   build_and_push_docker_image_amd64:
     name: Push to DockerHub (tag=stellar/anchor-platform:${{ github.event.release.tag_name }}) - AMD64
+    needs: [ check_release_tag ]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -58,14 +59,13 @@ jobs:
           build-args: |
             TARGETARCH=amd64
           tags: |
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
-            stellar/anchor-platform:latest
-          # add build cache for faster rebuilds
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   build_and_push_docker_image_arm64:
     name: Push to DockerHub (tag=stellar/anchor-platform:${{ github.event.release.tag_name }}) - ARM64
+    needs: [ check_release_tag ]
     # Having a separate job for ARM64 helps to reduce overall build time.
     # The multi-arch build takes longer if running the arm build on an amd64 runner via emulation.
     runs-on: ubuntu-24.04-arm
@@ -100,15 +100,44 @@ jobs:
           build-args: |
             TARGETARCH=arm64
           tags: |
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
-            stellar/anchor-platform:latest
-          # Optional: add build cache for faster rebuilds
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  create_multi_arch_manifest:
+    name: Create Multi-Arch Manifest
+    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get EXPECTED_RELEASE_TAG
+        shell: bash
+        run: echo "EXPECTED_RELEASE_TAG=$(./gradlew -q printVersionName)" >> "$GITHUB_ENV"
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest for version tag
+        run: |
+          docker manifest create stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }} \
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64 \
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
+          docker manifest push stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
+
+      - name: Create and push multi-arch manifest for latest tag
+        run: |
+          docker manifest create stellar/anchor-platform:latest \
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64 \
+            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
+          docker manifest push stellar/anchor-platform:latest
+
   complete:
     if: always()
-    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64, check_release_tag ]
+    needs: [ check_release_tag, build_and_push_docker_image_amd64, build_and_push_docker_image_arm64, create_multi_arch_manifest ]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [ created, edited ]
 
+permissions:
+  contents: read
+
 jobs:
   check_release_tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Each release job now pushes to a temporary arch-specific tag (-amd64, -arm64), and a new `create_multi_arch_manifest` job combines them into a single multi-arch manifest.

Same for `on_push_to_develop`

### Context

Since 4.1.1, the release workflow has been publishing only one architecture per release due to a race condition, the amd64 and arm64 jobs both push to the same Docker tag, so whichever finishes last overwrites the other.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

