### PR TITLE
[ANCHOR-1190] Fix multi-arch image build

### DIFF
--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -14,13 +14,14 @@ permissions:
   contents: read
 
 jobs:
-  build_and_push_docker_image_amd64:
-    name: Push to DockerHub - AMD64
+  build_docker_image_amd64:
+    name: Build Docker Image - AMD64
     runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
-      # Use a Buildx builder with the docker-container driver (required for --platform)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -29,22 +30,14 @@ jobs:
           driver-opts: |
             image=moby/buildkit:latest
 
-      - name: Get current date
-        id: get_date
-        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Calculate Github SHA
-        shell: bash
-        id: get_sha
-        run: echo "SHA=$(git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
-
       - name: Login to DockerHub
         uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images - AMD64
+      - name: Build and push by digest - AMD64
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -53,19 +46,18 @@ jobs:
           platforms: linux/amd64
           build-args: |
             TARGETARCH=amd64
-          tags: |
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64
-          # add build cache for faster rebuilds
+          outputs: type=image,name=stellar/anchor-platform,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build_and_push_docker_image_arm64:
-    name: Push to DockerHub - ARM64
+  build_docker_image_arm64:
+    name: Build Docker Image - ARM64
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
-      # Use a Buildx builder with the docker-container driver (required for --platform)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -74,22 +66,14 @@ jobs:
           driver-opts: |
             image=moby/buildkit:latest
 
-      - name: Get current date
-        id: get_date
-        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Calculate Github SHA
-        shell: bash
-        id: get_sha
-        run: echo "SHA=$(git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
-
       - name: Login to DockerHub
         uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images - ARM64
+      - name: Build and push by digest - ARM64
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -98,15 +82,13 @@ jobs:
           platforms: linux/arm64
           build-args: |
             TARGETARCH=arm64
-          tags: |
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
-          # add build cache for faster rebuilds
+          outputs: type=image,name=stellar/anchor-platform,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest
-    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64 ]
+    needs: [ build_docker_image_amd64, build_docker_image_arm64 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -120,6 +102,9 @@ jobs:
         id: get_sha
         run: echo "SHA=$(git rev-parse --short ${{ github.sha }} )" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
         uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
         with:
@@ -128,21 +113,19 @@ jobs:
 
       - name: Create and push multi-arch manifest for edge tag
         run: |
-          docker manifest create stellar/anchor-platform:edge \
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64 \
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
-          docker manifest push stellar/anchor-platform:edge
+          docker buildx imagetools create -t stellar/anchor-platform:edge \
+            stellar/anchor-platform@${{ needs.build_docker_image_amd64.outputs.digest }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_arm64.outputs.digest }}
 
       - name: Create and push multi-arch manifest for dated tag
         run: |
-          docker manifest create stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }} \
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-amd64 \
-            stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}-arm64
-          docker manifest push stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }}
+          docker buildx imagetools create -t stellar/anchor-platform:edge-${{ steps.get_date.outputs.DATE }}-${{ steps.get_sha.outputs.SHA }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_amd64.outputs.digest }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_arm64.outputs.digest }}
 
   complete:
     if: always()
-    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64, create_multi_arch_manifest ]
+    needs: [ build_docker_image_amd64, build_docker_image_arm64, create_multi_arch_manifest ]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -27,16 +27,14 @@ jobs:
           echo "The release tag must match project version."
           exit 1
 
-  build_and_push_docker_image_amd64:
-    name: Push to DockerHub (tag=stellar/anchor-platform:${{ github.event.release.tag_name }}) - AMD64
+  build_docker_image_amd64:
+    name: Build Docker Image - AMD64
     needs: [ check_release_tag ]
     runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get EXPECTED_RELEASE_TAG
-        shell: bash
-        run: echo "EXPECTED_RELEASE_TAG=$(./gradlew -q printVersionName)" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -52,7 +50,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images - AMD64
+      - name: Build and push by digest - AMD64
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -61,23 +60,20 @@ jobs:
           platforms: linux/amd64
           build-args: |
             TARGETARCH=amd64
-          tags: |
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64
+          outputs: type=image,name=stellar/anchor-platform,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build_and_push_docker_image_arm64:
-    name: Push to DockerHub (tag=stellar/anchor-platform:${{ github.event.release.tag_name }}) - ARM64
+  build_docker_image_arm64:
+    name: Build Docker Image - ARM64
     needs: [ check_release_tag ]
     # Having a separate job for ARM64 helps to reduce overall build time.
     # The multi-arch build takes longer if running the arm build on an amd64 runner via emulation.
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get EXPECTED_RELEASE_TAG
-        shell: bash
-        run: echo "EXPECTED_RELEASE_TAG=$(./gradlew -q printVersionName)" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -93,7 +89,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images - ARM64
+      - name: Build and push by digest - ARM64
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -102,14 +99,13 @@ jobs:
           platforms: linux/arm64
           build-args: |
             TARGETARCH=arm64
-          tags: |
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
+          outputs: type=image,name=stellar/anchor-platform,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest
-    needs: [ build_and_push_docker_image_amd64, build_and_push_docker_image_arm64 ]
+    needs: [ build_docker_image_amd64, build_docker_image_arm64 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -117,6 +113,9 @@ jobs:
       - name: Get EXPECTED_RELEASE_TAG
         shell: bash
         run: echo "EXPECTED_RELEASE_TAG=$(./gradlew -q printVersionName)" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Login
         uses: docker/login-action@v3
@@ -126,21 +125,19 @@ jobs:
 
       - name: Create and push multi-arch manifest for version tag
         run: |
-          docker manifest create stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }} \
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64 \
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
-          docker manifest push stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}
+          docker buildx imagetools create -t stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_amd64.outputs.digest }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_arm64.outputs.digest }}
 
       - name: Create and push multi-arch manifest for latest tag
         run: |
-          docker manifest create stellar/anchor-platform:latest \
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-amd64 \
-            stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }}-arm64
-          docker manifest push stellar/anchor-platform:latest
+          docker buildx imagetools create -t stellar/anchor-platform:latest \
+            stellar/anchor-platform@${{ needs.build_docker_image_amd64.outputs.digest }} \
+            stellar/anchor-platform@${{ needs.build_docker_image_arm64.outputs.digest }}
 
   complete:
     if: always()
-    needs: [ check_release_tag, build_and_push_docker_image_amd64, build_and_push_docker_image_arm64, create_multi_arch_manifest ]
+    needs: [ check_release_tag, build_docker_image_amd64, build_docker_image_arm64, create_multi_arch_manifest ]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
### Description

  - Switch to Docker's recommended pattern: 
    - Build jobs push by digest only (no intermediate -amd64 -arm64 tags)
    - Then a `create_multi_arch_manifest` job uses `docker buildx imagetools create` to merge both digests into a single multi-arch manifest.
  - Apply the same fix to `on_push_to_develop`

### Context

https://github.com/stellar/anchor-platform/pull/1922 failed because `docker manifest create` (used to merge the amd64 and arm64 builds) expects each source image to be a plain image manifest. However, `build-push-action` v6 with buildx wraps each single-platform image into a manifest list (containing the image + provenance attestation), so the command rejects them with the error "is a manifest list"

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

