### PR TITLE
[ANCHOR -1195] Fix error serialization when Horizon look up fails

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/InternalErrorException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/InternalErrorException.java
@@ -10,8 +10,4 @@ public class InternalErrorException extends RpcException {
   public InternalErrorException(String message) {
     super(INTERNAL_ERROR, message);
   }
-
-  public InternalErrorException(String message, Throwable ex) {
-    super(INTERNAL_ERROR, message, ex);
-  }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/InvalidParamsException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/InvalidParamsException.java
@@ -10,8 +10,4 @@ public class InvalidParamsException extends RpcException {
   public InvalidParamsException(String message) {
     super(INVALID_PARAMS, message);
   }
-
-  public InvalidParamsException(String message, Throwable e) {
-    super(INVALID_PARAMS, message, e);
-  }
 }

--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/RpcException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/rpc/RpcException.java
@@ -9,16 +9,9 @@ import org.stellar.anchor.api.rpc.RpcErrorCode;
 @EqualsAndHashCode(callSuper = false)
 public class RpcException extends AnchorException {
   private final RpcErrorCode errorCode;
-  private Object additionalData;
 
   public RpcException(RpcErrorCode errorCode, String message) {
     super(message);
     this.errorCode = errorCode;
-  }
-
-  public RpcException(RpcErrorCode errorCode, String message, Object additionalData) {
-    super(message);
-    this.errorCode = errorCode;
-    this.additionalData = additionalData;
   }
 }

--- a/core/src/main/java/org/stellar/anchor/ledger/Horizon.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/Horizon.java
@@ -108,7 +108,11 @@ public class Horizon implements LedgerClient {
       debug("Transaction not found: " + txnHash);
       return null;
     } catch (NetworkException nex) {
-      throw new LedgerException("Error getting transaction: " + txnHash, nex);
+      throw new LedgerException(
+          String.format(
+              "Error getting transaction: %s. Code: %s, body: %s",
+              txnHash, nex.getCode(), nex.getBody()),
+          nex);
     }
 
     TransactionEnvelope txnEnv;

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -182,7 +182,9 @@ public class NotifyOnchainFundsReceivedHandler
     } catch (LedgerException ex) {
       errorEx(String.format("Failed to retrieve stellar transaction by ID[%s]", stellarTxnId), ex);
       throw new InternalErrorException(
-          String.format("Failed to retrieve Stellar transaction by ID[%s]", stellarTxnId), ex);
+          String.format(
+              "Failed to retrieve Stellar transaction by ID[%s]: %s",
+              stellarTxnId, ex.getMessage()));
     }
 
     if (request.getAmountIn() != null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandler.java
@@ -120,7 +120,9 @@ public class NotifyOnchainFundsSentHandler
     } catch (LedgerException ex) {
       errorEx(String.format("Failed to retrieve stellar transaction by ID[%s]", stellarTxnId), ex);
       throw new InternalErrorException(
-          String.format("Failed to retrieve Stellar transaction by ID[%s]", stellarTxnId), ex);
+          String.format(
+              "Failed to retrieve Stellar transaction by ID[%s]: %s",
+              stellarTxnId, ex.getMessage()));
     }
 
     txn.setTransferReceivedAt(transferReceivedAt);

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -171,7 +171,8 @@ public class RequestOnchainFundsHandler
       try {
         memo = makeMemo(request.getMemo(), "id");
       } catch (SepException e) {
-        throw new InvalidParamsException(String.format("Invalid id memo : %s", e.getMessage()));
+        Log.errorEx("Invalid id memo", e);
+        throw new InvalidParamsException(String.format("Invalid id memo: %s", e.getMessage()));
       }
 
       if (memo == null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -171,7 +171,7 @@ public class RequestOnchainFundsHandler
       try {
         memo = makeMemo(request.getMemo(), "id");
       } catch (SepException e) {
-        throw new InvalidParamsException(String.format("Invalid id memo : %s", e.getMessage()), e);
+        throw new InvalidParamsException(String.format("Invalid id memo : %s", e.getMessage()));
       }
 
       if (memo == null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/RpcUtil.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/RpcUtil.java
@@ -47,7 +47,6 @@ public class RpcUtil {
                 .id(getTransactionId(rpcRequest.getParams()))
                 .code(ex.getErrorCode().getErrorCode())
                 .message(ex.getMessage())
-                .data(ex.getAdditionalData())
                 .build())
         .build();
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -595,7 +595,10 @@ class NotifyOnchainFundsReceivedHandlerTest {
       LedgerException("Invalid stellar transaction")
 
     val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+    assertEquals(
+      "Failed to retrieve Stellar transaction by ID[stellarTxId]: Invalid stellar transaction",
+      ex.message
+    )
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
@@ -1019,7 +1022,10 @@ class NotifyOnchainFundsReceivedHandlerTest {
       LedgerException("Invalid stellar transaction")
 
     val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+    assertEquals(
+      "Failed to retrieve Stellar transaction by ID[stellarTxId]: Invalid stellar transaction",
+      ex.message
+    )
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
@@ -207,7 +207,10 @@ class NotifyOnchainFundsSentHandlerTest {
     every { horizon.getTransaction(any()) } throws LedgerException("Invalid stellar transaction")
 
     val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals("Failed to retrieve Stellar transaction by ID[stellarTxId]", ex.message)
+    assertEquals(
+      "Failed to retrieve Stellar transaction by ID[stellarTxId]: Invalid stellar transaction",
+      ex.message
+    )
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -295,7 +295,7 @@ class RequestOnchainFundsHandlerTest {
     every { txn24Store.save(capture(sep24TxnCapture)) } returns null
 
     val ex = assertThrows<InvalidParamsException> { handler.handle(request) }
-    assertEquals("Invalid id memo : Invalid memo testMemo of type: MEMO_ID", ex.message)
+    assertEquals("Invalid id memo: Invalid memo testMemo of type: MEMO_ID", ex.message)
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }


### PR DESCRIPTION
### Description

Include HTTP status code and response body in the error message string instead of passing the exception object, matching the existing pattern in `RpcService`. Remove the dangerous `(String, Throwable)` constructors to prevent this class of bug.

### Context

When Horizon fails (e.g., rate limiting, network issues), the platform tries to return an error but crashes on serializing the exception, resulting in an unhelpful HTTP 500 (`HttpMessageNotWritableException`).

Root cause: `InternalErrorException(message, Throwable)` looks like it sets the Java exception cause, but actually passes the `Throwable` into `RpcException`'s `additionalData` field (an `Object`). Spring then tries to JSON-serialize that `Throwable` and fails because `Throwable#detailMessage` is a private field.

### Testing

- `./gradlew test`
- Updated assertions in `NotifyOnchainFundsReceivedHandlerTest`, `NotifyOnchainFundsSentHandlerTest`

### Documentation

N/A

### Known limitations

N/A

