### PR TITLE
[ANCHOR-1196] Fix discarded return value in muxed account address encoding

### DIFF
--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
@@ -58,13 +58,12 @@ public class LedgerClientHelper {
                   StrKey.encodeEd25519PublicKey(payment.getDestination().getEd25519().getUint256());
               case KEY_TYPE_MUXED_ED25519 -> {
                 try {
-                  StrKey.encodeMed25519PublicKey(
+                  yield StrKey.encodeMed25519PublicKey(
                       payment.getDestination().getMed25519().toXdrByteArray());
                 } catch (IOException ioex) {
                   throw new LedgerException(
                       "Failed to encode muxed account: " + payment.getDestination(), ioex);
                 }
-                yield null;
               }
               default -> {
                 debugF("Unsupported payment destination type: {}", payment.getDestination());
@@ -103,13 +102,12 @@ public class LedgerClientHelper {
                             .getUint256());
                 case KEY_TYPE_MUXED_ED25519 -> {
                   try {
-                    StrKey.encodeMed25519PublicKey(
+                    yield StrKey.encodeMed25519PublicKey(
                         payment.getDestination().getMed25519().toXdrByteArray());
                   } catch (IOException ioex) {
                     throw new LedgerException(
                         "Failed to encode muxed account: " + payment.getDestination(), ioex);
                   }
-                  yield null;
                 }
                 default -> {
                   debugF("Unsupported payment destination type: {}", payment.getDestination());
@@ -127,13 +125,12 @@ public class LedgerClientHelper {
                         payment.getDestination().getEd25519().getUint256());
                 case KEY_TYPE_MUXED_ED25519 -> {
                   try {
-                    StrKey.encodeMed25519PublicKey(
+                    yield StrKey.encodeMed25519PublicKey(
                         payment.getDestination().getMed25519().toXdrByteArray());
                   } catch (IOException ioex) {
                     throw new LedgerException(
                         "Failed to encode muxed account: " + payment.getDestination(), ioex);
                   }
-                  yield null;
                 }
                 default -> {
                   debugF("Unsupported payment destination type: {}", payment.getDestination());

--- a/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
@@ -11,6 +11,7 @@ import org.stellar.sdk.xdr.CryptoKeyType.KEY_TYPE_ED25519
 import org.stellar.sdk.xdr.EnvelopeType.*
 import org.stellar.sdk.xdr.MemoType.MEMO_TEXT
 import org.stellar.sdk.xdr.OperationType.PATH_PAYMENT_STRICT_RECEIVE
+import org.stellar.sdk.xdr.OperationType.PATH_PAYMENT_STRICT_SEND
 import org.stellar.sdk.xdr.SignerKeyType.*
 
 internal class LedgerClientHelperTest {
@@ -85,6 +86,63 @@ internal class LedgerClientHelperTest {
       )
 
     assertNull(ledgerOperation)
+  }
+
+  @Test
+  fun `test convert() with muxed destination payment returns M-address`() {
+    val operation = GsonUtils.getInstance().fromJson(testMuxedPaymentOpJson, Operation::class.java)
+
+    val ledgerOperation =
+      LedgerClientHelper.convert(
+        "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
+        1708638L,
+        5,
+        1,
+        operation,
+      )
+
+    assertEquals(OperationType.PAYMENT, ledgerOperation.type)
+    assertNotNull(ledgerOperation.paymentOperation.to)
+    assertTrue(ledgerOperation.paymentOperation.to.startsWith("M"))
+  }
+
+  @Test
+  fun `test convert() with muxed destination path payment strict receive returns M-address`() {
+    val operation =
+      GsonUtils.getInstance()
+        .fromJson(testMuxedPathPaymentStrictReceiveOpJson, Operation::class.java)
+
+    val ledgerOperation =
+      LedgerClientHelper.convert(
+        "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
+        1708638L,
+        5,
+        1,
+        operation,
+      )
+
+    assertEquals(PATH_PAYMENT_STRICT_RECEIVE, ledgerOperation.type)
+    assertNotNull(ledgerOperation.pathPaymentOperation.to)
+    assertTrue(ledgerOperation.pathPaymentOperation.to.startsWith("M"))
+  }
+
+  @Test
+  fun `test convert() with muxed destination path payment strict send returns M-address`() {
+    val operation =
+      GsonUtils.getInstance().fromJson(testMuxedPathPaymentStrictSendOpJson, Operation::class.java)
+
+    val ledgerOperation =
+      LedgerClientHelper.convert(
+        "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
+        1708638L,
+        5,
+        1,
+        operation,
+      )
+
+    assertEquals(PATH_PAYMENT_STRICT_SEND, ledgerOperation.type)
+    assertNotNull(ledgerOperation.pathPaymentOperation.to)
+    assertTrue(ledgerOperation.pathPaymentOperation.to.startsWith("M"))
   }
 
   @Test
@@ -246,6 +304,90 @@ private const val testPathPaymentOpJson =
             "discriminant":"KEY_TYPE_ED25519",
             "ed25519":{
                "uint256":"0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlU="
+            }
+         },
+         "destAsset":{
+            "discriminant":"ASSET_TYPE_NATIVE"
+         },
+         "destAmount":{
+            "int64":1230
+         }
+      }
+   }
+}
+"""
+
+private const val testMuxedPaymentOpJson =
+  """
+{
+   "body":{
+      "discriminant":"PAYMENT",
+      "paymentOp":{
+         "destination":{
+            "discriminant":"KEY_TYPE_MUXED_ED25519",
+            "med25519":{
+               "id":{"uint64":{"number":12345}},
+               "ed25519":{"uint256":"0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlU="}
+            }
+         },
+         "asset":{
+            "discriminant":"ASSET_TYPE_NATIVE"
+         },
+         "amount":{
+            "int64":1230
+         }
+      }
+   }
+}
+"""
+
+private const val testMuxedPathPaymentStrictReceiveOpJson =
+  """
+{
+   "body":{
+      "discriminant":"PATH_PAYMENT_STRICT_RECEIVE",
+      "pathPaymentStrictReceiveOp":{
+         "sendAsset":{
+             "discriminant":"ASSET_TYPE_NATIVE"
+         },
+         "sendMax":{
+             "int64":1230
+         },
+         "destination":{
+            "discriminant":"KEY_TYPE_MUXED_ED25519",
+            "med25519":{
+               "id":{"uint64":{"number":12345}},
+               "ed25519":{"uint256":"0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlU="}
+            }
+         },
+         "destAsset":{
+            "discriminant":"ASSET_TYPE_NATIVE"
+         },
+         "destAmount":{
+            "int64":1230
+         }
+      }
+   }
+}
+"""
+
+private const val testMuxedPathPaymentStrictSendOpJson =
+  """
+{
+   "body":{
+      "discriminant":"PATH_PAYMENT_STRICT_SEND",
+      "pathPaymentStrictSendOp":{
+         "sendAsset":{
+             "discriminant":"ASSET_TYPE_NATIVE"
+         },
+         "sendAmount":{
+             "int64":1230
+         },
+         "destination":{
+            "discriminant":"KEY_TYPE_MUXED_ED25519",
+            "med25519":{
+               "id":{"uint64":{"number":12345}},
+               "ed25519":{"uint256":"0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlU="}
             }
          },
          "destAsset":{

--- a/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
@@ -393,7 +393,7 @@ private const val testMuxedPathPaymentStrictSendOpJson =
          "destAsset":{
             "discriminant":"ASSET_TYPE_NATIVE"
          },
-         "destAmount":{
+         "destMin":{
             "int64":1230
          }
       }


### PR DESCRIPTION
### Description

Fix muxed (M-address) payment destinations were discarded after resolved, causing deposit matching to silently fail  

### Context

https://github.com/stellar/internal-agents/issues/93
Finding 11 — Muxed Account Address Discarded → NPE

### Testing

- `./gradlew test`
- Added unit tests asserting `convert()` returns a non-null M-address for muxed destinations across `PAYMENT`, `PATH_PAYMENT_STRICT_RECEIVE`, and `PATH_PAYMENT_STRICT_SEND`   

### Documentation

N/A

### Known limitations

N/A

