### PR TITLE
[ANCHOR-1202] Fix muxed-account auth collapse in SEP-24 and SEP-6 transaction

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -209,7 +209,7 @@ public class Sep24Service {
                 sep24Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep24Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .fromAccount(sourceAccount)
             .toAccount(asset.getDistributionAccount())
@@ -391,7 +391,7 @@ public class Sep24Service {
                 sep24Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep24Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
@@ -484,8 +484,9 @@ public class Sep24Service {
           (txReq.getAssetCode() == null) ? "null" : txReq.getAssetCode());
       throw new SepValidationException("asset code not supported");
     }
+    String tokenAccount = Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount());
     List<Sep24Transaction> txns =
-        txnStore.findTransactions(token.getAccount(), token.getAccountMemo(), txReq);
+        txnStore.findTransactions(tokenAccount, token.getAccountMemo(), txReq);
     GetTransactionsResponse result = new GetTransactionsResponse();
     List<TransactionResponse> list = new ArrayList<>();
     debugF("found {} transactions", txns.size());
@@ -530,13 +531,18 @@ public class Sep24Service {
           "One of id, stellar_transaction_id or external_transaction_id is required.");
     }
 
-    // We should not return the transaction that belongs to other accounts.
-    if (txn == null || !Objects.equals(txn.getWebAuthAccount(), token.getAccount())) {
+    // Match the stored web_auth_account against the requesting token. To preserve
+    // access to transactions created before muxed-aware storage was introduced
+    // (where muxed customers had their sub-id collapsed to the underlying G), we
+    // branch on the stored value: M-prefixed values require exact muxed match
+    // (post-fix isolation); non-muxed values fall back to comparing the underlying
+    // G-account. The listing endpoint is kept strict, so legacy rows are reachable
+    // by direct ID only — they are not enumerable.
+    if (txn == null || !webAuthAccountMatches(txn.getWebAuthAccount(), token)) {
       infoF("no transactions found with account:{}", token.getAccount());
       throw new SepNotFoundException("transaction not found");
     }
 
-    // Make sure the transaction belongs to the account with the same memo.
     if (!Objects.equals(txn.getWebAuthAccountMemo(), token.getAccountMemo())) {
       infoF(
           "no transactions found with account:{} memo:{}",
@@ -600,5 +606,21 @@ public class Sep24Service {
     builder.amountOut(quote.getBuyAmount());
     builder.amountOutAsset(quote.getBuyAsset());
     builder.feeDetails(quote.getFee());
+  }
+
+  /**
+   * Whether the stored web_auth_account belongs to the requesting token. M-prefixed stored values
+   * (post-fix muxed-aware storage) require an exact muxed match; non-muxed stored values fall back
+   * to the underlying G so that legacy rows predating muxed-aware storage remain reachable by their
+   * original creator.
+   */
+  private static boolean webAuthAccountMatches(String storedAccount, WebAuthJwt token) {
+    if (storedAccount == null) {
+      return false;
+    }
+    if (storedAccount.startsWith("M")) {
+      return storedAccount.equals(token.getMuxedAccount());
+    }
+    return storedAccount.equals(token.getAccount());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -141,7 +141,7 @@ public class Sep6Service {
                 sep6Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(request.getAccount())
             .clientDomain(token.getClientDomain())
@@ -256,7 +256,7 @@ public class Sep6Service {
                 sep6Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(request.getAccount())
             .clientDomain(token.getClientDomain())
@@ -336,7 +336,7 @@ public class Sep6Service {
                 sep6Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .fromAccount(sourceAccount)
             .clientDomain(token.getClientDomain())
@@ -433,7 +433,7 @@ public class Sep6Service {
                 sep6Config.getInitialUserDeadlineSeconds() == null
                     ? null
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
-            .webAuthAccount(token.getAccount())
+            .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
             .fromAccount(sourceAccount)
             .clientDomain(token.getClientDomain())
@@ -467,7 +467,8 @@ public class Sep6Service {
     if (request == null) {
       throw new SepValidationException("missing request");
     }
-    if (!request.getAccount().equals(token.getAccount())) {
+    String tokenAccount = Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount());
+    if (!request.getAccount().equals(tokenAccount)) {
       throw new SepNotAuthorizedException("account does not match token");
     }
     if (assetService.getAsset(request.getAssetCode()) == null) {
@@ -477,7 +478,7 @@ public class Sep6Service {
 
     // Query the transaction store
     List<Sep6Transaction> transactions =
-        txnStore.findTransactions(token.getAccount(), token.getAccountMemo(), request);
+        txnStore.findTransactions(tokenAccount, token.getAccountMemo(), request);
     List<Sep6TransactionResponse> responses = new ArrayList<>();
     for (Sep6Transaction txn : transactions) {
       String lang = validateLanguage(languageConfig, request.getLang());
@@ -512,12 +513,13 @@ public class Sep6Service {
           "One of id, stellar_transaction_id, or external_transaction_id is required");
     }
 
-    // Validate the transaction
-    if (txn == null) {
+    // Validate the transaction. M-prefixed stored values (post-fix muxed-aware
+    // storage) require an exact muxed match; non-muxed stored values fall back to
+    // the underlying G so that legacy rows predating muxed-aware storage remain
+    // reachable by their original creator. The listing endpoint stays strict, so
+    // legacy rows are reachable by direct ID only — they are not enumerable.
+    if (txn == null || !webAuthAccountMatches(txn.getWebAuthAccount(), token)) {
       throw new NotFoundException("transaction not found");
-    }
-    if (!Objects.equals(txn.getWebAuthAccount(), token.getAccount())) {
-      throw new NotFoundException("account does not match token");
     }
     if (!Objects.equals(txn.getWebAuthAccountMemo(), token.getAccountMemo())) {
       throw new NotFoundException("account memo does not match token");
@@ -597,5 +599,21 @@ public class Sep6Service {
       }
     }
     return response;
+  }
+
+  /**
+   * Whether the stored web_auth_account belongs to the requesting token. M-prefixed stored values
+   * (post-fix muxed-aware storage) require an exact muxed match; non-muxed stored values fall back
+   * to the underlying G so that legacy rows predating muxed-aware storage remain reachable by their
+   * original creator.
+   */
+  private static boolean webAuthAccountMatches(String storedAccount, WebAuthJwt token) {
+    if (storedAccount == null) {
+      return false;
+    }
+    if (storedAccount.startsWith("M")) {
+      return storedAccount.equals(token.getMuxedAccount());
+    }
+    return storedAccount.equals(token.getAccount());
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
@@ -1,12 +1,14 @@
 package org.stellar.anchor
 
 import io.mockk.every
+import java.math.BigInteger
 import javax.crypto.SecretKey
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
 import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.util.KeyUtil
 import org.stellar.anchor.util.KeyUtil.toSecretKeySpecOrNull
+import org.stellar.sdk.MuxedAccount
 
 class TestHelper {
   companion object {
@@ -24,6 +26,26 @@ class TestHelper {
       return Sep10Jwt.of(
         "$hostUrl/auth",
         if (accountMemo == null) account else "$account:$accountMemo",
+        issuedAt,
+        issuedAt + 60,
+        "",
+        clientDomain,
+        homeDomain,
+      )
+    }
+
+    fun createMuxedWebAuthJwt(
+      account: String = TEST_ACCOUNT,
+      muxedId: Long,
+      hostUrl: String = "",
+      clientDomain: String = "vibrant.stellar.org",
+      homeDomain: String = "test.stellar.org",
+    ): WebAuthJwt {
+      val muxedAddress = MuxedAccount(account, BigInteger.valueOf(muxedId)).address
+      val issuedAt: Long = System.currentTimeMillis() / 1000L
+      return Sep10Jwt.of(
+        "$hostUrl/auth",
+        muxedAddress,
         issuedAt,
         issuedAt + 60,
         "",

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -778,6 +778,94 @@ internal class Sep24ServiceTest {
     assertTrue(response.url.indexOf("lang=en") != -1)
   }
 
+  @Test
+  fun `test withdraw with muxed token stores muxed address as webAuthAccount`() {
+    val strToken = jwtService.encode(createTestInteractiveJwt(null))
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+      "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
+    val slotTxn = slot<Sep24Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val muxedJwt =
+      TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
+    sep24Service.withdraw(muxedJwt, createTestTransactionRequest())
+
+    assertEquals(muxedJwt.muxedAccount, slotTxn.captured.webAuthAccount)
+    assertNotEquals(TEST_ACCOUNT, slotTxn.captured.webAuthAccount)
+    assertNull(slotTxn.captured.webAuthAccountMemo)
+  }
+
+  @Test
+  fun `test deposit with muxed token stores muxed address as webAuthAccount`() {
+    val strToken = jwtService.encode(createTestInteractiveJwt(null))
+    every { interactiveUrlConstructor.construct(any(), any(), any(), any()) } returns
+      "${TEST_SEP24_INTERACTIVE_URL}?lang=en&token=$strToken"
+    val slotTxn = slot<Sep24Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+
+    val muxedJwt =
+      TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
+    sep24Service.deposit(muxedJwt, createTestTransactionRequest())
+
+    assertEquals(muxedJwt.muxedAccount, slotTxn.captured.webAuthAccount)
+    assertNotEquals(TEST_ACCOUNT, slotTxn.captured.webAuthAccount)
+    assertNull(slotTxn.captured.webAuthAccountMemo)
+  }
+
+  @Test
+  fun `test find transaction rejects different muxed sub-id on same underlying account`() {
+    val muxedAJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    val muxedBJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 22L)
+
+    val testTxn = createTestTransaction("deposit")
+    testTxn.webAuthAccount = muxedAJwt.muxedAccount
+    every { txnStore.findByTransactionId(any()) } returns testTxn
+
+    val gtr = GetTransactionRequest(TEST_TRANSACTION_ID_0, null, null, "en-US")
+    // muxed-A can read its own
+    assertEquals(
+      testTxn.transactionId,
+      sep24Service.findTransaction(muxedAJwt, gtr).transaction.id,
+    )
+    // muxed-B (same underlying G) cannot
+    assertThrows<SepNotFoundException> { sep24Service.findTransaction(muxedBJwt, gtr) }
+  }
+
+  @Test
+  fun `test find transaction allows muxed user to read own legacy G-stored row by ID`() {
+    // Backwards-compat path for transactions created before muxed-aware storage:
+    // webAuthAccount was stored as the underlying G-account. A muxed token reading
+    // such a legacy row by ID is admitted via the G-fallback branch.
+    val muxedJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+
+    val legacyTxn = createTestTransaction("deposit")
+    legacyTxn.webAuthAccount = TEST_ACCOUNT // legacy: G-stored, no muxed info
+    legacyTxn.webAuthAccountMemo = null
+    every { txnStore.findByTransactionId(any()) } returns legacyTxn
+
+    val gtr = GetTransactionRequest(TEST_TRANSACTION_ID_0, null, null, "en-US")
+    assertEquals(
+      legacyTxn.transactionId,
+      sep24Service.findTransaction(muxedJwt, gtr).transaction.id,
+    )
+  }
+
+  @Test
+  fun `test find transactions only returns rows for own muxed sub-id`() {
+    val muxedAJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    every { txnStore.findTransactions(muxedAJwt.muxedAccount, null, any()) } returns
+      createTestTransactions("deposit")
+    every { txnStore.findTransactions(TEST_ACCOUNT, null, any()) } returns emptyList()
+
+    val request = GetTransactionsRequest()
+    request.assetCode = TEST_ASSET
+    val response = sep24Service.findTransactions(muxedAJwt, request)
+
+    assertEquals(2, response.transactions.size)
+    verify(exactly = 1) { txnStore.findTransactions(muxedAJwt.muxedAccount, null, any()) }
+    verify(exactly = 0) { txnStore.findTransactions(TEST_ACCOUNT, null, any()) }
+  }
+
   private fun createTestWebAuthJwt(): WebAuthJwt {
     return TestHelper.createWebAuthJwt(TEST_ACCOUNT, null, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -1421,6 +1421,119 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(Sep6ServiceTestData.transactionsJson, gson.toJson(response), true)
   }
 
+  @Test
+  fun `test deposit with muxed token stores muxed address as webAuthAccount`() {
+    val muxedJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(TEST_ACCOUNT)
+        .fundingMethod("bank_account")
+        .amount("100")
+        .build()
+    sep6Service.deposit(muxedJwt, request)
+
+    assertEquals(muxedJwt.muxedAccount, slotTxn.captured.webAuthAccount)
+    Assertions.assertNotEquals(TEST_ACCOUNT, slotTxn.captured.webAuthAccount)
+  }
+
+  @Test
+  fun `test withdraw with muxed token stores muxed address as webAuthAccount`() {
+    val muxedJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartWithdrawRequest.builder()
+        .assetCode(TEST_ASSET)
+        .fundingMethod("bank_account")
+        .amount("100")
+        .build()
+    sep6Service.withdraw(muxedJwt, request)
+
+    assertEquals(muxedJwt.muxedAccount, slotTxn.captured.webAuthAccount)
+    Assertions.assertNotEquals(TEST_ACCOUNT, slotTxn.captured.webAuthAccount)
+  }
+
+  @Test
+  fun `test find transaction rejects different muxed sub-id on same underlying account`() {
+    val muxedAJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    val muxedBJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 22L)
+
+    val depositTxn = createDepositTxn(muxedAJwt.muxedAccount)
+    val request = GetTransactionRequest.builder().id(depositTxn.id).lang("en-US").build()
+    every { txnStore.findByTransactionId(depositTxn.id) } returns depositTxn
+
+    // Muxed A can read its own transaction.
+    sep6Service.findTransaction(muxedAJwt, request)
+    // Muxed B (same underlying G) cannot.
+    assertThrows<NotFoundException> { sep6Service.findTransaction(muxedBJwt, request) }
+  }
+
+  @Test
+  fun `test find transaction allows muxed user to read own legacy G-stored row by ID`() {
+    // Backwards-compat path for transactions created before muxed-aware storage:
+    // webAuthAccount was stored as the underlying G-account. A muxed token reading
+    // such a legacy row by ID is admitted via the G-fallback branch.
+    val muxedJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+
+    val legacyTxn = createDepositTxn(TEST_ACCOUNT) // legacy: G-stored, no muxed info
+    val request = GetTransactionRequest.builder().id(legacyTxn.id).lang("en-US").build()
+    every { txnStore.findByTransactionId(legacyTxn.id) } returns legacyTxn
+
+    sep6Service.findTransaction(muxedJwt, request)
+
+    verify { txnStore.findByTransactionId(legacyTxn.id) }
+  }
+
+  @Test
+  fun `test find transactions only queries store for muxed account, not underlying G`() {
+    val muxedAJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+    val depositTxn = createDepositTxn(muxedAJwt.muxedAccount)
+    every { txnStore.findTransactions(muxedAJwt.muxedAccount, any(), any()) } returns
+      listOf(depositTxn)
+
+    val request =
+      GetTransactionsRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(muxedAJwt.muxedAccount)
+        .noOlderThan(Instant.now().toString())
+        .limit(10)
+        .kind("deposit")
+        .pagingId("1")
+        .lang("en-US")
+        .build()
+
+    sep6Service.findTransactions(muxedAJwt, request)
+
+    verify(exactly = 1) { txnStore.findTransactions(muxedAJwt.muxedAccount, null, request) }
+    verify(exactly = 0) { txnStore.findTransactions(TEST_ACCOUNT, null, request) }
+  }
+
+  @Test
+  fun `test find transactions rejects request using underlying G when authenticated as muxed`() {
+    val muxedAJwt = TestHelper.createMuxedWebAuthJwt(TEST_ACCOUNT, 11L)
+
+    val request =
+      GetTransactionsRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(TEST_ACCOUNT)
+        .noOlderThan(Instant.now().toString())
+        .limit(10)
+        .kind("deposit")
+        .pagingId("1")
+        .lang("en-US")
+        .build()
+
+    assertThrows<SepNotAuthorizedException> { sep6Service.findTransactions(muxedAJwt, request) }
+    verify { txnStore wasNot Called }
+  }
+
   private fun createDepositTxn(
     webAuthAccount: String,
     webAuthAccountMemo: String? = null,


### PR DESCRIPTION
### Description

- For muxed accounts, storage at all six creation sites (`Sep24Service` deposit/withdraw, `Sep6Service` deposit/depositExchange/withdraw/withdrawExchange) now writes the **muxed M-address** as `webAuthAccount` instead of the underlying G-address, using `Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount())`.

-  Validation on `GET/transactions` in both SEPs. The database is queried for rows where `webAuthAccount` matches the JWT's muxed M-address if it has one, and the G-account otherwise. A muxed customer only sees rows whose `webAuthAccount` equals their M-address now.

- G-accounts stay unaffected.

### Context

`Sep24Service` and `Sep6Service` previously stored `webAuthAccount = token.getAccount()`, which collapses muxed JWTs' sub-id to the underlying G-address. Two muxed customers on a shared custodial G could read each other's transactions. 

### Testing

- `./gradlew test`
- New tests verify storage behavior, post-fix isolation, findTransactions, findTransaction by id

### Documentation

N/A

### Known limitations

**Breaking changes for muxed accounts**
                                   
- `GET /transactions` endpoint will no longer return muxed customers'pre-fix legacy rows; those must be fetched by direct ID.
- On `GET /transaction?id=..` endpoint, if customer A learns customer B' transaction ID for a row created before this change, customer A can still fetch that row's details. Both customers' rows were stored with `webAuthAccount = G_shared` and `accountMemo = null`, and the muxed sub-ID was never recorded, so we can't tell their pre-change rows apart.
