### PR TITLE
[ANCHOR-1206] Add Gateway API support to helm charts

### DIFF
--- a/helm-charts/reference-server/Chart.yaml
+++ b/helm-charts/reference-server/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - "https://github.com/stellar/anchor-platform"
 name: ap-reference-server
-version: 0.1.0
+version: 0.2.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/reference-server/templates/gateway.yaml
+++ b/helm-charts/reference-server/templates/gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/reference-server/templates/httproute.yaml
+++ b/helm-charts/reference-server/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+          port: {{ .Values.services.ref.servicePort | default 8091 }}
+{{- end }}

--- a/helm-charts/reference-server/templates/ingress.yaml
+++ b/helm-charts/reference-server/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -51,3 +52,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
                 port:
                   number: {{ .Values.services.ref.servicePort | default 8091 }}
+{{- end }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -34,9 +34,41 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
+  enabled: true
   name: ingress-reference-server
   rules:
     host: reference-server.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: reference-server-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: reference-server.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: reference-server-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - https://github.com/stellar/anchor-platform
 name: sep
-version: 1.0.0
+version: 1.1.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/sep-service/templates/sepserver-gateway.yaml
+++ b/helm-charts/sep-service/templates/sepserver-gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-sep-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm-charts/sep-service/templates/sepserver-httproute.yaml
+++ b/helm-charts/sep-service/templates/sepserver-httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}-sep
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-sep
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+          port: {{ .Values.services.sep.servicePort | default 8080 }}
+{{- end }}

--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -55,3 +56,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
                 port:
                   number: {{ .Values.services.sep.servicePort | default 8080 }}
+{{- end }}

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -137,10 +137,42 @@ config:
       base_url: http://localhost:3000/txn
 
 ingress:
+  enabled: true
   name: ingress-anchor-platform
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: sep-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: sep.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: sep-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}
 
 sep1_toml: |
   ACCOUNTS = ["GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE"]

--- a/helm-charts/sep24-reference-ui/Chart.yaml
+++ b/helm-charts/sep24-reference-ui/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - https://github.com/stellar/sep24-reference-ui
 name: sep24-reference-ui
-version: 0.1.0
+version: 0.2.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/sep24-reference-ui/templates/gateway.yaml
+++ b/helm-charts/sep24-reference-ui/templates/gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/templates/httproute.yaml
+++ b/helm-charts/sep24-reference-ui/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
+          port: {{ .Values.services.ui.servicePort | default 3000 }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/templates/ingress.yaml
+++ b/helm-charts/sep24-reference-ui/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -51,3 +52,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
                 port:
                   number: {{ .Values.services.ui.servicePort | default 3000 }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -26,9 +26,41 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
+  enabled: true
   name: ingress-sep24-reference-ui
   rules:
     host: sep24-reference-ui.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: sep24-reference-ui-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: sep24-reference-ui.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: sep24-reference-ui-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}


### PR DESCRIPTION
### Description

 Adds Gateway API (`Gateway` + `HTTPRoute`) support to all three Anchor Platform helm charts.
 
### Context

Gateway Migration

### Testing

- `./gradlew test`
- `helm lint` passes for all three charts.
- `helm template` with default. Ingress still emitted, no Gateway/HTTPRoute. 
- `helm template` with Gateway API enabled. renders match the shape in `stellar/kube`.
- Server-side dry-run not available locally

### Documentation

N/A

### Known limitations

N/A

