### PR TITLE
[ANCHOR-1206] Carry forward security headers for Gateway API migration

### DIFF
--- a/helm-charts/reference-server/templates/httproute.yaml
+++ b/helm-charts/reference-server/templates/httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
           port: {{ .Values.services.ref.servicePort | default 8091 }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -51,6 +51,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""

--- a/helm-charts/sep-service/templates/sepserver-httproute.yaml
+++ b/helm-charts/sep-service/templates/sepserver-httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
           port: {{ .Values.services.sep.servicePort | default 8080 }}

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -152,6 +152,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""

--- a/helm-charts/sep24-reference-ui/templates/httproute.yaml
+++ b/helm-charts/sep24-reference-ui/templates/httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
           port: {{ .Values.services.ui.servicePort | default 3000 }}

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -43,6 +43,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""


### PR DESCRIPTION
### Description

- adds an `httpRoute.responseHeaders` values block that emits a Gateway API filter to set security response headers 
- Explicit `namespace` + `sectionName` on `parentRefs` when using the chart-managed Gateway

### Context

The first migration PR dropped the existing `ingress.responseHeaders` block.
Adding `namespace` + `sectionName` on `parentRefs` is purely a consistency fix to match the established Gateway API pattern.

### Testing

- `helm lint` passes for all three charts. 
- `helm template` with Gateway API enabled.

### Documentation

N/A

### Known limitations

N/A

