### PR TITLE
[ANCHOR-1939]: per-client event isolation

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -19,6 +19,7 @@ public class AnchorEvent {
   String id;
   String sep;
   String clientName;
+  String clientDomain;
   GetTransactionResponse transaction;
   GetQuoteResponse quote;
   Sep12GetCustomerResponse customer;

--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -18,6 +18,7 @@ public class AnchorEvent {
   Type type;
   String id;
   String sep;
+  String clientName;
   GetTransactionResponse transaction;
   GetQuoteResponse quote;
   Sep12GetCustomerResponse customer;

--- a/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
@@ -19,6 +19,10 @@ public interface ClientConfig {
     private String sep12;
   }
 
+  default boolean matchesDomain(String domain) {
+    return false;
+  }
+
   /**
    * Returns true if any of the callback URLs are set.
    *

--- a/core/src/main/java/org/stellar/anchor/client/NonCustodialClient.java
+++ b/core/src/main/java/org/stellar/anchor/client/NonCustodialClient.java
@@ -22,6 +22,11 @@ public class NonCustodialClient implements ClientConfig {
   /** The domains associated with the client, used for verifying the client's identity. */
   Set<String> domains;
 
+  @Override
+  public boolean matchesDomain(String domain) {
+    return domain != null && domains != null && domains.contains(domain);
+  }
+
   /**
    * The URLs to which the service can send callbacks for different SEP types. Optional due to some
    * wallets may opt to poll instead, or may use polling first before implementing callbacks at a

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.sep12;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_12;
 import static org.stellar.anchor.util.Log.infoF;
+import static org.stellar.anchor.util.Log.warnF;
 import static org.stellar.anchor.util.MetricConstants.*;
 import static org.stellar.anchor.util.MetricConstants.SEP12_CUSTOMER;
 
@@ -105,7 +106,11 @@ public class Sep12Service {
 
     try {
       clientName = clientFinder.getClientName(token);
-    } catch (Exception ignored) {
+    } catch (SepNotAuthorizedException e) {
+      warnF(
+          "Client attribution required but client is not authorized; CUSTOMER_UPDATED event will have no clientName. token={}, reason={}",
+          token.getAccount(),
+          e.getMessage());
     }
 
     eventSession.publish(
@@ -114,6 +119,7 @@ public class Sep12Service {
             .sep(SEP_12.getSep().toString())
             .type(AnchorEvent.Type.CUSTOMER_UPDATED)
             .clientName(clientName)
+            .clientDomain(token.getClientDomain())
             .customer(GetCustomerResponse.to(updatedCustomer))
             .build());
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -107,7 +107,7 @@ public class Sep12Service {
       clientName = clientFinder.getClientName(token);
     } catch (Exception ignored) {
     }
-    
+
     eventSession.publish(
         AnchorEvent.builder()
             .id(UUID.randomUUID().toString())

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -23,6 +23,7 @@ import org.stellar.anchor.api.sep.sep12.*;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.MemoHelper;
@@ -38,15 +39,18 @@ public class Sep12Service {
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_DELETE_CUSTOMER);
   private final PlatformApiClient platformApiClient;
   private final EventService.Session eventSession;
+  private final ClientFinder clientFinder;
 
   public Sep12Service(
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
-      EventService eventService) {
+      EventService eventService,
+      ClientFinder clientFinder) {
     this.customerIntegration = customerIntegration;
     this.platformApiClient = platformApiClient;
     this.eventSession =
         eventService.createSession(this.getClass().getName(), EventService.EventQueue.TRANSACTION);
+    this.clientFinder = clientFinder;
 
     Log.info("Sep12Service initialized.");
   }
@@ -97,12 +101,19 @@ public class Sep12Service {
     PutCustomerResponse updatedCustomer =
         customerIntegration.putCustomer(PutCustomerRequest.from(request));
 
-    // Only publish event if the customer was updated.
+    String clientName = null;
+
+    try {
+      clientName = clientFinder.getClientName(token);
+    } catch (Exception ignored) {
+    }
+    
     eventSession.publish(
         AnchorEvent.builder()
             .id(UUID.randomUUID().toString())
             .sep(SEP_12.getSep().toString())
             .type(AnchorEvent.Type.CUSTOMER_UPDATED)
+            .clientName(clientName)
             .customer(GetCustomerResponse.to(updatedCustomer))
             .build());
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -414,6 +414,7 @@ class Sep12ServiceTest {
     assertNotNull(kycUpdateEventSlot.captured.id)
     assertEquals("12", kycUpdateEventSlot.captured.sep)
     assertEquals(AnchorEvent.Type.CUSTOMER_UPDATED, kycUpdateEventSlot.captured.type)
+    assertEquals(CLIENT_DOMAIN, kycUpdateEventSlot.captured.clientDomain)
     assertEquals(
       GetCustomerResponse.to(mockCallbackApiGetCustomerResponse),
       kycUpdateEventSlot.captured.customer,
@@ -423,6 +424,25 @@ class Sep12ServiceTest {
     verify(exactly = 1) { customerIntegration.putCustomer(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
     assertEquals(TEST_ACCOUNT, mockPutRequest.account)
+  }
+
+  @Test
+  fun `Test put customer publishes event with null clientName and logs warning when client is not authorized`() {
+    val kycUpdateEventSlot = slot<AnchorEvent>()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("customer-id").build()
+    every { eventSession.publish(capture(kycUpdateEventSlot)) } returns Unit
+    every { clientFinder.getClientName(any<WebAuthJwt>()) } throws
+      SepNotAuthorizedException("Client not found")
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    assertDoesNotThrow {
+      sep12Service.putCustomer(jwtToken, Sep12PutCustomerRequest.builder().build())
+    }
+
+    verify(exactly = 1) { eventSession.publish(any()) }
+    assertEquals(AnchorEvent.Type.CUSTOMER_UPDATED, kycUpdateEventSlot.captured.type)
+    assertEquals(null, kycUpdateEventSlot.captured.clientName)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -33,6 +33,7 @@ import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.util.StringHelper.json
 
@@ -100,6 +101,7 @@ class Sep12ServiceTest {
   @MockK(relaxed = true) private lateinit var platformApiClient: PlatformApiClient
   @MockK(relaxed = true) private lateinit var eventService: EventService
   @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
+  @MockK(relaxed = true) private lateinit var clientFinder: ClientFinder
 
   @BeforeEach
   fun setup() {
@@ -111,7 +113,7 @@ class Sep12ServiceTest {
     every { assetService.getAssets() } returns assets
     every { eventService.createSession(any(), any()) } returns eventSession
 
-    sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService)
+    sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService, clientFinder)
   }
 
   @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
@@ -24,8 +24,8 @@ import org.stellar.walletsdk.asset.IssuedAssetId
  * fires an HTTP request. A second callback-enabled client ("circleWallet") that does not own the
  * transaction must receive nothing.
  *
- * Requires the platform to be running with the clients.yaml that contains both the "reference"
- * noncustodial client (callback → wallet-server:8092) and the "circleWallet" noncustodial client
+ * Requires the platform to be running with the clients.yaml that contains the "referenceCustodial"
+ * custodial client (callback → wallet-server:8092) and the "circleWallet" noncustodial client
  * (callback → localhost:19091). Start via: ./gradlew startAllServers
  */
 @TestInstance(PER_CLASS)
@@ -80,7 +80,7 @@ class MultiClientCallbackTests : IntegrationTestBase(TestConfig()) {
           Sep24GetTransactionResponse::class.java,
         )
       assertThat(callbacks)
-        .withFailMessage("reference client should receive exactly one SEP-24 callback")
+        .withFailMessage("referenceCustodial client should receive exactly one SEP-24 callback")
         .hasSize(1)
 
       assertThat(circleWalletServer.requestCount)

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
@@ -1,0 +1,132 @@
+package org.stellar.anchor.platform.integrationtest
+
+import com.google.gson.reflect.TypeToken
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.stellar.anchor.api.platform.PatchTransactionsRequest
+import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse
+import org.stellar.anchor.apiclient.PlatformApiClient
+import org.stellar.anchor.auth.AuthHelper
+import org.stellar.anchor.platform.IntegrationTestBase
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.reference.wallet.WalletServerClient
+import org.stellar.walletsdk.asset.IssuedAssetId
+
+/**
+ * Verifies per-client callback isolation: when the event processor broadcasts a
+ * TRANSACTION_STATUS_CHANGED event, only the ClientStatusCallbackHandler bound to the owning client
+ * fires an HTTP request. A second callback-enabled client ("circleWallet") that does not own the
+ * transaction must receive nothing.
+ *
+ * Requires the platform to be running with the clients.yaml that contains both the "reference"
+ * noncustodial client (callback → wallet-server:8092) and the "circleWallet" noncustodial client
+ * (callback → localhost:19091). Start via: ./gradlew startAllServers
+ */
+@TestInstance(PER_CLASS)
+class MultiClientCallbackTests : IntegrationTestBase(TestConfig()) {
+  private lateinit var circleWalletServer: MockWebServer
+
+  private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
+  private val platformApiClient =
+    PlatformApiClient(AuthHelper.forNone(), config.env["platform.server.url"]!!)
+
+  @BeforeAll
+  fun startCircleWalletServer() {
+    circleWalletServer = MockWebServer()
+    repeat(5) { circleWalletServer.enqueue(MockResponse().setResponseCode(200)) }
+    circleWalletServer.start(CIRCLE_WALLET_PORT)
+  }
+
+  @AfterAll
+  fun stopCircleWalletServer() {
+    circleWalletServer.shutdown()
+  }
+
+  @Test
+  fun `sep24 withdrawal callback is delivered only to the owning client and not to the circleWallet`() =
+    runBlocking {
+      walletServerClient.clearCallbacks()
+
+      val withdrawRequest: HashMap<String, String> =
+        GsonUtils.getInstance()
+          .fromJson(
+            WITHDRAW_REQUEST_JSON,
+            object : TypeToken<HashMap<String, String>>() {}.type,
+          )
+      val response =
+        anchor
+          .sep24()
+          .withdraw(
+            IssuedAssetId("USDC", USDC_ISSUER),
+            token,
+            withdrawRequest,
+            WITHDRAW_SOURCE_ACCOUNT,
+          )
+      val txnId = response.id
+
+      platformApiClient.patchTransaction(buildPatchRequest(txnId))
+
+      val callbacks =
+        walletServerClient.pollTransactionCallbacks(
+          "sep24",
+          txnId,
+          1,
+          Sep24GetTransactionResponse::class.java,
+        )
+      assertThat(callbacks)
+        .withFailMessage("reference client should receive exactly one SEP-24 callback")
+        .hasSize(1)
+
+      assertThat(circleWalletServer.requestCount)
+        .withFailMessage(
+          "circleWallet callback receiver (localhost:$CIRCLE_WALLET_PORT) must not receive any requests"
+        )
+        .isEqualTo(0)
+    }
+
+  private fun buildPatchRequest(txnId: String): PatchTransactionsRequest =
+    GsonUtils.getInstance()
+      .fromJson(
+        """
+        {
+          "records": [{
+            "transaction": {
+              "id": "$txnId",
+              "status": "completed",
+              "amount_in":  {"amount": "10", "asset": "stellar:USDC:$USDC_ISSUER"},
+              "amount_out": {"amount": "10", "asset": "iso4217:USD"},
+              "fee_details": {"total": "1",  "asset": "stellar:USDC:$USDC_ISSUER"},
+              "message": "completed by MultiClientCallbackTests"
+            }
+          }]
+        }
+        """
+          .trimIndent(),
+        PatchTransactionsRequest::class.java,
+      )
+
+  companion object {
+    private const val CIRCLE_WALLET_PORT = 19091
+    private const val USDC_ISSUER = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    private const val WITHDRAW_SOURCE_ACCOUNT =
+      "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4"
+
+    private val WITHDRAW_REQUEST_JSON =
+      """
+      {
+        "amount": "10",
+        "asset_code": "USDC",
+        "asset_issuer": "$USDC_ISSUER",
+        "account": "$WITHDRAW_SOURCE_ACCOUNT",
+        "lang": "en"
+      }
+      """
+        .trimIndent()
+  }
+}

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -342,7 +342,7 @@ class PaymentObserverTests {
   private suspend fun waitForEventsCoroutine(
     fromAccountId: String,
     listener: EventCapturingListener,
-    timeout: Long = 10000L,
+    timeout: Long = 60000L,
   ) {
     val startTime = System.currentTimeMillis()
     while (System.currentTimeMillis() - startTime <= timeout) {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -185,8 +185,9 @@ public class SepBeans {
   Sep12Service sep12Service(
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
-      EventService eventService) {
-    return new Sep12Service(customerIntegration, platformApiClient, eventService);
+      EventService eventService,
+      ClientFinder clientFinder) {
+    return new Sep12Service(customerIntegration, platformApiClient, eventService, clientFinder);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -79,9 +79,11 @@ public class ClientStatusCallbackHandler extends EventHandler {
     String eventClientDomain = (tx != null) ? tx.getClientDomain() : null;
 
     boolean isAttributed = eventClientName != null || eventClientDomain != null;
-    if (isAttributed
-        && !clientConfig.getName().equals(eventClientName)
-        && !clientConfig.matchesDomain(eventClientDomain)) {
+
+    boolean isClientName = clientConfig.getName().equals(eventClientName);
+    boolean isClientDomain = clientConfig.matchesDomain(eventClientDomain);
+
+    if (!isAttributed || (isAttributed && !isClientName && !isClientDomain)) {
       return true;
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -73,20 +73,25 @@ public class ClientStatusCallbackHandler extends EventHandler {
 
   @Override
   boolean handleEvent(AnchorEvent event) throws IOException {
-    if (event.getTransaction() != null || event.getCustomer() != null) {
-      KeyPair signer = KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed());
-      Request request = buildHttpRequest(signer, event);
+    GetTransactionResponse tx = event.getTransaction();
 
-      if (request != null) {
-        try (Response response = httpClient.newCall(request).execute()) {
-          debugF("Sending event: {} to client status api: {}", json(event), request.url());
-          if (response.code() < 200 || response.code() >= 400) {
-            errorF("Failed to send event to client status API. Error code: {}", response.code());
-            return false;
-          }
+    if (tx == null || !clientConfig.getName().equals(tx.getClientName())) {
+      return true;
+    }
+
+    KeyPair signer = KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed());
+    Request request = buildHttpRequest(signer, event);
+
+    if (request != null) {
+      try (Response response = httpClient.newCall(request).execute()) {
+        debugF("Sending event: {} to client status api: {}", json(event), request.url());
+        if (response.code() < 200 || response.code() >= 400) {
+          errorF("Failed to send event to client status API. Error code: {}", response.code());
+          return false;
         }
       }
     }
+
     return true;
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -78,7 +78,9 @@ public class ClientStatusCallbackHandler extends EventHandler {
     String eventClientName = (tx != null) ? tx.getClientName() : event.getClientName();
     String eventClientDomain = (tx != null) ? tx.getClientDomain() : null;
 
-    if (!clientConfig.getName().equals(eventClientName)
+    boolean isAttributed = eventClientName != null || eventClientDomain != null;
+    if (isAttributed
+        && !clientConfig.getName().equals(eventClientName)
         && !clientConfig.matchesDomain(eventClientDomain)) {
       return true;
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -76,14 +76,22 @@ public class ClientStatusCallbackHandler extends EventHandler {
     GetTransactionResponse tx = event.getTransaction();
 
     String eventClientName = (tx != null) ? tx.getClientName() : event.getClientName();
-    String eventClientDomain = (tx != null) ? tx.getClientDomain() : null;
+    String eventClientDomain = (tx != null) ? tx.getClientDomain() : event.getClientDomain();
 
     boolean isAttributed = eventClientName != null || eventClientDomain != null;
+
+    if (!isAttributed) {
+      debugF(
+          "Skipping event id={} type={}: no clientName or clientDomain — event cannot be attributed to any client",
+          event.getId(),
+          event.getType());
+      return true;
+    }
 
     boolean isClientName = clientConfig.getName().equals(eventClientName);
     boolean isClientDomain = clientConfig.matchesDomain(eventClientDomain);
 
-    if (!isAttributed || (isAttributed && !isClientName && !isClientDomain)) {
+    if (!isClientName && !isClientDomain) {
       return true;
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -75,7 +75,14 @@ public class ClientStatusCallbackHandler extends EventHandler {
   boolean handleEvent(AnchorEvent event) throws IOException {
     GetTransactionResponse tx = event.getTransaction();
 
-    if (tx == null || !clientConfig.getName().equals(tx.getClientName())) {
+    if (tx == null) {
+      return true;
+    }
+
+    boolean isClientName = clientConfig.getName().equals(tx.getClientName());
+    boolean isClientDomain = clientConfig.matchesDomain(tx.getClientDomain());
+
+    if (!isClientName && !isClientDomain) {
       return true;
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -75,14 +75,11 @@ public class ClientStatusCallbackHandler extends EventHandler {
   boolean handleEvent(AnchorEvent event) throws IOException {
     GetTransactionResponse tx = event.getTransaction();
 
-    if (tx == null) {
-      return true;
-    }
+    String eventClientName = (tx != null) ? tx.getClientName() : event.getClientName();
+    String eventClientDomain = (tx != null) ? tx.getClientDomain() : null;
 
-    boolean isClientName = clientConfig.getName().equals(tx.getClientName());
-    boolean isClientDomain = clientConfig.matchesDomain(tx.getClientDomain());
-
-    if (!isClientName && !isClientDomain) {
+    if (!clientConfig.getName().equals(eventClientName)
+        && !clientConfig.matchesDomain(eventClientDomain)) {
       return true;
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
@@ -23,6 +23,7 @@ import org.stellar.anchor.api.sep.sep12.Sep12Status;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSep24Transaction;
 import org.stellar.anchor.platform.data.JdbcSep31Transaction;
 import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
@@ -85,11 +86,17 @@ public class NotifyCustomerInfoUpdatedHandler
       status = customer.getStatus();
 
       String clientName = null;
+      String clientDomain = null;
 
       if (txn instanceof JdbcSep6Transaction) {
         clientName = ((JdbcSep6Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep6Transaction) txn).getClientDomain();
+      } else if (txn instanceof JdbcSep24Transaction) {
+        clientName = ((JdbcSep24Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep24Transaction) txn).getClientDomain();
       } else if (txn instanceof JdbcSep31Transaction) {
         clientName = ((JdbcSep31Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep31Transaction) txn).getClientDomain();
       }
       eventSession.publish(
           AnchorEvent.builder()
@@ -97,6 +104,7 @@ public class NotifyCustomerInfoUpdatedHandler
               .sep(SEP_12.getSep().toString())
               .type(AnchorEvent.Type.CUSTOMER_UPDATED)
               .clientName(clientName)
+              .clientDomain(clientDomain)
               .customer(GetCustomerResponse.to(customer))
               .build());
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
@@ -23,6 +23,8 @@ import org.stellar.anchor.api.sep.sep12.Sep12Status;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSep31Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
@@ -81,11 +83,20 @@ public class NotifyCustomerInfoUpdatedHandler
                   .type(request.getCustomerType())
                   .build());
       status = customer.getStatus();
+
+      String clientName = null;
+
+      if (txn instanceof JdbcSep6Transaction) {
+        clientName = ((JdbcSep6Transaction) txn).getClientName();
+      } else if (txn instanceof JdbcSep31Transaction) {
+        clientName = ((JdbcSep31Transaction) txn).getClientName();
+      }
       eventSession.publish(
           AnchorEvent.builder()
               .id(UUID.randomUUID().toString())
               .sep(SEP_12.getSep().toString())
               .type(AnchorEvent.Type.CUSTOMER_UPDATED)
+              .clientName(clientName)
               .customer(GetCustomerResponse.to(customer))
               .build());
     }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -7,6 +7,8 @@ import io.mockk.spyk
 import io.mockk.verify
 import java.util.*
 import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -427,6 +429,87 @@ class ClientStatusCallbackHandlerTest {
 
     Assertions.assertTrue(result)
     verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  @LockAndMockStatic([Sep24Helper::class])
+  fun `two handlers bound to different clients - only matching handler fires HTTP callback on SEP-24 withdrawal`() {
+    val circleServer = MockWebServer()
+    val walletBServer = MockWebServer()
+    circleServer.start()
+    walletBServer.start()
+    try {
+      circleServer.enqueue(MockResponse().setResponseCode(200))
+
+      val circleClient =
+        CustodialClient.builder()
+          .name("circle")
+          .signingKeys(setOf("GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"))
+          .callbackUrls(
+            CallbackUrls.builder().sep24(circleServer.url("/callback/sep24").toString()).build()
+          )
+          .allowAnyDestination(false)
+          .destinationAccounts(emptySet())
+          .build()
+
+      val walletBClient =
+        CustodialClient.builder()
+          .name("wallet-b")
+          .signingKeys(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
+          .callbackUrls(
+            CallbackUrls.builder().sep24(walletBServer.url("/callback/sep24").toString()).build()
+          )
+          .allowAnyDestination(false)
+          .destinationAccounts(emptySet())
+          .build()
+
+      val circleHandler =
+        ClientStatusCallbackHandler(
+          secretConfig,
+          circleClient,
+          assetService,
+          sep6MoreInfoUrlConstructor,
+          sep24MoreInfoUrlConstructor
+        )
+      val walletBHandler =
+        ClientStatusCallbackHandler(
+          secretConfig,
+          walletBClient,
+          assetService,
+          sep6MoreInfoUrlConstructor,
+          sep24MoreInfoUrlConstructor
+        )
+
+      val withdrawalEvent =
+        AnchorEvent().apply {
+          transaction =
+            GetTransactionResponse().apply {
+              sep = SEP_24
+              kind = Kind.WITHDRAWAL
+              status = COMPLETED
+              clientName = "circle"
+            }
+        }
+
+      every { fromTxn(any(), any(), any(), any()) } returns mockk(relaxed = true)
+
+      circleHandler.handleEvent(withdrawalEvent)
+      walletBHandler.handleEvent(withdrawalEvent)
+
+      assertEquals(
+        1,
+        circleServer.requestCount,
+        "circle's callback receiver should get exactly one POST"
+      )
+      assertEquals(
+        0,
+        walletBServer.requestCount,
+        "wallet-b's callback receiver must not receive any request"
+      )
+    } finally {
+      circleServer.shutdown()
+      walletBServer.shutdown()
+    }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -3,6 +3,8 @@ package org.stellar.anchor.platform.event
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import java.util.*
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions
@@ -26,6 +28,7 @@ import org.stellar.anchor.api.shared.FeeDetails
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.client.ClientConfig.CallbackUrls
 import org.stellar.anchor.client.CustodialClient
+import org.stellar.anchor.client.NonCustodialClient
 import org.stellar.anchor.platform.config.PropertySecretConfig
 import org.stellar.anchor.platform.service.Sep24MoreInfoUrlConstructor
 import org.stellar.anchor.platform.service.Sep6MoreInfoUrlConstructor
@@ -292,6 +295,110 @@ class ClientStatusCallbackHandlerTest {
     assertEquals("client.com", sep24Txn.clientDomain)
     assertEquals("quote-id", sep24Txn.quoteId)
     assertEquals("message", sep24Txn.message)
+  }
+
+  @Test
+  fun `handleEvent should skip and return true when transaction belongs to a different client`() {
+    val handlerSpy = spyk(handler)
+    event.transaction.clientName = "other-wallet"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should build and send request when transaction clientName matches handler client`() {
+    val handlerSpy = spyk(handler)
+    event.transaction.clientName = "circle"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip when transaction clientName is null`() {
+    val handlerSpy = spyk(handler)
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip customer events because Sep12GetCustomerResponse carries no client attribution`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should fire for noncustodial client when clientDomain matches even if clientName is null`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep24("https://wallet.example.com/callback/sep24").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction.clientName = null
+    event.transaction.clientDomain = "wallet.example.com"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip when neither clientName nor clientDomain matches noncustodial client`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep24("https://wallet.example.com/callback/sep24").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction.clientName = "other-wallet"
+    event.transaction.clientDomain = "other.example.com"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -300,7 +300,7 @@ class ClientStatusCallbackHandlerTest {
   @Test
   fun `handleEvent should skip and return true when transaction belongs to a different client`() {
     val handlerSpy = spyk(handler)
-    event.transaction.clientName = "other-wallet"
+    event.transaction.clientName = "wallet-a"
     every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
 
     val result = handlerSpy.handleEvent(event)
@@ -332,9 +332,10 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
-  fun `handleEvent should skip customer events because Sep12GetCustomerResponse carries no client attribution`() {
+  fun `handleEvent should skip customer event when clientName does not match`() {
     val handlerSpy = spyk(handler)
     event.transaction = null
+    event.clientName = "wallet-a"
     event.customer = Sep12GetCustomerResponse.builder().build()
     every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
 
@@ -342,6 +343,33 @@ class ClientStatusCallbackHandlerTest {
 
     Assertions.assertTrue(result)
     verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip customer event when clientName is null`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.clientName = null
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should fire for customer event when clientName matches`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.clientName = "circle"
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -373,6 +373,36 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
+  fun `handleEvent should fire for noncustodial client customer event when clientDomain matches`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep12("https://wallet.example.com/callback/sep12").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction = null
+    event.clientName = null
+    event.clientDomain = "wallet.example.com"
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
   fun `handleEvent should fire for noncustodial client when clientDomain matches even if clientName is null`() {
     val nonCustodialClient =
       NonCustodialClient.builder()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -323,14 +323,13 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
-  fun `handleEvent should skip when transaction clientName is null`() {
+  fun `handleEvent should send callback when transaction is unattributed (clientName and clientDomain both null)`() {
     val handlerSpy = spyk(handler)
     every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
 
-    val result = handlerSpy.handleEvent(event)
+    handlerSpy.handleEvent(event)
 
-    Assertions.assertTrue(result)
-    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test
@@ -348,17 +347,16 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
-  fun `handleEvent should skip customer event when clientName is null`() {
+  fun `handleEvent should send callback for unattributed customer event (clientName null)`() {
     val handlerSpy = spyk(handler)
     event.transaction = null
     event.clientName = null
     event.customer = Sep12GetCustomerResponse.builder().build()
     every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
 
-    val result = handlerSpy.handleEvent(event)
+    handlerSpy.handleEvent(event)
 
-    Assertions.assertTrue(result)
-    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -323,13 +323,13 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
-  fun `handleEvent should send callback when transaction is unattributed (clientName and clientDomain both null)`() {
+  fun `handleEvent should not send callback when transaction is unattributed (clientName and clientDomain both null)`() {
     val handlerSpy = spyk(handler)
     every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
 
     handlerSpy.handleEvent(event)
 
-    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test
@@ -347,7 +347,7 @@ class ClientStatusCallbackHandlerTest {
   }
 
   @Test
-  fun `handleEvent should send callback for unattributed customer event (clientName null)`() {
+  fun `handleEvent should not send callback for unattributed customer event (clientName null)`() {
     val handlerSpy = spyk(handler)
     event.transaction = null
     event.clientName = null
@@ -356,7 +356,7 @@ class ClientStatusCallbackHandlerTest {
 
     handlerSpy.handleEvent(event)
 
-    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
   }
 
   @Test

--- a/service-runner/src/main/resources/config/clients.yaml
+++ b/service-runner/src/main/resources/config/clients.yaml
@@ -3,6 +3,15 @@ items:
     type: custodial
     signing_keys:
       - GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG
+      - GD4C2QRT7YL4WJFJPYQCYRXEDBB7ERHC3XZGWR6KXKRHPEFXXNXIVNFY
+      - GC56VTOVOJDRQAJRYLZW6DLQGVTQSYDTZU7ISNIZ2VJIE3FYWI2HMD5G
+      - GDC2U5GRKUSPGV5XENLBWKQZH2C4PG7ZEVMQOUA2QZKIRXE5FYYEMEF7
+      - GASI56WX7UKIDFPZRCQEI4OQE3V3QBGXEOB4ZY6ZMU5MZXPHQHIDA7JU
+    callback_urls:
+      sep6: http://wallet-server:8092/callbacks/sep6
+      sep24: http://wallet-server:8092/callbacks/sep24
+      sep31: http://wallet-server:8092/callbacks/sep31
+      sep12: http://wallet-server:8092/callbacks/sep12
   - name: stellar_anchor_tests
     type: custodial
     signing_keys:

--- a/service-runner/src/main/resources/config/clients.yaml
+++ b/service-runner/src/main/resources/config/clients.yaml
@@ -16,3 +16,9 @@ items:
       sep24: http://wallet-server:8092/callbacks/sep24
       sep31: http://wallet-server:8092/callbacks/sep31
       sep12: http://wallet-server:8092/callbacks/sep12
+  - name: circleWallet
+    type: noncustodial
+    domains:
+      - circlewallet.example.com
+    callback_urls:
+      sep24: http://localhost:19091/callbacks/sep24


### PR DESCRIPTION
### Description
Before this change every configured wallet's callback URL received every transaction event, leaking memos across wallet boundaries. Now `ClientStatusCallbackHandler` skips events whose `clientName`/`clientDomain` don't match the handler's client.

#### Changes
- [x] In ClientStatusCallbackHandler.handleEvent, short-circuit when the event does not belong to this handler's client.
  
#### Acceptance Criteria

- [x] Wallet A's callback URL never receives an event whose transaction (or customer) belongs to wallet B, for any combination of client types.
- [x] Existing SEP-24 / SEP-6 / SEP-31 happy paths and single-client callback flows continue to pass.

### Context
#1939

### Testing

- [x] `ClientStatusCallbackHandlerTest` — handler bound to client A, event with `clientName=B`: no HTTP request issued. Event with `clientName=A`: request fires.
- [x] `ClientStatusCallbackHandlerTest` — event with null clientName and null clientDomain must not match any handler (events with no client attribution should not leak to any callback URL).
- [x] `ClientStatusCallbackHandlerTest` — customer event path: same filter logic applies on event.getCustomer().
- [x] Integration (`Sep24Tests` or new `MultiClientCallbackTests` under essential-tests/)
    - Configure two callback-enabled clients in `clients.yaml` with separate mock callback receivers
    - Drive a SEP-24 withdrawal under one client
    - Assert only that client's receiver gets the webhook.
- [x] Regression: existing single-client SEP-24/SEP-6/SEP-31 callback paths continue to pass.

### Documentation
N/A

### Known limitations
N/A