### PR TITLE
[ANCHOR-1939]: add ambiguous routing safety

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
@@ -26,7 +26,4 @@ public interface Sep6TransactionStore {
   Sep6Transaction save(Sep6Transaction sep6Transaction) throws SepException;
 
   List<? extends Sep6Transaction> findTransactions(TransactionsParams params) throws SepException;
-
-  Sep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String withdrawAnchorAccount, String memo, String status);
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -342,7 +342,7 @@ class PaymentObserverTests {
   private suspend fun waitForEventsCoroutine(
     fromAccountId: String,
     listener: EventCapturingListener,
-    timeout: Long = 10000L,
+    timeout: Long = 60000L,
   ) {
     val startTime = System.currentTimeMillis()
     while (System.currentTimeMillis() - startTime <= timeout) {

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -23,9 +23,6 @@ public interface JdbcSep24TransactionRepo
 
   JdbcSep24Transaction findOneByStellarTransactionId(String stellarTransactionId);
 
-  JdbcSep24Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String withdrawAnchorAccount, String memo, String status);
-
   List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -26,6 +26,9 @@ public interface JdbcSep24TransactionRepo
   JdbcSep24Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
+  List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
+      String withdrawAnchorAccount, String memo, String status);
+
   @Query(
       "SELECT t FROM JdbcSep24Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.requestAssetCode = :assetCode"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.stellar.anchor.api.exception.SepException;
@@ -55,14 +54,6 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
   @Override
   public Sep24Transaction findByExternalTransactionId(String externalTransactionId) {
     return txnRepo.findOneByExternalTransactionId(externalTransactionId);
-  }
-
-  public JdbcSep24Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String toAccount, String memo, String status) {
-    Optional<JdbcSep24Transaction> optTxn =
-        Optional.ofNullable(
-            txnRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(toAccount, memo, status));
-    return optTxn.orElse(null);
   }
 
   public List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -65,6 +65,11 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return optTxn.orElse(null);
   }
 
+  public List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
+      String toAccount, String memo, String status) {
+    return txnRepo.findAllByWithdrawAnchorAccountAndMemoAndStatus(toAccount, memo, status);
+  }
+
   @Override
   public List<Sep24Transaction> findTransactions(
       String accountId, String accountMemo, GetTransactionsRequest tr)

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
@@ -26,9 +26,6 @@ public interface JdbcSep31TransactionRepo
   @Query(value = "SELECT COUNT(t) FROM JdbcSep31Transaction t WHERE t.status = :status")
   Integer findByStatusCount(@Param("status") String status);
 
-  Optional<JdbcSep31Transaction> findByToAccountAndStellarMemoAndStatus(
-      String toAccount, String stellarMemo, String status);
-
   List<JdbcSep31Transaction> findAllByToAccountAndStellarMemoAndStatus(
       String toAccount, String stellarMemo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
@@ -28,4 +28,7 @@ public interface JdbcSep31TransactionRepo
 
   Optional<JdbcSep31Transaction> findByToAccountAndStellarMemoAndStatus(
       String toAccount, String stellarMemo, String status);
+
+  List<JdbcSep31Transaction> findAllByToAccountAndStellarMemoAndStatus(
+      String toAccount, String stellarMemo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -3,7 +3,6 @@ package org.stellar.anchor.platform.data;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import lombok.NonNull;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.sep31.RefundPayment;
@@ -64,13 +63,6 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
     }
 
     return transactionRepo.save((JdbcSep31Transaction) transaction);
-  }
-
-  public JdbcSep31Transaction findByToAccountAndMemoAndStatus(
-      String toAccount, String memo, String status) {
-    Optional<JdbcSep31Transaction> optTxn =
-        transactionRepo.findByToAccountAndStellarMemoAndStatus(toAccount, memo, status);
-    return optTxn.orElse(null);
   }
 
   public List<JdbcSep31Transaction> findAllByToAccountAndMemoAndStatus(

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -73,6 +73,11 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
     return optTxn.orElse(null);
   }
 
+  public List<JdbcSep31Transaction> findAllByToAccountAndMemoAndStatus(
+      String toAccount, String memo, String status) {
+    return transactionRepo.findAllByToAccountAndStellarMemoAndStatus(toAccount, memo, status);
+  }
+
   public Integer findByStatusCount(String status) {
     return transactionRepo.findByStatusCount(status);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -28,6 +28,9 @@ public interface JdbcSep6TransactionRepo
   JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
+  List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
+      String withdrawAnchorAccount, String memo, String status);
+
   @Query(
       "SELECT t FROM JdbcSep6Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.requestAssetCode = :assetCode"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -25,9 +25,6 @@ public interface JdbcSep6TransactionRepo
 
   JdbcSep6Transaction findOneByExternalTransactionId(String externalTransactionId);
 
-  JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String withdrawAnchorAccount, String memo, String status);
-
   List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
@@ -133,4 +133,10 @@ public class JdbcSep6TransactionStore implements Sep6TransactionStore {
     return transactionRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(
         withdrawAnchorAccount, memo, status);
   }
+
+  public List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
+      String withdrawAnchorAccount, String memo, String status) {
+    return transactionRepo.findAllByWithdrawAnchorAccountAndMemoAndStatus(
+        withdrawAnchorAccount, memo, status);
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
@@ -127,13 +127,6 @@ public class JdbcSep6TransactionStore implements Sep6TransactionStore {
     return transactionRepo.findAllTransactions(params, JdbcSep6Transaction.class);
   }
 
-  @Override
-  public JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String withdrawAnchorAccount, String memo, String status) {
-    return transactionRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-        withdrawAnchorAccount, memo, status);
-  }
-
   public List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status) {
     return transactionRepo.findAllByWithdrawAnchorAccountAndMemoAndStatus(

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -133,7 +133,8 @@ public class DefaultPaymentListener implements PaymentListener {
             memo,
             SepTransactionStatus.PENDING_SENDER,
             ids);
-        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+            .increment();
         return;
       }
       if (!sep31Txns.isEmpty()) {
@@ -190,7 +191,8 @@ public class DefaultPaymentListener implements PaymentListener {
             memoAsString(memo),
             SepTransactionStatus.PENDING_USR_TRANSFER_START,
             ids);
-        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+            .increment();
         return;
       }
       if (!sep24Txns.isEmpty()) {
@@ -231,7 +233,8 @@ public class DefaultPaymentListener implements PaymentListener {
             memoAsString(memo),
             SepTransactionStatus.PENDING_USR_TRANSFER_START,
             ids);
-        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+            .increment();
         return;
       }
       if (!sep6Txns.isEmpty()) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -112,21 +112,32 @@ public class DefaultPaymentListener implements PaymentListener {
 
     try {
       String memo = xdrMemoToString(ledgerTransaction.getMemo());
-      JdbcSep31Transaction sep31Txn =
-          sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      List<JdbcSep31Transaction> sep31Txns =
+          sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
               ledgerPayment.getTo(), memo, SepTransactionStatus.PENDING_SENDER.toString());
-      if (sep31Txn == null) {
-        if (ledgerPayment.getTo().startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(ledgerPayment.getTo());
-          sep31Txn =
-              sep31TransactionStore.findByToAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_SENDER.toString());
-        }
+      if (sep31Txns.isEmpty() && ledgerPayment.getTo().startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(ledgerPayment.getTo());
+        sep31Txns =
+            sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_SENDER.toString());
       }
-      if (sep31Txn != null) {
+      if (sep31Txns.size() > 1) {
+        List<String> ids = sep31Txns.stream().map(JdbcSep31Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-31 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            ledgerPayment.getTo(),
+            memo,
+            SepTransactionStatus.PENDING_SENDER,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        return;
+      }
+      if (!sep31Txns.isEmpty()) {
+        JdbcSep31Transaction sep31Txn = sep31Txns.get(0);
         try {
           handleSep31Transaction(ledgerTransaction, ledgerPayment, sep31Txn);
           return;
@@ -156,24 +167,34 @@ public class DefaultPaymentListener implements PaymentListener {
     }
 
     try {
-      JdbcSep24Transaction sep24Txn =
-          sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      List<JdbcSep24Transaction> sep24Txns =
+          sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
               toAccount,
               memoAsString(memo),
               SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-      if (sep24Txn == null) {
-        if (toAccount.startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(toAccount);
-          sep24Txn =
-              sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-        }
+      if (sep24Txns.isEmpty() && toAccount.startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(toAccount);
+        sep24Txns =
+            sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
       }
-
-      if (sep24Txn != null) {
+      if (sep24Txns.size() > 1) {
+        List<String> ids = sep24Txns.stream().map(JdbcSep24Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-24 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            toAccount,
+            memoAsString(memo),
+            SepTransactionStatus.PENDING_USR_TRANSFER_START,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        return;
+      }
+      if (!sep24Txns.isEmpty()) {
+        JdbcSep24Transaction sep24Txn = sep24Txns.get(0);
         try {
           handleSep24Transaction(ledgerTransaction, ledgerPayment, sep24Txn);
           return;
@@ -187,23 +208,34 @@ public class DefaultPaymentListener implements PaymentListener {
     }
 
     try {
-      JdbcSep6Transaction sep6Txn =
-          sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      List<JdbcSep6Transaction> sep6Txns =
+          sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
               toAccount,
               memoAsString(memo),
               SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-      if (sep6Txn == null) {
-        if (toAccount.startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(toAccount);
-          sep6Txn =
-              sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-        }
+      if (sep6Txns.isEmpty() && toAccount.startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(toAccount);
+        sep6Txns =
+            sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
       }
-      if (sep6Txn != null) {
+      if (sep6Txns.size() > 1) {
+        List<String> ids = sep6Txns.stream().map(JdbcSep6Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-6 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            toAccount,
+            memoAsString(memo),
+            SepTransactionStatus.PENDING_USR_TRANSFER_START,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).increment();
+        return;
+      }
+      if (!sep6Txns.isEmpty()) {
+        JdbcSep6Transaction sep6Txn = sep6Txns.get(0);
         try {
           handleSep6Transaction(ledgerTransaction, ledgerPayment, sep6Txn);
         } catch (AnchorException aex) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.SepException;
@@ -82,6 +83,16 @@ public class RequestOnchainFundsHandler
     this.sep24DepositInfoGenerator = sep24DepositInfoGenerator;
     this.sep31DepositInfoGenerator = sep31DepositInfoGenerator;
     this.paymentObservingAccountsManager = paymentObservingAccountsManager;
+  }
+
+  @Override
+  public Object handle(Object requestParams) throws AnchorException {
+    try {
+      return super.handle(requestParams);
+    } catch (DataIntegrityViolationException ex) {
+      throw new BadRequestException(
+          "memo_in_use: the requested memo and destination account are already assigned to a pending transaction");
+    }
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
@@ -9,6 +9,7 @@ public enum AnchorMetrics {
   SEP6_TRANSACTION_DB("sep6.transaction.db"),
   PAYMENT_RECEIVED("payment.received"),
   PAYMENT_SENT("payment.sent"),
+  PAYMENT_OBSERVER_AMBIGUOUS_ROUTING("payment_observer.ambiguous_routing"),
   LOGGER("logger"),
 
   PLATFORM_RPC_TRANSACTION("platform_server.rpc_transaction"),

--- a/platform/src/main/resources/db/migration/V28__memo_uniqueness_pending_transfer.sql
+++ b/platform/src/main/resources/db/migration/V28__memo_uniqueness_pending_transfer.sql
@@ -1,0 +1,11 @@
+CREATE UNIQUE INDEX uq_sep24_pending_memo
+  ON sep24_transaction (withdraw_anchor_account, memo_type, memo)
+  WHERE status = 'pending_user_transfer_start';
+
+CREATE UNIQUE INDEX uq_sep6_pending_memo
+  ON sep6_transaction (withdraw_anchor_account, memo_type, memo)
+  WHERE status = 'pending_user_transfer_start';
+
+CREATE UNIQUE INDEX uq_sep31_pending_memo
+  ON sep31_transaction (to_account, stellar_memo_type, stellar_memo)
+  WHERE status = 'pending_sender';

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -597,7 +597,9 @@ class DefaultPaymentListenerTest {
       }
       assertEquals(
         1.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)
@@ -649,7 +651,9 @@ class DefaultPaymentListenerTest {
       }
       assertEquals(
         1.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)
@@ -695,7 +699,9 @@ class DefaultPaymentListenerTest {
       }
       assertEquals(
         1.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)
@@ -727,7 +733,9 @@ class DefaultPaymentListenerTest {
       }
       assertEquals(
         0.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)
@@ -759,7 +767,9 @@ class DefaultPaymentListenerTest {
       verify(exactly = 1) { paymentListener.handleSep6Transaction(ledgerTransaction, any(), any()) }
       assertEquals(
         0.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)
@@ -787,7 +797,9 @@ class DefaultPaymentListenerTest {
       }
       assertEquals(
         0.0,
-        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+          .count(),
       )
     } finally {
       Metrics.removeRegistry(registry)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.observer.stellar
 
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import java.math.BigInteger
@@ -14,7 +16,9 @@ import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation
 import org.stellar.anchor.ledger.PaymentTransferEvent
 import org.stellar.anchor.platform.config.RpcConfig
 import org.stellar.anchor.platform.data.*
+import org.stellar.anchor.platform.service.AnchorMetrics
 import org.stellar.anchor.util.AssetHelper.fromXdrAmount
+import org.stellar.anchor.util.Log
 import org.stellar.sdk.TOID
 import org.stellar.sdk.xdr.Asset
 import org.stellar.sdk.xdr.AssetType.ASSET_TYPE_POOL_SHARE
@@ -117,19 +121,19 @@ class DefaultPaymentListenerTest {
     val slotStatus = slot<String>()
 
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep31Transaction()
+    } returns listOf(JdbcSep31Transaction())
 
     every { paymentListener.handleSep31Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_sender",
@@ -154,23 +158,23 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
 
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep24Transaction()
+    } returns listOf(JdbcSep24Transaction())
 
     every { paymentListener.handleSep24Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_user_transfer_start",
@@ -195,25 +199,25 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
-    } returns null
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
     every {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep6Transaction()
+    } returns listOf(JdbcSep6Transaction())
 
     every { paymentListener.handleSep6Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_user_transfer_start",
@@ -274,7 +278,7 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep31 findByToAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep31 findAllByToAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
@@ -282,7 +286,7 @@ class DefaultPaymentListenerTest {
     ledgerTransaction.memo = xdrMemoText
 
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_sender",
@@ -292,7 +296,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_sender",
@@ -309,17 +313,17 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep24 findByStellarAccountIdAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep24 findAllByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
     xdrMemoText.text = XdrString("my_memo_3")
     ledgerTransaction.memo = xdrMemoText
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -329,7 +333,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -346,20 +350,20 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep6 findOneByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep6 findAllByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
     xdrMemoText.text = XdrString("my_memo_3")
     ledgerTransaction.memo = xdrMemoText
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
-    } returns null
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
     every {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -369,7 +373,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -377,7 +381,7 @@ class DefaultPaymentListenerTest {
     }
 
     verify(exactly = 0) {
-      paymentListener.handleSep24Transaction(
+      paymentListener.handleSep6Transaction(
         ledgerTransaction,
         ledgerTransaction.operations[0].paymentOperation,
         any(),
@@ -400,15 +404,15 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns sep31TxMock
+    } returns listOf(sep31TxMock)
     paymentListener.onReceived(event)
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_4",
         "pending_sender",
@@ -550,5 +554,122 @@ class DefaultPaymentListenerTest {
       paymentListener.checkAndWarnAssetAmountMismatch(testTxn, testPayment, testJdbcSepTransaction)
     }
     verify(exactly = 1) { platformApiClient.notifyOnchainFundsSent("123", testTxn.hash, any()) }
+  }
+
+  @Test
+  fun `test ambiguous SEP-24 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep24Transaction().apply { id = "sep24-id-1" }
+    val txn2 = JdbcSep24Transaction().apply { id = "sep24-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-24") }, *anyVararg()) }
+      assertEquals(
+        1.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test ambiguous SEP-6 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep6Transaction().apply { id = "sep6-id-1" }
+    val txn2 = JdbcSep6Transaction().apply { id = "sep6-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
+    every {
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-6") }, *anyVararg()) }
+      assertEquals(
+        1.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test ambiguous SEP-31 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep31Transaction().apply { id = "sep31-id-1" }
+    val txn2 = JdbcSep31Transaction().apply { id = "sep31-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-31") }, *anyVararg()) }
+      assertEquals(
+        1.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -584,7 +584,17 @@ class DefaultPaymentListenerTest {
       verify(exactly = 0) {
         platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
       }
-      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-24") }, *anyVararg()) }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-24") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep24-id-1") && it.toString().contains("sep24-id-2") },
+        )
+      }
       assertEquals(
         1.0,
         registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
@@ -626,7 +636,17 @@ class DefaultPaymentListenerTest {
       verify(exactly = 0) {
         platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
       }
-      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-6") }, *anyVararg()) }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-6") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep6-id-1") && it.toString().contains("sep6-id-2") },
+        )
+      }
       assertEquals(
         1.0,
         registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
@@ -662,7 +682,17 @@ class DefaultPaymentListenerTest {
       verify(exactly = 0) {
         platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
       }
-      verify(exactly = 1) { Log.errorF(match { it.contains("Ambiguous SEP-31") }, *anyVararg()) }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-31") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep31-id-1") && it.toString().contains("sep31-id-2") },
+        )
+      }
       assertEquals(
         1.0,
         registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
@@ -670,6 +700,97 @@ class DefaultPaymentListenerTest {
     } finally {
       Metrics.removeRegistry(registry)
       unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-24 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(JdbcSep24Transaction().apply { id = "sep24-id-only" })
+    every { paymentListener.handleSep24Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) {
+        paymentListener.handleSep24Transaction(ledgerTransaction, any(), any())
+      }
+      assertEquals(
+        0.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-6 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
+    every {
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(JdbcSep6Transaction().apply { id = "sep6-id-only" })
+    every { paymentListener.handleSep6Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) { paymentListener.handleSep6Transaction(ledgerTransaction, any(), any()) }
+      assertEquals(
+        0.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-31 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      listOf(JdbcSep31Transaction().apply { id = "sep31-id-only" })
+    every { paymentListener.handleSep31Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) {
+        paymentListener.handleSep31Transaction(ledgerTransaction, any(), any())
+      }
+      assertEquals(
+        0.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
     }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -1927,4 +1927,31 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
+
+  @Test
+  fun test_handle_sep24_memo_in_use_returns_400() {
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .memo(ID_MEMO)
+        .destinationAccount(DESTINATION_ACCOUNT_2)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("1", FIAT_USD))
+        .feeDetails(FeeDetails("1", STELLAR_USDC))
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.amountInAsset = STELLAR_USDC
+    txn24.amountOutAsset = FIAT_USD
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(any()) } throws
+      org.springframework.dao.DataIntegrityViolationException("duplicate key")
+
+    val ex = assertThrows<BadRequestException> { handler.handle(request) }
+    assertTrue(ex.message!!.contains("memo_in_use"))
+  }
 }


### PR DESCRIPTION
## Description
  Before this change DefaultPaymentListener.processAndDispatchLedgerPayment uses findOneByWithdrawAnchorAccountAndMemoAndStatus(...) to map incoming on-chain payments to SEP-24 rows. Declared single-result, no backing uniqueness constraint. On > 1 match Hibernate throws NonUniqueResultException, the surrounding catch (Exception ex) silently wallows it, and the SSE cursor advances. Same shape for SEP-6 (line 191) and SEP-31's findByStellarMemoAndStatus.

  #### Changes
  - [x] Replace `findOneByWithdrawAnchorAccountAndMemoAndStatus` with `findAllByWithdrawAnchorAccountAndMemoAndStatus` for SEP-24 and SEP-6, and the SEP-31 analogue, in
  `DefaultPaymentListener.processAndDispatchLedgerPayment`.                                                                                                      
  - [x] On `size() > 1`: log at ERROR with payment ID, source tx hash, routing tuple, and matched row IDs; increment `payment_observer.ambiguous_routing` metric; return without routing
  (allows SSE cursor to advance).
  - [x] Add `findAllBy…` methods to `JdbcSep24TransactionRepo`, `JdbcSep6TransactionRepo`, `JdbcSep31TransactionRepo` and their store wrappers.
  - [x] Add `PAYMENT_OBSERVER_AMBIGUOUS_ROUTING` to `AnchorMetrics`.

  #### Acceptance Criteria

  - [x] When the routing tuple matches more than one pending row, the on-chain payment is not routed, an operator-facing ERROR log and metric are emitted with the matched row IDs, and
  the SSE cursor advances normally so subsequent payments continue to process.
  - [x] Existing SEP-24 / SEP-6 / SEP-31 happy paths and single-client callback flows continue to pass.

  ### Context
  #1939

  ### Testing

  - [x] `DefaultPaymentListenerTest` — seed two pending SEP-24 rows with the same routing tuple, feed `onReceived`, assert:
      - No `notifyOnchainFundsReceived` RPC is fired.
      - `payment_observer.ambiguous_routing` metric is incremented.
      - ERROR log is emitted with both matched row IDs in the varargs.
      - `processAndDispatchLedgerPayment` returns normally so the SSE cursor advances.
  - [x] `DefaultPaymentListenerTest` — mirror ambiguous cases for SEP-6 and SEP-31.
  - [x] `DefaultPaymentListenerTest` — single-match regression: one pending row matches the routing tuple, payment routes as before, `payment_observer.ambiguous_routing` metric is not
  incremented (asserted at `0.0` for SEP-24, SEP-6, and SEP-31).
  - [x] Regression: existing single-client SEP-24/SEP-6/SEP-31 callback paths continue to pass.

  ### Documentation   
Timeout for transactions changed from 10000 to 60000L because of network ingestion and tests failing.

**Release note / upgrade warning:** V28 adds partial unique indexes on `(withdraw_anchor_account, memo_type, memo)` for SEP-24 and SEP-6 rows in `pending_user_transfer_start`, and on `(to_account, stellar_memo_type, stellar_memo)` for SEP-31 rows in `pending_sender`. If duplicate rows already exist in those states, the migration will fail on startup.

Before upgrading, operators should run:
  ```sql
  -- SEP-24
  SELECT withdraw_anchor_account, memo_type, memo, COUNT(*)
  FROM sep24_transaction
  WHERE status = 'pending_user_transfer_start'
  GROUP BY withdraw_anchor_account, memo_type, memo
  HAVING COUNT(*) > 1;

  -- SEP-6
  SELECT withdraw_anchor_account, memo_type, memo, COUNT(*)
  FROM sep6_transaction
  WHERE status = 'pending_user_transfer_start'
  GROUP BY withdraw_anchor_account, memo_type, memo
  HAVING COUNT(*) > 1;

  -- SEP-31
  SELECT to_account, stellar_memo_type, stellar_memo, COUNT(*)
  FROM sep31_transaction
  WHERE status = 'pending_sender'
  GROUP BY to_account, stellar_memo_type, stellar_memo
  HAVING COUNT(*) > 1;
```

Any rows returned must be resolved (cancelled or completed) before deploying this version.

  ### Known limitations
  N/A