### PR TITLE
[ANCHOR-1943]: rpc observer DoS via malformed soroban transfer event

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.asset.AssetService
@@ -359,7 +358,9 @@ class PaymentObserverTests {
       }
       delay(1000)
     }
-    fail("Timed out after ${timeout}ms waiting for event from account $fromAccountId")
+    throw AssertionError(
+      "Timed out after ${timeout}ms waiting for event from account $fromAccountId"
+    )
   }
 
   private fun sendTestPayment(fromKeyPair: KeyPair, toKeyPair: KeyPair): Transaction {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.asset.AssetService
@@ -358,9 +359,7 @@ class PaymentObserverTests {
       }
       delay(1000)
     }
-    assertNotNull(null) {
-      "Timed out after ${timeout}ms waiting for event from account $fromAccountId"
-    }
+    fail("Timed out after ${timeout}ms waiting for event from account $fromAccountId")
   }
 
   private fun sendTestPayment(fromKeyPair: KeyPair, toKeyPair: KeyPair): Transaction {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -347,7 +347,7 @@ class PaymentObserverTests {
   private suspend fun waitForEventsCoroutine(
     fromAccountId: String,
     listener: EventCapturingListener,
-    timeout: Long = 30000L,
+    timeout: Long = 60000L,
   ) {
     val startTime = System.currentTimeMillis()
     while (System.currentTimeMillis() - startTime <= timeout) {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -301,9 +302,11 @@ class PaymentObserverTests {
     fromEvent: List<PaymentTransferEvent>?,
     toEvent: List<PaymentTransferEvent>?,
   ) {
-    assertEquals(1, fromEvent?.size)
-    assertEquals(1, toEvent?.size)
-    assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
+    assertNotNull(fromEvent) { "Observer did not capture a fromEvent within timeout" }
+    assertNotNull(toEvent) { "Observer did not capture a toEvent within timeout" }
+    assertEquals(1, fromEvent!!.size)
+    assertEquals(1, toEvent!!.size)
+    assertEquals(fromKeyPair.accountId, fromEvent[0].from)
     assertEquals(toKeyPair.accountId, fromEvent[0].to)
     val paymentOperation: PaymentOperation = txn.operations[0] as PaymentOperation
     assertEquals(
@@ -322,9 +325,11 @@ class PaymentObserverTests {
     fromEvent: List<PaymentTransferEvent>?,
     toEvent: List<PaymentTransferEvent>?,
   ) {
-    assertEquals(1, fromEvent?.size)
-    assertEquals(1, toEvent?.size)
-    assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
+    assertNotNull(fromEvent) { "Observer did not capture a fromEvent within timeout" }
+    assertNotNull(toEvent) { "Observer did not capture a toEvent within timeout" }
+    assertEquals(1, fromEvent!!.size)
+    assertEquals(1, toEvent!!.size)
+    assertEquals(fromKeyPair.accountId, fromEvent[0].from)
     assertEquals(toKeyPair.accountId, fromEvent[0].to)
     val paymentOperation: PathPaymentStrictSendOperation =
       txn.operations[0] as PathPaymentStrictSendOperation
@@ -342,7 +347,7 @@ class PaymentObserverTests {
   private suspend fun waitForEventsCoroutine(
     fromAccountId: String,
     listener: EventCapturingListener,
-    timeout: Long = 10000L,
+    timeout: Long = 30000L,
   ) {
     val startTime = System.currentTimeMillis()
     while (System.currentTimeMillis() - startTime <= timeout) {
@@ -353,7 +358,9 @@ class PaymentObserverTests {
       }
       delay(1000)
     }
-    info("Timeout waiting for event for account: $fromAccountId")
+    assertNotNull(null) {
+      "Timed out after ${timeout}ms waiting for event from account $fromAccountId"
+    }
   }
 
   private fun sendTestPayment(fromKeyPair: KeyPair, toKeyPair: KeyPair): Transaction {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -235,7 +235,10 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
                 new MuxedAccount(Scv.fromAddress(to).toString(), Scv.fromUint64(memoVal))
                     .getAddress();
           } catch (IllegalArgumentException iae) {
-            warnF("Cannot build MuxedAccount for address '{}', using unmuxed value. ex={}", toAddr, iae.getMessage());
+            warnF(
+                "Cannot build MuxedAccount for address '{}', using unmuxed value. ex={}",
+                toAddr,
+                iae.getMessage());
           }
         }
       }
@@ -254,11 +257,9 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
           .eventMemo(eventMemo)
           .sep11Asset(asset.getStr().getSCString().toString())
           .build();
-    } catch (IOException ioex) {
+    } catch (Exception ex) {
       warnF(
-          "Skip processing event: {}. ex={}",
-          GsonUtils.getInstance().toJson(event),
-          ioex.getMessage());
+          "Skip processing event: {}. ex={}", GsonUtils.getInstance().toJson(event), ex.toString());
       return builder.build();
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -227,8 +227,16 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       if (scValue.getDiscriminant() == SCValType.SCV_I128) {
         amount = Scv.fromInt128(scValue).longValue();
       } else if (scValue.getDiscriminant() == SCValType.SCV_MAP) {
-        amount = Scv.fromInt128(scValue.getMap().getSCMap()[0].getVal()).longValue();
-        SCVal memoVal = scValue.getMap().getSCMap()[1].getVal();
+        var entries = scValue.getMap() == null ? null : scValue.getMap().getSCMap();
+        if (entries == null || entries.length < 2) {
+          return builder.build();
+        }
+        SCVal amountVal = entries[0].getVal();
+        SCVal memoVal = entries[1].getVal();
+        if (amountVal.getDiscriminant() != SCValType.SCV_I128) {
+          return builder.build();
+        }
+        amount = Scv.fromInt128(amountVal).longValue();
         eventMemo =
             switch (memoVal.getDiscriminant()) {
               case SCV_STRING -> memoVal.getStr().getSCString().toString();

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -131,6 +131,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       } finally {
         try {
           saveCursor(response.getCursor());
+          streamBackoffTimer.reset();
           metricLatestBlockProcessed.set(response.getLatestLedger());
         } catch (Exception tex) {
           warnF("Failed to persist RPC cursor. Will retry next tick. ex={}", tex.getMessage());

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -82,6 +82,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
   @Override
   void shutdownInternal() {
     task.cancel(true);
+    executorService.shutdownNow();
     status = ObserverStatus.SHUTDOWN;
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -123,17 +123,18 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       lastActivityTime = Instant.now();
       silenceTimeoutCount = 0;
       metricLatestBlockRead.set(response.getLatestLedger());
-      if (response.getEvents() != null && !response.getEvents().isEmpty()) {
-        processEvents(response.getEvents());
-      }
-      // Save the cursor for the next request
-      cursor = response.getCursor();
       try {
-        saveCursor(cursor);
-        metricLatestBlockProcessed.set(response.getLatestLedger());
-      } catch (Exception tex) {
-        warnF("Failed to persist RPC cursor. Will retry next tick. ex={}", tex.getMessage());
-        setStatus(ObserverStatus.DATABASE_ERROR);
+        if (response.getEvents() != null && !response.getEvents().isEmpty()) {
+          processEvents(response.getEvents());
+        }
+      } finally {
+        try {
+          saveCursor(response.getCursor());
+          metricLatestBlockProcessed.set(response.getLatestLedger());
+        } catch (Exception tex) {
+          warnF("Failed to persist RPC cursor. Will retry next tick. ex={}", tex.getMessage());
+          setStatus(ObserverStatus.DATABASE_ERROR);
+        }
       }
     } catch (IOException ioex) {
       warnF(

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -153,9 +153,16 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
     debugF("Processing {} 'transfer' events", events.size());
 
     for (EventInfo event : events) {
-      ShouldProcessResult result = shouldProcess(event);
-      if (result.shouldProcess) {
-        processTransferEvent(result);
+      try {
+        ShouldProcessResult result = shouldProcess(event);
+        if (result.shouldProcess) {
+          processTransferEvent(result);
+        }
+      } catch (Exception ex) {
+        warnF(
+            "Skip event due to unexpected error: {}. ex={}",
+            GsonUtils.getInstance().toJson(event),
+            ex.toString());
       }
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -229,12 +229,14 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
                   new String(Base64.getEncoder().encode(memoVal.getBytes().getSCBytes()));
               default -> null;
             };
-        if (scValue.getMap().getSCMap()[1].getVal().getDiscriminant() == SCValType.SCV_U64) {
-          toAddr =
-              new MuxedAccount(
-                      Scv.fromAddress(to).toString(),
-                      Scv.fromUint64(scValue.getMap().getSCMap()[1].getVal()))
-                  .getAddress();
+        if (memoVal.getDiscriminant() == SCValType.SCV_U64) {
+          try {
+            toAddr =
+                new MuxedAccount(Scv.fromAddress(to).toString(), Scv.fromUint64(memoVal))
+                    .getAddress();
+          } catch (IllegalArgumentException iae) {
+            warnF("Cannot build MuxedAccount for address '{}', using unmuxed value. ex={}", toAddr, iae.getMessage());
+          }
         }
       }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverPoisonResilienceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverPoisonResilienceTest.kt
@@ -1,0 +1,307 @@
+package org.stellar.anchor.platform.observer.stellar
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import java.math.BigInteger
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.platform.HealthCheckStatus.GREEN
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.ledger.StellarRpc
+import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
+import org.stellar.anchor.platform.observer.PaymentListener
+import org.stellar.anchor.platform.observer.stellar.AbstractPaymentObserver.ObserverStatus
+import org.stellar.sdk.Address
+import org.stellar.sdk.KeyPair
+import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest
+import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
+import org.stellar.sdk.scval.Scv
+import org.stellar.sdk.xdr.SCMap
+import org.stellar.sdk.xdr.SCMapEntry
+import org.stellar.sdk.xdr.SCVal
+import org.stellar.sdk.xdr.SCValType
+
+class StellarRpcObserverPoisonResilienceTest {
+  private lateinit var config: StellarPaymentObserverConfig
+  private lateinit var observer: StellarRpcPaymentObserver
+  private lateinit var sorobanServer: SorobanServer
+  private lateinit var stellarRpc: StellarRpc
+  private lateinit var paymentObservingAccountsManager: PaymentObservingAccountsManager
+  private lateinit var cursorStore: InMemoryCursorStore
+  private lateinit var assetService: AssetService
+
+  @BeforeEach
+  fun setUp() {
+    config =
+      StellarPaymentObserverConfig().apply {
+        silenceCheckInterval = 60
+        silenceTimeout = 300
+        silenceTimeoutRetries = 3
+        initialStreamBackoffTime = 500
+        maxStreamBackoffTime = 5000
+        initialEventBackoffTime = 250
+        maxEventBackoffTime = 2500
+      }
+    stellarRpc = mockk(relaxed = true)
+    sorobanServer = mockk(relaxed = true)
+    every { stellarRpc.sorobanServer } returns sorobanServer
+    every { stellarRpc.getSorobanServer() } returns sorobanServer
+    every { sorobanServer.getLatestLedger() } returns mockk { every { sequence } returns 10 }
+
+    paymentObservingAccountsManager = mockk(relaxed = true)
+    cursorStore = InMemoryCursorStore()
+    assetService = mockk(relaxed = true)
+
+    observer =
+      spyk(
+        StellarRpcPaymentObserver(
+          stellarRpc,
+          config,
+          emptyList<PaymentListener>(),
+          paymentObservingAccountsManager,
+          cursorStore,
+          MockSacToAssetMapper(),
+          assetService,
+        ),
+        recordPrivateCalls = true,
+      )
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    runCatching { observer.shutdown() }
+  }
+
+  @Test
+  fun `observer stays RUNNING after empty SCV_MAP poison event on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after one-entry SCV_MAP poison event on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(arrayOf(SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(100)))))
+        )
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after SCV_MAP with wrong first-entry type on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toUint64(BigInteger.valueOf(100))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toString("memo123")),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after contract-address recipient with SCV_U64 memo on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(500))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toUint64(BigInteger.valueOf(42))),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+    val contractAddress = Address.fromContract(ByteArray(32)).toSCVal()
+
+    setupSequentialResponses(poisonValue, toSCVal = contractAddress)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer health check returns GREEN after processing poison events`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    val healthResult = observer.check()
+    assertNotNull(healthResult)
+    assertEquals(GREEN, healthResult.status)
+  }
+
+  @Test
+  fun `observer advances cursor past mixed batch containing poison and valid events`() {
+    val emptyMapPoison =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+    val validValue = Scv.toInt128(BigInteger.valueOf(100)).toXdrBase64()
+
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockBatchResponse(listOf(emptyMapPoison, validValue), "BATCH_CUR")
+        else mockEmptyBatchResponse("NORMAL_CUR")
+      }
+
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────────
+
+  private fun setupSequentialResponses(
+    poisonValueBase64: String,
+    toSCVal: SCVal = Scv.toAddress(KeyPair.random().accountId),
+  ) {
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockPoisonResponse(poisonValueBase64, toSCVal, "POISON_CUR")
+        else mockEmptyBatchResponse("NORMAL_CUR")
+      }
+  }
+
+  private fun mockPoisonResponse(
+    valueBase64: String,
+    toSCVal: SCVal,
+    cursor: String,
+  ): GetEventsResponse {
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+        toSCVal.toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+    val event = mockk<GetEventsResponse.EventInfo>()
+    every { event.topic } returns topics
+    every { event.value } returns valueBase64
+
+    return mockk<GetEventsResponse>().also {
+      every { it.events } returns listOf(event)
+      every { it.latestLedger } returns 100L
+      every { it.cursor } returns cursor
+    }
+  }
+
+  private fun mockBatchResponse(
+    valuesBase64: List<String>,
+    cursor: String,
+  ): GetEventsResponse {
+    val events =
+      valuesBase64.map { valueBase64 ->
+        val topics =
+          listOf(
+            Scv.toSymbol("transfer").toXdrBase64(),
+            Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+            Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+            Scv.toString("native").toXdrBase64(),
+          )
+        mockk<GetEventsResponse.EventInfo>().also {
+          every { it.topic } returns topics
+          every { it.value } returns valueBase64
+        }
+      }
+    return mockk<GetEventsResponse>().also {
+      every { it.events } returns events
+      every { it.latestLedger } returns 100L
+      every { it.cursor } returns cursor
+    }
+  }
+
+  private fun mockEmptyBatchResponse(cursor: String): GetEventsResponse =
+    mockk<GetEventsResponse>().also {
+      every { it.events } returns emptyList()
+      every { it.latestLedger } returns 101L
+      every { it.cursor } returns cursor
+    }
+
+  private fun waitForCursor(expected: String, timeoutMs: Long = 6000) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      if (cursorStore.loadStellarRpcCursor() == expected) return
+      Thread.sleep(100)
+    }
+  }
+}
+
+private class InMemoryCursorStore : StellarPaymentStreamerCursorStore {
+  private var horizonCursor = ""
+  private var stellarRpcCursor = ""
+
+  override fun saveHorizonCursor(cursor: String) {
+    horizonCursor = cursor
+  }
+  override fun loadHorizonCursor(): String = horizonCursor
+  override fun saveStellarRpcCursor(cursor: String) {
+    stellarRpcCursor = cursor
+  }
+  override fun loadStellarRpcCursor(): String = stellarRpcCursor
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -31,6 +31,10 @@ import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest
 import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
 import org.stellar.sdk.scval.Scv
 import org.stellar.sdk.xdr.OperationType
+import org.stellar.sdk.xdr.SCMap
+import org.stellar.sdk.xdr.SCMapEntry
+import org.stellar.sdk.xdr.SCVal
+import org.stellar.sdk.xdr.SCValType
 
 class StellarRpcPaymentObserverTest {
   private lateinit var config: StellarPaymentObserverConfig
@@ -375,6 +379,46 @@ class StellarRpcPaymentObserverTest {
 
     assertDoesNotThrow { observer.fetchEvents() }
     assertEquals(ObserverStatus.STREAM_ERROR, observer.getStatus())
+  }
+
+  @Test
+  fun `fetchEvents skips empty SCV_MAP poison event without crashing or stalling`() {
+    val distAccount = KeyPair.random().accountId
+    val attackerAccount = KeyPair.random().accountId
+    
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(distAccount).toXdrBase64(),
+        Scv.toAddress(attackerAccount).toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+      
+    val emptyMapValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+        
+    val poisonEvent = mockk<GetEventsResponse.EventInfo>()
+    every { poisonEvent.topic } returns topics
+    every { poisonEvent.value } returns emptyMapValue
+
+    val response = mockk<GetEventsResponse>()
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { response.events } returns listOf(poisonEvent)
+    every { response.latestLedger } returns 777L
+    every { response.cursor } returns "SAFE_CUR"
+    every { sorobanServer.getEvents(any()) } returns response
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+
+    observer.setStatus(ObserverStatus.RUNNING)
+    
+    assertDoesNotThrow { observer.fetchEvents() }
+    
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("SAFE_CUR", observer.cursor)
   }
 }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -22,6 +22,7 @@ import org.stellar.anchor.ledger.StellarRpc
 import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
 import org.stellar.anchor.platform.observer.PaymentListener
 import org.stellar.anchor.platform.observer.stellar.AbstractPaymentObserver.ObserverStatus
+import org.stellar.sdk.Address
 import org.stellar.sdk.Asset
 import org.stellar.sdk.KeyPair
 import org.stellar.sdk.SorobanServer
@@ -385,7 +386,7 @@ class StellarRpcPaymentObserverTest {
   fun `fetchEvents skips empty SCV_MAP poison event without crashing or stalling`() {
     val distAccount = KeyPair.random().accountId
     val attackerAccount = KeyPair.random().accountId
-    
+
     val topics =
       listOf(
         Scv.toSymbol("transfer").toXdrBase64(),
@@ -393,14 +394,14 @@ class StellarRpcPaymentObserverTest {
         Scv.toAddress(attackerAccount).toXdrBase64(),
         Scv.toString("native").toXdrBase64(),
       )
-      
+
     val emptyMapValue =
       SCVal.builder()
         .discriminant(SCValType.SCV_MAP)
         .map(SCMap(emptyArray<SCMapEntry>()))
         .build()
         .toXdrBase64()
-        
+
     val poisonEvent = mockk<GetEventsResponse.EventInfo>()
     every { poisonEvent.topic } returns topics
     every { poisonEvent.value } returns emptyMapValue
@@ -414,11 +415,112 @@ class StellarRpcPaymentObserverTest {
     justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
 
     observer.setStatus(ObserverStatus.RUNNING)
-    
+
     assertDoesNotThrow { observer.fetchEvents() }
-    
+
     assertEquals(ObserverStatus.RUNNING, observer.getStatus())
     assertEquals("SAFE_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents skips one-entry SCV_MAP without crashing or stalling`() {
+    val oneEntryMap =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(arrayOf(SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(100)))))
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns mockPoisonResponse(oneEntryMap)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents skips SCV_MAP with wrong first-entry type without crashing or stalling`() {
+    val wrongTypeMap =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toUint64(BigInteger.valueOf(100))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toString("memo123")),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns mockPoisonResponse(wrongTypeMap)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents handles contract-address recipient with SCV_U64 memo without crashing`() {
+    val contractAddress = Address.fromContract(ByteArray(32)).toSCVal()
+    val validMapWithU64Memo =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(500))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toUint64(BigInteger.valueOf(42))),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns
+      mockPoisonResponse(validMapWithU64Memo, toSCVal = contractAddress)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  private fun mockPoisonResponse(
+    valueBase64: String,
+    fromAccount: String = KeyPair.random().accountId,
+    toSCVal: SCVal = Scv.toAddress(KeyPair.random().accountId),
+  ): GetEventsResponse {
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(fromAccount).toXdrBase64(),
+        toSCVal.toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+    val event = mockk<GetEventsResponse.EventInfo>()
+    every { event.topic } returns topics
+    every { event.value } returns valueBase64
+
+    val response = mockk<GetEventsResponse>()
+    every { response.events } returns listOf(event)
+    every { response.latestLedger } returns 777L
+    every { response.cursor } returns "POISON_CUR"
+    return response
   }
 }
 


### PR DESCRIPTION
### Description

Before this change, the Stellar RPC payment observer could be permanently shut down by any Soroban contract emitting a `transfer` event with a malformed `value` field.

The `shouldProcess` method indexed `SCV_MAP` entries at `[0]` and `[1]` without bounds or type validation, and the surrounding `catch` only handled `IOException` — letting `ArrayIndexOutOfBoundsException`, `IllegalArgumentException`, and `NullPointerException` propagate.

Because `saveCursor` is called after `processEvents`, a single poison event stalled the cursor, causing the same event to be replayed on every 1-second tick until the exponential backoff timer maxed out (~10 min) and the observer called `shutdown()`. All SEP-6/24/31 withdrawals stopped completing until the process was manually restarted.

**Changes**
- [x] Validate `SCV_MAP` shape in `shouldProcess` before indexing: null-check `getMap()`, require `entries.length >= 2`, require `entries[0]` discriminant is `SCV_I128`; return a skip result early otherwise.
- [x] Catch `IllegalArgumentException` from `new MuxedAccount(C…, u64)` when `to` is a contract address; log a warning and fall back to the unmuxed address.
- [x] Broaden `catch (IOException)` to `catch (Exception)` in `shouldProcess` so all unchecked runtime exceptions are logged and skipped instead of propagating.
- [x] Wrap each event in `processEvents` with its own `try/catch(Exception)` so one bad event cannot abort the entire batch.
- [x] Move `saveCursor` into a `finally` block in `fetchEvents` so the cursor always advances when `getEvents` succeeds, preventing infinite replay of a poison event.

**Acceptance Criteria**
- [x] An empty `SCV_MAP` event does not crash the observer or set `STREAM_ERROR`.
- [x] A one-entry `SCV_MAP` event does not crash the observer.
- [x] An `SCV_MAP` whose first entry is not `SCV_I128` does not crash the observer.
- [x] A contract-address recipient with `SCV_U64` memo logs a warning and completes without crashing.
- [x] In all four cases above, the observer status remains `RUNNING` and the cursor advances past the poison event.
- [x] Existing SEP-24 / SEP-6 / SEP-31 happy paths and single-client callback flows continue to pass.

### Context

[#1943](https://github.com/stellar/anchor-platform/issues/1943)

### Testing
Four new unit tests in `StellarRpcPaymentObserverTest`:
- `fetchEvents skips empty SCV_MAP poison event without crashing or stalling` (P1)
- `fetchEvents skips one-entry SCV_MAP without crashing or stalling` (P2)
- `fetchEvents skips SCV_MAP with wrong first-entry type without crashing or stalling` (P3)
- `fetchEvents handles contract-address recipient with SCV_U64 memo without crashing` (P4)

Each test confirms `ObserverStatus.RUNNING` and cursor advancement after the poison event is processed.

**Integration tests**
- P1–P4 poison variants each confirm `ObserverStatus.RUNNING` and cursor advance on the live scheduler
- Health check returns `GREEN` after processing a poison event
- Mixed batch containing a poison and a valid event advances cursor past both
- Increased `waitForEventsCoroutine` default timeout from 10 s to 60 s to account for testnet ledger close time (~6 s) plus network latency
- `waitForEventsCoroutine` now fails with an explicit assertion message on timeout instead of silently returning
- `assertEventsPayment` / `assertEventsPathPayment` use `assertNotNull` before indexing so null events produce a readable failure

### Documentation
N/A

### Known limitations
N/A