### PR TITLE
chore(release): merge release/4.4.0 to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v4.3.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=4.3.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v4.4.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=4.4.0)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/event/AnchorEvent.java
@@ -18,6 +18,8 @@ public class AnchorEvent {
   Type type;
   String id;
   String sep;
+  String clientName;
+  String clientDomain;
   GetTransactionResponse transaction;
   GetQuoteResponse quote;
   Sep12GetCustomerResponse customer;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "4.3.0"
+  version = "4.4.0"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
+++ b/core/src/main/java/org/stellar/anchor/client/ClientConfig.java
@@ -19,6 +19,10 @@ public interface ClientConfig {
     private String sep12;
   }
 
+  default boolean matchesDomain(String domain) {
+    return false;
+  }
+
   /**
    * Returns true if any of the callback URLs are set.
    *

--- a/core/src/main/java/org/stellar/anchor/client/NonCustodialClient.java
+++ b/core/src/main/java/org/stellar/anchor/client/NonCustodialClient.java
@@ -22,6 +22,11 @@ public class NonCustodialClient implements ClientConfig {
   /** The domains associated with the client, used for verifying the client's identity. */
   Set<String> domains;
 
+  @Override
+  public boolean matchesDomain(String domain) {
+    return domain != null && domains != null && domains.contains(domain);
+  }
+
   /**
    * The URLs to which the service can send callbacks for different SEP types. Optional due to some
    * wallets may opt to poll instead, or may use polling first before implementing callbacks at a

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -59,7 +59,10 @@ public class Sep12Service {
   public Sep12GetCustomerResponse getCustomer(WebAuthJwt token, Sep12GetCustomerRequest request)
       throws AnchorException {
     validateGetOrPutRequest(request, token);
-    if (request.getAccount() == null && token.getAccount() != null) {
+    if (request.getAccount() == null
+        && token.getAccount() != null
+        && request.getId() == null
+        && request.getTransactionId() == null) {
       request.setAccount(token.getAccount());
     }
 
@@ -76,7 +79,10 @@ public class Sep12Service {
       throws AnchorException {
     validateGetOrPutRequest(request, token);
 
-    if (request.getAccount() == null && token.getAccount() != null) {
+    if (request.getAccount() == null
+        && token.getAccount() != null
+        && request.getId() == null
+        && request.getTransactionId() == null) {
       request.setAccount(token.getAccount());
     }
 
@@ -170,8 +176,11 @@ public class Sep12Service {
     sep12DeleteCustomerCounter.increment();
   }
 
+  private static final String ERR_CUSTOMER_ID_NOT_AUTHORIZED = "not authorized for customer id";
+
   void validateGetOrPutRequest(Sep12CustomerRequestBase requestBase, WebAuthJwt token)
       throws SepException {
+    boolean isIdPath = false;
     if (requestBase.getTransactionId() != null) {
       try {
         // `transactionId` should be used in conjunction with customer type `type` (sep6,
@@ -204,10 +213,51 @@ public class Sep12Service {
       } catch (Exception e) {
         throw new SepNotAuthorizedException("The transaction specified does not exist");
       }
+    } else if (requestBase.getId() != null) {
+      isIdPath = true;
+
+      try {
+        String tokenAccount =
+            token.getMuxedAccount() != null ? token.getMuxedAccount() : token.getAccount();
+        String tokenMemo =
+            token.getMuxedAccountId() != null
+                ? token.getMuxedAccountId().toString()
+                : token.getAccountMemo();
+
+        GetCustomerResponse owned =
+            customerIntegration.getCustomer(
+                GetCustomerRequest.builder()
+                    .memo(tokenMemo)
+                    .memoType(tokenMemo != null ? "id" : null)
+                    .account(tokenAccount)
+                    .type(requestBase.getType())
+                    .build());
+
+        if (owned == null || !requestBase.getId().equals(owned.getId())) {
+          throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+        }
+
+        requestBase.setAccount(tokenAccount);
+      } catch (SepNotAuthorizedException e) {
+        throw e;
+      } catch (Exception e) {
+        Log.warnEx(e);
+        throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+      }
     }
-    validateRequestAndTokenAccounts(requestBase, token);
-    validateRequestAndTokenMemos(requestBase, token);
-    updateRequestMemoAndMemoType(requestBase, token);
+
+    try {
+      validateRequestAndTokenAccounts(requestBase, token);
+
+      if (!isIdPath) {
+        validateRequestAndTokenMemos(requestBase, token);
+      }
+
+      updateRequestMemoAndMemoType(requestBase, token);
+    } catch (SepException e) {
+      if (isIdPath) throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+      throw e;
+    }
   }
 
   void validateRequestAndTokenAccounts(

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.sep12;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_12;
 import static org.stellar.anchor.util.Log.infoF;
+import static org.stellar.anchor.util.Log.warnF;
 import static org.stellar.anchor.util.MetricConstants.*;
 import static org.stellar.anchor.util.MetricConstants.SEP12_CUSTOMER;
 
@@ -23,6 +24,7 @@ import org.stellar.anchor.api.sep.sep12.*;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.MemoHelper;
@@ -38,15 +40,18 @@ public class Sep12Service {
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_DELETE_CUSTOMER);
   private final PlatformApiClient platformApiClient;
   private final EventService.Session eventSession;
+  private final ClientFinder clientFinder;
 
   public Sep12Service(
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
-      EventService eventService) {
+      EventService eventService,
+      ClientFinder clientFinder) {
     this.customerIntegration = customerIntegration;
     this.platformApiClient = platformApiClient;
     this.eventSession =
         eventService.createSession(this.getClass().getName(), EventService.EventQueue.TRANSACTION);
+    this.clientFinder = clientFinder;
 
     Log.info("Sep12Service initialized.");
   }
@@ -97,12 +102,24 @@ public class Sep12Service {
     PutCustomerResponse updatedCustomer =
         customerIntegration.putCustomer(PutCustomerRequest.from(request));
 
-    // Only publish event if the customer was updated.
+    String clientName = null;
+
+    try {
+      clientName = clientFinder.getClientName(token);
+    } catch (SepNotAuthorizedException e) {
+      warnF(
+          "Client attribution required but client is not authorized; CUSTOMER_UPDATED event will have no clientName. token={}, reason={}",
+          token.getAccount(),
+          e.getMessage());
+    }
+
     eventSession.publish(
         AnchorEvent.builder()
             .id(UUID.randomUUID().toString())
             .sep(SEP_12.getSep().toString())
             .type(AnchorEvent.Type.CUSTOMER_UPDATED)
+            .clientName(clientName)
+            .clientDomain(token.getClientDomain())
             .customer(GetCustomerResponse.to(updatedCustomer))
             .build());
 

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -25,6 +25,7 @@ import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import io.micrometer.core.instrument.Counter;
+import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -123,6 +124,13 @@ public class Sep24Service {
     info("Sep24Service initialized.");
   }
 
+  @Transactional(
+      rollbackOn = {
+        AnchorException.class,
+        MalformedURLException.class,
+        URISyntaxException.class,
+        RuntimeException.class
+      })
   public InteractiveTransactionResponse withdraw(
       WebAuthJwt token, Map<String, String> withdrawRequest)
       throws AnchorException, MalformedURLException, URISyntaxException {
@@ -246,6 +254,10 @@ public class Sep24Service {
     Sep24Transaction txn = builder.build();
     txnStore.save(txn);
 
+    if (quoteId != null) {
+      exchangeAmountsCalculator.bindQuoteToTransaction(quoteId, txn.getTransactionId());
+    }
+
     eventSession.publish(
         AnchorEvent.builder()
             .id(UUID.randomUUID().toString())
@@ -271,6 +283,13 @@ public class Sep24Service {
     return response;
   }
 
+  @Transactional(
+      rollbackOn = {
+        AnchorException.class,
+        MalformedURLException.class,
+        URISyntaxException.class,
+        RuntimeException.class
+      })
   public InteractiveTransactionResponse deposit(
       WebAuthJwt token, Map<String, String> depositRequest)
       throws AnchorException, MalformedURLException, URISyntaxException {
@@ -431,6 +450,10 @@ public class Sep24Service {
 
     Sep24Transaction txn = builder.build();
     txnStore.save(txn);
+
+    if (quoteId != null) {
+      exchangeAmountsCalculator.bindQuoteToTransaction(quoteId, txn.getTransactionId());
+    }
 
     eventSession.publish(
         AnchorEvent.builder()

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -54,6 +54,7 @@ import org.stellar.anchor.config.Sep31Config;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep38.Sep38Quote;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
+import org.stellar.anchor.util.ExchangeAmountsCalculator;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.SepRequestValidator;
 import org.stellar.anchor.util.TransactionMapper;
@@ -72,6 +73,7 @@ public class Sep31Service {
   private final EventService.Session eventSession;
   private final Counter sep31TransactionCreatedCounter = counter(SEP31_TRANSACTION_CREATED);
   private final Counter sep31TransactionPatchedCounter = counter(SEP31_TRANSACTION_PATCHED);
+  final ExchangeAmountsCalculator exchangeAmountsCalculator;
 
   public Sep31Service(
       LanguageConfig languageConfig,
@@ -83,7 +85,8 @@ public class Sep31Service {
       AssetService assetService,
       RateIntegration rateIntegration,
       EventService eventService,
-      Clock clock) {
+      Clock clock,
+      ExchangeAmountsCalculator exchangeAmountsCalculator) {
     debug("sep31Config:", sep31Config);
     this.languageConfig = languageConfig;
     this.sep10Config = sep10Config;
@@ -94,6 +97,7 @@ public class Sep31Service {
     this.assetService = assetService;
     this.rateIntegration = rateIntegration;
     this.clock = clock;
+    this.exchangeAmountsCalculator = exchangeAmountsCalculator;
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.infoResponse = sep31InfoResponseFromAssetInfoList(assetService.getAssets());
     Log.info("Sep31Service initialized.");
@@ -214,6 +218,11 @@ public class Sep31Service {
 
     Context.get().setTransaction(sep31TransactionStore.save(txn));
     txn = Context.get().getTransaction();
+
+    Sep38Quote consumedQuote = Context.get().getQuote();
+    if (consumedQuote != null) {
+      exchangeAmountsCalculator.bindQuoteToTransaction(consumedQuote.getId(), txn.getId());
+    }
 
     eventSession.publish(
         AnchorEvent.builder()
@@ -467,6 +476,15 @@ public class Sep31Service {
       infoF("Quote ({}) was not found", request.getQuoteId());
       throw new BadRequestException(
           String.format("quote(id=%s) was not found.", request.getQuoteId()));
+    }
+
+    if (quote.getTransactionId() != null) {
+      infoF(
+          "Quote ({}) has already been used in transaction ({})",
+          request.getQuoteId(),
+          quote.getTransactionId());
+      throw new BadRequestException(
+          String.format("quote(id=%s) has already been used", request.getQuoteId()));
     }
 
     if (quote.getExpiresAt() != null && !quote.getExpiresAt().isAfter(clock.instant())) {

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38QuoteStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38QuoteStore.java
@@ -24,4 +24,15 @@ public interface Sep38QuoteStore {
    */
   @SuppressWarnings("UnusedReturnValue")
   Sep38Quote save(Sep38Quote sep38Quote) throws SepException;
+
+  /**
+   * Bind this quote to a transaction.
+   *
+   * @param quoteId The quote ID
+   * @param transactionId The transaction ID to bind
+   * @return true if the quote was bound, false if it was already bound to another transaction
+   * @throws SepException if a storage error occurs
+   */
+  boolean bindToTransaction(@NonNull String quoteId, @NonNull String transactionId)
+      throws SepException;
 }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -13,6 +13,7 @@ import static org.stellar.anchor.util.SepLanguageHelper.validateLanguage;
 
 import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.Counter;
+import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.*;
 import org.stellar.anchor.MoreInfoUrlConstructor;
@@ -184,6 +185,7 @@ public class Sep6Service {
         .build();
   }
 
+  @Transactional(rollbackOn = {AnchorException.class, RuntimeException.class})
   public StartDepositResponse depositExchange(WebAuthJwt token, StartDepositExchangeRequest request)
       throws AnchorException {
     sep6TransactionRequestedCounter.increment();
@@ -273,6 +275,10 @@ public class Sep6Service {
     Sep6Transaction txn = builder.build();
     txnStore.save(txn);
 
+    if (request.getQuoteId() != null) {
+      exchangeAmountsCalculator.bindQuoteToTransaction(request.getQuoteId(), id);
+    }
+
     eventSession.publish(
         AnchorEvent.builder()
             .id(UUID.randomUUID().toString())
@@ -360,6 +366,7 @@ public class Sep6Service {
     return StartWithdrawResponse.builder().id(txn.getId()).build();
   }
 
+  @Transactional(rollbackOn = {AnchorException.class, RuntimeException.class})
   public StartWithdrawResponse withdrawExchange(
       WebAuthJwt token, StartWithdrawExchangeRequest request) throws AnchorException {
     sep6TransactionRequestedCounter.increment();
@@ -445,6 +452,10 @@ public class Sep6Service {
 
     Sep6Transaction txn = builder.build();
     txnStore.save(txn);
+
+    if (request.getQuoteId() != null) {
+      exchangeAmountsCalculator.bindQuoteToTransaction(request.getQuoteId(), id);
+    }
 
     eventSession.publish(
         AnchorEvent.builder()

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
@@ -26,7 +26,4 @@ public interface Sep6TransactionStore {
   Sep6Transaction save(Sep6Transaction sep6Transaction) throws SepException;
 
   List<? extends Sep6Transaction> findTransactions(TransactionsParams params) throws SepException;
-
-  Sep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
-      String withdrawAnchorAccount, String memo, String status);
 }

--- a/core/src/main/java/org/stellar/anchor/util/ExchangeAmountsCalculator.java
+++ b/core/src/main/java/org/stellar/anchor/util/ExchangeAmountsCalculator.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.stellar.anchor.api.asset.AssetInfo;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
+import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.exception.SepValidationException;
 import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.sep38.Sep38Quote;
@@ -61,6 +62,10 @@ public class ExchangeAmountsCalculator {
       throw new BadRequestException("Quote not found");
     }
 
+    if (quote.getTransactionId() != null) {
+      throw new BadRequestException(String.format("quote(id=%s) has already been used", quoteId));
+    }
+
     if (quote.getExpiresAt() != null && !quote.getExpiresAt().isAfter(clock.instant())) {
       throw new BadRequestException(
           String.format("quote(id=%s) has expired at %s", quoteId, quote.getExpiresAt()));
@@ -93,6 +98,21 @@ public class ExchangeAmountsCalculator {
     }
 
     return quote;
+  }
+
+  /**
+   * Bind a quote to a transaction. Delegates to {@link Sep38QuoteStore#bindToTransaction}.
+   *
+   * @param quoteId The quote ID
+   * @param transactionId The transaction ID to bind
+   * @throws BadRequestException if the quote has already been bound to a transaction
+   * @throws SepException if a storage error occurs
+   */
+  public void bindQuoteToTransaction(String quoteId, String transactionId)
+      throws BadRequestException, SepException {
+    if (!sep38QuoteStore.bindToTransaction(quoteId, transactionId)) {
+      throw new BadRequestException(String.format("quote(id=%s) has already been used", quoteId));
+    }
   }
 
   /** Amounts calculated for an exchange request. */

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -33,6 +33,7 @@ import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.util.StringHelper.json
 
@@ -100,6 +101,7 @@ class Sep12ServiceTest {
   @MockK(relaxed = true) private lateinit var platformApiClient: PlatformApiClient
   @MockK(relaxed = true) private lateinit var eventService: EventService
   @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
+  @MockK(relaxed = true) private lateinit var clientFinder: ClientFinder
 
   @BeforeEach
   fun setup() {
@@ -111,7 +113,7 @@ class Sep12ServiceTest {
     every { assetService.getAssets() } returns assets
     every { eventService.createSession(any(), any()) } returns eventSession
 
-    sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService)
+    sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService, clientFinder)
   }
 
   @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
@@ -412,6 +414,7 @@ class Sep12ServiceTest {
     assertNotNull(kycUpdateEventSlot.captured.id)
     assertEquals("12", kycUpdateEventSlot.captured.sep)
     assertEquals(AnchorEvent.Type.CUSTOMER_UPDATED, kycUpdateEventSlot.captured.type)
+    assertEquals(CLIENT_DOMAIN, kycUpdateEventSlot.captured.clientDomain)
     assertEquals(
       GetCustomerResponse.to(mockCallbackApiGetCustomerResponse),
       kycUpdateEventSlot.captured.customer,
@@ -421,6 +424,25 @@ class Sep12ServiceTest {
     verify(exactly = 1) { customerIntegration.putCustomer(any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
     assertEquals(TEST_ACCOUNT, mockPutRequest.account)
+  }
+
+  @Test
+  fun `Test put customer publishes event with null clientName and logs warning when client is not authorized`() {
+    val kycUpdateEventSlot = slot<AnchorEvent>()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("customer-id").build()
+    every { eventSession.publish(capture(kycUpdateEventSlot)) } returns Unit
+    every { clientFinder.getClientName(any<WebAuthJwt>()) } throws
+      SepNotAuthorizedException("Client not found")
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    assertDoesNotThrow {
+      sep12Service.putCustomer(jwtToken, Sep12PutCustomerRequest.builder().build())
+    }
+
+    verify(exactly = 1) { eventSession.publish(any()) }
+    assertEquals(AnchorEvent.Type.CUSTOMER_UPDATED, kycUpdateEventSlot.captured.type)
+    assertEquals(null, kycUpdateEventSlot.captured.clientName)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -577,10 +578,12 @@ class Sep12ServiceTest {
   @Test
   fun `Test get customer request with id injects account`() {
     val callbackApiGetRequestSlot = slot<GetCustomerRequest>()
-    val mockCallbackApiGetCustomerResponse = GetCustomerResponse()
-    mockCallbackApiGetCustomerResponse.id = "customer-id"
-    every { customerIntegration.getCustomer(capture(callbackApiGetRequestSlot)) } returns
-      mockCallbackApiGetCustomerResponse
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    val fullResponse = GetCustomerResponse()
+    fullResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(capture(callbackApiGetRequestSlot)) } returnsMany
+      listOf(prefetchResponse, fullResponse)
 
     val mockGetRequest = Sep12GetCustomerRequest.builder().id("customer-id").build()
     val jwtToken = createJwtToken(TEST_ACCOUNT)
@@ -596,6 +599,9 @@ class Sep12ServiceTest {
   @Test
   fun `Test put customer request with id injects account`() {
     val callbackApiPutRequestSlot = slot<PutCustomerRequest>()
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(any()) } returns prefetchResponse
     val mockCallbackApiPutCustomerResponse = PutCustomerResponse.builder().id("customer-id").build()
     every { customerIntegration.putCustomer(capture(callbackApiPutRequestSlot)) } returns
       mockCallbackApiPutCustomerResponse
@@ -609,6 +615,227 @@ class Sep12ServiceTest {
       PutCustomerRequest.builder().id("customer-id").account(TEST_ACCOUNT).build()
     assertEquals(wantCallbackApiPutRequest, callbackApiPutRequestSlot.captured)
     assertEquals(TEST_ACCOUNT, mockPutRequest.account)
+  }
+
+  @Test
+  fun `test get customer with id belonging to different account should throw`() {
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("account mismatch")
+
+    val attackerToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("victim-customer-id").build()
+
+    val ex: SepException = assertThrows {
+      sep12Service.validateGetOrPutRequest(request, attackerToken)
+    }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 1) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test put customer with id belonging to different account should throw`() {
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("account mismatch")
+
+    val attackerToken = createJwtToken(TEST_ACCOUNT)
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .id("victim-customer-id")
+        .bankAccountNumber("attacker-iban")
+        .build()
+
+    val ex: SepException = assertThrows { sep12Service.putCustomer(attackerToken, request) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
+  }
+
+  @Test
+  fun `test get customer with unknown id should throw`() {
+    val notFoundResponse = GetCustomerResponse()
+    every { customerIntegration.getCustomer(any()) } returns notFoundResponse
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("nonexistent-id").build()
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+  }
+
+  @Test
+  fun `test id ownership mismatch fails closed`() {
+    every { customerIntegration.getCustomer(any()) } throws
+      RuntimeException("not found for account")
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("some-other-id").build()
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+  }
+
+  @Test
+  fun `test id path normalizes error message across all failure modes`() {
+    val attackerToken = createJwtToken(TEST_ACCOUNT)
+
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("account mismatch")
+    val accountMismatchEx: SepException = assertThrows {
+      sep12Service.validateGetOrPutRequest(
+        Sep12GetCustomerRequest.builder().id("victim-id").build(),
+        attackerToken
+      )
+    }
+
+    every { customerIntegration.getCustomer(any()) } returns GetCustomerResponse()
+    val unknownEx: SepException = assertThrows {
+      sep12Service.validateGetOrPutRequest(
+        Sep12GetCustomerRequest.builder().id("unknown-id").build(),
+        attackerToken
+      )
+    }
+
+    assertEquals(accountMismatchEx.message, unknownEx.message)
+    assertEquals("not authorized for customer id", accountMismatchEx.message)
+  }
+
+  @Test
+  fun `test id path converts callback exception to 403`() {
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("db error")
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("customer-id").build()
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+  }
+
+  @Test
+  fun `test id prefetch includes type in request`() {
+    val prefetchSlot = slot<GetCustomerRequest>()
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(capture(prefetchSlot)) } returns prefetchResponse
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("customer-id").type("sep31-receiver").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertNull(prefetchSlot.captured.id)
+    assertEquals(TEST_ACCOUNT, prefetchSlot.captured.account)
+    assertEquals("sep31-receiver", prefetchSlot.captured.type)
+  }
+
+  @Test
+  fun `test memo-only customer with no-memo token is allowed when account matches`() {
+    val ownedCustomer = GetCustomerResponse()
+    ownedCustomer.id = "customer-id"
+    every { customerIntegration.getCustomer(any()) } returns ownedCustomer
+
+    val noMemoToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("customer-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, noMemoToken) }
+  }
+
+  @Test
+  fun `test memo-only customer with matching token memo is allowed`() {
+    // Reverse lookup: account+memo finds the customer; returned id matches the request.
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(any()) } returns prefetchResponse
+
+    val memoToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    val request = Sep12GetCustomerRequest.builder().id("customer-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, memoToken) }
+  }
+
+  @Test
+  fun `test getCustomer denies no-memo token when business server rejects account mismatch end-to-end`() {
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("account mismatch")
+
+    val noMemoToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: AnchorException = assertThrows {
+      sep12Service.getCustomer(
+        noMemoToken,
+        Sep12GetCustomerRequest.builder().id("customer-id").build(),
+      )
+    }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 1) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test putCustomer denies no-memo token when business server rejects account mismatch end-to-end`() {
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("account mismatch")
+
+    val noMemoToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: AnchorException = assertThrows {
+      sep12Service.putCustomer(
+        noMemoToken,
+        Sep12PutCustomerRequest.builder().id("customer-id").firstName("Alice").build(),
+      )
+    }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
+  }
+
+  @Test
+  fun `test id path forwards token account to callback on get`() {
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    val callbackSlot = slot<GetCustomerRequest>()
+    val callbackResponse = GetCustomerResponse()
+    callbackResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(capture(callbackSlot)) } returnsMany
+      listOf(prefetchResponse, callbackResponse)
+
+    val memoToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    sep12Service.getCustomer(memoToken, Sep12GetCustomerRequest.builder().id("customer-id").build())
+
+    assertEquals("customer-id", callbackSlot.captured.id)
+    assertEquals(TEST_ACCOUNT, callbackSlot.captured.account)
+    assertNull(callbackSlot.captured.memo)
+  }
+
+  @Test
+  fun `test id path forwards token account to callback on put`() {
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    val callbackSlot = slot<PutCustomerRequest>()
+    every { customerIntegration.getCustomer(any()) } returns prefetchResponse
+    every { customerIntegration.putCustomer(capture(callbackSlot)) } returns
+      PutCustomerResponse.builder().id("customer-id").build()
+
+    val memoToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    sep12Service.putCustomer(
+      memoToken,
+      Sep12PutCustomerRequest.builder().id("customer-id").firstName("Alice").build(),
+    )
+
+    assertEquals("customer-id", callbackSlot.captured.id)
+    assertEquals(TEST_ACCOUNT, callbackSlot.captured.account)
+    assertNull(callbackSlot.captured.memo)
+  }
+
+  @Test
+  fun `test id path sets token account and memo on request`() {
+    val prefetchResponse = GetCustomerResponse()
+    prefetchResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(any()) } returns prefetchResponse
+
+    val memoToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    val request = Sep12GetCustomerRequest.builder().id("customer-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, memoToken) }
+    assertEquals(TEST_ACCOUNT, request.account)
+    assertNull(request.memo)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -263,6 +263,7 @@ internal class Sep24ServiceTest {
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep38QuoteStore.findByQuoteId(any()) } returns withdrawQuote
+    every { sep38QuoteStore.bindToTransaction(any(), any()) } returns true
     sep24Service.withdraw(
       createTestWebAuthJwtWithMemo(),
       createTestTransactionRequest(withdrawQuote.id),
@@ -411,6 +412,7 @@ internal class Sep24ServiceTest {
     val slotTxn = slot<Sep24Transaction>()
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep38QuoteStore.findByQuoteId(any()) } returns depositQuote
+    every { sep38QuoteStore.bindToTransaction(any(), any()) } returns true
     sep24Service.deposit(
       createTestWebAuthJwtWithMemo(),
       createTestTransactionRequest(depositQuote.id),
@@ -877,6 +879,66 @@ internal class Sep24ServiceTest {
       TEST_HOME_DOMAIN,
       TEST_CLIENT_DOMAIN,
     )
+  }
+
+  @Test
+  fun `test withdraw rejects already-bound quote`() {
+    every { sep38QuoteStore.findByQuoteId(any()) } returns
+      withdrawQuote.apply { transactionId = "already-used-txn" }
+    val ex =
+      assertThrows<BadRequestException> {
+        sep24Service.withdraw(
+          createTestWebAuthJwtWithMemo(),
+          createTestTransactionRequest(withdrawQuote.id)
+        )
+      }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test withdraw bind failure rejects second use`() {
+    every { sep38QuoteStore.findByQuoteId(any()) } returns
+      withdrawQuote.apply { transactionId = null }
+    every { txnStore.save(any()) } returns null
+    every { sep38QuoteStore.bindToTransaction(any(), any()) } returns false
+    val ex =
+      assertThrows<BadRequestException> {
+        sep24Service.withdraw(
+          createTestWebAuthJwtWithMemo(),
+          createTestTransactionRequest(withdrawQuote.id)
+        )
+      }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test deposit rejects already-bound quote`() {
+    every { sep38QuoteStore.findByQuoteId(any()) } returns
+      depositQuote.apply { transactionId = "already-used-txn" }
+    val ex =
+      assertThrows<BadRequestException> {
+        sep24Service.deposit(
+          createTestWebAuthJwtWithMemo(),
+          createTestTransactionRequest(depositQuote.id)
+        )
+      }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test deposit bind failure rejects second use`() {
+    every { sep38QuoteStore.findByQuoteId(any()) } returns
+      depositQuote.apply { transactionId = null }
+    every { txnStore.save(any()) } returns null
+    every { sep38QuoteStore.bindToTransaction(any(), any()) } returns false
+    val ex =
+      assertThrows<BadRequestException> {
+        sep24Service.deposit(
+          createTestWebAuthJwtWithMemo(),
+          createTestTransactionRequest(depositQuote.id)
+        )
+      }
+    assert(ex.message!!.contains("has already been used"))
   }
 
   private fun createTestInteractiveJwt(accountMemo: String?): Sep24InteractiveUrlJwt {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -52,6 +52,7 @@ import org.stellar.anchor.sep31.Sep31Service.Context
 import org.stellar.anchor.sep38.PojoSep38Quote
 import org.stellar.anchor.sep38.Sep38QuoteStore
 import org.stellar.anchor.setupMock
+import org.stellar.anchor.util.ExchangeAmountsCalculator
 import org.stellar.anchor.util.GsonUtils
 
 @Order(13)
@@ -250,6 +251,7 @@ class Sep31ServiceTest {
   @MockK(relaxed = true) lateinit var sep31Config: Sep31Config
   @MockK(relaxed = true) lateinit var sep31DepositInfoGenerator: Sep31DepositInfoGenerator
   @MockK(relaxed = true) lateinit var quoteStore: Sep38QuoteStore
+  @MockK(relaxed = true) lateinit var exchangeAmountsCalculator: ExchangeAmountsCalculator
   @MockK(relaxed = true) lateinit var rateIntegration: RateIntegration
   @MockK(relaxed = true) lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) lateinit var eventService: EventService
@@ -287,6 +289,7 @@ class Sep31ServiceTest {
         rateIntegration,
         eventService,
         Clock.systemUTC(),
+        exchangeAmountsCalculator,
       )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
@@ -700,7 +703,6 @@ class Sep31ServiceTest {
         firstArg<Sep31Transaction>().id = "ABC-123"
         firstArg()
       }
-
     // POST transaction
     val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
     var gotResponse: Sep31PostTransactionResponse? = null
@@ -708,6 +710,7 @@ class Sep31ServiceTest {
 
     // verify if the mocks were called
     verify(exactly = 1) { quoteStore.findByQuoteId("my_quote_id") }
+    verify(exactly = 1) { exchangeAmountsCalculator.bindQuoteToTransaction("my_quote_id", any()) }
     verify(exactly = 1) { eventSession.publish(any()) }
 
     // validate the values of the saved sep31Transaction
@@ -749,6 +752,93 @@ class Sep31ServiceTest {
     // validate the final response
     val wantResponse = Sep31PostTransactionResponse.builder().id(txId).build()
     assertEquals(wantResponse, gotResponse)
+  }
+
+  @Test
+  fun `test preValidateQuote rejects already-bound quote`() {
+    val tomorrow = Instant.now().plus(1, ChronoUnit.DAYS)
+    val boundQuote =
+      PojoSep38Quote().apply {
+        id = "bound-quote-id"
+        sellAsset = stellarUSDC
+        sellAmount = "100"
+        buyAsset = stellarJPYC
+        buyAmount = "12500"
+        expiresAt = tomorrow
+        fee = FeeDetails("10", stellarUSDC)
+        transactionId = "already-used-txn"
+      }
+    every { quoteStore.findByQuoteId("bound-quote-id") } returns boundQuote
+
+    val postTxRequest = Sep31PostTransactionRequest()
+    postTxRequest.amount = "100"
+    postTxRequest.assetCode = "USDC"
+    postTxRequest.assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    postTxRequest.quoteId = "bound-quote-id"
+    postTxRequest.fundingMethod = "SEPA"
+    postTxRequest.fields =
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "SWIFT",
+          "receiver_routing_number" to "1"
+        )
+      )
+
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    val ex = assertThrows<AnchorException> { sep31Service.postTransaction(jwtToken, postTxRequest) }
+    assertInstanceOf(BadRequestException::class.java, ex)
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test POST transaction atomic bind failure rejects second use`() {
+    val tomorrow = Instant.now().plus(1, ChronoUnit.DAYS)
+    val quoteId = "race-quote-id"
+    val freshQuote =
+      PojoSep38Quote().apply {
+        id = quoteId
+        sellAsset = stellarUSDC
+        sellAmount = "100"
+        buyAsset = stellarJPYC
+        buyAmount = "12500"
+        expiresAt = tomorrow
+        fee = FeeDetails("10", stellarUSDC)
+      }
+    every { quoteStore.findByQuoteId(quoteId) } returns freshQuote
+    every { exchangeAmountsCalculator.bindQuoteToTransaction(quoteId, any()) } throws
+      BadRequestException("quote(id=$quoteId) has already been used")
+
+    val postTxRequest = Sep31PostTransactionRequest()
+    postTxRequest.amount = "100"
+    postTxRequest.assetCode = "USDC"
+    postTxRequest.assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    postTxRequest.quoteId = quoteId
+    postTxRequest.fundingMethod = "SEPA"
+    postTxRequest.fields =
+      Sep31TxnFields(
+        hashMapOf(
+          "receiver_account_number" to "1",
+          "type" to "SWIFT",
+          "receiver_routing_number" to "1"
+        )
+      )
+
+    val mockCustomer = GetCustomerResponse()
+    mockCustomer.status = Sep12Status.ACCEPTED.name
+    every { customerIntegration.getCustomer(any()) } returns mockCustomer
+    every { sep10Config.allowedClientNames } returns listOf("vibrant")
+    every { clientService.getClientConfigBySigningKey(any()) } returns
+      CustodialClient().apply { name = "vibrant" }
+    every { txnStore.save(any()) } answers
+      {
+        firstArg<Sep31Transaction>().also { it.id = "TXN-RACE" }
+      }
+
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    val ex = assertThrows<AnchorException> { sep31Service.postTransaction(jwtToken, postTxRequest) }
+    assertInstanceOf(BadRequestException::class.java, ex)
+    assert(ex.message!!.contains("has already been used"))
   }
 
   @Test
@@ -812,6 +902,7 @@ class Sep31ServiceTest {
         rateIntegration,
         eventService,
         Clock.systemUTC(),
+        exchangeAmountsCalculator,
       )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -22,6 +22,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
 import org.stellar.anchor.TestHelper
 import org.stellar.anchor.api.asset.StellarAssetInfo
 import org.stellar.anchor.api.event.AnchorEvent
+import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.exception.SepValidationException
@@ -1578,5 +1579,89 @@ class Sep6ServiceTest {
     txn.requiredInfoUpdates = listOf("first_name", "last_name")
 
     return txn
+  }
+
+  @Test
+  fun `test depositExchange rejects already-bound quote`() {
+    every { exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any()) } throws
+      BadRequestException("quote(id=$TEST_QUOTE_ID) has already been used")
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .fundingMethod("SWIFT")
+        .build()
+    val ex = assertThrows<BadRequestException> { sep6Service.depositExchange(token, request) }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test depositExchange bind failure rejects second use`() {
+    every { exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any()) } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset("iso4217:USD")
+        .amountOut("98")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .feeDetails(FeeDetails("2", TEST_ASSET_SEP38_FORMAT))
+        .build()
+    every { txnStore.save(any()) } returns null
+    every { exchangeAmountsCalculator.bindQuoteToTransaction(TEST_QUOTE_ID, any()) } throws
+      BadRequestException("quote(id=$TEST_QUOTE_ID) has already been used")
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .fundingMethod("SWIFT")
+        .build()
+    val ex = assertThrows<BadRequestException> { sep6Service.depositExchange(token, request) }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test withdrawExchange rejects already-bound quote`() {
+    every { exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any()) } throws
+      BadRequestException("quote(id=$TEST_QUOTE_ID) has already been used")
+    val request =
+      StartWithdrawExchangeRequest.builder()
+        .sourceAsset(TEST_ASSET)
+        .destinationAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .fundingMethod("bank_account")
+        .amount("100")
+        .build()
+    val ex = assertThrows<BadRequestException> { sep6Service.withdrawExchange(token, request) }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test withdrawExchange bind failure rejects second use`() {
+    every { exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any()) } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset(TEST_ASSET_SEP38_FORMAT)
+        .amountOut("98")
+        .amountOutAsset("iso4217:USD")
+        .feeDetails(FeeDetails("2", "iso4217:USD"))
+        .build()
+    every { txnStore.save(any()) } returns null
+    every { exchangeAmountsCalculator.bindQuoteToTransaction(TEST_QUOTE_ID, any()) } throws
+      BadRequestException("quote(id=$TEST_QUOTE_ID) has already been used")
+    val request =
+      StartWithdrawExchangeRequest.builder()
+        .sourceAsset(TEST_ASSET)
+        .destinationAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .fundingMethod("bank_account")
+        .amount("100")
+        .build()
+    val ex = assertThrows<BadRequestException> { sep6Service.withdrawExchange(token, request) }
+    assert(ex.message!!.contains("has already been used"))
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/util/ExchangeAmountsCalculatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ExchangeAmountsCalculatorTest.kt
@@ -132,4 +132,63 @@ class ExchangeAmountsCalculatorTest {
       )
     }
   }
+
+  @Test
+  fun `test calculateFromQuote rejects already-bound quote`() {
+    val quoteId = "id"
+    every { sep38QuoteStore.findByQuoteId(quoteId) } returns
+      usdcQuote().apply { transactionId = "existing-txn-id" }
+    val ex =
+      assertThrows<BadRequestException> {
+        calculator.calculateFromQuote(quoteId, assetService.getAsset("USDC"), "100")
+      }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test validateQuoteAgainstRequestInfo passes for unbound quote`() {
+    val quoteId = "id"
+    every { sep38QuoteStore.findByQuoteId(quoteId) } returns usdcQuote()
+    val result =
+      calculator.validateQuoteAgainstRequestInfo(
+        quoteId,
+        assetService.getAsset("USDC"),
+        null,
+        "100",
+      )
+    assertEquals(TEST_ASSET_SEP38_FORMAT, result.sellAsset)
+  }
+
+  @Test
+  fun `test bindQuoteToTransaction succeeds when unbound`() {
+    every { sep38QuoteStore.bindToTransaction("id", "txn1") } returns true
+    calculator.bindQuoteToTransaction("id", "txn1")
+  }
+
+  @Test
+  fun `test bindQuoteToTransaction throws when already bound`() {
+    every { sep38QuoteStore.bindToTransaction("id", "txn2") } returns false
+    val ex = assertThrows<BadRequestException> { calculator.bindQuoteToTransaction("id", "txn2") }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test calculateFromQuote rejects T2 after T1 is cancelled`() {
+    val quoteId = "q-cancel"
+    every { sep38QuoteStore.findByQuoteId(quoteId) } returns
+      usdcQuote().apply { transactionId = "T1-cancelled" }
+    val ex =
+      assertThrows<BadRequestException> {
+        calculator.calculateFromQuote(quoteId, assetService.getAsset("USDC"), "100")
+      }
+    assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test bindQuoteToTransaction rejects T2 after T1 is cancelled`() {
+    every { sep38QuoteStore.bindToTransaction("q-cancel", "T2") } returns false
+    val ex =
+      assertThrows<BadRequestException> { calculator.bindQuoteToTransaction("q-cancel", "T2") }
+    assert(ex.message!!.contains("has already been used"))
+  }
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/MultiClientCallbackTests.kt
@@ -1,0 +1,132 @@
+package org.stellar.anchor.platform.integrationtest
+
+import com.google.gson.reflect.TypeToken
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.stellar.anchor.api.platform.PatchTransactionsRequest
+import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse
+import org.stellar.anchor.apiclient.PlatformApiClient
+import org.stellar.anchor.auth.AuthHelper
+import org.stellar.anchor.platform.IntegrationTestBase
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.reference.wallet.WalletServerClient
+import org.stellar.walletsdk.asset.IssuedAssetId
+
+/**
+ * Verifies per-client callback isolation: when the event processor broadcasts a
+ * TRANSACTION_STATUS_CHANGED event, only the ClientStatusCallbackHandler bound to the owning client
+ * fires an HTTP request. A second callback-enabled client ("circleWallet") that does not own the
+ * transaction must receive nothing.
+ *
+ * Requires the platform to be running with the clients.yaml that contains the "referenceCustodial"
+ * custodial client (callback → wallet-server:8092) and the "circleWallet" noncustodial client
+ * (callback → localhost:19091). Start via: ./gradlew startAllServers
+ */
+@TestInstance(PER_CLASS)
+class MultiClientCallbackTests : IntegrationTestBase(TestConfig()) {
+  private lateinit var circleWalletServer: MockWebServer
+
+  private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
+  private val platformApiClient =
+    PlatformApiClient(AuthHelper.forNone(), config.env["platform.server.url"]!!)
+
+  @BeforeAll
+  fun startCircleWalletServer() {
+    circleWalletServer = MockWebServer()
+    repeat(5) { circleWalletServer.enqueue(MockResponse().setResponseCode(200)) }
+    circleWalletServer.start(CIRCLE_WALLET_PORT)
+  }
+
+  @AfterAll
+  fun stopCircleWalletServer() {
+    circleWalletServer.shutdown()
+  }
+
+  @Test
+  fun `sep24 withdrawal callback is delivered only to the owning client and not to the circleWallet`() =
+    runBlocking {
+      walletServerClient.clearCallbacks()
+
+      val withdrawRequest: HashMap<String, String> =
+        GsonUtils.getInstance()
+          .fromJson(
+            WITHDRAW_REQUEST_JSON,
+            object : TypeToken<HashMap<String, String>>() {}.type,
+          )
+      val response =
+        anchor
+          .sep24()
+          .withdraw(
+            IssuedAssetId("USDC", USDC_ISSUER),
+            token,
+            withdrawRequest,
+            WITHDRAW_SOURCE_ACCOUNT,
+          )
+      val txnId = response.id
+
+      platformApiClient.patchTransaction(buildPatchRequest(txnId))
+
+      val callbacks =
+        walletServerClient.pollTransactionCallbacks(
+          "sep24",
+          txnId,
+          1,
+          Sep24GetTransactionResponse::class.java,
+        )
+      assertThat(callbacks)
+        .withFailMessage("referenceCustodial client should receive exactly one SEP-24 callback")
+        .hasSize(1)
+
+      assertThat(circleWalletServer.requestCount)
+        .withFailMessage(
+          "circleWallet callback receiver (localhost:$CIRCLE_WALLET_PORT) must not receive any requests"
+        )
+        .isEqualTo(0)
+    }
+
+  private fun buildPatchRequest(txnId: String): PatchTransactionsRequest =
+    GsonUtils.getInstance()
+      .fromJson(
+        """
+        {
+          "records": [{
+            "transaction": {
+              "id": "$txnId",
+              "status": "completed",
+              "amount_in":  {"amount": "10", "asset": "stellar:USDC:$USDC_ISSUER"},
+              "amount_out": {"amount": "10", "asset": "iso4217:USD"},
+              "fee_details": {"total": "1",  "asset": "stellar:USDC:$USDC_ISSUER"},
+              "message": "completed by MultiClientCallbackTests"
+            }
+          }]
+        }
+        """
+          .trimIndent(),
+        PatchTransactionsRequest::class.java,
+      )
+
+  companion object {
+    private const val CIRCLE_WALLET_PORT = 19091
+    private const val USDC_ISSUER = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    private const val WITHDRAW_SOURCE_ACCOUNT =
+      "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4"
+
+    private val WITHDRAW_REQUEST_JSON =
+      """
+      {
+        "amount": "10",
+        "asset_code": "USDC",
+        "asset_issuer": "$USDC_ISSUER",
+        "account": "$WITHDRAW_SOURCE_ACCOUNT",
+        "lang": "en"
+      }
+      """
+        .trimIndent()
+  }
+}

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -301,9 +302,11 @@ class PaymentObserverTests {
     fromEvent: List<PaymentTransferEvent>?,
     toEvent: List<PaymentTransferEvent>?,
   ) {
-    assertEquals(1, fromEvent?.size)
-    assertEquals(1, toEvent?.size)
-    assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
+    assertNotNull(fromEvent) { "Observer did not capture a fromEvent within timeout" }
+    assertNotNull(toEvent) { "Observer did not capture a toEvent within timeout" }
+    assertEquals(1, fromEvent!!.size)
+    assertEquals(1, toEvent!!.size)
+    assertEquals(fromKeyPair.accountId, fromEvent[0].from)
     assertEquals(toKeyPair.accountId, fromEvent[0].to)
     val paymentOperation: PaymentOperation = txn.operations[0] as PaymentOperation
     assertEquals(
@@ -322,9 +325,11 @@ class PaymentObserverTests {
     fromEvent: List<PaymentTransferEvent>?,
     toEvent: List<PaymentTransferEvent>?,
   ) {
-    assertEquals(1, fromEvent?.size)
-    assertEquals(1, toEvent?.size)
-    assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
+    assertNotNull(fromEvent) { "Observer did not capture a fromEvent within timeout" }
+    assertNotNull(toEvent) { "Observer did not capture a toEvent within timeout" }
+    assertEquals(1, fromEvent!!.size)
+    assertEquals(1, toEvent!!.size)
+    assertEquals(fromKeyPair.accountId, fromEvent[0].from)
     assertEquals(toKeyPair.accountId, fromEvent[0].to)
     val paymentOperation: PathPaymentStrictSendOperation =
       txn.operations[0] as PathPaymentStrictSendOperation
@@ -353,7 +358,9 @@ class PaymentObserverTests {
       }
       delay(1000)
     }
-    info("Timeout waiting for event for account: $fromAccountId")
+    throw AssertionError(
+      "Timed out after ${timeout}ms waiting for event from account $fromAccountId"
+    )
   }
 
   private fun sendTestPayment(fromKeyPair: KeyPair, toKeyPair: KeyPair): Transaction {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -342,7 +342,7 @@ class PaymentObserverTests {
   private suspend fun waitForEventsCoroutine(
     fromAccountId: String,
     listener: EventCapturingListener,
-    timeout: Long = 10000L,
+    timeout: Long = 60000L,
   ) {
     val startTime = System.currentTimeMillis()
     while (System.currentTimeMillis() - startTime <= timeout) {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep12Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep12Tests.kt
@@ -167,6 +167,45 @@ open class Sep12Tests : IntegrationTestBase(TestConfig()) {
     }
   }
 
+  @Test
+  fun `test cross-account id access is rejected`() = runBlocking {
+    val sepDomain = config.env["anchor.domain"]!!
+
+    val victimKeyPair = SigningKeyPair(KeyPair.random())
+    val victimToken = anchor.auth().authenticate(victimKeyPair)
+    val victimPr =
+      anchor
+        .sep12(victimToken)
+        .add(
+          Json.decodeFromString<Map<String, String>>(testCustomer1Json).toMutableMap(),
+          type = "sep24",
+        )
+    val victimCustomerId = victimPr.id
+
+    val attackerKeyPair = SigningKeyPair(KeyPair.random())
+    val attackerToken = anchor.auth().authenticate(attackerKeyPair)
+
+    HttpClient().use { httpClient ->
+      val getResponse =
+        httpClient.get("$sepDomain/sep12/customer") {
+          headers { bearerAuth(attackerToken.token) }
+          parameter("id", victimCustomerId)
+        }
+      assertEquals(HttpStatusCode.Forbidden, getResponse.status)
+
+      val putResponse =
+        httpClient.put("$sepDomain/sep12/customer") {
+          headers { bearerAuth(attackerToken.token) }
+          contentType(ContentType.Application.Json)
+          setBody("""{"id":"$victimCustomerId","bank_account_number":"attacker-iban"}""")
+        }
+      assertEquals(HttpStatusCode.Forbidden, putResponse.status)
+    }
+
+    val victimGr = anchor.sep12(victimToken).get(victimCustomerId, type = "sep24")
+    assert(victimGr.providedFields!!.containsKey("bank_account_number"))
+  }
+
   companion object {
     const val customerJson =
       """

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep38Tests.kt
@@ -2,19 +2,42 @@ package org.stellar.anchor.platform.integrationtest
 
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.stellar.anchor.api.exception.SepException
+import org.stellar.anchor.api.sep.sep12.Sep12PutCustomerRequest
+import org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP31
 import org.stellar.anchor.api.sep.sep38.Sep38Context.SEP6
+import org.stellar.anchor.client.Sep12Client
+import org.stellar.anchor.client.Sep24Client
+import org.stellar.anchor.client.Sep31Client
 import org.stellar.anchor.client.Sep38Client
+import org.stellar.anchor.client.Sep6Client
 import org.stellar.anchor.platform.IntegrationTestBase
 import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.platform.TestSecrets.CLIENT_WALLET_SECRET
+import org.stellar.anchor.platform.integrationtest.Sep12Tests.Companion.testCustomer1Json
+import org.stellar.anchor.platform.integrationtest.Sep12Tests.Companion.testCustomer2Json
 import org.stellar.anchor.platform.printRequest
 import org.stellar.anchor.platform.printResponse
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.sdk.KeyPair
 
 class Sep38Tests : IntegrationTestBase(TestConfig()) {
   private val sep38Client: Sep38Client =
     Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), this.token.token)
+  private val sep31Client: Sep31Client =
+    Sep31Client(toml.getString("DIRECT_PAYMENT_SERVER"), this.token.token)
+  private val sep24Client: Sep24Client =
+    Sep24Client(toml.getString("TRANSFER_SERVER_SEP0024"), this.token.token)
+  private val sep6Client: Sep6Client =
+    Sep6Client(toml.getString("TRANSFER_SERVER"), this.token.token)
+  private val sep12Client: Sep12Client = Sep12Client(toml.getString("KYC_SERVER"), this.token.token)
+  private val clientWalletAccount = KeyPair.fromSecretSeed(CLIENT_WALLET_SECRET).accountId
+  private val gson = GsonUtils.getInstance()
 
   @Test
   fun `test sep38 info, price and prices endpoints`() {
@@ -84,5 +107,152 @@ class Sep38Tests : IntegrationTestBase(TestConfig()) {
     val getQuote = sep38Client.getQuote(postQuote.id)
     printResponse(getQuote)
     assertEquals(postQuote, getQuote)
+  }
+
+  @Test
+  fun `test quote cannot be reused across SEPs`() {
+    // Register SEP-12 customers needed for SEP-31
+    val sender =
+      sep12Client.putCustomer(
+        gson.fromJson(testCustomer1Json, Sep12PutCustomerRequest::class.java)
+      )!!
+    val receiver =
+      sep12Client.putCustomer(
+        gson.fromJson(testCustomer2Json, Sep12PutCustomerRequest::class.java)
+      )!!
+
+    // Create a firm quote
+    val quote =
+      sep38Client.postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      )
+
+    // First use: SEP-31 transaction — must succeed and consume the quote
+    val txnRequest =
+      Sep31PostTransactionRequest().apply {
+        amount = "10"
+        assetCode = "USDC"
+        assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+        senderId = sender.id
+        receiverId = receiver.id
+        quoteId = quote.id
+        fundingMethod = "SEPA"
+        fields =
+          org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest.Sep31TxnFields(
+            hashMapOf(
+              "receiver_routing_number" to "r0123",
+              "receiver_account_number" to "a0456",
+              "type" to "SWIFT",
+            )
+          )
+      }
+    sep31Client.postTransaction(txnRequest)
+
+    // Second use: SEP-31 again with the same quote — must fail
+    val ex31 = assertThrows<SepException> { sep31Client.postTransaction(txnRequest) }
+    assert(ex31.message!!.contains("has already been used")) {
+      "Expected 'has already been used' but got: ${ex31.message}"
+    }
+
+    // Cross-SEP: SEP-6 deposit-exchange with the consumed quote — must fail
+    val ex6 =
+      assertThrows<SepException> {
+        sep6Client.deposit(
+          mapOf(
+            "destination_asset" to "USDC",
+            "source_asset" to "iso4217:USD",
+            "amount" to "10",
+            "account" to clientWalletAccount,
+            "type" to "SWIFT",
+            "quote_id" to quote.id,
+          ),
+          exchange = true,
+        )
+      }
+    assert(ex6.message!!.contains("has already been used")) {
+      "Expected 'has already been used' but got: ${ex6.message}"
+    }
+
+    // Cross-SEP: SEP-24 withdraw with the consumed quote — must fail
+    val ex24 =
+      assertThrows<SepException> {
+        sep24Client.withdraw(
+          mapOf(
+            "asset_code" to "USDC",
+            "amount" to "10",
+            "quote_id" to quote.id,
+          )
+        )
+      }
+    assert(ex24.message!!.contains("has already been used")) {
+      "Expected 'has already been used' but got: ${ex24.message}"
+    }
+  }
+
+  @Test
+  fun `test concurrent POST sep31 transactions with same quote_id result in exactly one success`() {
+    val sender =
+      sep12Client.putCustomer(
+        gson.fromJson(testCustomer1Json, Sep12PutCustomerRequest::class.java)
+      )!!
+    val receiver =
+      sep12Client.putCustomer(
+        gson.fromJson(testCustomer2Json, Sep12PutCustomerRequest::class.java)
+      )!!
+
+    val quote =
+      sep38Client.postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      )
+
+    val txnRequest =
+      Sep31PostTransactionRequest().apply {
+        amount = "10"
+        assetCode = "USDC"
+        assetIssuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+        senderId = sender.id
+        receiverId = receiver.id
+        quoteId = quote.id
+        fundingMethod = "SEPA"
+        fields =
+          org.stellar.anchor.api.sep.sep31.Sep31PostTransactionRequest.Sep31TxnFields(
+            hashMapOf(
+              "receiver_routing_number" to "r0123",
+              "receiver_account_number" to "a0456",
+              "type" to "SWIFT",
+            )
+          )
+      }
+
+    val executor = Executors.newFixedThreadPool(2)
+    val futures =
+      (1..2).map {
+        executor.submit<Exception?> {
+          try {
+            sep31Client.postTransaction(txnRequest)
+            null
+          } catch (e: SepException) {
+            e
+          }
+        }
+      }
+
+    val exceptions = futures.map { it.get() }
+    executor.shutdown()
+
+    val successCount = exceptions.count { it == null }
+    val failureCount = exceptions.count { it != null }
+
+    assertEquals(1, successCount, "Expected exactly 1 successful transaction, got $successCount")
+    assertEquals(1, failureCount, "Expected exactly 1 failed transaction, got $failureCount")
+
+    val error = exceptions.first { it != null }!!
+    assert(error.message!!.contains("has already been used")) {
+      "Expected 'has already been used' but got: ${error.message}"
+    }
   }
 }

--- a/helm-charts/reference-server/Chart.yaml
+++ b/helm-charts/reference-server/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - "https://github.com/stellar/anchor-platform"
 name: ap-reference-server
-version: 0.1.0
+version: 0.2.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/reference-server/templates/gateway.yaml
+++ b/helm-charts/reference-server/templates/gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/reference-server/templates/httproute.yaml
+++ b/helm-charts/reference-server/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
+          port: {{ .Values.services.ref.servicePort | default 8091 }}
+{{- end }}

--- a/helm-charts/reference-server/templates/httproute.yaml
+++ b/helm-charts/reference-server/templates/httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
           port: {{ .Values.services.ref.servicePort | default 8091 }}

--- a/helm-charts/reference-server/templates/ingress.yaml
+++ b/helm-charts/reference-server/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -51,3 +52,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.ref.name }}
                 port:
                   number: {{ .Values.services.ref.servicePort | default 8091 }}
+{{- end }}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -34,9 +34,41 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
+  enabled: true
   name: ingress-reference-server
   rules:
     host: reference-server.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: reference-server-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: reference-server.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: reference-server-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -51,6 +51,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - https://github.com/stellar/anchor-platform
 name: sep
-version: 1.0.0
+version: 1.1.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/sep-service/templates/sepserver-gateway.yaml
+++ b/helm-charts/sep-service/templates/sepserver-gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-sep-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm-charts/sep-service/templates/sepserver-httproute.yaml
+++ b/helm-charts/sep-service/templates/sepserver-httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}-sep
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-sep
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
+          port: {{ .Values.services.sep.servicePort | default 8080 }}
+{{- end }}

--- a/helm-charts/sep-service/templates/sepserver-httproute.yaml
+++ b/helm-charts/sep-service/templates/sepserver-httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-sep-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
           port: {{ .Values.services.sep.servicePort | default 8080 }}

--- a/helm-charts/sep-service/templates/sepserver-ingress.yaml
+++ b/helm-charts/sep-service/templates/sepserver-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -55,3 +56,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.sep.name }}
                 port:
                   number: {{ .Values.services.sep.servicePort | default 8080 }}
+{{- end }}

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -152,6 +152,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -137,10 +137,42 @@ config:
       base_url: http://localhost:3000/txn
 
 ingress:
+  enabled: true
   name: ingress-anchor-platform
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: sep-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: sep.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: sep-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}
 
 sep1_toml: |
   ACCOUNTS = ["GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE"]

--- a/helm-charts/sep24-reference-ui/Chart.yaml
+++ b/helm-charts/sep24-reference-ui/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 sources:
   - https://github.com/stellar/sep24-reference-ui
 name: sep24-reference-ui
-version: 0.1.0
+version: 0.2.0
 icon: https://github.com/stellar/anchor-platform/blob/develop/icon.png

--- a/helm-charts/sep24-reference-ui/templates/gateway.yaml
+++ b/helm-charts/sep24-reference-ui/templates/gateway.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}-gateway
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "httpRoute.gateway.gatewayClassName is required when httpRoute.gateway.enabled is true" .Values.httpRoute.gateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.httpRoute.gateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ tpl .hostname $ | quote }}
+      {{- end }}
+      {{- if .allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml .allowedRoutes | nindent 8 }}
+      {{- end }}
+      {{- if .tls }}
+      tls:
+        {{- toYaml .tls | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/templates/httproute.yaml
+++ b/helm-charts/sep24-reference-ui/templates/httproute.yaml
@@ -20,6 +20,10 @@ spec:
   parentRefs:
     {{- if .Values.httpRoute.gateway.enabled }}
     - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+      namespace: {{ .Values.namespace }}
+      {{- with (first .Values.httpRoute.gateway.listeners) }}
+      sectionName: {{ .name }}
+      {{- end }}
     {{- else }}
     {{- range .Values.httpRoute.parentRefs }}
     - name: {{ .name }}
@@ -42,6 +46,16 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      {{- if .Values.httpRoute.responseHeaders }}
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              {{- range $key, $value := .Values.httpRoute.responseHeaders }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end }}
+      {{- end }}
       backendRefs:
         - name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
           port: {{ .Values.services.ui.servicePort | default 3000 }}

--- a/helm-charts/sep24-reference-ui/templates/httproute.yaml
+++ b/helm-charts/sep24-reference-ui/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.fullName }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if .Values.httpRoute.gateway.enabled }}
+    - name: {{ .Values.httpRoute.gateway.name | default (printf "%s-gateway" .Values.fullName) }}
+    {{- else }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
+          port: {{ .Values.services.ui.servicePort | default 3000 }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/templates/ingress.yaml
+++ b/helm-charts/sep24-reference-ui/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 data:
   {{- if .Values.ingress.responseHeaders }}
@@ -51,3 +52,4 @@ spec:
                 name: {{ .Values.fullName }}-svc-{{ .Values.services.ui.name }}
                 port:
                   number: {{ .Values.services.ui.servicePort | default 3000 }}
+{{- end }}

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -43,6 +43,7 @@ httpRoute:
   hostnames: []
   annotations: {}
   labels: {}
+  responseHeaders: {}
   gateway:
     enabled: false
     gatewayClassName: ""

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -26,9 +26,41 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
+  enabled: true
   name: ingress-sep24-reference-ui
   rules:
     host: sep24-reference-ui.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: sep24-reference-ui-gateway
+      namespace: ""      # defaults to release namespace
+      sectionName: ""
+  hostnames: []
+  annotations: {}
+  labels: {}
+  gateway:
+    enabled: false
+    gatewayClassName: ""
+    name: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      # - name: https
+      #   protocol: HTTPS
+      #   port: 443
+      #   hostname: sep24-reference-ui.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - name: sep24-reference-ui-tls-cert
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+    annotations: {}
+    labels: {}

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -155,8 +155,6 @@ public class SepBeans {
       Clock clock,
       Sep38QuoteStore sep38QuoteStore,
       @Qualifier("sep6MoreInfoUrlConstructor") MoreInfoUrlConstructor sep6MoreInfoUrlConstructor) {
-    ExchangeAmountsCalculator exchangeAmountsCalculator =
-        new ExchangeAmountsCalculator(sep38QuoteStore, clock);
     return new Sep6Service(
         languageConfig,
         sep6Config,
@@ -164,7 +162,7 @@ public class SepBeans {
         requestValidator,
         clientFinder,
         txnStore,
-        exchangeAmountsCalculator,
+        exchangeAmountsCalculator(sep38QuoteStore, clock),
         eventService,
         sep6MoreInfoUrlConstructor);
   }
@@ -192,6 +190,13 @@ public class SepBeans {
   }
 
   @Bean
+  @OnAllSepsEnabled(seps = {"sep6", "sep24", "sep31"})
+  ExchangeAmountsCalculator exchangeAmountsCalculator(
+      Sep38QuoteStore sep38QuoteStore, Clock clock) {
+    return new ExchangeAmountsCalculator(sep38QuoteStore, clock);
+  }
+
+  @Bean
   @OnAllSepsEnabled(seps = {"sep24"})
   Sep24Service sep24Service(
       LanguageConfig languageConfig,
@@ -208,8 +213,6 @@ public class SepBeans {
       InteractiveUrlConstructor interactiveUrlConstructor,
       @Qualifier("sep24MoreInfoUrlConstructor") MoreInfoUrlConstructor sep24MoreInfoUrlConstructor,
       Sep38QuoteStore sep38QuoteStore) {
-    ExchangeAmountsCalculator exchangeAmountsCalculator =
-        new ExchangeAmountsCalculator(sep38QuoteStore, clock);
     return new Sep24Service(
         languageConfig,
         stellarNetworkConfig,
@@ -223,7 +226,7 @@ public class SepBeans {
         eventService,
         interactiveUrlConstructor,
         sep24MoreInfoUrlConstructor,
-        exchangeAmountsCalculator);
+        exchangeAmountsCalculator(sep38QuoteStore, clock));
   }
 
   @Bean
@@ -260,7 +263,8 @@ public class SepBeans {
         assetService,
         rateIntegration,
         eventService,
-        clock);
+        clock,
+        exchangeAmountsCalculator(sep38QuoteStore, clock));
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -185,8 +185,9 @@ public class SepBeans {
   Sep12Service sep12Service(
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
-      EventService eventService) {
-    return new Sep12Service(customerIntegration, platformApiClient, eventService);
+      EventService eventService,
+      ClientFinder clientFinder) {
+    return new Sep12Service(customerIntegration, platformApiClient, eventService, clientFinder);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceRepo.java
@@ -1,11 +1,11 @@
 package org.stellar.anchor.platform.data;
 
+import jakarta.transaction.Transactional;
 import java.time.Instant;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface JdbcNonceRepo extends CrudRepository<JdbcNonce, String> {
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -23,7 +23,7 @@ public interface JdbcSep24TransactionRepo
 
   JdbcSep24Transaction findOneByStellarTransactionId(String stellarTransactionId);
 
-  JdbcSep24Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+  List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
   @Query(

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.stellar.anchor.api.exception.SepException;
@@ -57,12 +56,9 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return txnRepo.findOneByExternalTransactionId(externalTransactionId);
   }
 
-  public JdbcSep24Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+  public List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String toAccount, String memo, String status) {
-    Optional<JdbcSep24Transaction> optTxn =
-        Optional.ofNullable(
-            txnRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(toAccount, memo, status));
-    return optTxn.orElse(null);
+    return txnRepo.findAllByWithdrawAnchorAccountAndMemoAndStatus(toAccount, memo, status);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionRepo.java
@@ -26,6 +26,6 @@ public interface JdbcSep31TransactionRepo
   @Query(value = "SELECT COUNT(t) FROM JdbcSep31Transaction t WHERE t.status = :status")
   Integer findByStatusCount(@Param("status") String status);
 
-  Optional<JdbcSep31Transaction> findByToAccountAndStellarMemoAndStatus(
+  List<JdbcSep31Transaction> findAllByToAccountAndStellarMemoAndStatus(
       String toAccount, String stellarMemo, String status);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31TransactionStore.java
@@ -3,7 +3,6 @@ package org.stellar.anchor.platform.data;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import lombok.NonNull;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.sep31.RefundPayment;
@@ -66,11 +65,9 @@ public class JdbcSep31TransactionStore implements Sep31TransactionStore {
     return transactionRepo.save((JdbcSep31Transaction) transaction);
   }
 
-  public JdbcSep31Transaction findByToAccountAndMemoAndStatus(
+  public List<JdbcSep31Transaction> findAllByToAccountAndMemoAndStatus(
       String toAccount, String memo, String status) {
-    Optional<JdbcSep31Transaction> optTxn =
-        transactionRepo.findByToAccountAndStellarMemoAndStatus(toAccount, memo, status);
-    return optTxn.orElse(null);
+    return transactionRepo.findAllByToAccountAndStellarMemoAndStatus(toAccount, memo, status);
   }
 
   public Integer findByStatusCount(String status) {

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep38QuoteRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep38QuoteRepo.java
@@ -1,9 +1,21 @@
 package org.stellar.anchor.platform.data;
 
+import jakarta.transaction.Transactional;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 
 public interface JdbcSep38QuoteRepo extends CrudRepository<JdbcSep38Quote, String> {
   Optional<JdbcSep38Quote> findById(@NonNull String id);
+
+  @Modifying
+  @Transactional
+  @Query(
+      "UPDATE JdbcSep38Quote q SET q.transactionId = :transactionId"
+          + " WHERE q.id = :quoteId AND q.transactionId IS NULL")
+  int bindToTransaction(
+      @Param("quoteId") String quoteId, @Param("transactionId") String transactionId);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep38QuoteStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep38QuoteStore.java
@@ -30,4 +30,9 @@ public class JdbcSep38QuoteStore implements Sep38QuoteStore {
     }
     return quoteRepo.save((JdbcSep38Quote) sep38Quote);
   }
+
+  @Override
+  public boolean bindToTransaction(@NonNull String quoteId, @NonNull String transactionId) {
+    return quoteRepo.bindToTransaction(quoteId, transactionId) > 0;
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -25,7 +25,7 @@ public interface JdbcSep6TransactionRepo
 
   JdbcSep6Transaction findOneByExternalTransactionId(String externalTransactionId);
 
-  JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+  List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
   @Query(

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
@@ -127,10 +127,9 @@ public class JdbcSep6TransactionStore implements Sep6TransactionStore {
     return transactionRepo.findAllTransactions(params, JdbcSep6Transaction.class);
   }
 
-  @Override
-  public JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
+  public List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status) {
-    return transactionRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+    return transactionRepo.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         withdrawAnchorAccount, memo, status);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/event/ClientStatusCallbackHandler.java
@@ -73,20 +73,41 @@ public class ClientStatusCallbackHandler extends EventHandler {
 
   @Override
   boolean handleEvent(AnchorEvent event) throws IOException {
-    if (event.getTransaction() != null || event.getCustomer() != null) {
-      KeyPair signer = KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed());
-      Request request = buildHttpRequest(signer, event);
+    GetTransactionResponse tx = event.getTransaction();
 
-      if (request != null) {
-        try (Response response = httpClient.newCall(request).execute()) {
-          debugF("Sending event: {} to client status api: {}", json(event), request.url());
-          if (response.code() < 200 || response.code() >= 400) {
-            errorF("Failed to send event to client status API. Error code: {}", response.code());
-            return false;
-          }
+    String eventClientName = (tx != null) ? tx.getClientName() : event.getClientName();
+    String eventClientDomain = (tx != null) ? tx.getClientDomain() : event.getClientDomain();
+
+    boolean isAttributed = eventClientName != null || eventClientDomain != null;
+
+    if (!isAttributed) {
+      debugF(
+          "Skipping event id={} type={}: no clientName or clientDomain — event cannot be attributed to any client",
+          event.getId(),
+          event.getType());
+      return true;
+    }
+
+    boolean isClientName = clientConfig.getName().equals(eventClientName);
+    boolean isClientDomain = clientConfig.matchesDomain(eventClientDomain);
+
+    if (!isClientName && !isClientDomain) {
+      return true;
+    }
+
+    KeyPair signer = KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed());
+    Request request = buildHttpRequest(signer, event);
+
+    if (request != null) {
+      try (Response response = httpClient.newCall(request).execute()) {
+        debugF("Sending event: {} to client status api: {}", json(event), request.url());
+        if (response.code() < 200 || response.code() >= 400) {
+          errorF("Failed to send event to client status API. Error code: {}", response.code());
+          return false;
         }
       }
     }
+
     return true;
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -112,21 +112,33 @@ public class DefaultPaymentListener implements PaymentListener {
 
     try {
       String memo = xdrMemoToString(ledgerTransaction.getMemo());
-      JdbcSep31Transaction sep31Txn =
-          sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      List<JdbcSep31Transaction> sep31Txns =
+          sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
               ledgerPayment.getTo(), memo, SepTransactionStatus.PENDING_SENDER.toString());
-      if (sep31Txn == null) {
-        if (ledgerPayment.getTo().startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(ledgerPayment.getTo());
-          sep31Txn =
-              sep31TransactionStore.findByToAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_SENDER.toString());
-        }
+      if (sep31Txns.isEmpty() && ledgerPayment.getTo().startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(ledgerPayment.getTo());
+        sep31Txns =
+            sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_SENDER.toString());
       }
-      if (sep31Txn != null) {
+      if (sep31Txns.size() > 1) {
+        List<String> ids = sep31Txns.stream().map(JdbcSep31Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-31 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            ledgerPayment.getTo(),
+            memo,
+            SepTransactionStatus.PENDING_SENDER,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+            .increment();
+        return;
+      }
+      if (!sep31Txns.isEmpty()) {
+        JdbcSep31Transaction sep31Txn = sep31Txns.get(0);
         try {
           handleSep31Transaction(ledgerTransaction, ledgerPayment, sep31Txn);
           return;
@@ -156,24 +168,35 @@ public class DefaultPaymentListener implements PaymentListener {
     }
 
     try {
-      JdbcSep24Transaction sep24Txn =
-          sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      List<JdbcSep24Transaction> sep24Txns =
+          sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
               toAccount,
               memoAsString(memo),
               SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-      if (sep24Txn == null) {
-        if (toAccount.startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(toAccount);
-          sep24Txn =
-              sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-        }
+      if (sep24Txns.isEmpty() && toAccount.startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(toAccount);
+        sep24Txns =
+            sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
       }
-
-      if (sep24Txn != null) {
+      if (sep24Txns.size() > 1) {
+        List<String> ids = sep24Txns.stream().map(JdbcSep24Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-24 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            toAccount,
+            memoAsString(memo),
+            SepTransactionStatus.PENDING_USR_TRANSFER_START,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+            .increment();
+        return;
+      }
+      if (!sep24Txns.isEmpty()) {
+        JdbcSep24Transaction sep24Txn = sep24Txns.get(0);
         try {
           handleSep24Transaction(ledgerTransaction, ledgerPayment, sep24Txn);
           return;
@@ -187,23 +210,35 @@ public class DefaultPaymentListener implements PaymentListener {
     }
 
     try {
-      JdbcSep6Transaction sep6Txn =
-          sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      List<JdbcSep6Transaction> sep6Txns =
+          sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
               toAccount,
               memoAsString(memo),
               SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-      if (sep6Txn == null) {
-        if (toAccount.startsWith("M")) {
-          // Try again if the destination account is a muxed account.
-          MuxedAccount muxedAccount = new MuxedAccount(toAccount);
-          sep6Txn =
-              sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-                  muxedAccount.getAccountId(),
-                  String.valueOf(muxedAccount.getMuxedId()),
-                  SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
-        }
+      if (sep6Txns.isEmpty() && toAccount.startsWith("M")) {
+        MuxedAccount muxedAccount = new MuxedAccount(toAccount);
+        sep6Txns =
+            sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
+                muxedAccount.getAccountId(),
+                String.valueOf(muxedAccount.getMuxedId()),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
       }
-      if (sep6Txn != null) {
+      if (sep6Txns.size() > 1) {
+        List<String> ids = sep6Txns.stream().map(JdbcSep6Transaction::getId).toList();
+        errorF(
+            "Ambiguous SEP-6 payment routing: paymentId={}, txHash={}, toAccount={}, memo={}, status={}, matchedIds={}",
+            ledgerPayment.getId(),
+            ledgerTransaction.getHash(),
+            toAccount,
+            memoAsString(memo),
+            SepTransactionStatus.PENDING_USR_TRANSFER_START,
+            ids);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+            .increment();
+        return;
+      }
+      if (!sep6Txns.isEmpty()) {
+        JdbcSep6Transaction sep6Txn = sep6Txns.get(0);
         try {
           handleSep6Transaction(ledgerTransaction, ledgerPayment, sep6Txn);
         } catch (AnchorException aex) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -82,6 +82,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
   @Override
   void shutdownInternal() {
     task.cancel(true);
+    executorService.shutdownNow();
     status = ObserverStatus.SHUTDOWN;
   }
 
@@ -123,17 +124,19 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       lastActivityTime = Instant.now();
       silenceTimeoutCount = 0;
       metricLatestBlockRead.set(response.getLatestLedger());
-      if (response.getEvents() != null && !response.getEvents().isEmpty()) {
-        processEvents(response.getEvents());
-      }
-      // Save the cursor for the next request
-      cursor = response.getCursor();
       try {
-        saveCursor(cursor);
-        metricLatestBlockProcessed.set(response.getLatestLedger());
-      } catch (Exception tex) {
-        warnF("Failed to persist RPC cursor. Will retry next tick. ex={}", tex.getMessage());
-        setStatus(ObserverStatus.DATABASE_ERROR);
+        if (response.getEvents() != null && !response.getEvents().isEmpty()) {
+          processEvents(response.getEvents());
+        }
+      } finally {
+        try {
+          saveCursor(response.getCursor());
+          streamBackoffTimer.reset();
+          metricLatestBlockProcessed.set(response.getLatestLedger());
+        } catch (Exception tex) {
+          warnF("Failed to persist RPC cursor. Will retry next tick. ex={}", tex.getMessage());
+          setStatus(ObserverStatus.DATABASE_ERROR);
+        }
       }
     } catch (IOException ioex) {
       warnF(
@@ -153,9 +156,16 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
     debugF("Processing {} 'transfer' events", events.size());
 
     for (EventInfo event : events) {
-      ShouldProcessResult result = shouldProcess(event);
-      if (result.shouldProcess) {
-        processTransferEvent(result);
+      try {
+        ShouldProcessResult result = shouldProcess(event);
+        if (result.shouldProcess) {
+          processTransferEvent(result);
+        }
+      } catch (Exception ex) {
+        warnF(
+            "Skip event due to unexpected error: {}. ex={}",
+            GsonUtils.getInstance().toJson(event),
+            ex.toString());
       }
     }
   }
@@ -219,8 +229,16 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       if (scValue.getDiscriminant() == SCValType.SCV_I128) {
         amount = Scv.fromInt128(scValue).longValue();
       } else if (scValue.getDiscriminant() == SCValType.SCV_MAP) {
-        amount = Scv.fromInt128(scValue.getMap().getSCMap()[0].getVal()).longValue();
-        SCVal memoVal = scValue.getMap().getSCMap()[1].getVal();
+        var entries = scValue.getMap() == null ? null : scValue.getMap().getSCMap();
+        if (entries == null || entries.length < 2) {
+          return builder.build();
+        }
+        SCVal amountVal = entries[0].getVal();
+        SCVal memoVal = entries[1].getVal();
+        if (amountVal.getDiscriminant() != SCValType.SCV_I128) {
+          return builder.build();
+        }
+        amount = Scv.fromInt128(amountVal).longValue();
         eventMemo =
             switch (memoVal.getDiscriminant()) {
               case SCV_STRING -> memoVal.getStr().getSCString().toString();
@@ -229,12 +247,17 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
                   new String(Base64.getEncoder().encode(memoVal.getBytes().getSCBytes()));
               default -> null;
             };
-        if (scValue.getMap().getSCMap()[1].getVal().getDiscriminant() == SCValType.SCV_U64) {
-          toAddr =
-              new MuxedAccount(
-                      Scv.fromAddress(to).toString(),
-                      Scv.fromUint64(scValue.getMap().getSCMap()[1].getVal()))
-                  .getAddress();
+        if (memoVal.getDiscriminant() == SCValType.SCV_U64) {
+          try {
+            toAddr =
+                new MuxedAccount(Scv.fromAddress(to).toString(), Scv.fromUint64(memoVal))
+                    .getAddress();
+          } catch (IllegalArgumentException iae) {
+            warnF(
+                "Cannot build MuxedAccount for address '{}', using unmuxed value. ex={}",
+                toAddr,
+                iae.getMessage());
+          }
         }
       }
 
@@ -252,11 +275,9 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
           .eventMemo(eventMemo)
           .sep11Asset(asset.getStr().getSCString().toString())
           .build();
-    } catch (IOException ioex) {
+    } catch (Exception ex) {
       warnF(
-          "Skip processing event: {}. ex={}",
-          GsonUtils.getInstance().toJson(event),
-          ioex.getMessage());
+          "Skip processing event: {}. ex={}", GsonUtils.getInstance().toJson(event), ex.toString());
       return builder.build();
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyCustomerInfoUpdatedHandler.java
@@ -23,6 +23,9 @@ import org.stellar.anchor.api.sep.sep12.Sep12Status;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.metrics.MetricsService;
+import org.stellar.anchor.platform.data.JdbcSep24Transaction;
+import org.stellar.anchor.platform.data.JdbcSep31Transaction;
+import org.stellar.anchor.platform.data.JdbcSep6Transaction;
 import org.stellar.anchor.platform.data.JdbcSepTransaction;
 import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
@@ -81,11 +84,27 @@ public class NotifyCustomerInfoUpdatedHandler
                   .type(request.getCustomerType())
                   .build());
       status = customer.getStatus();
+
+      String clientName = null;
+      String clientDomain = null;
+
+      if (txn instanceof JdbcSep6Transaction) {
+        clientName = ((JdbcSep6Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep6Transaction) txn).getClientDomain();
+      } else if (txn instanceof JdbcSep24Transaction) {
+        clientName = ((JdbcSep24Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep24Transaction) txn).getClientDomain();
+      } else if (txn instanceof JdbcSep31Transaction) {
+        clientName = ((JdbcSep31Transaction) txn).getClientName();
+        clientDomain = ((JdbcSep31Transaction) txn).getClientDomain();
+      }
       eventSession.publish(
           AnchorEvent.builder()
               .id(UUID.randomUUID().toString())
               .sep(SEP_12.getSep().toString())
               .type(AnchorEvent.Type.CUSTOMER_UPDATED)
+              .clientName(clientName)
+              .clientDomain(clientDomain)
               .customer(GetCustomerResponse.to(customer))
               .build());
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.SepException;
@@ -82,6 +83,16 @@ public class RequestOnchainFundsHandler
     this.sep24DepositInfoGenerator = sep24DepositInfoGenerator;
     this.sep31DepositInfoGenerator = sep31DepositInfoGenerator;
     this.paymentObservingAccountsManager = paymentObservingAccountsManager;
+  }
+
+  @Override
+  public Object handle(Object requestParams) throws AnchorException {
+    try {
+      return super.handle(requestParams);
+    } catch (DataIntegrityViolationException ex) {
+      throw new BadRequestException(
+          "memo_in_use: the requested memo and destination account are already assigned to a pending transaction");
+    }
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/AnchorMetrics.java
@@ -9,6 +9,7 @@ public enum AnchorMetrics {
   SEP6_TRANSACTION_DB("sep6.transaction.db"),
   PAYMENT_RECEIVED("payment.received"),
   PAYMENT_SENT("payment.sent"),
+  PAYMENT_OBSERVER_AMBIGUOUS_ROUTING("payment_observer.ambiguous_routing"),
   LOGGER("logger"),
 
   PLATFORM_RPC_TRANSACTION("platform_server.rpc_transaction"),

--- a/platform/src/main/resources/db/migration/V27__exchange_quote_single_use.sql
+++ b/platform/src/main/resources/db/migration/V27__exchange_quote_single_use.sql
@@ -1,0 +1,2 @@
+ALTER TABLE exchange_quote
+    ADD CONSTRAINT uq_exchange_quote_transaction_id UNIQUE (transaction_id);

--- a/platform/src/main/resources/db/migration/V28__memo_uniqueness_pending_transfer.sql
+++ b/platform/src/main/resources/db/migration/V28__memo_uniqueness_pending_transfer.sql
@@ -1,0 +1,11 @@
+CREATE UNIQUE INDEX uq_sep24_pending_memo
+  ON sep24_transaction (withdraw_anchor_account, memo_type, memo)
+  WHERE status = 'pending_user_transfer_start';
+
+CREATE UNIQUE INDEX uq_sep6_pending_memo
+  ON sep6_transaction (withdraw_anchor_account, memo_type, memo)
+  WHERE status = 'pending_user_transfer_start';
+
+CREATE UNIQUE INDEX uq_sep31_pending_memo
+  ON sep31_transaction (to_account, stellar_memo_type, stellar_memo)
+  WHERE status = 'pending_sender';

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/event/ClientStatusCallbackHandlerTest.kt
@@ -3,8 +3,12 @@ package org.stellar.anchor.platform.event
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import java.util.*
 import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -26,6 +30,7 @@ import org.stellar.anchor.api.shared.FeeDetails
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.client.ClientConfig.CallbackUrls
 import org.stellar.anchor.client.CustodialClient
+import org.stellar.anchor.client.NonCustodialClient
 import org.stellar.anchor.platform.config.PropertySecretConfig
 import org.stellar.anchor.platform.service.Sep24MoreInfoUrlConstructor
 import org.stellar.anchor.platform.service.Sep6MoreInfoUrlConstructor
@@ -292,6 +297,247 @@ class ClientStatusCallbackHandlerTest {
     assertEquals("client.com", sep24Txn.clientDomain)
     assertEquals("quote-id", sep24Txn.quoteId)
     assertEquals("message", sep24Txn.message)
+  }
+
+  @Test
+  fun `handleEvent should skip and return true when transaction belongs to a different client`() {
+    val handlerSpy = spyk(handler)
+    event.transaction.clientName = "wallet-a"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should build and send request when transaction clientName matches handler client`() {
+    val handlerSpy = spyk(handler)
+    event.transaction.clientName = "circle"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should not send callback when transaction is unattributed (clientName and clientDomain both null)`() {
+    val handlerSpy = spyk(handler)
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip customer event when clientName does not match`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.clientName = "wallet-a"
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should not send callback for unattributed customer event (clientName null)`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.clientName = null
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should fire for customer event when clientName matches`() {
+    val handlerSpy = spyk(handler)
+    event.transaction = null
+    event.clientName = "circle"
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should fire for noncustodial client customer event when clientDomain matches`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep12("https://wallet.example.com/callback/sep12").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction = null
+    event.clientName = null
+    event.clientDomain = "wallet.example.com"
+    event.customer = Sep12GetCustomerResponse.builder().build()
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should fire for noncustodial client when clientDomain matches even if clientName is null`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep24("https://wallet.example.com/callback/sep24").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction.clientName = null
+    event.transaction.clientDomain = "wallet.example.com"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    handlerSpy.handleEvent(event)
+
+    verify(exactly = 1) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  fun `handleEvent should skip when neither clientName nor clientDomain matches noncustodial client`() {
+    val nonCustodialClient =
+      NonCustodialClient.builder()
+        .name("noncustodial-wallet")
+        .domains(setOf("wallet.example.com"))
+        .callbackUrls(
+          CallbackUrls.builder().sep24("https://wallet.example.com/callback/sep24").build()
+        )
+        .build()
+    val ncHandler =
+      ClientStatusCallbackHandler(
+        secretConfig,
+        nonCustodialClient,
+        assetService,
+        sep6MoreInfoUrlConstructor,
+        sep24MoreInfoUrlConstructor
+      )
+    val handlerSpy = spyk(ncHandler)
+    event.transaction.clientName = "other-wallet"
+    event.transaction.clientDomain = "other.example.com"
+    every { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) } returns null
+
+    val result = handlerSpy.handleEvent(event)
+
+    Assertions.assertTrue(result)
+    verify(exactly = 0) { handlerSpy.buildHttpRequest(any<KeyPair>(), any<AnchorEvent>()) }
+  }
+
+  @Test
+  @LockAndMockStatic([Sep24Helper::class])
+  fun `two handlers bound to different clients - only matching handler fires HTTP callback on SEP-24 withdrawal`() {
+    val circleServer = MockWebServer()
+    val walletBServer = MockWebServer()
+    circleServer.start()
+    walletBServer.start()
+    try {
+      circleServer.enqueue(MockResponse().setResponseCode(200))
+
+      val circleClient =
+        CustodialClient.builder()
+          .name("circle")
+          .signingKeys(setOf("GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEGN2"))
+          .callbackUrls(
+            CallbackUrls.builder().sep24(circleServer.url("/callback/sep24").toString()).build()
+          )
+          .allowAnyDestination(false)
+          .destinationAccounts(emptySet())
+          .build()
+
+      val walletBClient =
+        CustodialClient.builder()
+          .name("wallet-b")
+          .signingKeys(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
+          .callbackUrls(
+            CallbackUrls.builder().sep24(walletBServer.url("/callback/sep24").toString()).build()
+          )
+          .allowAnyDestination(false)
+          .destinationAccounts(emptySet())
+          .build()
+
+      val circleHandler =
+        ClientStatusCallbackHandler(
+          secretConfig,
+          circleClient,
+          assetService,
+          sep6MoreInfoUrlConstructor,
+          sep24MoreInfoUrlConstructor
+        )
+      val walletBHandler =
+        ClientStatusCallbackHandler(
+          secretConfig,
+          walletBClient,
+          assetService,
+          sep6MoreInfoUrlConstructor,
+          sep24MoreInfoUrlConstructor
+        )
+
+      val withdrawalEvent =
+        AnchorEvent().apply {
+          transaction =
+            GetTransactionResponse().apply {
+              sep = SEP_24
+              kind = Kind.WITHDRAWAL
+              status = COMPLETED
+              clientName = "circle"
+            }
+        }
+
+      every { fromTxn(any(), any(), any(), any()) } returns mockk(relaxed = true)
+
+      circleHandler.handleEvent(withdrawalEvent)
+      walletBHandler.handleEvent(withdrawalEvent)
+
+      assertEquals(
+        1,
+        circleServer.requestCount,
+        "circle's callback receiver should get exactly one POST"
+      )
+      assertEquals(
+        0,
+        walletBServer.requestCount,
+        "wallet-b's callback receiver must not receive any request"
+      )
+    } finally {
+      circleServer.shutdown()
+      walletBServer.shutdown()
+    }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.observer.stellar
 
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import java.math.BigInteger
@@ -14,7 +16,9 @@ import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation
 import org.stellar.anchor.ledger.PaymentTransferEvent
 import org.stellar.anchor.platform.config.RpcConfig
 import org.stellar.anchor.platform.data.*
+import org.stellar.anchor.platform.service.AnchorMetrics
 import org.stellar.anchor.util.AssetHelper.fromXdrAmount
+import org.stellar.anchor.util.Log
 import org.stellar.sdk.TOID
 import org.stellar.sdk.xdr.Asset
 import org.stellar.sdk.xdr.AssetType.ASSET_TYPE_POOL_SHARE
@@ -117,19 +121,19 @@ class DefaultPaymentListenerTest {
     val slotStatus = slot<String>()
 
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep31Transaction()
+    } returns listOf(JdbcSep31Transaction())
 
     every { paymentListener.handleSep31Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_sender",
@@ -154,23 +158,23 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
 
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep24Transaction()
+    } returns listOf(JdbcSep24Transaction())
 
     every { paymentListener.handleSep24Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_user_transfer_start",
@@ -195,25 +199,25 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
-    } returns null
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
     every {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns JdbcSep6Transaction()
+    } returns listOf(JdbcSep6Transaction())
 
     every { paymentListener.handleSep6Transaction(any(), any(), any()) } answers {}
 
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_1",
         "pending_user_transfer_start",
@@ -274,7 +278,7 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep31 findByToAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep31 findAllByToAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
@@ -282,7 +286,7 @@ class DefaultPaymentListenerTest {
     ledgerTransaction.memo = xdrMemoText
 
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_sender",
@@ -292,7 +296,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_sender",
@@ -309,17 +313,17 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep24 findByStellarAccountIdAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep24 findAllByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
     xdrMemoText.text = XdrString("my_memo_3")
     ledgerTransaction.memo = xdrMemoText
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -329,7 +333,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -346,20 +350,20 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
-  fun `test if Sep6 findOneByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
+  fun `test if Sep6 findAllByWithdrawAnchorAccountAndMemoAndStatus throws an exception, we shouldn't trigger any updates`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction
 
     xdrMemoText.text = XdrString("my_memo_3")
     ledgerTransaction.memo = xdrMemoText
 
-    every { sep31TransactionStore.findByToAccountAndMemoAndStatus(any(), any(), any()) } returns
-      null
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
     every {
-      sep24TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
-    } returns null
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
     every {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -369,7 +373,7 @@ class DefaultPaymentListenerTest {
     paymentListener.onReceived(event)
 
     verify(exactly = 1) {
-      sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_3",
         "pending_user_transfer_start",
@@ -377,7 +381,7 @@ class DefaultPaymentListenerTest {
     }
 
     verify(exactly = 0) {
-      paymentListener.handleSep24Transaction(
+      paymentListener.handleSep6Transaction(
         ledgerTransaction,
         ledgerTransaction.operations[0].paymentOperation,
         any(),
@@ -400,15 +404,15 @@ class DefaultPaymentListenerTest {
     val slotAccount = slot<String>()
     val slotStatus = slot<String>()
     every {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         capture(slotAccount),
         capture(slotMemo),
         capture(slotStatus),
       )
-    } returns sep31TxMock
+    } returns listOf(sep31TxMock)
     paymentListener.onReceived(event)
     verify(exactly = 1) {
-      sep31TransactionStore.findByToAccountAndMemoAndStatus(
+      sep31TransactionStore.findAllByToAccountAndMemoAndStatus(
         "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "my_memo_4",
         "pending_sender",
@@ -550,5 +554,255 @@ class DefaultPaymentListenerTest {
       paymentListener.checkAndWarnAssetAmountMismatch(testTxn, testPayment, testJdbcSepTransaction)
     }
     verify(exactly = 1) { platformApiClient.notifyOnchainFundsSent("123", testTxn.hash, any()) }
+  }
+
+  @Test
+  fun `test ambiguous SEP-24 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep24Transaction().apply { id = "sep24-id-1" }
+    val txn2 = JdbcSep24Transaction().apply { id = "sep24-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-24") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep24-id-1") && it.toString().contains("sep24-id-2") },
+        )
+      }
+      assertEquals(
+        1.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test ambiguous SEP-6 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep6Transaction().apply { id = "sep6-id-1" }
+    val txn2 = JdbcSep6Transaction().apply { id = "sep6-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
+    every {
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-6") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep6-id-1") && it.toString().contains("sep6-id-2") },
+        )
+      }
+      assertEquals(
+        1.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test ambiguous SEP-31 routing does not route payment and increments metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("dup_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    val txn1 = JdbcSep31Transaction().apply { id = "sep31-id-1" }
+    val txn2 = JdbcSep31Transaction().apply { id = "sep31-id-2" }
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      listOf(txn1, txn2)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    mockkStatic(Log::class)
+    try {
+      every { Log.debugF(any(), *anyVararg()) } just Runs
+      every { Log.errorF(any(), *anyVararg()) } just Runs
+
+      paymentListener.onReceived(event)
+
+      verify(exactly = 0) {
+        platformApiClient.notifyOnchainFundsReceived(any(), any(), any(), any())
+      }
+      verify(exactly = 1) {
+        Log.errorF(
+          match { it.contains("Ambiguous SEP-31") },
+          any(),
+          any(),
+          any(),
+          any(),
+          any(),
+          match { it.toString().contains("sep31-id-1") && it.toString().contains("sep31-id-2") },
+        )
+      }
+      assertEquals(
+        1.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+      unmockkStatic(Log::class)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-24 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(JdbcSep24Transaction().apply { id = "sep24-id-only" })
+    every { paymentListener.handleSep24Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) {
+        paymentListener.handleSep24Transaction(ledgerTransaction, any(), any())
+      }
+      assertEquals(
+        0.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "24")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-6 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      emptyList()
+    every {
+      sep24TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns emptyList()
+    every {
+      sep6TransactionStore.findAllByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
+    } returns listOf(JdbcSep6Transaction().apply { id = "sep6-id-only" })
+    every { paymentListener.handleSep6Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) { paymentListener.handleSep6Transaction(ledgerTransaction, any(), any()) }
+      assertEquals(
+        0.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "6")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
+  fun `test single-match SEP-31 routes payment and does not increment ambiguous metric`() {
+    val event = createTestTransferEvent()
+    val ledgerTransaction = event.ledgerTransaction
+    xdrMemoText.text = XdrString("unique_memo")
+    ledgerTransaction.memo = xdrMemoText
+
+    every { sep31TransactionStore.findAllByToAccountAndMemoAndStatus(any(), any(), any()) } returns
+      listOf(JdbcSep31Transaction().apply { id = "sep31-id-only" })
+    every { paymentListener.handleSep31Transaction(any(), any(), any()) } answers {}
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      paymentListener.onReceived(event)
+
+      verify(exactly = 1) {
+        paymentListener.handleSep31Transaction(ledgerTransaction, any(), any())
+      }
+      assertEquals(
+        0.0,
+        registry
+          .counter(AnchorMetrics.PAYMENT_OBSERVER_AMBIGUOUS_ROUTING.toString(), "sep", "31")
+          .count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverPoisonResilienceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverPoisonResilienceTest.kt
@@ -1,0 +1,307 @@
+package org.stellar.anchor.platform.observer.stellar
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import java.math.BigInteger
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.platform.HealthCheckStatus.GREEN
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.ledger.StellarRpc
+import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
+import org.stellar.anchor.platform.observer.PaymentListener
+import org.stellar.anchor.platform.observer.stellar.AbstractPaymentObserver.ObserverStatus
+import org.stellar.sdk.Address
+import org.stellar.sdk.KeyPair
+import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest
+import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
+import org.stellar.sdk.scval.Scv
+import org.stellar.sdk.xdr.SCMap
+import org.stellar.sdk.xdr.SCMapEntry
+import org.stellar.sdk.xdr.SCVal
+import org.stellar.sdk.xdr.SCValType
+
+class StellarRpcObserverPoisonResilienceTest {
+  private lateinit var config: StellarPaymentObserverConfig
+  private lateinit var observer: StellarRpcPaymentObserver
+  private lateinit var sorobanServer: SorobanServer
+  private lateinit var stellarRpc: StellarRpc
+  private lateinit var paymentObservingAccountsManager: PaymentObservingAccountsManager
+  private lateinit var cursorStore: InMemoryCursorStore
+  private lateinit var assetService: AssetService
+
+  @BeforeEach
+  fun setUp() {
+    config =
+      StellarPaymentObserverConfig().apply {
+        silenceCheckInterval = 60
+        silenceTimeout = 300
+        silenceTimeoutRetries = 3
+        initialStreamBackoffTime = 500
+        maxStreamBackoffTime = 5000
+        initialEventBackoffTime = 250
+        maxEventBackoffTime = 2500
+      }
+    stellarRpc = mockk(relaxed = true)
+    sorobanServer = mockk(relaxed = true)
+    every { stellarRpc.sorobanServer } returns sorobanServer
+    every { stellarRpc.getSorobanServer() } returns sorobanServer
+    every { sorobanServer.getLatestLedger() } returns mockk { every { sequence } returns 10 }
+
+    paymentObservingAccountsManager = mockk(relaxed = true)
+    cursorStore = InMemoryCursorStore()
+    assetService = mockk(relaxed = true)
+
+    observer =
+      spyk(
+        StellarRpcPaymentObserver(
+          stellarRpc,
+          config,
+          emptyList<PaymentListener>(),
+          paymentObservingAccountsManager,
+          cursorStore,
+          MockSacToAssetMapper(),
+          assetService,
+        ),
+        recordPrivateCalls = true,
+      )
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    runCatching { observer.shutdown() }
+  }
+
+  @Test
+  fun `observer stays RUNNING after empty SCV_MAP poison event on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after one-entry SCV_MAP poison event on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(arrayOf(SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(100)))))
+        )
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after SCV_MAP with wrong first-entry type on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toUint64(BigInteger.valueOf(100))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toString("memo123")),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer stays RUNNING after contract-address recipient with SCV_U64 memo on real scheduler`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(500))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toUint64(BigInteger.valueOf(42))),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+    val contractAddress = Address.fromContract(ByteArray(32)).toSCVal()
+
+    setupSequentialResponses(poisonValue, toSCVal = contractAddress)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  @Test
+  fun `observer health check returns GREEN after processing poison events`() {
+    val poisonValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+
+    setupSequentialResponses(poisonValue)
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    val healthResult = observer.check()
+    assertNotNull(healthResult)
+    assertEquals(GREEN, healthResult.status)
+  }
+
+  @Test
+  fun `observer advances cursor past mixed batch containing poison and valid events`() {
+    val emptyMapPoison =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+    val validValue = Scv.toInt128(BigInteger.valueOf(100)).toXdrBase64()
+
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockBatchResponse(listOf(emptyMapPoison, validValue), "BATCH_CUR")
+        else mockEmptyBatchResponse("NORMAL_CUR")
+      }
+
+    observer.start()
+
+    waitForCursor("NORMAL_CUR")
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("NORMAL_CUR", cursorStore.loadStellarRpcCursor())
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────────
+
+  private fun setupSequentialResponses(
+    poisonValueBase64: String,
+    toSCVal: SCVal = Scv.toAddress(KeyPair.random().accountId),
+  ) {
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockPoisonResponse(poisonValueBase64, toSCVal, "POISON_CUR")
+        else mockEmptyBatchResponse("NORMAL_CUR")
+      }
+  }
+
+  private fun mockPoisonResponse(
+    valueBase64: String,
+    toSCVal: SCVal,
+    cursor: String,
+  ): GetEventsResponse {
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+        toSCVal.toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+    val event = mockk<GetEventsResponse.EventInfo>()
+    every { event.topic } returns topics
+    every { event.value } returns valueBase64
+
+    return mockk<GetEventsResponse>().also {
+      every { it.events } returns listOf(event)
+      every { it.latestLedger } returns 100L
+      every { it.cursor } returns cursor
+    }
+  }
+
+  private fun mockBatchResponse(
+    valuesBase64: List<String>,
+    cursor: String,
+  ): GetEventsResponse {
+    val events =
+      valuesBase64.map { valueBase64 ->
+        val topics =
+          listOf(
+            Scv.toSymbol("transfer").toXdrBase64(),
+            Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+            Scv.toAddress(KeyPair.random().accountId).toXdrBase64(),
+            Scv.toString("native").toXdrBase64(),
+          )
+        mockk<GetEventsResponse.EventInfo>().also {
+          every { it.topic } returns topics
+          every { it.value } returns valueBase64
+        }
+      }
+    return mockk<GetEventsResponse>().also {
+      every { it.events } returns events
+      every { it.latestLedger } returns 100L
+      every { it.cursor } returns cursor
+    }
+  }
+
+  private fun mockEmptyBatchResponse(cursor: String): GetEventsResponse =
+    mockk<GetEventsResponse>().also {
+      every { it.events } returns emptyList()
+      every { it.latestLedger } returns 101L
+      every { it.cursor } returns cursor
+    }
+
+  private fun waitForCursor(expected: String, timeoutMs: Long = 6000) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      if (cursorStore.loadStellarRpcCursor() == expected) return
+      Thread.sleep(100)
+    }
+  }
+}
+
+private class InMemoryCursorStore : StellarPaymentStreamerCursorStore {
+  private var horizonCursor = ""
+  private var stellarRpcCursor = ""
+
+  override fun saveHorizonCursor(cursor: String) {
+    horizonCursor = cursor
+  }
+  override fun loadHorizonCursor(): String = horizonCursor
+  override fun saveStellarRpcCursor(cursor: String) {
+    stellarRpcCursor = cursor
+  }
+  override fun loadStellarRpcCursor(): String = stellarRpcCursor
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -22,6 +22,7 @@ import org.stellar.anchor.ledger.StellarRpc
 import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
 import org.stellar.anchor.platform.observer.PaymentListener
 import org.stellar.anchor.platform.observer.stellar.AbstractPaymentObserver.ObserverStatus
+import org.stellar.sdk.Address
 import org.stellar.sdk.Asset
 import org.stellar.sdk.KeyPair
 import org.stellar.sdk.SorobanServer
@@ -31,6 +32,10 @@ import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest
 import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
 import org.stellar.sdk.scval.Scv
 import org.stellar.sdk.xdr.OperationType
+import org.stellar.sdk.xdr.SCMap
+import org.stellar.sdk.xdr.SCMapEntry
+import org.stellar.sdk.xdr.SCVal
+import org.stellar.sdk.xdr.SCValType
 
 class StellarRpcPaymentObserverTest {
   private lateinit var config: StellarPaymentObserverConfig
@@ -375,6 +380,147 @@ class StellarRpcPaymentObserverTest {
 
     assertDoesNotThrow { observer.fetchEvents() }
     assertEquals(ObserverStatus.STREAM_ERROR, observer.getStatus())
+  }
+
+  @Test
+  fun `fetchEvents skips empty SCV_MAP poison event without crashing or stalling`() {
+    val distAccount = KeyPair.random().accountId
+    val attackerAccount = KeyPair.random().accountId
+
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(distAccount).toXdrBase64(),
+        Scv.toAddress(attackerAccount).toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+
+    val emptyMapValue =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(SCMap(emptyArray<SCMapEntry>()))
+        .build()
+        .toXdrBase64()
+
+    val poisonEvent = mockk<GetEventsResponse.EventInfo>()
+    every { poisonEvent.topic } returns topics
+    every { poisonEvent.value } returns emptyMapValue
+
+    val response = mockk<GetEventsResponse>()
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { response.events } returns listOf(poisonEvent)
+    every { response.latestLedger } returns 777L
+    every { response.cursor } returns "SAFE_CUR"
+    every { sorobanServer.getEvents(any()) } returns response
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("SAFE_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents skips one-entry SCV_MAP without crashing or stalling`() {
+    val oneEntryMap =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(arrayOf(SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(100)))))
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns mockPoisonResponse(oneEntryMap)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents skips SCV_MAP with wrong first-entry type without crashing or stalling`() {
+    val wrongTypeMap =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toUint64(BigInteger.valueOf(100))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toString("memo123")),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns mockPoisonResponse(wrongTypeMap)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  @Test
+  fun `fetchEvents handles contract-address recipient with SCV_U64 memo without crashing`() {
+    val contractAddress = Address.fromContract(ByteArray(32)).toSCVal()
+    val validMapWithU64Memo =
+      SCVal.builder()
+        .discriminant(SCValType.SCV_MAP)
+        .map(
+          SCMap(
+            arrayOf(
+              SCMapEntry(Scv.toSymbol("amount"), Scv.toInt128(BigInteger.valueOf(500))),
+              SCMapEntry(Scv.toSymbol("memo"), Scv.toUint64(BigInteger.valueOf(42))),
+            )
+          )
+        )
+        .build()
+        .toXdrBase64()
+
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns
+      mockPoisonResponse(validMapWithU64Memo, toSCVal = contractAddress)
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+    observer.setStatus(ObserverStatus.RUNNING)
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  private fun mockPoisonResponse(
+    valueBase64: String,
+    fromAccount: String = KeyPair.random().accountId,
+    toSCVal: SCVal = Scv.toAddress(KeyPair.random().accountId),
+  ): GetEventsResponse {
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(fromAccount).toXdrBase64(),
+        toSCVal.toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+    val event = mockk<GetEventsResponse.EventInfo>()
+    every { event.topic } returns topics
+    every { event.value } returns valueBase64
+
+    val response = mockk<GetEventsResponse>()
+    every { response.events } returns listOf(event)
+    every { response.latestLedger } returns 777L
+    every { response.cursor } returns "POISON_CUR"
+    return response
   }
 }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -1927,4 +1927,31 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
   }
+
+  @Test
+  fun test_handle_sep24_memo_in_use_returns_400() {
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .memo(ID_MEMO)
+        .destinationAccount(DESTINATION_ACCOUNT_2)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("1", FIAT_USD))
+        .feeDetails(FeeDetails("1", STELLAR_USDC))
+        .build()
+    val txn24 = JdbcSep24Transaction()
+    txn24.status = PENDING_ANCHOR.toString()
+    txn24.kind = WITHDRAWAL.kind
+    txn24.amountInAsset = STELLAR_USDC
+    txn24.amountOutAsset = FIAT_USD
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(TX_ID) } returns txn24
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every { txn24Store.save(any()) } throws
+      org.springframework.dao.DataIntegrityViolationException("duplicate key")
+
+    val ex = assertThrows<BadRequestException> { handler.handle(request) }
+    assertTrue(ex.message!!.contains("memo_in_use"))
+  }
 }

--- a/service-runner/src/main/resources/config/clients.yaml
+++ b/service-runner/src/main/resources/config/clients.yaml
@@ -3,6 +3,15 @@ items:
     type: custodial
     signing_keys:
       - GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG
+      - GD4C2QRT7YL4WJFJPYQCYRXEDBB7ERHC3XZGWR6KXKRHPEFXXNXIVNFY
+      - GC56VTOVOJDRQAJRYLZW6DLQGVTQSYDTZU7ISNIZ2VJIE3FYWI2HMD5G
+      - GDC2U5GRKUSPGV5XENLBWKQZH2C4PG7ZEVMQOUA2QZKIRXE5FYYEMEF7
+      - GASI56WX7UKIDFPZRCQEI4OQE3V3QBGXEOB4ZY6ZMU5MZXPHQHIDA7JU
+    callback_urls:
+      sep6: http://wallet-server:8092/callbacks/sep6
+      sep24: http://wallet-server:8092/callbacks/sep24
+      sep31: http://wallet-server:8092/callbacks/sep31
+      sep12: http://wallet-server:8092/callbacks/sep12
   - name: stellar_anchor_tests
     type: custodial
     signing_keys:
@@ -16,3 +25,9 @@ items:
       sep24: http://wallet-server:8092/callbacks/sep24
       sep31: http://wallet-server:8092/callbacks/sep31
       sep12: http://wallet-server:8092/callbacks/sep12
+  - name: circleWallet
+    type: noncustodial
+    domains:
+      - circlewallet.example.com
+    callback_urls:
+      sep24: http://localhost:19091/callbacks/sep24

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=4.3.0
+version=4.4.0

--- a/soroban/Cargo.lock
+++ b/soroban/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -22,10 +22,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -58,116 +58,140 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ec"
-version = "0.4.2"
+name = "ark-bn254"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "ark-std",
- "derivative",
- "hashbrown 0.13.2",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
  "itertools",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "derivative",
+ "arrayvec",
  "digest",
+ "educe",
  "itertools",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "ark-poly"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
+ "ahash",
  "ark-ff",
  "ark-serialize",
  "ark-std",
- "derivative",
- "hashbrown 0.13.2",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
+ "arrayvec",
  "digest",
  "num-bigint",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "ark-std"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "arrayvec"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
@@ -177,21 +201,15 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "block-buffer"
@@ -203,10 +221,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -223,35 +250,46 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -268,9 +306,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -310,13 +348,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
- "quote",
- "syn 2.0.96",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "curve25519-dalek"
@@ -342,55 +386,89 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.96",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -398,23 +476,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "serde_core",
 ]
 
 [[package]]
@@ -425,7 +492,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -445,6 +512,27 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -471,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -485,10 +573,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.13.0"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -509,10 +609,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
+name = "enum-ordinalize"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "escape-bytes"
@@ -522,15 +642,15 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -543,16 +663,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -561,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -584,6 +734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,18 +750,34 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -630,14 +805,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -670,13 +846,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -687,25 +864,27 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -724,36 +903,47 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-bigint"
@@ -767,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -779,7 +969,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -802,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
@@ -825,6 +1015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,21 +1038,21 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -870,27 +1066,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -917,6 +1113,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,15 +1153,44 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "schemars"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "sec1"
@@ -962,55 +1207,69 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
- "base64 0.22.1",
+ "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
- "serde",
- "serde_derive",
+ "indexmap 2.14.0",
+ "schemars 0.8.22",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1018,21 +1277,21 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1041,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
@@ -1066,28 +1325,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "22.1.3"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
+checksum = "35a3a2b57b132b800e132d2c81e1818359bb2cf787ca39c61c151d6bd0798403"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-env-common"
-version = "22.1.3"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
+checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1104,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "22.1.3"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
+checksum = "15aeed6d7a4dc4d3bba65e2ac92f7eeaa664900bbc82e1055e024bf637d74ed3"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1114,11 +1379,12 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "22.1.3"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e8b03a4191d485eab03f066336112b2a50541a7553179553dc838b986b94dd"
+checksum = "6fb523456b4efe9cdf869233cff5a2a1a5ebfae8c0acc405e57479c83781a20c"
 dependencies = [
  "ark-bls12-381",
+ "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
@@ -1144,15 +1410,15 @@ dependencies = [
  "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
  "wasmparser",
 ]
 
 [[package]]
 name = "soroban-env-macros"
-version = "22.1.3"
+version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
+checksum = "2ada3449bb23c964a88a1bf633ac66ca3ebac2061693f53148b199ce816791d0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1160,14 +1426,14 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "22.0.5"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fa784df79d0d30432ba999906bd47fcad12b2980d1bd651992f2191c7c92f4"
+checksum = "0d519682f5cf750a769f2c89f32ee089f48b9e645e01af34fc3b98a78e9a4ede"
 dependencies = [
  "serde",
  "serde_json",
@@ -1179,12 +1445,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "22.0.5"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf0c0e19b20977d27b66a5659951893b0ea25f2a01692196861c6db700ada3"
+checksum = "d03acd78bf4c80d5cacc8ee149966a49aaf8873b9936315af09f820887085c5e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
+ "crate-git-revision",
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
@@ -1196,36 +1463,38 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey",
+ "stellar-strkey 0.0.16",
+ "visibility",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "22.0.5"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9612ffb704c7a36703e86a60f286dbd3e1ffca42237a8b353328a05d88f8b028"
+checksum = "9751225bd51b04257eb4aca60fcc996a3b6d69c81ac39ca24e68e9bf97aabe83"
 dependencies = [
- "crate-git-revision",
- "darling",
+ "darling 0.20.11",
+ "heck",
  "itertools",
+ "macro-string",
  "proc-macro2",
  "quote",
- "rustc_version",
  "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "22.0.5"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709db692196f0600678cd8ec2a7e2b269dd63a32477dcdec5b3a353fb26bb128"
+checksum = "867c8b583180e7398af6c43134202dc1324e42c32b32d859aa921ce61de6c9ca"
 dependencies = [
- "base64 0.13.1",
+ "base64",
+ "sha2",
  "stellar-xdr",
  "thiserror",
  "wasmparser",
@@ -1233,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "22.0.5"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457bba1f081b7b78ef219bc5a523649df4927dd0625dfa723a0682b36fb198de"
+checksum = "f41517bf9490f66cf0403d1048bdf1b9560c4f88b2e067b7f8ec73241b4c4514"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1243,7 +1512,7 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.96",
+ "syn",
  "thiserror",
 ]
 
@@ -1277,6 +1546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,29 +1559,42 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.9"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
- "thiserror",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "heapless",
 ]
 
 [[package]]
 name = "stellar-xdr"
-version = "22.1.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
+checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
  "arbitrary",
- "base64 0.13.1",
+ "base64",
+ "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
+ "ethnum",
  "hex",
  "serde",
  "serde_with",
- "stellar-strkey",
+ "sha2",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]
@@ -1323,20 +1611,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1360,51 +1637,66 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"
@@ -1413,42 +1705,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "visibility"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1456,22 +1746,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
- "wasm-bindgen-backend",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1500,7 +1790,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1522,114 +1812,105 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-implement"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "windows-interface"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
+name = "windows-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
+name = "windows-strings"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/soroban/Cargo.toml
+++ b/soroban/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "22"
+soroban-sdk = "26.0.0"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### Description

Merges `release/4.4.0` into `main` for the 4.4.0 release.

### Context

- **[ANCHOR-1215]** Fix SEP-12 IDOR via unvalidated customer `id` — prevents cross-customer KYC disclosure and payout destination overwrite (#1946)
- **[ANCHOR-1943]** Fix RPC observer DoS via malformed Soroban transfer event (#1944)
- **[ANCHOR-1939]** Add per-client event isolation and ambiguous payment routing safety (#1941, #1942)
- **[ANCHOR-1934]** Enforce single-use on SEP-38 quotes (#1935)
- **[ANCHOR-1206]** Add Gateway API support to Helm charts and carry forward security headers (#1936, #1940)
- **[Chore]** Bump Soroban SDK from v22 to v26 (#1937)
- **[Chore]** Bump version to 4.4.0


[ANCHOR-1215]: https://stellarorg.atlassian.net/browse/ANCHOR-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANCHOR-1206]: https://stellarorg.atlassian.net/browse/ANCHOR-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ