### PR TITLE
[ANCHOR-1206]: Default `ingress.enabled` to `false` in favor of Gateway API

### DIFF
--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -34,7 +34,7 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
-  enabled: true
+  enabled: false
   name: ingress-reference-server
   rules:
     host: reference-server.local

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -135,9 +135,8 @@ config:
       base_url: http://localhost:3000
     more_info_url:
       base_url: http://localhost:3000/txn
-
 ingress:
-  enabled: true
+  enabled: false
   name: ingress-anchor-platform
   className: nginx
   annotations:

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -26,7 +26,7 @@ services:
           memory: 1Gi
           cpu: 1
 ingress:
-  enabled: true
+  enabled: false
   name: ingress-sep24-reference-ui
   rules:
     host: sep24-reference-ui.local


### PR DESCRIPTION
### Description

Flips the Ingress default to false across all three helm charts so deploys no longer render an nginx-classed Ingress by default.

https://buildmeister-v3.stellar-ops.com/job/ProductEngineering/job/stellar-anchor-platform-dev/819/console

### Context

gateway migration

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

