### PR TITLE
[ANCHOR-1218]: StellarRpcPaymentObserver indexes filtered op list with full-tx operationIndex → payments never credited

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -37,6 +37,7 @@ import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.Log;
 import org.stellar.sdk.MuxedAccount;
 import org.stellar.sdk.SorobanServer;
+import org.stellar.sdk.TOID;
 import org.stellar.sdk.exception.NetworkException;
 import org.stellar.sdk.requests.sorobanrpc.EventFilterType;
 import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest;
@@ -174,7 +175,27 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
     debug("Processing transfer event: {}", GsonUtils.getInstance().toJson(result.event));
     try {
       LedgerTransaction txn = stellarRpc.getTransaction(result.event.getTransactionHash());
-      LedgerOperation op = txn.getOperations().get(result.event.getOperationIndex().intValue());
+      String wantedOpId =
+          String.valueOf(
+              new TOID(
+                      txn.getSequenceNumber().intValue(),
+                      txn.getApplicationOrder(),
+                      result.event.getOperationIndex().intValue() + 1)
+                  .toInt64());
+      LedgerOperation op =
+          txn.getOperations().stream()
+              .filter(o -> wantedOpId.equals(getOperationId(o)))
+              .findFirst()
+              .orElse(null);
+      if (op == null) {
+        errorF(
+            "No creditable operation found for transfer event: txHash={}, operationIndex={}."
+                + " The operation may be a contract sub-invocation with no direct representation"
+                + " in the filtered operation list. Skipping.",
+            result.event.getTransactionHash(),
+            result.event.getOperationIndex());
+        return;
+      }
       processOperation(txn, op);
     } catch (Exception ex) {
       warnF(
@@ -182,6 +203,14 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
           GsonUtils.getInstance().toJson(result.event),
           ex.getMessage());
     }
+  }
+
+  private String getOperationId(LedgerOperation op) {
+    if (op.getPaymentOperation() != null) return op.getPaymentOperation().getId();
+    if (op.getPathPaymentOperation() != null) return op.getPathPaymentOperation().getId();
+    if (op.getInvokeHostFunctionOperation() != null)
+      return op.getInvokeHostFunctionOperation().getId();
+    return null;
   }
 
   @Builder

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
@@ -332,7 +332,9 @@ class StellarRpcObserverIndexDomainTest {
       if (cursorStore.loadStellarRpcCursor() == expected) return
       Thread.sleep(100)
     }
-    throw AssertionError("Timed out waiting for cursor '$expected' (last='${cursorStore.loadStellarRpcCursor()}')")
+    throw AssertionError(
+      "Timed out waiting for cursor '$expected' (last='${cursorStore.loadStellarRpcCursor()}')"
+    )
   }
 }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
@@ -1,0 +1,362 @@
+package org.stellar.anchor.platform.observer.stellar
+
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.ledger.LedgerTransaction
+import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation
+import org.stellar.anchor.ledger.PaymentTransferEvent
+import org.stellar.anchor.ledger.StellarRpc
+import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
+import org.stellar.anchor.platform.observer.PaymentListener
+import org.stellar.anchor.platform.observer.stellar.AbstractPaymentObserver.ObserverStatus
+import org.stellar.sdk.Asset
+import org.stellar.sdk.KeyPair
+import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.TOID
+import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
+import org.stellar.sdk.scval.Scv
+import org.stellar.sdk.xdr.OperationType
+
+class StellarRpcObserverIndexDomainTest {
+  private lateinit var config: StellarPaymentObserverConfig
+  private lateinit var observer: StellarRpcPaymentObserver
+  private lateinit var sorobanServer: SorobanServer
+  private lateinit var stellarRpc: StellarRpc
+  private lateinit var paymentObservingAccountsManager: PaymentObservingAccountsManager
+  private lateinit var cursorStore: LocalCursorStore
+  private lateinit var assetService: AssetService
+  private lateinit var listener: CaptureListener
+
+  @BeforeEach
+  fun setUp() {
+    config =
+      StellarPaymentObserverConfig().apply {
+        silenceCheckInterval = 60
+        silenceTimeout = 300
+        silenceTimeoutRetries = 3
+        initialStreamBackoffTime = 500
+        maxStreamBackoffTime = 5000
+        initialEventBackoffTime = 250
+        maxEventBackoffTime = 2500
+      }
+    stellarRpc = mockk(relaxed = true)
+    sorobanServer = mockk(relaxed = true)
+    every { stellarRpc.sorobanServer } returns sorobanServer
+    every { stellarRpc.getSorobanServer() } returns sorobanServer
+    every { sorobanServer.getLatestLedger() } returns mockk { every { sequence } returns 10 }
+
+    paymentObservingAccountsManager = mockk(relaxed = true)
+    cursorStore = LocalCursorStore()
+    assetService = mockk(relaxed = true)
+    listener = CaptureListener()
+
+    observer =
+      StellarRpcPaymentObserver(
+        stellarRpc,
+        config,
+        listOf(listener),
+        paymentObservingAccountsManager,
+        cursorStore,
+        MockSacToAssetMapper(),
+        assetService,
+      )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    runCatching { observer.shutdown() }
+  }
+
+  @Test
+  fun `payment at operationIndex=1 in multi-op transaction is credited via real scheduler`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val amount = BigInteger.valueOf(5_000_000L)
+    val txHash = "txHashMultiOpIntegration"
+    val seqNum = 400L
+    val appOrder = 1
+    val paymentOpId = TOID(seqNum.toInt(), appOrder, 2).toInt64().toString()
+
+    every { paymentObservingAccountsManager.lookupAndUpdate(toAccount) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(fromAccount) } returns false
+
+    val paymentOp =
+      LedgerTransaction.LedgerPaymentOperation().apply {
+        from = fromAccount
+        to = toAccount
+        asset = Asset.createNativeAsset().toXdr()
+        this.amount = amount
+        id = paymentOpId
+      }
+    val op =
+      LedgerOperation().apply {
+        type = OperationType.PAYMENT
+        paymentOperation = paymentOp
+      }
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(listOf(op))
+        .build()
+    every { stellarRpc.getTransaction(txHash) } returns txn
+
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockEventBatch(
+            listOf(Triple(fromAccount, toAccount, txHash to 1L)),
+            listOf(amount),
+            "MULTI_OP_CUR",
+          )
+        else emptyBatch("IDLE_CUR")
+      }
+
+    observer.start()
+    waitForCursor("IDLE_CUR")
+
+    val captured = listener.getByTo(toAccount)
+    assertEquals(1, captured?.size)
+    assertEquals(fromAccount, captured!![0].from)
+    assertEquals(toAccount, captured[0].to)
+    assertEquals(amount, captured[0].amount)
+    assertEquals(paymentOpId, captured[0].operationId)
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+  }
+
+  @Test
+  fun `sub-invocation transfer event is skipped and observer stays RUNNING via real scheduler`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val txHash = "txHashSubInvokeIntegration"
+    val seqNum = 500L
+    val appOrder = 1
+
+    every { paymentObservingAccountsManager.lookupAndUpdate(toAccount) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(fromAccount) } returns false
+
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(emptyList())
+        .build()
+    every { stellarRpc.getTransaction(txHash) } returns txn
+
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockEventBatch(
+            listOf(Triple(fromAccount, toAccount, txHash to 0L)),
+            listOf(BigInteger.valueOf(1_000_000L)),
+            "SUB_INVOKE_CUR",
+          )
+        else emptyBatch("IDLE_CUR")
+      }
+
+    observer.start()
+    waitForCursor("IDLE_CUR")
+
+    assertNull(listener.getByTo(toAccount))
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+  }
+
+  @Test
+  fun `mixed batch credits normal and multi-op events while skipping sub-invocation`() {
+    val from1 = KeyPair.random().accountId
+    val to1 = KeyPair.random().accountId
+    val from2 = KeyPair.random().accountId
+    val to2 = KeyPair.random().accountId
+    val from3 = KeyPair.random().accountId
+    val to3 = KeyPair.random().accountId
+
+    val amount1 = BigInteger.valueOf(1_000_000L)
+    val amount2 = BigInteger.valueOf(2_000_000L)
+    val amount3 = BigInteger.valueOf(3_000_000L)
+
+    val seqNum = 600L
+    val appOrder = 1
+
+    val txHash1 = "txHashNormalOp"
+    val opId1 = TOID(seqNum.toInt(), appOrder, 1).toInt64().toString()
+
+    val txHash2 = "txHashMultiOp2"
+    val opId2 = TOID((seqNum + 1).toInt(), appOrder, 2).toInt64().toString()
+
+    val txHash3 = "txHashSubInvoke"
+
+    every { paymentObservingAccountsManager.lookupAndUpdate(to1) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(from1) } returns false
+    every { paymentObservingAccountsManager.lookupAndUpdate(to2) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(from2) } returns false
+    every { paymentObservingAccountsManager.lookupAndUpdate(to3) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(from3) } returns false
+
+    every { stellarRpc.getTransaction(txHash1) } returns
+      LedgerTransaction.builder()
+        .hash(txHash1)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(
+          listOf(
+            LedgerOperation().apply {
+              type = OperationType.PAYMENT
+              paymentOperation =
+                LedgerTransaction.LedgerPaymentOperation().apply {
+                  from = from1
+                  to = to1
+                  asset = Asset.createNativeAsset().toXdr()
+                  amount = amount1
+                  id = opId1
+                }
+            }
+          )
+        )
+        .build()
+
+    every { stellarRpc.getTransaction(txHash2) } returns
+      LedgerTransaction.builder()
+        .hash(txHash2)
+        .sequenceNumber(seqNum + 1)
+        .applicationOrder(appOrder)
+        .operations(
+          listOf(
+            LedgerOperation().apply {
+              type = OperationType.PAYMENT
+              paymentOperation =
+                LedgerTransaction.LedgerPaymentOperation().apply {
+                  from = from2
+                  to = to2
+                  asset = Asset.createNativeAsset().toXdr()
+                  amount = amount2
+                  id = opId2
+                }
+            }
+          )
+        )
+        .build()
+
+    every { stellarRpc.getTransaction(txHash3) } returns
+      LedgerTransaction.builder()
+        .hash(txHash3)
+        .sequenceNumber(seqNum + 2)
+        .applicationOrder(appOrder)
+        .operations(emptyList())
+        .build()
+
+    val callCount = AtomicInteger(0)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (callCount.incrementAndGet() == 1)
+          mockEventBatch(
+            listOf(
+              Triple(from1, to1, txHash1 to 0L),
+              Triple(from2, to2, txHash2 to 1L),
+              Triple(from3, to3, txHash3 to 0L),
+            ),
+            listOf(amount1, amount2, amount3),
+            "MIXED_CUR",
+          )
+        else emptyBatch("IDLE_CUR")
+      }
+
+    observer.start()
+    waitForCursor("IDLE_CUR")
+
+    val captured1 = listener.getByTo(to1)
+    assertEquals(1, captured1?.size)
+    assertEquals(amount1, captured1!![0].amount)
+    assertEquals(opId1, captured1[0].operationId)
+
+    val captured2 = listener.getByTo(to2)
+    assertEquals(1, captured2?.size)
+    assertEquals(amount2, captured2!![0].amount)
+    assertEquals(opId2, captured2[0].operationId)
+
+    assertNull(listener.getByTo(to3))
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+  }
+
+  private fun mockEventBatch(
+    transfers: List<Triple<String, String, Pair<String, Long>>>,
+    amounts: List<BigInteger>,
+    cursor: String,
+  ): GetEventsResponse {
+    val events =
+      transfers.mapIndexed { i, (from, to, hashAndIndex) ->
+        val (txHash, operationIndex) = hashAndIndex
+        val topics =
+          listOf(
+            Scv.toSymbol("transfer").toXdrBase64(),
+            Scv.toAddress(from).toXdrBase64(),
+            Scv.toAddress(to).toXdrBase64(),
+            Scv.toString("native").toXdrBase64(),
+          )
+        mockk<GetEventsResponse.EventInfo>(relaxed = true).also {
+          every { it.topic } returns topics
+          every { it.value } returns Scv.toInt128(amounts[i]).toXdrBase64()
+          every { it.transactionHash } returns txHash
+          every { it.operationIndex } returns operationIndex
+        }
+      }
+    return mockk<GetEventsResponse>().also {
+      every { it.events } returns events
+      every { it.latestLedger } returns 100L
+      every { it.cursor } returns cursor
+    }
+  }
+
+  private fun emptyBatch(cursor: String): GetEventsResponse =
+    mockk<GetEventsResponse>().also {
+      every { it.events } returns emptyList()
+      every { it.latestLedger } returns 101L
+      every { it.cursor } returns cursor
+    }
+
+  private fun waitForCursor(expected: String, timeoutMs: Long = 6000) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      if (cursorStore.loadStellarRpcCursor() == expected) return
+      Thread.sleep(100)
+    }
+  }
+}
+
+private class LocalCursorStore : StellarPaymentStreamerCursorStore {
+  private var stellarRpcCursor = ""
+
+  override fun saveHorizonCursor(cursor: String) {}
+
+  override fun loadHorizonCursor(): String = ""
+
+  override fun saveStellarRpcCursor(cursor: String) {
+    stellarRpcCursor = cursor
+  }
+
+  override fun loadStellarRpcCursor(): String = stellarRpcCursor
+}
+
+private class CaptureListener : PaymentListener {
+  private val byTo = mutableMapOf<String, MutableList<PaymentTransferEvent>>()
+  private val lock = Any()
+
+  override fun onReceived(event: PaymentTransferEvent?) {
+    event ?: return
+    synchronized(lock) { byTo.getOrPut(event.to) { CopyOnWriteArrayList() }.add(event) }
+  }
+
+  fun getByTo(to: String): List<PaymentTransferEvent>? = synchronized(lock) { byTo[to]?.toList() }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
@@ -332,6 +332,7 @@ class StellarRpcObserverIndexDomainTest {
       if (cursorStore.loadStellarRpcCursor() == expected) return
       Thread.sleep(100)
     }
+    throw AssertionError("Timed out waiting for cursor '$expected' (last='${cursorStore.loadStellarRpcCursor()}')")
   }
 }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcObserverIndexDomainTest.kt
@@ -337,7 +337,7 @@ class StellarRpcObserverIndexDomainTest {
 }
 
 private class LocalCursorStore : StellarPaymentStreamerCursorStore {
-  private var stellarRpcCursor = ""
+  @Volatile private var stellarRpcCursor = ""
 
   override fun saveHorizonCursor(cursor: String) {}
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -5,6 +5,7 @@ import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.verify
 import java.io.IOException
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -26,6 +27,7 @@ import org.stellar.sdk.Address
 import org.stellar.sdk.Asset
 import org.stellar.sdk.KeyPair
 import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.TOID
 import org.stellar.sdk.exception.NetworkException
 import org.stellar.sdk.requests.sorobanrpc.EventFilterType
 import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest
@@ -498,6 +500,168 @@ class StellarRpcPaymentObserverTest {
 
     assertEquals(ObserverStatus.RUNNING, observer.getStatus())
     assertEquals("POISON_CUR", observer.cursor)
+  }
+
+  private fun setupTransferEvent(
+    fromAccount: String,
+    toAccount: String,
+    amount: BigInteger,
+    txHash: String,
+    operationIndex: Long,
+    cursorValue: String = "CURSOR",
+  ): GetEventsResponse.EventInfo {
+    val topics =
+      listOf(
+        Scv.toSymbol("transfer").toXdrBase64(),
+        Scv.toAddress(fromAccount).toXdrBase64(),
+        Scv.toAddress(toAccount).toXdrBase64(),
+        Scv.toString("native").toXdrBase64(),
+      )
+    val event = mockk<GetEventsResponse.EventInfo>(relaxed = true)
+    every { event.topic } returns topics
+    every { event.value } returns Scv.toInt128(amount).toXdrBase64()
+    every { event.transactionHash } returns txHash
+    every { event.operationIndex } returns operationIndex
+
+    every { paymentObservingAccountsManager.lookupAndUpdate(toAccount) } returns true
+    every { paymentObservingAccountsManager.lookupAndUpdate(fromAccount) } returns false
+
+    val response = mockk<GetEventsResponse>()
+    every { observer.buildEventRequest(any()) } returns mockk<GetEventsRequest>()
+    every { sorobanServer.getEvents(any()) } returns response
+    every { response.events } returns listOf(event)
+    every { response.latestLedger } returns 100L
+    every { response.cursor } returns cursorValue
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+
+    return event
+  }
+
+  @Test
+  fun `processTransferEvent credits payment at operationIndex=0 in single-op transaction`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val amount = BigInteger.valueOf(1_000_000L)
+    val txHash = "txHashSingleOp"
+    val seqNum = 100L
+    val appOrder = 1
+    val paymentOpId = TOID(seqNum.toInt(), appOrder, 1).toInt64().toString()
+
+    setupTransferEvent(fromAccount, toAccount, amount, txHash, operationIndex = 0L)
+
+    val paymentOp =
+      LedgerTransaction.LedgerPaymentOperation().apply {
+        from = fromAccount
+        to = toAccount
+        asset = Asset.createNativeAsset().toXdr()
+        this.amount = amount
+        id = paymentOpId
+      }
+    val op =
+      LedgerOperation().apply {
+        type = OperationType.PAYMENT
+        paymentOperation = paymentOp
+      }
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(listOf(op))
+        .build()
+    every { stellarRpc.getTransaction(txHash) } returns txn
+
+    val capturedEvent = slot<PaymentTransferEvent>()
+    every { observer["handleEvent"](capture(capturedEvent)) } answers {}
+
+    observer.fetchEvents()
+
+    assertEquals(txHash, capturedEvent.captured.txHash)
+    assertEquals(fromAccount, capturedEvent.captured.from)
+    assertEquals(toAccount, capturedEvent.captured.to)
+    assertEquals(amount, capturedEvent.captured.amount)
+    assertEquals(paymentOpId, capturedEvent.captured.operationId)
+  }
+
+  @Test
+  fun `processTransferEvent correctly credits payment at operationIndex=1 when a non-payment op precedes it`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val amount = BigInteger.valueOf(2_000_000L)
+    val txHash = "txHashMultiOp"
+    val seqNum = 200L
+    val appOrder = 1
+    val paymentOpId = TOID(seqNum.toInt(), appOrder, 2).toInt64().toString()
+
+    setupTransferEvent(fromAccount, toAccount, amount, txHash, operationIndex = 1L, "CURSOR_MULTI")
+
+    val paymentOp =
+      LedgerTransaction.LedgerPaymentOperation().apply {
+        from = fromAccount
+        to = toAccount
+        asset = Asset.createNativeAsset().toXdr()
+        this.amount = amount
+        id = paymentOpId
+      }
+    val op =
+      LedgerOperation().apply {
+        type = OperationType.PAYMENT
+        paymentOperation = paymentOp
+      }
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(listOf(op))
+        .build()
+    every { stellarRpc.getTransaction(txHash) } returns txn
+
+    val capturedEvent = slot<PaymentTransferEvent>()
+    every { observer["handleEvent"](capture(capturedEvent)) } answers {}
+
+    observer.fetchEvents()
+
+    assertEquals(txHash, capturedEvent.captured.txHash)
+    assertEquals(fromAccount, capturedEvent.captured.from)
+    assertEquals(toAccount, capturedEvent.captured.to)
+    assertEquals(amount, capturedEvent.captured.amount)
+    assertEquals(paymentOpId, capturedEvent.captured.operationId)
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("CURSOR_MULTI", observer.cursor)
+  }
+
+  @Test
+  fun `processTransferEvent skips and logs error when no creditable op matches operationIndex`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val txHash = "txHashSubInvocation"
+    val seqNum = 300L
+    val appOrder = 1
+
+    setupTransferEvent(
+      fromAccount,
+      toAccount,
+      BigInteger.valueOf(500_000L),
+      txHash,
+      operationIndex = 0L,
+      "CURSOR_SUBINVOKE",
+    )
+
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(emptyList())
+        .build()
+    every { stellarRpc.getTransaction(txHash) } returns txn
+
+    assertDoesNotThrow { observer.fetchEvents() }
+
+    verify(exactly = 0) { observer["handleEvent"](any<PaymentTransferEvent>()) }
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertEquals("CURSOR_SUBINVOKE", observer.cursor)
   }
 
   private fun mockPoisonResponse(


### PR DESCRIPTION
### Description

Before this change, `StellarRpcPaymentObserver.processTransferEvent` selected the credited operation with:

```java
LedgerOperation op = txn.getOperations().get(result.event.getOperationIndex().intValue());
```

`event.getOperationIndex()` is a 0-based index into the **full on-chain operation array** as returned by the Soroban-RPC `getEvents` API. `txn.getOperations()` is **not** that full array — it is the compacted output of `LedgerClientHelper.getLedgerOperations()`, which silently drops every operation for which `convert()` returns `null` (`MANAGE_DATA`, `CHANGE_TRUST`, `CREATE_ACCOUNT`, `BUMP_SEQUENCE`, `SET_OPTIONS`, any `INVOKE_HOST_FUNCTION` whose direct function name is not `"transfer"`, etc.) with no placeholder. Using the full-list index against the shorter compacted list produced two failure modes:

- **Silent drop (Variant A):** any multi-operation transaction containing a filtered op at or before the payment → `IndexOutOfBoundsException` → caught by the generic handler → event permanently dropped, SEP-6/24/31 transaction frozen, user funds received but never credited.
- **Sub-invocation skip (Variant B):** a top-level `INVOKE_HOST_FUNCTION` whose direct function name is not `"transfer"` (contract/SEP-45 sub-invocation) emits a `transfer` event at the full-list index of that op, which `convert()` drops → same out-of-bounds or wrong-element result.

The fix stops trusting positional alignment. `convert()` stores the TOID — derived from `(sequenceNumber, applicationOrder, 1-based opIndex)` — as each operation's `id`. The event's `operationIndex` (0-based) is converted to the same 1-based coordinate, the TOID for the target operation is derived, and the compacted list is stream-filtered by identity match. When no match is found (sub-invocation variant), the event is logged at `error` level and skipped rather than silently swallowed as a generic `WARN`.

**Changes**
- [x] `StellarRpcPaymentObserver.processTransferEvent`: replaced `txn.getOperations().get(operationIndex)` with a TOID-based identity lookup — derives `wantedOpId` from `new TOID(sequenceNumber, applicationOrder, operationIndex + 1).toInt64()`, then stream-filters `txn.getOperations()` by `getOperationId(o).equals(wantedOpId)`. Adds `import org.stellar.sdk.TOID`.
- [x] `StellarRpcPaymentObserver.getOperationId`: new private helper that extracts the `id` field from whichever sub-operation (`paymentOperation`, `pathPaymentOperation`, or `invokeHostFunctionOperation`) is set on a `LedgerOperation`.
- [x] `StellarRpcPaymentObserver.processTransferEvent` null branch: when TOID lookup yields no match, logs an `errorF` message identifying the transaction hash and operation index, then returns — no exception is swallowed, the observer stays `RUNNING`.
- [x] `StellarRpcPaymentObserverTest`: three new unit regression tests for `processTransferEvent` — single-op at `operationIndex=0` still credited, multi-op with non-payment op at index 0 and payment at index 1 correctly credited, sub-invocation with empty compacted list skips without calling `handleEvent`.
- [x] `StellarRpcObserverIndexDomainTest` (new file): three integration tests using a real scheduler (`observer.start()`) and a `CaptureListener` — multi-op transaction credited end-to-end, sub-invocation skipped with observer remaining `RUNNING`, mixed batch crediting both normal and multi-op events while skipping the sub-invocation.

**Acceptance Criteria**
- [x] A two-operation transaction `[MANAGE_DATA, PAYMENT→dist]` with `transfer` event at `operationIndex=1` is credited with the correct from/to/amount/operationId.
- [x] A `transfer` event whose corresponding full-list operation is absent from the compacted list (contract sub-invocation) is not credited; no `PaymentTransferEvent` is dispatched to listeners.
- [x] A mixed batch containing a normal single-op, a multi-op, and a sub-invocation event processes all three without crashing, crediting the two creditable ops and skipping the sub-invocation.
- [x] Observer status remains `RUNNING` after any of the above scenarios.
- [x] Existing `StellarRpcPaymentObserverTest` and `StellarRpcObserverPoisonResilienceTest` tests continue to pass unchanged.
- [x] Horizon mode (`HorizonPaymentObserver`) is unaffected.

### Context

[#3791580](https://hackerone.com/reports/3791580)

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.observer.stellar.StellarRpcPaymentObserverTest"`
- Integration: `./gradlew :platform:test --tests "org.stellar.anchor.platform.observer.stellar.StellarRpcObserverIndexDomainTest"`
- Full platform suite: `./gradlew :platform:test`

### Documentation
N/A

### Known limitations

The sub-invocation case (Variant B) — a `transfer` event emitted by a contract that moves tokens internally rather than via a top-level SAC `transfer` call — is logged as an error and skipped. Crediting from the authenticated event fields (the reporter's Option 2) would handle this variant without requiring a matching operation in the compacted list, but it requires verifying that the SAC contract address can be reliably resolved to an anchor asset from the event alone, which is not currently supported by `SacToAssetMapper`. Variant B is tracked separately.
