### PR TITLE
[ANCHOR-1221]: NPE in notify_onchain_funds_received (hardcoded op index 0 + unsafe getPaymentOperation) strands received funds

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -177,7 +177,7 @@ public class NotifyOnchainFundsReceivedHandler
             ledgerTxn.getOperations().stream()
                 .map(op -> getLedgerPayment(op))
                 .filter(Objects::nonNull)
-                .filter(p -> Objects.equals(p.getTo(), txn31.getToAccount()))
+                .filter(p -> txn31.getToAccount() != null && txn31.getToAccount().equals(p.getTo()))
                 .findFirst()
                 .orElse(null);
         if (payment != null) txn31.setFromAccount(payment.getFrom());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -5,10 +5,12 @@ import static org.stellar.anchor.api.platform.PlatformTransactionData.Kind.WITHD
 import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_ONCHAIN_FUNDS_RECEIVED;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 import static org.stellar.anchor.platform.utils.PaymentHelper.addStellarTransaction;
+import static org.stellar.anchor.platform.utils.PaymentHelper.getLedgerPayment;
 import static org.stellar.anchor.util.Log.errorEx;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
@@ -27,7 +29,7 @@ import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.ledger.LedgerClient;
 import org.stellar.anchor.ledger.LedgerTransaction;
-import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation;
+import org.stellar.anchor.ledger.LedgerTransaction.LedgerPayment;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
 import org.stellar.anchor.platform.data.JdbcSep31Transaction;
@@ -39,7 +41,6 @@ import org.stellar.anchor.platform.validator.RequestValidator;
 import org.stellar.anchor.sep24.Sep24TransactionStore;
 import org.stellar.anchor.sep31.Sep31TransactionStore;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
-import org.stellar.sdk.xdr.OperationType;
 
 public class NotifyOnchainFundsReceivedHandler
     extends RpcTransactionStatusHandler<NotifyOnchainFundsReceivedRequest> {
@@ -172,12 +173,14 @@ public class NotifyOnchainFundsReceivedHandler
 
       if (Sep.SEP_31.equals(Sep.from(txn.getProtocol()))) {
         JdbcSep31Transaction txn31 = (JdbcSep31Transaction) txn;
-        LedgerOperation operation = ledgerTxn.getOperations().get(0);
-        if (operation.getType() == OperationType.INVOKE_HOST_FUNCTION) {
-          txn31.setFromAccount(operation.getInvokeHostFunctionOperation().getFrom());
-        } else {
-          txn31.setFromAccount(ledgerTxn.getOperations().get(0).getPaymentOperation().getFrom());
-        }
+        LedgerPayment payment =
+            ledgerTxn.getOperations().stream()
+                .map(op -> getLedgerPayment(op))
+                .filter(Objects::nonNull)
+                .filter(p -> Objects.equals(p.getTo(), txn31.getToAccount()))
+                .findFirst()
+                .orElse(null);
+        if (payment != null) txn31.setFromAccount(payment.getFrom());
       }
     } catch (LedgerException ex) {
       errorEx(String.format("Failed to retrieve stellar transaction by ID[%s]", stellarTxnId), ex);

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -8,6 +8,7 @@ import java.math.BigInteger
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -823,6 +824,130 @@ class NotifyOnchainFundsReceivedHandlerTest {
     handler.handle(request)
 
     assertEquals("sender", sep31TxnCapture.captured.fromAccount)
+    assertEquals(PENDING_RECEIVER.toString(), sep31TxnCapture.captured.status)
+    verify(exactly = 1) { txn31Store.save(any()) }
+  }
+
+  @Test
+  fun `test_handle_sep31_null_toAccount_leaves_fromAccount_unset`() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = PENDING_SENDER.toString()
+    txn31.toAccount = null
+    val sep31TxnCapture = slot<JdbcSep31Transaction>()
+
+    val ledgerTxn =
+      LedgerTransaction.builder()
+        .hash(STELLAR_TX_ID)
+        .ledger(1L)
+        .applicationOrder(1)
+        .memo(MemoHelper.toXdr(Memo.id(12345)))
+        .sourceAccount("sender")
+        .createdAt(Instant.parse(STELLAR_PAYMENT_DATE))
+        .fee(100)
+        .envelopeXdr("testEnvelopeXdr")
+        .operations(
+          listOf(
+            LedgerOperation.builder()
+              .type(OperationType.PAYMENT)
+              .paymentOperation(
+                LedgerPaymentOperation.builder()
+                  .id("11111")
+                  .amount(BigInteger.valueOf(150000000))
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("sender")
+                  .to(null)
+                  .build()
+              )
+              .build()
+          )
+        )
+        .build()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
+    every { ledgerClient.getTransaction(STELLAR_TX_ID) } returns ledgerTxn
+    every { eventSession.publish(any()) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
+      sepTransactionCounter
+
+    handler.handle(request)
+
+    assertNull(sep31TxnCapture.captured.fromAccount)
+    assertEquals(PENDING_RECEIVER.toString(), sep31TxnCapture.captured.status)
+  }
+
+  @Test
+  fun `test_handle_sep31_path_payment_is_the_matching_op_credits_correct_from_account`() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = PENDING_SENDER.toString()
+    txn31.toAccount = "distAccount"
+    val sep31TxnCapture = slot<JdbcSep31Transaction>()
+
+    val twoOpLedgerTxn =
+      LedgerTransaction.builder()
+        .hash(STELLAR_TX_ID)
+        .ledger(1L)
+        .applicationOrder(1)
+        .memo(MemoHelper.toXdr(Memo.id(12345)))
+        .sourceAccount("pathSender")
+        .createdAt(Instant.parse(STELLAR_PAYMENT_DATE))
+        .fee(100)
+        .envelopeXdr("testEnvelopeXdr")
+        .operations(
+          listOf(
+            LedgerOperation.builder()
+              .type(OperationType.PAYMENT)
+              .paymentOperation(
+                LedgerPaymentOperation.builder()
+                  .id("11111")
+                  .amount(BigInteger.ONE)
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("decoy")
+                  .to("someoneElse")
+                  .build()
+              )
+              .build(),
+            LedgerOperation.builder()
+              .type(OperationType.PATH_PAYMENT_STRICT_SEND)
+              .pathPaymentOperation(
+                LedgerPathPaymentOperation.builder()
+                  .id("22222")
+                  .type(OperationType.PATH_PAYMENT_STRICT_SEND)
+                  .amount(BigInteger.valueOf(150000000))
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("pathSender")
+                  .to("distAccount")
+                  .build()
+              )
+              .build()
+          )
+        )
+        .build()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
+    every { ledgerClient.getTransaction(STELLAR_TX_ID) } returns twoOpLedgerTxn
+    every { eventSession.publish(any()) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
+      sepTransactionCounter
+
+    handler.handle(request)
+
+    assertEquals("pathSender", sep31TxnCapture.captured.fromAccount)
     assertEquals(PENDING_RECEIVER.toString(), sep31TxnCapture.captured.status)
     verify(exactly = 1) { txn31Store.save(any()) }
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -38,6 +38,7 @@ import org.stellar.anchor.event.EventService.Session
 import org.stellar.anchor.ledger.LedgerClient
 import org.stellar.anchor.ledger.LedgerTransaction
 import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation
+import org.stellar.anchor.ledger.LedgerTransaction.LedgerPathPaymentOperation
 import org.stellar.anchor.ledger.LedgerTransaction.LedgerPaymentOperation
 import org.stellar.anchor.metrics.MetricsService
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
@@ -615,6 +616,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
         .build()
     val txn31 = JdbcSep31Transaction()
     txn31.status = PENDING_SENDER.toString()
+    txn31.toAccount = "testTo"
     val sep31TxnCapture = slot<JdbcSep31Transaction>()
     val anchorEventCapture = slot<AnchorEvent>()
 
@@ -638,6 +640,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     val expectedSep31Txn = JdbcSep31Transaction()
     expectedSep31Txn.status = PENDING_RECEIVER.toString()
     expectedSep31Txn.fromAccount = testLedgerTxn.sourceAccount
+    expectedSep31Txn.toAccount = "testTo"
     expectedSep31Txn.updatedAt = sep31TxnCapture.captured.updatedAt
     expectedSep31Txn.transferReceivedAt = Instant.parse(STELLAR_PAYMENT_DATE)
     expectedSep31Txn.stellarTransactionId = STELLAR_TX_ID
@@ -659,6 +662,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
     expectedResponse.amountOut = Amount()
     expectedResponse.amountExpected = Amount()
     expectedResponse.sourceAccount = testLedgerTxn.sourceAccount
+    expectedResponse.destinationAccount = "testTo"
     expectedResponse.stellarTransactions = stellarTransactions
     expectedResponse.customers = Customers(StellarId(), StellarId())
 
@@ -684,6 +688,143 @@ class NotifyOnchainFundsReceivedHandlerTest {
 
     assertTrue(sep31TxnCapture.captured.updatedAt >= startDate)
     assertTrue(sep31TxnCapture.captured.updatedAt <= endDate)
+  }
+
+  @Test
+  fun `test_handle_sep31_path_payment_as_first_op_credits_correct_from_account`() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = PENDING_SENDER.toString()
+    txn31.toAccount = "distAccount"
+    val sep31TxnCapture = slot<JdbcSep31Transaction>()
+
+    val twoOpLedgerTxn =
+      LedgerTransaction.builder()
+        .hash(STELLAR_TX_ID)
+        .ledger(1L)
+        .applicationOrder(1)
+        .memo(MemoHelper.toXdr(Memo.id(12345)))
+        .sourceAccount("senderFrom")
+        .createdAt(Instant.parse(STELLAR_PAYMENT_DATE))
+        .fee(100)
+        .envelopeXdr("testEnvelopeXdr")
+        .operations(
+          listOf(
+            LedgerOperation.builder()
+              .type(OperationType.PATH_PAYMENT_STRICT_SEND)
+              .pathPaymentOperation(
+                LedgerPathPaymentOperation.builder()
+                  .id("11111")
+                  .type(OperationType.PATH_PAYMENT_STRICT_SEND)
+                  .amount(BigInteger.ONE)
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("attackerFrom")
+                  .to("someoneElse")
+                  .build()
+              )
+              .build(),
+            LedgerOperation.builder()
+              .type(OperationType.PAYMENT)
+              .paymentOperation(
+                LedgerPaymentOperation.builder()
+                  .id("22222")
+                  .amount(BigInteger.valueOf(150000000))
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("senderFrom")
+                  .to("distAccount")
+                  .build()
+              )
+              .build()
+          )
+        )
+        .build()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
+    every { ledgerClient.getTransaction(STELLAR_TX_ID) } returns twoOpLedgerTxn
+    every { eventSession.publish(any()) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
+      sepTransactionCounter
+
+    handler.handle(request)
+
+    assertEquals("senderFrom", sep31TxnCapture.captured.fromAccount)
+    assertEquals(PENDING_RECEIVER.toString(), sep31TxnCapture.captured.status)
+    verify(exactly = 1) { txn31Store.save(any()) }
+  }
+
+  @Test
+  fun `test_handle_sep31_paying_op_not_at_index_0_credits_correct_from_account`() {
+    val request =
+      NotifyOnchainFundsReceivedRequest.builder()
+        .transactionId(TX_ID)
+        .stellarTransactionId(STELLAR_TX_ID)
+        .build()
+    val txn31 = JdbcSep31Transaction()
+    txn31.status = PENDING_SENDER.toString()
+    txn31.toAccount = "distAccount"
+    val sep31TxnCapture = slot<JdbcSep31Transaction>()
+
+    val twoOpLedgerTxn =
+      LedgerTransaction.builder()
+        .hash(STELLAR_TX_ID)
+        .ledger(1L)
+        .applicationOrder(1)
+        .memo(MemoHelper.toXdr(Memo.id(12345)))
+        .sourceAccount("sender")
+        .createdAt(Instant.parse(STELLAR_PAYMENT_DATE))
+        .fee(100)
+        .envelopeXdr("testEnvelopeXdr")
+        .operations(
+          listOf(
+            LedgerOperation.builder()
+              .type(OperationType.PAYMENT)
+              .paymentOperation(
+                LedgerPaymentOperation.builder()
+                  .id("11111")
+                  .amount(BigInteger.ONE)
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("attacker")
+                  .to("someoneElse")
+                  .build()
+              )
+              .build(),
+            LedgerOperation.builder()
+              .type(OperationType.PAYMENT)
+              .paymentOperation(
+                LedgerPaymentOperation.builder()
+                  .id("22222")
+                  .amount(BigInteger.valueOf(150000000))
+                  .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
+                  .from("sender")
+                  .to("distAccount")
+                  .build()
+              )
+              .build()
+          )
+        )
+        .build()
+
+    every { txn6Store.findByTransactionId(any()) } returns null
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(TX_ID) } returns txn31
+    every { txn31Store.save(capture(sep31TxnCapture)) } returns null
+    every { ledgerClient.getTransaction(STELLAR_TX_ID) } returns twoOpLedgerTxn
+    every { eventSession.publish(any()) } just Runs
+    every { metricsService.counter(PLATFORM_RPC_TRANSACTION, "SEP", "sep31") } returns
+      sepTransactionCounter
+
+    handler.handle(request)
+
+    assertEquals("sender", sep31TxnCapture.captured.fromAccount)
+    assertEquals(PENDING_RECEIVER.toString(), sep31TxnCapture.captured.status)
+    verify(exactly = 1) { txn31Store.save(any()) }
   }
 
   @CsvSource(value = ["deposit", "deposit-exchange", "withdrawal", "withdrawal-exchange"])


### PR DESCRIPTION
### Description

Before this change, `NotifyOnchainFundsReceivedHandler.updateTransactionWithRpcRequest` set `from_account` on SEP-31 transactions by taking `ledgerTxn.getOperations().get(0)` and calling `getPaymentOperation().getFrom()` on it. Two bugs followed from that:

1. **`NullPointerException`** — `getPaymentOperation()` returns `null` when the operation is a `PATH_PAYMENT_STRICT_SEND` or `PATH_PAYMENT_STRICT_RECEIVE` (those set `pathPaymentOperation`, not `paymentOperation`). Calling `.getFrom()` on null throws an NPE that escapes the `catch (LedgerException)` guard, is swallowed by `DefaultPaymentListener`'s outer catch, and leaves the SEP-31 transaction stuck in `PENDING_SENDER` permanently. The on-chain payment is received but never credited; no retry happens.

2. **Wrong sender attribution** — the operation at index 0 of the filtered list is not necessarily the one that paid the anchor. A Sending Anchor can prepend an unrelated payment at index 0; the handler would record that operation's `from` as `from_account` instead of the actual payer, corrupting the recorded sender for compliance and refund attribution.

The safe accessor `PaymentHelper.getLedgerPayment()` was already present in the same file, used correctly one line above. The SEP-31 block simply never used it.

**Changes**

- `NotifyOnchainFundsReceivedHandler`: replaced the `get(0)` + `getPaymentOperation()` block with a stream over all operations that calls `PaymentHelper.getLedgerPayment()` (null-safe for `PAYMENT`, `PATH_PAYMENT_STRICT_SEND/RECEIVE`, and `INVOKE_HOST_FUNCTION`) and filters for the first payment whose `to` address matches `txn31.getToAccount()`. Removed the now-unused `LedgerOperation` and `OperationType` imports.
- `NotifyOnchainFundsReceivedHandlerTest`:
  - Updated `test_handle_ok_sep31_withoutAmounts`: set `txn31.toAccount = "testTo"` so the filter matches the payment correctly; added `toAccount` and `destinationAccount` to the expected objects to match the updated JSON.
  - Added `test_handle_sep31_path_payment_as_first_op_credits_correct_from_account`: a two-op transaction with a `PATH_PAYMENT_STRICT_SEND` at index 0 (pointing to a different destination) and a `PAYMENT` at index 1 paying the distribution account — asserts `fromAccount` is set from the paying op and no exception is thrown.
  - Added `test_handle_sep31_paying_op_not_at_index_0_credits_correct_from_account`: a two-op transaction where a decoy `PAYMENT` to a different account is at index 0 and the real payment is at index 1 — asserts `fromAccount` is taken from the correct op.

**Acceptance Criteria**

- [x] A SEP-31 transaction settled by a `PATH_PAYMENT_STRICT_SEND` advances to `PENDING_RECEIVER` without throwing; `from_account` is set to the path-payment sender.
- [x] A multi-op transaction where the paying operation is not at index 0 records the correct sender in `from_account`.
- [x] All existing `NotifyOnchainFundsReceivedHandlerTest` tests continue to pass.

### Context

[#3793568](https://hackerone.com/reports/3793568)

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.rpc.NotifyOnchainFundsReceivedHandlerTest"`

### Documentation
N/A

### Known limitations

If `toAccount` is null on the SEP-31 transaction (i.e. the anchor never recorded where the payment should arrive), the filter finds no match and `from_account` is left unset. This is a safe-default — the alternative (setting `from_account` from an arbitrary op) is the bug being fixed.
