### PR TITLE
[ANCHOR-1212]: SEP-6 deposit persists unapproved account as to_account without enforcing destinationAccounts

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -194,7 +194,8 @@ public class Sep24Service {
       }
     }
 
-    requestValidator.validateDestinationAccount(token, sourceAccount);
+    // Validate sourceAccount
+    requestValidator.validateAccount(sourceAccount);
 
     if (token.getClientDomain() != null)
       withdrawRequest.put("client_domain", token.getClientDomain());
@@ -329,8 +330,6 @@ public class Sep24Service {
       destinationAccount = token.getAccount();
     }
 
-    requestValidator.validateDestinationAccount(token, destinationAccount);
-
     if (assetService.getAsset(assetCode, assetIssuer) == null) {
       infoF("The asset_code of the deposit request must be set.");
       throw new SepValidationException("The asset_code of the deposit request must be set");
@@ -369,6 +368,8 @@ public class Sep24Service {
             String.format("amount exceeds asset's maximum limit: %s", strAmount));
       }
     }
+
+    requestValidator.validateDestinationAccount(token, destinationAccount);
 
     if (token.getClientDomain() != null)
       depositRequest.put("client_domain", token.getClientDomain());

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -194,8 +194,7 @@ public class Sep24Service {
       }
     }
 
-    // Validate sourceAccount
-    requestValidator.validateAccount(sourceAccount);
+    requestValidator.validateDestinationAccount(token, sourceAccount);
 
     if (token.getClientDomain() != null)
       withdrawRequest.put("client_domain", token.getClientDomain());
@@ -370,9 +369,6 @@ public class Sep24Service {
             String.format("amount exceeds asset's maximum limit: %s", strAmount));
       }
     }
-
-    // validate destination account
-    requestValidator.validateAccount(destinationAccount);
 
     if (token.getClientDomain() != null)
       depositRequest.put("client_domain", token.getClientDomain());

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -49,7 +49,6 @@ import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.WebAuthJwt;
 import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.client.ClientService;
-import org.stellar.anchor.client.CustodialClient;
 import org.stellar.anchor.config.LanguageConfig;
 import org.stellar.anchor.config.Sep24Config;
 import org.stellar.anchor.config.StellarNetworkConfig;
@@ -331,26 +330,7 @@ public class Sep24Service {
       destinationAccount = token.getAccount();
     }
 
-    if (!destinationAccount.equals(token.getAccount())) {
-      CustodialClient clientConfig = clientService.getClientConfigBySigningKey(token.getAccount());
-      if (clientConfig != null && clientConfig.getDestinationAccounts() != null) {
-        if (!clientConfig.getDestinationAccounts().contains(destinationAccount)) {
-          infoF(
-              "The request account:{} for wallet:{} is not in the allowed destination accounts list",
-              destinationAccount,
-              clientConfig.getName());
-          throw new SepValidationException("Provided 'account' is not allowed");
-        }
-      } else {
-        if (clientConfig == null || !clientConfig.isAllowAnyDestination()) {
-          infoF(
-              "The request account:{} does not match the one in the token:{}",
-              destinationAccount,
-              token.getAccount());
-          throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
-        }
-      }
-    }
+    requestValidator.validateDestinationAccount(token, destinationAccount);
 
     if (assetService.getAsset(assetCode, assetIssuer) == null) {
       infoF("The asset_code of the deposit request must be set.");

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -125,7 +125,7 @@ public class Sep6Service {
           asset.getSep6().getDeposit().getMaxAmount());
     }
     String destinationAccount =
-        request.getAccount() != null ? request.getAccount() : token.getAccount();
+        StringHelper.isEmpty(request.getAccount()) ? token.getAccount() : request.getAccount();
     requestValidator.validateDestinationAccount(token, destinationAccount);
 
     String id = generateSepTransactionId();
@@ -217,7 +217,7 @@ public class Sep6Service {
         buyAsset.getSep6().getDeposit().getMinAmount(),
         buyAsset.getSep6().getDeposit().getMaxAmount());
     String destinationAccount =
-        request.getAccount() != null ? request.getAccount() : token.getAccount();
+        StringHelper.isEmpty(request.getAccount()) ? token.getAccount() : request.getAccount();
     requestValidator.validateDestinationAccount(token, destinationAccount);
 
     Amounts amounts;
@@ -324,7 +324,8 @@ public class Sep6Service {
           asset.getSep6().getWithdraw().getMinAmount(),
           asset.getSep6().getWithdraw().getMaxAmount());
     }
-    String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
+    String sourceAccount =
+        StringHelper.isEmpty(request.getAccount()) ? token.getAccount() : request.getAccount();
     requestValidator.validateDestinationAccount(token, sourceAccount);
 
     String id = generateSepTransactionId();
@@ -400,7 +401,8 @@ public class Sep6Service {
         sellAsset.getSignificantDecimals(),
         sellAsset.getSep6().getWithdraw().getMinAmount(),
         sellAsset.getSep6().getWithdraw().getMaxAmount());
-    String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
+    String sourceAccount =
+        StringHelper.isEmpty(request.getAccount()) ? token.getAccount() : request.getAccount();
     requestValidator.validateDestinationAccount(token, sourceAccount);
 
     String id = generateSepTransactionId();

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -124,7 +124,9 @@ public class Sep6Service {
           asset.getSep6().getDeposit().getMinAmount(),
           asset.getSep6().getDeposit().getMaxAmount());
     }
-    requestValidator.validateAccount(request.getAccount());
+    String destinationAccount =
+        request.getAccount() != null ? request.getAccount() : token.getAccount();
+    requestValidator.validateDestinationAccount(token, destinationAccount);
 
     String id = generateSepTransactionId();
     Sep6TransactionBuilder builder =
@@ -144,7 +146,7 @@ public class Sep6Service {
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
             .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
-            .toAccount(request.getAccount())
+            .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
             .clientName(clientFinder.getClientName(token))
             .requestClientIpAddress(request.getRequestClientIpAddress());
@@ -214,7 +216,9 @@ public class Sep6Service {
         buyAsset.getSignificantDecimals(),
         buyAsset.getSep6().getDeposit().getMinAmount(),
         buyAsset.getSep6().getDeposit().getMaxAmount());
-    requestValidator.validateAccount(request.getAccount());
+    String destinationAccount =
+        request.getAccount() != null ? request.getAccount() : token.getAccount();
+    requestValidator.validateDestinationAccount(token, destinationAccount);
 
     Amounts amounts;
     if (request.getQuoteId() != null) {
@@ -260,7 +264,7 @@ public class Sep6Service {
                     : Instant.now().plusSeconds(sep6Config.getInitialUserDeadlineSeconds()))
             .webAuthAccount(Objects.requireNonNullElse(token.getMuxedAccount(), token.getAccount()))
             .webAuthAccountMemo(token.getAccountMemo())
-            .toAccount(request.getAccount())
+            .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
             .clientName(clientFinder.getClientName(token))
             .quoteId(request.getQuoteId())
@@ -321,7 +325,7 @@ public class Sep6Service {
           asset.getSep6().getWithdraw().getMaxAmount());
     }
     String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
-    requestValidator.validateAccount(sourceAccount);
+    requestValidator.validateDestinationAccount(token, sourceAccount);
 
     String id = generateSepTransactionId();
 
@@ -397,7 +401,7 @@ public class Sep6Service {
         sellAsset.getSep6().getWithdraw().getMinAmount(),
         sellAsset.getSep6().getWithdraw().getMaxAmount());
     String sourceAccount = request.getAccount() != null ? request.getAccount() : token.getAccount();
-    requestValidator.validateAccount(sourceAccount);
+    requestValidator.validateDestinationAccount(token, sourceAccount);
 
     String id = generateSepTransactionId();
 

--- a/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
@@ -6,6 +6,7 @@ import static org.stellar.anchor.util.MathHelper.decimal;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.stellar.anchor.api.asset.StellarAssetInfo;
@@ -222,6 +223,90 @@ public class SepRequestValidator {
               "invalid type %s for asset %s, supported types are %s",
               requestType, assetCode, validTypes));
     }
+  }
+
+  /**
+   * Validates that the resolved destination account is permitted by the operator-configured
+   * destination policy (CustodialClient.destinationAccounts / allowAnyDestination), then verifies
+   * the address is syntactically valid. The caller is responsible for resolving the account to the
+   * SEP-10 subject when the request omits it (i.e. pass token.getAccount() when the request field
+   * is empty).
+   *
+   * @param token the SEP-10 JWT of the authenticated client
+   * @param destinationAccount the already-resolved destination account
+   * @throws SepValidationException if the account is not permitted or syntactically invalid
+   */
+  public void validateDestinationAccount(WebAuthJwt token, String destinationAccount)
+      throws AnchorException {
+    validateDestinationAccount(token.getAccount(), destinationAccount);
+  }
+
+  public void validateDestinationAccount(String webAuthAccount, String destinationAccount)
+      throws AnchorException {
+    String webAuthBase = webAuthAccount;
+    try {
+      if (SepHelper.accountType(webAuthAccount) == SepHelper.AccountType.Muxed) {
+        webAuthBase = new MuxedAccount(webAuthAccount).getAccountId();
+      }
+    } catch (RuntimeException ex) {
+      throw new SepValidationException(
+          String.format("invalid token account %s", webAuthAccount), ex);
+    }
+
+    String destinationBase = destinationAccount;
+    SepHelper.AccountType destAccountType;
+    try {
+      destAccountType = SepHelper.accountType(destinationAccount);
+    } catch (IllegalArgumentException ex) {
+      throw new SepValidationException(String.format("invalid account %s", destinationAccount), ex);
+    }
+    if (destAccountType == SepHelper.AccountType.Muxed) {
+      try {
+        destinationBase = new MuxedAccount(destinationAccount).getAccountId();
+      } catch (RuntimeException ex) {
+        Log.warnF(
+            "Failed to demux destination account {}: {}", destinationAccount, ex.getMessage());
+      }
+    }
+
+    if (!destinationBase.equals(webAuthBase)) {
+      CustodialClient clientConfig = clientService.getClientConfigBySigningKey(webAuthBase);
+
+      if (clientConfig == null) {
+        Log.infoF(
+            "The request account:{} does not match the one in the token:{}",
+            destinationAccount,
+            webAuthAccount);
+        throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
+      }
+
+      if (clientConfig.isAllowAnyDestination()) {
+        Log.infoF(
+            "The request account:{} for wallet:{} is allowed to use any destination",
+            destinationAccount,
+            webAuthAccount);
+      } else {
+        Set<String> destinationAccounts = clientConfig.getDestinationAccounts();
+        if (destinationAccounts != null && !destinationAccounts.isEmpty()) {
+          if (!destinationAccounts.contains(destinationBase)) {
+            Log.infoF(
+                "The request account:{} for wallet:{} is not in the allowed destination accounts"
+                    + " list",
+                destinationAccount,
+                webAuthAccount);
+            throw new SepValidationException("Provided 'account' is not allowed");
+          }
+        } else {
+          Log.infoF(
+              "The request account:{} does not match the one in the token:{}",
+              destinationAccount,
+              webAuthAccount);
+          throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
+        }
+      }
+    }
+
+    validateAccount(destinationAccount);
   }
 
   /**

--- a/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
@@ -277,6 +277,7 @@ public class SepRequestValidator {
             "The request account:{} does not match the one in the token:{}",
             destinationAccount,
             webAuthAccount);
+
         throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
       }
 

--- a/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
@@ -6,7 +6,6 @@ import static org.stellar.anchor.util.MathHelper.decimal;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.stellar.anchor.api.asset.StellarAssetInfo;
@@ -23,7 +22,8 @@ import org.stellar.sdk.scval.Scv;
 /** SEP request validations */
 @RequiredArgsConstructor
 public class SepRequestValidator {
-  static final String ERR_TOKEN_ACCOUNT_MISMATCH = "'account' does not match the one in the token";
+  public static final String ERR_TOKEN_ACCOUNT_MISMATCH =
+      "'account' does not match the one in the token";
 
   @NonNull private final AssetService assetService;
   @NonNull private final ClientService clientService;
@@ -274,45 +274,27 @@ public class SepRequestValidator {
             "Failed to demux destination account {}: {}", destinationAccount, ex.getMessage());
       }
     }
-
     if (!destinationBase.equals(webAuthBase)) {
       CustodialClient clientConfig = clientService.getClientConfigBySigningKey(webAuthBase);
-
-      if (clientConfig == null) {
+      if (clientConfig != null && clientConfig.isAllowAnyDestination()) {
+      } else if (clientConfig != null
+          && clientConfig.getDestinationAccounts() != null
+          && !clientConfig.getDestinationAccounts().isEmpty()) {
+        if (!clientConfig.getDestinationAccounts().contains(destinationBase)) {
+          Log.infoF(
+              "The request account:{} for wallet:{} is not in the allowed destination accounts list",
+              destinationAccount,
+              clientConfig.getName());
+          throw new SepValidationException("Provided 'account' is not allowed");
+        }
+      } else {
         Log.infoF(
             "The request account:{} does not match the one in the token:{}",
             destinationAccount,
             webAuthAccount);
-
         throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
       }
-
-      if (clientConfig.isAllowAnyDestination()) {
-        Log.infoF(
-            "The request account:{} for wallet:{} is allowed to use any destination",
-            destinationAccount,
-            webAuthAccount);
-      } else {
-        Set<String> destinationAccounts = clientConfig.getDestinationAccounts();
-        if (destinationAccounts != null && !destinationAccounts.isEmpty()) {
-          if (!destinationAccounts.contains(destinationBase)) {
-            Log.infoF(
-                "The request account:{} for wallet:{} is not in the allowed destination accounts"
-                    + " list",
-                destinationAccount,
-                webAuthAccount);
-            throw new SepValidationException("Provided 'account' is not allowed");
-          }
-        } else {
-          Log.infoF(
-              "The request account:{} does not match the one in the token:{}",
-              destinationAccount,
-              webAuthAccount);
-          throw new SepValidationException(ERR_TOKEN_ACCOUNT_MISMATCH);
-        }
-      }
     }
-
     validateAccount(destinationAccount);
   }
 

--- a/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/SepRequestValidator.java
@@ -13,6 +13,9 @@ import org.stellar.anchor.api.asset.StellarAssetInfo;
 import org.stellar.anchor.api.exception.*;
 import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.client.ClientService;
+import org.stellar.anchor.client.CustodialClient;
 import org.stellar.sdk.Address;
 import org.stellar.sdk.MuxedAccount;
 import org.stellar.sdk.scval.Scv;
@@ -20,7 +23,10 @@ import org.stellar.sdk.scval.Scv;
 /** SEP request validations */
 @RequiredArgsConstructor
 public class SepRequestValidator {
+  static final String ERR_TOKEN_ACCOUNT_MISMATCH = "'account' does not match the one in the token";
+
   @NonNull private final AssetService assetService;
+  @NonNull private final ClientService clientService;
 
   public static void validateAmount(String amount) throws AnchorException {
     validateAmount("", amount);

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -129,7 +129,7 @@ internal class Sep24ServiceTest {
     secretConfig.setupMock()
     every { txnStore.newInstance() } returns PojoSep24Transaction()
 
-    requestValidator = spyk(SepRequestValidator(assetService))
+    requestValidator = spyk(SepRequestValidator(assetService, clientService))
     jwtService = spyk(JwtService(secretConfig))
     testInteractiveUrlJwt = createTestInteractiveJwt(null)
     val strToken = jwtService.encode(testInteractiveUrlJwt)

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -491,46 +491,6 @@ internal class Sep24ServiceTest {
   }
 
   @Test
-  fun `test deposit rejects account outside destination policy`() {
-    val attackerAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-    every { clientService.getClientConfigBySigningKey(any()) } returns
-      CustodialClient.builder()
-        .name("referenceCustodial")
-        .signingKeys(setOf("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"))
-        .allowAnyDestination(false)
-        .destinationAccounts(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
-        .build()
-    val request = createTestTransactionRequest()
-    request["account"] = attackerAccount
-
-    val ex =
-      assertThrows<SepValidationException> { sep24Service.deposit(createTestWebAuthJwt(), request) }
-    assertEquals("Provided 'account' is not allowed", ex.message)
-    verify { txnStore wasNot Called }
-  }
-
-  @Test
-  fun `test withdraw rejects account outside destination policy`() {
-    val attackerAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-    every { clientService.getClientConfigBySigningKey(any()) } returns
-      CustodialClient.builder()
-        .name("referenceCustodial")
-        .signingKeys(setOf("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"))
-        .allowAnyDestination(false)
-        .destinationAccounts(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
-        .build()
-    val request = createTestTransactionRequest()
-    request["account"] = attackerAccount
-
-    val ex =
-      assertThrows<SepValidationException> {
-        sep24Service.withdraw(createTestWebAuthJwt(), request)
-      }
-    assertEquals("Provided 'account' is not allowed", ex.message)
-    verify { txnStore wasNot Called }
-  }
-
-  @Test
   fun `test deposit with bad requests`() {
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -491,6 +491,46 @@ internal class Sep24ServiceTest {
   }
 
   @Test
+  fun `test deposit rejects account outside destination policy`() {
+    val attackerAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { clientService.getClientConfigBySigningKey(any()) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"))
+        .allowAnyDestination(false)
+        .destinationAccounts(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
+        .build()
+    val request = createTestTransactionRequest()
+    request["account"] = attackerAccount
+
+    val ex =
+      assertThrows<SepValidationException> { sep24Service.deposit(createTestWebAuthJwt(), request) }
+    assertEquals("Provided 'account' is not allowed", ex.message)
+    verify { txnStore wasNot Called }
+  }
+
+  @Test
+  fun `test withdraw rejects account outside destination policy`() {
+    val attackerAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { clientService.getClientConfigBySigningKey(any()) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"))
+        .allowAnyDestination(false)
+        .destinationAccounts(setOf("GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"))
+        .build()
+    val request = createTestTransactionRequest()
+    request["account"] = attackerAccount
+
+    val ex =
+      assertThrows<SepValidationException> {
+        sep24Service.withdraw(createTestWebAuthJwt(), request)
+      }
+    assertEquals("Provided 'account' is not allowed", ex.message)
+    verify { txnStore wasNot Called }
+  }
+
+  @Test
   fun `test deposit with bad requests`() {
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -134,7 +134,12 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -189,7 +194,12 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -336,7 +346,12 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -391,7 +406,12 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) {
@@ -472,7 +492,12 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -648,7 +673,12 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -690,7 +720,12 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -752,7 +787,12 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) { requestValidator.validateAccount("requested_account") }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        "requested_account"
+      )
+    }
 
     // Verify effects
     assertEquals("requested_account", slotTxn.captured.fromAccount)
@@ -777,7 +817,12 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -923,7 +968,12 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -976,7 +1026,12 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) {
@@ -1050,7 +1105,12 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -1118,7 +1178,12 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) { requestValidator.validateAccount("requested_account") }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        "requested_account"
+      )
+    }
 
     // Verify effects
     assertEquals("requested_account", slotTxn.captured.fromAccount)
@@ -1264,7 +1329,12 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) { requestValidator.validateAccount(TEST_ACCOUNT) }
+    verify(exactly = 1) {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        TEST_ACCOUNT
+      )
+    }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -316,6 +316,27 @@ class Sep6ServiceTest {
   }
 
   @Test
+  fun `test deposit rejects account outside destination policy`() {
+    val attacker = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(attacker)
+        .fundingMethod("bank_account")
+        .build()
+    every {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        attacker,
+      )
+    } throws SepValidationException("Provided 'account' is not allowed")
+
+    assertThrows<SepValidationException> { sep6Service.deposit(token, request) }
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
   fun `test deposit does not send event if transaction fails to save`() {
     every { txnStore.save(any()) } throws RuntimeException("unexpected failure")
 
@@ -934,6 +955,22 @@ class Sep6ServiceTest {
     }
 
     // Verify effects
+    verify { txnStore wasNot Called }
+    verify { eventSession wasNot Called }
+  }
+
+  @Test
+  fun `test withdraw rejects account outside destination policy`() {
+    val attacker = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
+    val request = StartWithdrawRequest.builder().assetCode(TEST_ASSET).account(attacker).build()
+    every {
+      requestValidator.validateDestinationAccount(
+        any<org.stellar.anchor.auth.WebAuthJwt>(),
+        attacker,
+      )
+    } throws SepValidationException("Provided 'account' is not allowed")
+
+    assertThrows<SepValidationException> { sep6Service.withdraw(token, request) }
     verify { txnStore wasNot Called }
     verify { eventSession wasNot Called }
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -34,6 +34,8 @@ import org.stellar.anchor.api.shared.Refunds
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.client.ClientFinder
+import org.stellar.anchor.client.ClientService
+import org.stellar.anchor.client.CustodialClient
 import org.stellar.anchor.config.LanguageConfig
 import org.stellar.anchor.config.Sep6Config
 import org.stellar.anchor.config.StellarNetworkConfig
@@ -55,6 +57,7 @@ class Sep6ServiceTest {
   @MockK(relaxed = true) lateinit var stellarNetworkConfig: StellarNetworkConfig
   @MockK(relaxed = true) lateinit var sep6Config: Sep6Config
   @MockK(relaxed = true) lateinit var requestValidator: SepRequestValidator
+  @MockK(relaxed = true) lateinit var clientService: ClientService
   @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
   @MockK(relaxed = true) lateinit var txnStore: Sep6TransactionStore
   @MockK(relaxed = true) lateinit var exchangeAmountsCalculator: ExchangeAmountsCalculator
@@ -63,6 +66,7 @@ class Sep6ServiceTest {
   @MockK(relaxed = true) lateinit var sep6MoreInfoUrlConstructor: MoreInfoUrlConstructor
 
   private lateinit var sep6Service: Sep6Service
+  private lateinit var sep6ServiceWithRealValidator: Sep6Service
 
   @BeforeEach
   fun setup() {
@@ -82,6 +86,21 @@ class Sep6ServiceTest {
         sep6Config,
         assetService,
         requestValidator,
+        clientFinder,
+        txnStore,
+        exchangeAmountsCalculator,
+        eventService,
+        sep6MoreInfoUrlConstructor,
+      )
+    val realValidator = spyk(SepRequestValidator(assetService, clientService))
+    every { realValidator.getDepositAsset(TEST_ASSET) } returns asset
+    every { realValidator.getWithdrawAsset(TEST_ASSET) } returns asset
+    sep6ServiceWithRealValidator =
+      Sep6Service(
+        languageConfig,
+        sep6Config,
+        assetService,
+        realValidator,
         clientFinder,
         txnStore,
         exchangeAmountsCalculator,
@@ -134,12 +153,7 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -194,12 +208,7 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getDepositAsset(TEST_ASSET) }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -229,6 +238,112 @@ class Sep6ServiceTest {
       gson.toJson(response),
       JSONCompareMode.LENIENT,
     )
+  }
+
+  @Test
+  fun `test deposit rejects unauthorized destination account`() {
+    val attackerAccount = "GATTACKER00000000000000000000000000000000000000000000000000"
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(attackerAccount)
+        .fundingMethod("bank_account")
+        .build()
+    every { requestValidator.validateDestinationAccount(token, attackerAccount) } throws
+      SepValidationException("Provided 'account' is not allowed")
+
+    assertThrows<SepValidationException> { sep6Service.deposit(token, request) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test depositExchange rejects unauthorized destination account`() {
+    val attackerAccount = "GATTACKER00000000000000000000000000000000000000000000000000"
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .amount("100")
+        .account(attackerAccount)
+        .fundingMethod("SWIFT")
+        .build()
+    every { requestValidator.validateDestinationAccount(token, attackerAccount) } throws
+      SepValidationException("Provided 'account' is not allowed")
+
+    assertThrows<SepValidationException> { sep6Service.depositExchange(token, request) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test withdraw rejects unauthorized source account`() {
+    val attackerAccount = "GATTACKER00000000000000000000000000000000000000000000000000"
+    val request =
+      StartWithdrawRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(attackerAccount)
+        .fundingMethod("bank_account")
+        .build()
+    every { requestValidator.validateDestinationAccount(token, attackerAccount) } throws
+      SepValidationException("'account' does not match the one in the token")
+
+    assertThrows<SepValidationException> { sep6Service.withdraw(token, request) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test withdrawExchange rejects unauthorized source account`() {
+    val attackerAccount = "GATTACKER00000000000000000000000000000000000000000000000000"
+    val request =
+      StartWithdrawExchangeRequest.builder()
+        .sourceAsset(TEST_ASSET)
+        .destinationAsset("iso4217:USD")
+        .amount("100")
+        .account(attackerAccount)
+        .fundingMethod("bank_account")
+        .build()
+    every { requestValidator.validateDestinationAccount(token, attackerAccount) } throws
+      SepValidationException("'account' does not match the one in the token")
+
+    assertThrows<SepValidationException> { sep6Service.withdrawExchange(token, request) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test withdraw with empty account defaults to token subject`() {
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartWithdrawRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account("")
+        .fundingMethod("bank_account")
+        .build()
+    sep6Service.withdraw(token, request)
+
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
+    assertEquals(TEST_ACCOUNT, slotTxn.captured.fromAccount)
+  }
+
+  @Test
+  fun `test withdrawExchange with empty account defaults to token subject`() {
+    val slotTxn = slot<Sep6Transaction>()
+    every { txnStore.save(capture(slotTxn)) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartWithdrawExchangeRequest.builder()
+        .sourceAsset(TEST_ASSET)
+        .destinationAsset("iso4217:USD")
+        .amount("100")
+        .account("")
+        .fundingMethod("bank_account")
+        .build()
+    sep6Service.withdrawExchange(token, request)
+
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
+    assertEquals(TEST_ACCOUNT, slotTxn.captured.fromAccount)
   }
 
   @Test
@@ -316,27 +431,6 @@ class Sep6ServiceTest {
   }
 
   @Test
-  fun `test deposit rejects account outside destination policy`() {
-    val attacker = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
-    val request =
-      StartDepositRequest.builder()
-        .assetCode(TEST_ASSET)
-        .account(attacker)
-        .fundingMethod("bank_account")
-        .build()
-    every {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        attacker,
-      )
-    } throws SepValidationException("Provided 'account' is not allowed")
-
-    assertThrows<SepValidationException> { sep6Service.deposit(token, request) }
-    verify { txnStore wasNot Called }
-    verify { eventSession wasNot Called }
-  }
-
-  @Test
   fun `test deposit does not send event if transaction fails to save`() {
     every { txnStore.save(any()) } throws RuntimeException("unexpected failure")
 
@@ -367,12 +461,7 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -427,12 +516,7 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) {
@@ -513,12 +597,7 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -694,12 +773,7 @@ class Sep6ServiceTest {
         asset.sep6.deposit.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -741,12 +815,7 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -808,12 +877,7 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        "requested_account"
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, "requested_account") }
 
     // Verify effects
     assertEquals("requested_account", slotTxn.captured.fromAccount)
@@ -838,12 +902,7 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -960,22 +1019,6 @@ class Sep6ServiceTest {
   }
 
   @Test
-  fun `test withdraw rejects account outside destination policy`() {
-    val attacker = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
-    val request = StartWithdrawRequest.builder().assetCode(TEST_ASSET).account(attacker).build()
-    every {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        attacker,
-      )
-    } throws SepValidationException("Provided 'account' is not allowed")
-
-    assertThrows<SepValidationException> { sep6Service.withdraw(token, request) }
-    verify { txnStore wasNot Called }
-    verify { eventSession wasNot Called }
-  }
-
-  @Test
   fun `test withdraw does not send event if transaction fails to save`() {
     every { txnStore.save(any()) } throws RuntimeException("unexpected failure")
 
@@ -1005,12 +1048,7 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -1063,12 +1101,7 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) {
@@ -1142,12 +1175,7 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -1215,12 +1243,7 @@ class Sep6ServiceTest {
 
     // Verify validations
     verify(exactly = 1) { requestValidator.getWithdrawAsset(TEST_ASSET) }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        "requested_account"
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, "requested_account") }
 
     // Verify effects
     assertEquals("requested_account", slotTxn.captured.fromAccount)
@@ -1366,12 +1389,7 @@ class Sep6ServiceTest {
         asset.sep6.withdraw.maxAmount,
       )
     }
-    verify(exactly = 1) {
-      requestValidator.validateDestinationAccount(
-        any<org.stellar.anchor.auth.WebAuthJwt>(),
-        TEST_ACCOUNT
-      )
-    }
+    verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
 
     // Verify effects
     verify(exactly = 1) { txnStore.save(any()) }
@@ -1770,5 +1788,104 @@ class Sep6ServiceTest {
         .build()
     val ex = assertThrows<BadRequestException> { sep6Service.withdrawExchange(token, request) }
     assert(ex.message!!.contains("has already been used"))
+  }
+
+  @Test
+  fun `test deposit enforces destination policy — rejects account not on allowlist`() {
+    val allowedAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val attackerAccount = "GC6TP2RCW665CBOTMR5Q2JXNRK77FWV2FCTHNQXS3FNDMWZCGJBJ4QCY"
+    every { clientService.getClientConfigBySigningKey(TEST_ACCOUNT) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf(TEST_ACCOUNT))
+        .allowAnyDestination(false)
+        .destinationAccounts(setOf(allowedAccount))
+        .build()
+
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(attackerAccount)
+        .fundingMethod("SWIFT")
+        .build()
+
+    assertThrows<SepValidationException> { sep6ServiceWithRealValidator.deposit(token, request) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test deposit enforces destination policy — allows account on allowlist`() {
+    val whitelistedAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { clientService.getClientConfigBySigningKey(TEST_ACCOUNT) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf(TEST_ACCOUNT))
+        .allowAnyDestination(false)
+        .destinationAccounts(setOf(whitelistedAccount))
+        .build()
+    every { txnStore.save(any()) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(whitelistedAccount)
+        .fundingMethod("SWIFT")
+        .build()
+
+    val response = sep6ServiceWithRealValidator.deposit(token, request)
+    assertNotNull(response.id)
+    verify(exactly = 1) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test depositExchange enforces destination policy — rejects account not on allowlist`() {
+    val allowedAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val attackerAccount = "GC6TP2RCW665CBOTMR5Q2JXNRK77FWV2FCTHNQXS3FNDMWZCGJBJ4QCY"
+    every { clientService.getClientConfigBySigningKey(TEST_ACCOUNT) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf(TEST_ACCOUNT))
+        .allowAnyDestination(false)
+        .destinationAccounts(setOf(allowedAccount))
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .amount("100")
+        .account(attackerAccount)
+        .fundingMethod("SWIFT")
+        .build()
+
+    assertThrows<SepValidationException> {
+      sep6ServiceWithRealValidator.depositExchange(token, request)
+    }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test deposit allows any destination when allowAnyDestination is true`() {
+    val anyAccount = "GC6TP2RCW665CBOTMR5Q2JXNRK77FWV2FCTHNQXS3FNDMWZCGJBJ4QCY"
+    every { clientService.getClientConfigBySigningKey(TEST_ACCOUNT) } returns
+      CustodialClient.builder()
+        .name("referenceCustodial")
+        .signingKeys(setOf(TEST_ACCOUNT))
+        .allowAnyDestination(true)
+        .build()
+    every { txnStore.save(any()) } returns null
+    every { eventSession.publish(any()) } returns Unit
+
+    val request =
+      StartDepositRequest.builder()
+        .assetCode(TEST_ASSET)
+        .account(anyAccount)
+        .fundingMethod("SWIFT")
+        .build()
+
+    val response = sep6ServiceWithRealValidator.deposit(token, request)
+    assertNotNull(response.id)
+    verify(exactly = 1) { txnStore.save(any()) }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/util/SepRequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/SepRequestValidatorTest.kt
@@ -6,6 +6,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,16 +17,23 @@ import org.stellar.anchor.api.asset.StellarAssetInfo
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.client.ClientService
+import org.stellar.anchor.client.CustodialClient
 
 class SepRequestValidatorTest {
   @MockK(relaxed = true) lateinit var assetService: AssetService
+  @MockK(relaxed = true) lateinit var clientService: ClientService
 
   private lateinit var requestValidator: SepRequestValidator
+
+  private val TOKEN_ACCOUNT = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+  private val OTHER_ACCOUNT = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
 
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this, relaxUnitFun = true)
-    requestValidator = SepRequestValidator(assetService)
+    requestValidator = SepRequestValidator(assetService, clientService)
   }
 
   @Test
@@ -206,5 +214,82 @@ class SepRequestValidatorTest {
   )
   fun `test static validateAmount accepts reasonable amounts`(amount: String) {
     SepRequestValidator.validateAmount("", amount, false)
+  }
+
+  private fun mockToken(account: String): WebAuthJwt {
+    val token = mockk<WebAuthJwt>()
+    every { token.account } returns account
+    return token
+  }
+
+  @Test
+  fun `validateDestinationAccount passes when destination matches token subject`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, TOKEN_ACCOUNT) }
+  }
+
+  @Test
+  fun `validateDestinationAccount rejects when no client config and accounts differ`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns null
+    assertThrows<SepValidationException> {
+      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
+    }
+  }
+
+  @Test
+  fun `validateDestinationAccount allows when allowAnyDestination is true`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    val clientConfig = mockk<CustodialClient>()
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
+    every { clientConfig.isAllowAnyDestination } returns true
+    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT) }
+  }
+
+  @Test
+  fun `validateDestinationAccount allows when destination is in allowlist`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    val clientConfig = mockk<CustodialClient>()
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
+    every { clientConfig.isAllowAnyDestination } returns false
+    every { clientConfig.destinationAccounts } returns setOf(OTHER_ACCOUNT)
+    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT) }
+  }
+
+  @Test
+  fun `validateDestinationAccount rejects when destination is not in allowlist`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    val clientConfig = mockk<CustodialClient>()
+    val thirdAccount = "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
+    every { clientConfig.isAllowAnyDestination } returns false
+    every { clientConfig.destinationAccounts } returns setOf(OTHER_ACCOUNT)
+    assertThrows<SepValidationException> {
+      requestValidator.validateDestinationAccount(token, thirdAccount)
+    }
+  }
+
+  @Test
+  fun `validateDestinationAccount rejects when allowlist is empty and allowAnyDestination is false`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    val clientConfig = mockk<CustodialClient>()
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
+    every { clientConfig.isAllowAnyDestination } returns false
+    every { clientConfig.destinationAccounts } returns emptySet()
+    assertThrows<SepValidationException> {
+      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
+    }
+  }
+
+  @Test
+  fun `validateDestinationAccount rejects when allowlist is null and allowAnyDestination is false`() {
+    val token = mockToken(TOKEN_ACCOUNT)
+    val clientConfig = mockk<CustodialClient>()
+    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
+    every { clientConfig.isAllowAnyDestination } returns false
+    every { clientConfig.destinationAccounts } returns null
+    assertThrows<SepValidationException> {
+      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
+    }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/util/SepRequestValidatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/SepRequestValidatorTest.kt
@@ -4,20 +4,20 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
+import org.stellar.anchor.TestHelper
 import org.stellar.anchor.api.asset.DepositWithdrawOperation
 import org.stellar.anchor.api.asset.Sep6Info
 import org.stellar.anchor.api.asset.StellarAssetInfo
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.asset.AssetService
-import org.stellar.anchor.auth.WebAuthJwt
 import org.stellar.anchor.client.ClientService
 import org.stellar.anchor.client.CustodialClient
 
@@ -26,9 +26,6 @@ class SepRequestValidatorTest {
   @MockK(relaxed = true) lateinit var clientService: ClientService
 
   private lateinit var requestValidator: SepRequestValidator
-
-  private val TOKEN_ACCOUNT = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-  private val OTHER_ACCOUNT = "GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO"
 
   @BeforeEach
   fun setup() {
@@ -216,80 +213,234 @@ class SepRequestValidatorTest {
     SepRequestValidator.validateAmount("", amount, false)
   }
 
-  private fun mockToken(account: String): WebAuthJwt {
-    val token = mockk<WebAuthJwt>()
-    every { token.account } returns account
-    return token
+  @Test
+  fun `test validateDestinationAccount allows destination matching token account`() {
+    val token = TestHelper.createWebAuthJwt()
+    requestValidator.validateDestinationAccount(token, token.account)
   }
 
   @Test
-  fun `validateDestinationAccount passes when destination matches token subject`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, TOKEN_ACCOUNT) }
+  fun `test validateDestinationAccount allows muxed destination whose base account matches token`() {
+    val token = TestHelper.createWebAuthJwt()
+    val muxedDestination =
+      org.stellar.sdk.MuxedAccount(token.account, java.math.BigInteger.valueOf(99L)).address
+    requestValidator.validateDestinationAccount(token, muxedDestination)
   }
 
   @Test
-  fun `validateDestinationAccount rejects when no client config and accounts differ`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns null
+  fun `test validateDestinationAccount allows destination on client allowlist`() {
+    val token = TestHelper.createWebAuthJwt()
+    val allowedAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .destinationAccounts(setOf(allowedAccount))
+        .build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    requestValidator.validateDestinationAccount(token, allowedAccount)
+  }
+
+  @Test
+  fun `test validateDestinationAccount allows destination when allowAnyDestination is true`() {
+    val token = TestHelper.createWebAuthJwt()
+    val anyAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client = CustodialClient.builder().name("test-client").allowAnyDestination(true).build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    requestValidator.validateDestinationAccount(token, anyAccount)
+  }
+
+  @Test
+  fun `test validateDestinationAccount allows destination when allowAnyDestination is true even if destinationAccounts would not contain it`() {
+    val token = TestHelper.createWebAuthJwt()
+    val destination = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .allowAnyDestination(true)
+        .destinationAccounts(setOf("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBXT0E4EPJOS2W2YNHH6K"))
+        .build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    requestValidator.validateDestinationAccount(token, destination)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects destination not on allowlist with account-not-allowed message`() {
+    val token = TestHelper.createWebAuthJwt()
+    val attackerAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .destinationAccounts(setOf("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBXT0E4EPJOS2W2YNHH6K"))
+        .build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    val ex =
+      assertThrows<SepValidationException> {
+        requestValidator.validateDestinationAccount(token, attackerAccount)
+      }
+    assertEquals("Provided 'account' is not allowed", ex.message)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects empty destinationAccounts with token-mismatch message`() {
+    val token = TestHelper.createWebAuthJwt()
+    val differentAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .allowAnyDestination(false)
+        .destinationAccounts(emptySet())
+        .build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    val ex =
+      assertThrows<SepValidationException> {
+        requestValidator.validateDestinationAccount(token, differentAccount)
+      }
+    assertEquals(SepRequestValidator.ERR_TOKEN_ACCOUNT_MISMATCH, ex.message)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects when client config is null and account differs`() {
+    val token = TestHelper.createWebAuthJwt()
+    val differentAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { clientService.getClientConfigBySigningKey(token.account) } returns null
+
+    val ex =
+      assertThrows<SepValidationException> {
+        requestValidator.validateDestinationAccount(token, differentAccount)
+      }
+    assertEquals(SepRequestValidator.ERR_TOKEN_ACCOUNT_MISMATCH, ex.message)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects when client has no allowlist and allowAnyDestination is false`() {
+    val token = TestHelper.createWebAuthJwt()
+    val differentAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client = CustodialClient.builder().name("test-client").allowAnyDestination(false).build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    val ex =
+      assertThrows<SepValidationException> {
+        requestValidator.validateDestinationAccount(token, differentAccount)
+      }
+    assertEquals(SepRequestValidator.ERR_TOKEN_ACCOUNT_MISMATCH, ex.message)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects malformed muxed webAuthAccount`() {
     assertThrows<SepValidationException> {
-      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
+      requestValidator.validateDestinationAccount("MINVALIDMUXEDADDRESS", TestHelper.TEST_ACCOUNT)
     }
   }
 
   @Test
-  fun `validateDestinationAccount allows when allowAnyDestination is true`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    val clientConfig = mockk<CustodialClient>()
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
-    every { clientConfig.isAllowAnyDestination } returns true
-    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT) }
+  fun `test validateDestinationAccount accepts muxed destination when allowlist holds the base address`() {
+    val token = TestHelper.createWebAuthJwt()
+    val allowedBase = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val muxedDestination =
+      org.stellar.sdk.MuxedAccount(allowedBase, java.math.BigInteger.valueOf(42L)).address
+    val client =
+      CustodialClient.builder().name("test-client").destinationAccounts(setOf(allowedBase)).build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
+
+    requestValidator.validateDestinationAccount(token, muxedDestination)
   }
 
   @Test
-  fun `validateDestinationAccount allows when destination is in allowlist`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    val clientConfig = mockk<CustodialClient>()
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
-    every { clientConfig.isAllowAnyDestination } returns false
-    every { clientConfig.destinationAccounts } returns setOf(OTHER_ACCOUNT)
-    assertDoesNotThrow { requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT) }
-  }
+  fun `test validateDestinationAccount rejects muxed destination not on allowlist`() {
+    val token = TestHelper.createWebAuthJwt()
+    val allowedBase = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val muxedDestination =
+      org.stellar.sdk.MuxedAccount(allowedBase, java.math.BigInteger.valueOf(42L)).address
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .destinationAccounts(setOf("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBXT0E4EPJOS2W2YNHH6K"))
+        .build()
+    every { clientService.getClientConfigBySigningKey(token.account) } returns client
 
-  @Test
-  fun `validateDestinationAccount rejects when destination is not in allowlist`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    val clientConfig = mockk<CustodialClient>()
-    val thirdAccount = "GACYKME36AI6UYAV7A5ZUA6MG4C4K2VAPNYMW5YLOM6E7GS6FSHDPV4F"
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
-    every { clientConfig.isAllowAnyDestination } returns false
-    every { clientConfig.destinationAccounts } returns setOf(OTHER_ACCOUNT)
     assertThrows<SepValidationException> {
-      requestValidator.validateDestinationAccount(token, thirdAccount)
+      requestValidator.validateDestinationAccount(token, muxedDestination)
     }
   }
 
   @Test
-  fun `validateDestinationAccount rejects when allowlist is empty and allowAnyDestination is false`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    val clientConfig = mockk<CustodialClient>()
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
-    every { clientConfig.isAllowAnyDestination } returns false
-    every { clientConfig.destinationAccounts } returns emptySet()
-    assertThrows<SepValidationException> {
-      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
-    }
+  fun `test validateDestinationAccount allows classic destination when webAuthAccount is muxed`() {
+    val muxedWebAuth =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(7L))
+        .address
+    requestValidator.validateDestinationAccount(muxedWebAuth, TestHelper.TEST_ACCOUNT)
   }
 
   @Test
-  fun `validateDestinationAccount rejects when allowlist is null and allowAnyDestination is false`() {
-    val token = mockToken(TOKEN_ACCOUNT)
-    val clientConfig = mockk<CustodialClient>()
-    every { clientService.getClientConfigBySigningKey(TOKEN_ACCOUNT) } returns clientConfig
-    every { clientConfig.isAllowAnyDestination } returns false
-    every { clientConfig.destinationAccounts } returns null
+  fun `test validateDestinationAccount allows muxed destination when webAuthAccount is muxed with same base`() {
+    val muxedWebAuth =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(1L))
+        .address
+    val muxedDestination =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(2L))
+        .address
+    requestValidator.validateDestinationAccount(muxedWebAuth, muxedDestination)
+  }
+
+  @Test
+  fun `test validateDestinationAccount looks up client by base address when webAuthAccount is muxed`() {
+    val muxedWebAuth =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(5L))
+        .address
+    val allowedAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .destinationAccounts(setOf(allowedAccount))
+        .build()
+    every { clientService.getClientConfigBySigningKey(TestHelper.TEST_ACCOUNT) } returns client
+
+    requestValidator.validateDestinationAccount(muxedWebAuth, allowedAccount)
+  }
+
+  @Test
+  fun `test validateDestinationAccount accepts muxed destination whose base is on the allowlist`() {
+    val muxedWebAuth =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(3L))
+        .address
+    val allowedBase = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val muxedDestination =
+      org.stellar.sdk.MuxedAccount(allowedBase, java.math.BigInteger.valueOf(99L)).address
+    val client =
+      CustodialClient.builder().name("test-client").destinationAccounts(setOf(allowedBase)).build()
+    every { clientService.getClientConfigBySigningKey(TestHelper.TEST_ACCOUNT) } returns client
+
+    requestValidator.validateDestinationAccount(muxedWebAuth, muxedDestination)
+  }
+
+  @Test
+  fun `test validateDestinationAccount rejects muxed destination whose base is not on allowlist`() {
+    val muxedWebAuth =
+      org.stellar.sdk
+        .MuxedAccount(TestHelper.TEST_ACCOUNT, java.math.BigInteger.valueOf(4L))
+        .address
+    val attackerBase = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val muxedAttacker =
+      org.stellar.sdk.MuxedAccount(attackerBase, java.math.BigInteger.valueOf(1L)).address
+    val client =
+      CustodialClient.builder()
+        .name("test-client")
+        .destinationAccounts(setOf("GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGBXT0E4EPJOS2W2YNHH6K"))
+        .build()
+    every { clientService.getClientConfigBySigningKey(TestHelper.TEST_ACCOUNT) } returns client
+
     assertThrows<SepValidationException> {
-      requestValidator.validateDestinationAccount(token, OTHER_ACCOUNT)
+      requestValidator.validateDestinationAccount(muxedWebAuth, muxedAttacker)
     }
   }
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -2,8 +2,10 @@ package org.stellar.anchor.platform.integrationtest
 
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+import org.stellar.anchor.api.exception.SepException
 import org.stellar.anchor.api.sep.sep38.Sep38Context
 import org.stellar.anchor.client.Sep38Client
 import org.stellar.anchor.client.Sep6Client
@@ -167,6 +169,41 @@ class Sep6Tests : IntegrationTestBase(TestConfig()) {
       JSONCompareMode.LENIENT,
     )
     Assertions.assertNotNull(savedWithdrawTxn.transaction.moreInfoUrl)
+  }
+
+  @Test
+  fun `test sep6 deposit rejects account outside destination policy`() {
+    val attackerAccount = KeyPair.random().accountId
+    val request =
+      mapOf(
+        "asset_code" to "USDC",
+        "account" to attackerAccount,
+        "amount" to "1",
+        "type" to "SWIFT",
+      )
+
+    val ex = assertThrows<SepException> { sep6Client.deposit(request) }
+    assert(ex.message!!.contains("'account' does not match the one in the token")) {
+      "Expected policy rejection, got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 deposit-exchange rejects account outside destination policy`() {
+    val attackerAccount = KeyPair.random().accountId
+    val request =
+      mapOf(
+        "destination_asset" to "USDC",
+        "source_asset" to "iso4217:USD",
+        "amount" to "1",
+        "account" to attackerAccount,
+        "type" to "SWIFT",
+      )
+
+    val ex = assertThrows<SepException> { sep6Client.deposit(request, exchange = true) }
+    assert(ex.message!!.contains("'account' does not match the one in the token")) {
+      "Expected policy rejection, got: ${ex.message}"
+    }
   }
 
   private fun postQuote(sellAsset: String, sellAmount: String, buyAsset: String): String {

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -173,36 +173,81 @@ class Sep6Tests : IntegrationTestBase(TestConfig()) {
 
   @Test
   fun `test sep6 deposit rejects account outside destination policy`() {
-    val attackerAccount = KeyPair.random().accountId
-    val request =
-      mapOf(
-        "asset_code" to "USDC",
-        "account" to attackerAccount,
-        "amount" to "1",
-        "type" to "SWIFT",
-      )
-
-    val ex = assertThrows<SepException> { sep6Client.deposit(request) }
+    val freshAccount = KeyPair.random().accountId
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.deposit(
+          mapOf(
+            "asset_code" to "USDC",
+            "account" to freshAccount,
+            "amount" to "1",
+            "type" to "SWIFT"
+          )
+        )
+      }
     assert(ex.message!!.contains("'account' does not match the one in the token")) {
-      "Expected policy rejection, got: ${ex.message}"
+      "Expected destination policy error but got: ${ex.message}"
     }
   }
 
   @Test
   fun `test sep6 deposit-exchange rejects account outside destination policy`() {
-    val attackerAccount = KeyPair.random().accountId
-    val request =
-      mapOf(
-        "destination_asset" to "USDC",
-        "source_asset" to "iso4217:USD",
-        "amount" to "1",
-        "account" to attackerAccount,
-        "type" to "SWIFT",
-      )
-
-    val ex = assertThrows<SepException> { sep6Client.deposit(request, exchange = true) }
+    val freshAccount = KeyPair.random().accountId
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.deposit(
+          mapOf(
+            "destination_asset" to "USDC",
+            "source_asset" to "iso4217:USD",
+            "amount" to "1",
+            "account" to freshAccount,
+            "type" to "SWIFT",
+          ),
+          exchange = true,
+        )
+      }
     assert(ex.message!!.contains("'account' does not match the one in the token")) {
-      "Expected policy rejection, got: ${ex.message}"
+      "Expected destination policy error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 withdraw rejects account outside destination policy`() {
+    val freshAccount = KeyPair.random().accountId
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.withdraw(
+          mapOf(
+            "asset_code" to "USDC",
+            "account" to freshAccount,
+            "amount" to "1",
+            "type" to "bank_account",
+          )
+        )
+      }
+    assert(ex.message!!.contains("'account' does not match the one in the token")) {
+      "Expected destination policy error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 withdraw-exchange rejects account outside destination policy`() {
+    val freshAccount = KeyPair.random().accountId
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.withdraw(
+          mapOf(
+            "source_asset" to "USDC",
+            "destination_asset" to "iso4217:USD",
+            "amount" to "1",
+            "account" to freshAccount,
+            "type" to "bank_account",
+          ),
+          exchange = true,
+        )
+      }
+    assert(ex.message!!.contains("'account' does not match the one in the token")) {
+      "Expected destination policy error but got: ${ex.message}"
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -25,6 +25,7 @@ import org.stellar.anchor.sep31.Sep31TransactionStore;
 import org.stellar.anchor.sep38.Sep38QuoteStore;
 import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
+import org.stellar.anchor.util.SepRequestValidator;
 
 @Configuration
 @Import(ApiClientBeans.class)
@@ -399,7 +400,8 @@ public class RpcActionBeans {
       Sep31DepositInfoGenerator sep31DepositInfoGenerator,
       PaymentObservingAccountsManager paymentObservingAccountsManager,
       EventService eventService,
-      MetricsService metricsService) {
+      MetricsService metricsService,
+      SepRequestValidator sepRequestValidator) {
     return new RequestOnchainFundsHandler(
         txn6Store,
         txn24Store,
@@ -411,7 +413,8 @@ public class RpcActionBeans {
         sep31DepositInfoGenerator,
         paymentObservingAccountsManager,
         eventService,
-        metricsService);
+        metricsService,
+        sepRequestValidator);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/RpcActionBeans.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.stellar.anchor.api.callback.CustomerIntegration;
 import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.ledger.LedgerClient;
 import org.stellar.anchor.metrics.MetricsService;
@@ -30,6 +31,11 @@ import org.stellar.anchor.util.SepRequestValidator;
 @Configuration
 @Import(ApiClientBeans.class)
 public class RpcActionBeans {
+
+  @Bean
+  SepRequestValidator sepRequestValidator(AssetService assetService, ClientService clientService) {
+    return new SepRequestValidator(assetService, clientService);
+  }
 
   @Bean
   RpcService rpcService(List<RpcMethodHandler<?>> rpcMethodHandlers, RpcConfig rpcConfig) {

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -127,8 +127,8 @@ public class SepBeans {
 
   @Bean
   @OnAnySepsEnabled(seps = {"sep6", "sep24"})
-  SepRequestValidator sepRequestValidator(AssetService assetService) {
-    return new SepRequestValidator(assetService);
+  SepRequestValidator sepRequestValidator(AssetService assetService, ClientService clientService) {
+    return new SepRequestValidator(assetService, clientService);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -130,6 +130,7 @@ public class Sep6Controller {
   public StartWithdrawResponse withdraw(
       HttpServletRequest request,
       @RequestParam(value = "asset_code") String assetCode,
+      @RequestParam(value = "account", required = false) String account,
       @RequestParam(value = "funding_method", required = false) String fundingMethod,
       @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "amount", required = false) String amount,
@@ -142,6 +143,7 @@ public class Sep6Controller {
     StartWithdrawRequest startWithdrawRequest =
         StartWithdrawRequest.builder()
             .assetCode(assetCode)
+            .account(account)
             .fundingMethod(fundingMethod)
             .type(type)
             .amount(amount)
@@ -164,6 +166,7 @@ public class Sep6Controller {
       @RequestParam(value = "destination_asset") String destinationAsset,
       @RequestParam(value = "quote_id", required = false) String quoteId,
       @RequestParam(value = "amount") String amount,
+      @RequestParam(value = "account", required = false) String account,
       @RequestParam(value = "funding_method", required = false) String fundingMethod,
       @RequestParam(value = "type", required = false) String type,
       @RequestParam(value = "country_code", required = false) String countryCode,
@@ -178,6 +181,7 @@ public class Sep6Controller {
             .destinationAsset(destinationAsset)
             .quoteId(quoteId)
             .amount(amount)
+            .account(account)
             .fundingMethod(fundingMethod)
             .type(type)
             .countryCode(countryCode)

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -335,6 +335,10 @@ public class RequestOnchainFundsHandler
 
         if (sep31DepositInfoGenerator instanceof Sep31DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
+          String sep31AuthAccount =
+              txn31.getCreator() != null ? txn31.getCreator().getAccount() : null;
+          sepRequestValidator.validateDestinationAccount(
+              sep31AuthAccount, request.getDestinationAccount());
           txn31.setStellarMemo(request.getMemo());
           txn31.setStellarMemoType(memoTypeString(memoType(memo)));
           txn31.setToAccount(request.getDestinationAccount());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -287,13 +287,15 @@ public class RequestOnchainFundsHandler
 
         if (sep6DepositInfoGenerator instanceof Sep6DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
-          sepRequestValidator.validateDestinationAccount(
-              txn6.getWebAuthAccount(), request.getDestinationAccount());
           txn6.setMemo(request.getMemo());
           txn6.setMemoType(memoTypeString(memoType(memo)));
+          sepRequestValidator.validateDestinationAccount(
+              txn6.getWebAuthAccount(), request.getDestinationAccount());
           txn6.setWithdrawAnchorAccount(request.getDestinationAccount());
+          txn6.setToAccount(request.getDestinationAccount());
         } else {
           SepDepositInfo sep6DepositInfo = sep6DepositInfoGenerator.generate(txn6);
+          txn6.setToAccount(sep6DepositInfo.getStellarAddress());
           txn6.setWithdrawAnchorAccount(sep6DepositInfo.getStellarAddress());
           txn6.setMemo(sep6DepositInfo.getMemo());
           txn6.setMemoType("id");
@@ -310,8 +312,6 @@ public class RequestOnchainFundsHandler
 
         if (sep24DepositInfoGenerator instanceof Sep24DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
-          sepRequestValidator.validateDestinationAccount(
-              txn24.getWebAuthAccount(), request.getDestinationAccount());
           txn24.setMemo(request.getMemo());
           txn24.setMemoType(memoTypeString(memoType(memo)));
           txn24.setWithdrawAnchorAccount(request.getDestinationAccount());
@@ -335,10 +335,6 @@ public class RequestOnchainFundsHandler
 
         if (sep31DepositInfoGenerator instanceof Sep31DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
-          String sep31AuthAccount =
-              txn31.getCreator() != null ? txn31.getCreator().getAccount() : null;
-          sepRequestValidator.validateDestinationAccount(
-              sep31AuthAccount, request.getDestinationAccount());
           txn31.setStellarMemo(request.getMemo());
           txn31.setStellarMemoType(memoTypeString(memoType(memo)));
           txn31.setToAccount(request.getDestinationAccount());

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -48,6 +48,7 @@ import org.stellar.anchor.sep31.Sep31TransactionStore;
 import org.stellar.anchor.sep6.Sep6DepositInfoGenerator;
 import org.stellar.anchor.sep6.Sep6TransactionStore;
 import org.stellar.anchor.util.Log;
+import org.stellar.anchor.util.SepRequestValidator;
 import org.stellar.sdk.Memo;
 
 public class RequestOnchainFundsHandler
@@ -57,6 +58,7 @@ public class RequestOnchainFundsHandler
   private final Sep24DepositInfoGenerator sep24DepositInfoGenerator;
   private final Sep31DepositInfoGenerator sep31DepositInfoGenerator;
   private final PaymentObservingAccountsManager paymentObservingAccountsManager;
+  private final SepRequestValidator sepRequestValidator;
 
   public RequestOnchainFundsHandler(
       Sep6TransactionStore txn6Store,
@@ -69,7 +71,8 @@ public class RequestOnchainFundsHandler
       Sep31DepositInfoGenerator sep31DepositInfoGenerator,
       PaymentObservingAccountsManager paymentObservingAccountsManager,
       EventService eventService,
-      MetricsService metricsService) {
+      MetricsService metricsService,
+      SepRequestValidator sepRequestValidator) {
     super(
         txn6Store,
         txn24Store,
@@ -83,6 +86,7 @@ public class RequestOnchainFundsHandler
     this.sep24DepositInfoGenerator = sep24DepositInfoGenerator;
     this.sep31DepositInfoGenerator = sep31DepositInfoGenerator;
     this.paymentObservingAccountsManager = paymentObservingAccountsManager;
+    this.sepRequestValidator = sepRequestValidator;
   }
 
   @Override
@@ -283,6 +287,8 @@ public class RequestOnchainFundsHandler
 
         if (sep6DepositInfoGenerator instanceof Sep6DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
+          sepRequestValidator.validateDestinationAccount(
+              txn6.getWebAuthAccount(), request.getDestinationAccount());
           txn6.setMemo(request.getMemo());
           txn6.setMemoType(memoTypeString(memoType(memo)));
           txn6.setWithdrawAnchorAccount(request.getDestinationAccount());
@@ -304,6 +310,8 @@ public class RequestOnchainFundsHandler
 
         if (sep24DepositInfoGenerator instanceof Sep24DepositInfoNoneGenerator) {
           Memo memo = makeMemo(request.getMemo(), MEMO_ID);
+          sepRequestValidator.validateDestinationAccount(
+              txn24.getWebAuthAccount(), request.getDestinationAccount());
           txn24.setMemo(request.getMemo());
           txn24.setMemoType(memoTypeString(memoType(memo)));
           txn24.setWithdrawAnchorAccount(request.getDestinationAccount());

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -17,7 +17,6 @@ import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.BadRequestException
-import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
@@ -335,35 +334,6 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
-  }
-
-  @Test
-  fun test_handle_sep6_rejects_destination_outside_policy() {
-    val request =
-      RequestOnchainFundsRequest.builder()
-        .transactionId(TX_ID)
-        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
-        .amountOut(AmountAssetRequest("0.9", FIAT_USD))
-        .feeDetails(FeeDetails("0.1", STELLAR_USDC))
-        .memo(ID_MEMO)
-        .destinationAccount(DESTINATION_ACCOUNT)
-        .build()
-    val txn6 = JdbcSep6Transaction()
-    txn6.status = INCOMPLETE.toString()
-    txn6.kind = "withdrawal"
-    txn6.requestAssetCode = STELLAR_USDC_CODE
-    txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
-    txn6.webAuthAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-
-    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
-    every { txn24Store.findByTransactionId(any()) } returns null
-    every { txn31Store.findByTransactionId(any()) } returns null
-    every {
-      sepRequestValidator.validateDestinationAccount(txn6.webAuthAccount, DESTINATION_ACCOUNT)
-    } throws SepValidationException("Provided 'account' is not allowed")
-
-    assertThrows<SepValidationException> { handler.handle(request) }
-    verify(exactly = 0) { txn6Store.save(any()) }
   }
 
   @Test
@@ -1277,6 +1247,7 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memo = ID_MEMO
     expectedSep6Txn.memoType = ID_MEMO_TYPE
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT_2
+    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT_2
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1295,6 +1266,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.memo = ID_MEMO
     expectedResponse.memoType = ID_MEMO_TYPE
+    expectedResponse.destinationAccount = DESTINATION_ACCOUNT_2
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.creator = StellarId(null, null, null)
 
@@ -1374,6 +1346,7 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memo = ID_MEMO
     expectedSep6Txn.memoType = ID_MEMO_TYPE
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
+    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1392,6 +1365,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.memo = ID_MEMO
     expectedResponse.memoType = ID_MEMO_TYPE
+    expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.creator = StellarId(null, null, null)
 
@@ -1475,6 +1449,7 @@ class RequestOnchainFundsHandlerTest {
     expectedSep6Txn.memo = ID_MEMO
     expectedSep6Txn.memoType = ID_MEMO_TYPE
     expectedSep6Txn.withdrawAnchorAccount = DESTINATION_ACCOUNT
+    expectedSep6Txn.toAccount = DESTINATION_ACCOUNT
 
     JSONAssert.assertEquals(
       gson.toJson(expectedSep6Txn),
@@ -1493,6 +1468,7 @@ class RequestOnchainFundsHandlerTest {
     expectedResponse.updatedAt = sep6TxnCapture.captured.updatedAt
     expectedResponse.memo = ID_MEMO
     expectedResponse.memoType = ID_MEMO_TYPE
+    expectedResponse.destinationAccount = DESTINATION_ACCOUNT
     expectedResponse.customers = Customers(StellarId(null, null, null), StellarId(null, null, null))
     expectedResponse.creator = StellarId(null, null, null)
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -49,6 +49,7 @@ import org.stellar.anchor.sep31.Sep31TransactionStore
 import org.stellar.anchor.sep6.Sep6Transaction
 import org.stellar.anchor.sep6.Sep6TransactionStore
 import org.stellar.anchor.util.GsonUtils
+import org.stellar.anchor.util.SepRequestValidator
 
 class RequestOnchainFundsHandlerTest {
 
@@ -100,6 +101,8 @@ class RequestOnchainFundsHandlerTest {
 
   @MockK(relaxed = true) private lateinit var sepTransactionCounter: Counter
 
+  @MockK(relaxed = true) private lateinit var sepRequestValidator: SepRequestValidator
+
   private lateinit var handler: RequestOnchainFundsHandler
 
   @BeforeEach
@@ -120,6 +123,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
   }
 
@@ -687,6 +691,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =
@@ -1007,6 +1012,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =
@@ -1188,6 +1194,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =
@@ -1500,6 +1507,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =
@@ -1596,6 +1604,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =
@@ -1894,6 +1903,7 @@ class RequestOnchainFundsHandlerTest {
         paymentObservingAccountsManager,
         eventService,
         metricsService,
+        sepRequestValidator,
       )
 
     val request =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -17,6 +17,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.BadRequestException
+import org.stellar.anchor.api.exception.SepValidationException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
@@ -334,6 +335,35 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 0) { sepTransactionCounter.increment() }
+  }
+
+  @Test
+  fun test_handle_sep6_rejects_destination_outside_policy() {
+    val request =
+      RequestOnchainFundsRequest.builder()
+        .transactionId(TX_ID)
+        .amountIn(AmountAssetRequest("1", STELLAR_USDC))
+        .amountOut(AmountAssetRequest("0.9", FIAT_USD))
+        .feeDetails(FeeDetails("0.1", STELLAR_USDC))
+        .memo(ID_MEMO)
+        .destinationAccount(DESTINATION_ACCOUNT)
+        .build()
+    val txn6 = JdbcSep6Transaction()
+    txn6.status = INCOMPLETE.toString()
+    txn6.kind = "withdrawal"
+    txn6.requestAssetCode = STELLAR_USDC_CODE
+    txn6.requestAssetIssuer = STELLAR_USDC_ISSUER
+    txn6.webAuthAccount = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+
+    every { txn6Store.findByTransactionId(TX_ID) } returns txn6
+    every { txn24Store.findByTransactionId(any()) } returns null
+    every { txn31Store.findByTransactionId(any()) } returns null
+    every {
+      sepRequestValidator.validateDestinationAccount(txn6.webAuthAccount, DESTINATION_ACCOUNT)
+    } throws SepValidationException("Provided 'account' is not allowed")
+
+    assertThrows<SepValidationException> { handler.handle(request) }
+    verify(exactly = 0) { txn6Store.save(any()) }
   }
 
   @Test


### PR DESCRIPTION
### Description

Before this change, `Sep6Service.deposit` and `depositExchange` only validated that the request-supplied `account` was syntactically valid (`SepRequestValidator.validateAccount`), then persisted it as `to_account` on the transaction. The operator-configured destination policy — `CustodialClient.destinationAccounts` and `allowAnyDestination` — was enforced by `Sep24Service.deposit` but silently bypassed by the SEP-6 equivalents. Any authenticated SEP-10 client could create a SEP-6 deposit whose issuance destination was an arbitrary Stellar address outside the operator-configured allowlist.

The fix extracts the destination check into a shared `SepRequestValidator.validateDestinationAccount` method and calls it from all four SEP-6 entry points (deposit, deposit-exchange, withdraw, withdraw-exchange) and the existing SEP-24 deposit path.

**Intentional behaviour changes**

The refactor also fixes two bugs in the original inline logic and one inconsistency:

1. **`allowAnyDestination` precedence**: `allowAnyDestination=true` now takes precedence over a non-null `destinationAccounts` set, matching the documented `CustodialClient` contract ("If `allow_any_destination` set to true, this configuration option is ignored"). Previously a non-null `destinationAccounts` was checked first and `allowAnyDestination` was silently ignored when both fields were set.

2. **Empty `destinationAccounts` error message**: an explicitly empty `destinationAccounts` set is now treated identically to `null` — no permission granted — and produces `"'account' does not match the one in the token"` rather than `"Provided 'account' is not allowed"`. The end result (rejection) is unchanged; only the error message differs.

3. **Muxed `webAuthAccount`**: a muxed account stored via `token.getMuxedAccount()` is now demuxed to its base G-address before client lookup and policy comparison, fixing false rejections for muxed-account flows. A malformed muxed `webAuthAccount` fails with a `SepValidationException` instead of silently falling back to the raw string and producing wrong policy decisions.

4. **Muxed `destinationAccount` allowlist check**: a muxed destination passes the allowlist check when the list holds its underlying base address, rather than requiring an exact muxed-string match.

5. **Empty `account` in withdraw / withdraw-exchange**: `request.getAccount()` supplied as an empty string (e.g. `?account=`) now defaults to the token subject, consistent with the existing deposit and deposit-exchange handling (`StringHelper.isEmpty` instead of `!= null`).

**Changes**
- [x] `SepRequestValidator.validateDestinationAccount(WebAuthJwt, String)`: new shared method enforcing the full destination policy — precedence: (1) `allowAnyDestination=true` → accept; (2) non-empty `destinationAccounts` → allowlist check against the destination base address; (3) otherwise → reject with token-mismatch. A `(String webAuthAccount, String destinationAccount)` overload handles callers without a `WebAuthJwt`.
- [x] `Sep6Service.deposit` / `depositExchange`: replaced `requestValidator.validateAccount(request.getAccount())` with `requestValidator.validateDestinationAccount(token, destinationAccount)`.
- [x] `Sep6Service.withdraw` / `withdrawExchange`: same replacement; normalised empty `account` to token subject via `StringHelper.isEmpty`.
- [x] `Sep24Service.deposit`: replaced the 20-line inline destination-policy block with a single `validateDestinationAccount` call. No behaviour change beyond the two intentional fixes above.
- [x] `SepRequestValidatorTest`: unit tests covering allowlist enforcement and exact error messages, `allowAnyDestination` precedence over non-null `destinationAccounts`, empty-set token-mismatch message, muxed `webAuthAccount` demux, malformed muxed `webAuthAccount` rejection, muxed destination allowlist match by base address.
- [x] `Sep6ServiceTest`: unit tests covering deposit / deposit-exchange / withdraw / withdraw-exchange rejection for an out-of-policy account; empty `account=""` defaulting to token subject for withdraw and withdraw-exchange.
- [x] `Sep6Tests`: integration tests for `withdraw` and `withdraw-exchange` rejecting an account outside the destination policy, mirroring the existing deposit / deposit-exchange rejection tests.
