### PR TITLE
[ANCHOR-1231]: Race condition between RPC events and transaction index

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/WalletClient.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/WalletClient.kt
@@ -144,7 +144,7 @@ class WalletClient(
     simulationResponse.results.forEach {
       it.auth.forEach { entryXdr ->
         val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
-        val validUntilLedgerSeq = simulationResponse.latestLedger + 60
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 10
         val signedEntry = authorizeEntry(entry, keyPair, validUntilLedgerSeq, Network.TESTNET)
         signedAuthEntries.add(signedEntry)
       }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/WalletClient.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/WalletClient.kt
@@ -12,6 +12,7 @@ import org.stellar.sdk.AbstractTransaction.MIN_BASE_FEE
 import org.stellar.sdk.Auth.authorizeEntry
 import org.stellar.sdk.contract.AssembledTransaction
 import org.stellar.sdk.operations.InvokeHostFunctionOperation
+import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse
 import org.stellar.sdk.scval.Scv
 import org.stellar.sdk.xdr.SCVal
 import org.stellar.sdk.xdr.SCValType
@@ -143,7 +144,7 @@ class WalletClient(
     simulationResponse.results.forEach {
       it.auth.forEach { entryXdr ->
         val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
-        val validUntilLedgerSeq = simulationResponse.latestLedger + 10
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 60
         val signedEntry = authorizeEntry(entry, keyPair, validUntilLedgerSeq, Network.TESTNET)
         signedAuthEntries.add(signedEntry)
       }
@@ -170,6 +171,11 @@ class WalletClient(
     preparedTransaction.sign(keyPair)
 
     val transactionResponse = rpc.sendTransaction(preparedTransaction)
+    if (transactionResponse.status == SendTransactionResponse.SendTransactionStatus.ERROR) {
+      throw RuntimeException(
+        "sendTransaction rejected: errorResultXdr=${transactionResponse.errorResultXdr}"
+      )
+    }
 
     return transactionResponse.hash
   }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
@@ -340,7 +340,7 @@ open class Sep24End2EndTests : IntegrationTestBase(TestConfig()) {
     txnId: String,
     count: Int,
   ): List<Sep24GetTransactionResponse>? {
-    var retries = 30
+    var retries = 60
     var callbacks: List<Sep24GetTransactionResponse>? = null
     while (retries > 0) {
       callbacks =
@@ -362,7 +362,7 @@ open class Sep24End2EndTests : IntegrationTestBase(TestConfig()) {
     txnId: String,
     count: Int,
   ): List<SendEventRequest>? {
-    var retries = 30
+    var retries = 60
     var events: List<SendEventRequest>? = null
     while (retries > 0) {
       events = anchorReferenceServerClient.getEvents(txnId)

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep31End2EndTests.kt
@@ -234,7 +234,7 @@ open class Sep31End2EndTests : IntegrationTestBase(TestConfig()) {
     txnId: String,
     count: Int,
   ): List<Sep31GetTransactionResponse>? {
-    var retries = 30
+    var retries = 60
     var callbacks: List<Sep31GetTransactionResponse>? = null
     while (retries > 0) {
       callbacks =
@@ -256,7 +256,7 @@ open class Sep31End2EndTests : IntegrationTestBase(TestConfig()) {
     txnId: String,
     count: Int,
   ): List<SendEventRequest>? {
-    var retries = 30
+    var retries = 60
     var events: List<SendEventRequest>? = null
     while (retries > 0) {
       events = anchorReferenceServerClient.getEvents(txnId)

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
@@ -38,9 +38,10 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
     const val TEST_PAYMENT_DEST_ACCOUNT = "GBDYDBJKQBJK4GY4V7FAONSFF2IBJSKNTBYJ65F5KCGBY2BIGPGGLJOH"
     const val TEST_PAYMENT_ASSET_CIRCLE_USDC =
       "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
-  }
 
-  private lateinit var testPaymentValues: List<Pair<String, String>>
+    @Volatile private var sharedTestPaymentValues: List<Pair<String, String>>? = null
+    private val testPaymentLock = Any()
+  }
 
   fun inject(target: String, vararg replacements: Pair<String, String>): String {
     var result = target
@@ -56,14 +57,19 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
   }
 
   private fun getTestPaymentValues(): List<Pair<String, String>> {
-    if (!::testPaymentValues.isInitialized || testPaymentValues.isEmpty()) {
+    sharedTestPaymentValues?.let {
+      return it
+    }
+    synchronized(testPaymentLock) {
+      sharedTestPaymentValues?.let {
+        return it
+      }
       if (isNotEmpty(config.get("stellar_network.rpc_url"))) {
         val ledgerClient = StellarRpc(config.get("stellar_network.rpc_url")!!)
         val ledgerTxn = sendTestPayment(ledgerClient)
         setTestPaymentsValues(ledgerTxn!!)
       } else if (isNotEmpty(config.get("stellar_network.horizon_url"))) {
         val horizonServer = Server(config.get("stellar_network.horizon_url")!!)
-        // not the most optimized way to do this, but it works
         val payment = fetchTestPaymentFromHorizon(horizonServer)
         val ledgerTxn: LedgerTransaction? =
           if (payment != null) {
@@ -76,8 +82,8 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
       } else {
         throw Exception("None of stellar_network.rpc_url or stellar_network.horizon_url is not set")
       }
+      return sharedTestPaymentValues!!
     }
-    return testPaymentValues
   }
 
   private fun toLedgerTransaction(operationResponse: OperationResponse): LedgerTransaction {
@@ -166,7 +172,7 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
     txn.sign(sourceKey)
 
     val response = ledgerClient.submitTransaction(txn)
-    return waitForTransactionAvailable(ledgerClient, response.hash)
+    return waitForTransactionAvailable(ledgerClient, response.hash, 60, 60)
   }
 
   private fun setTestPaymentsValues(ledgerTxn: LedgerTransaction) {
@@ -174,7 +180,7 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
     val paymentOp = txnEnv.v1.tx.operations[0].body.paymentOp
     if (paymentOp != null) {
       // initialize the test payment value pairs for injection
-      testPaymentValues =
+      sharedTestPaymentValues =
         listOf(
           Pair(
             "%TESTPAYMENT_ID%",

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.integrationtest
 
 import java.math.BigDecimal
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 import org.stellar.anchor.ledger.Horizon
 import org.stellar.anchor.ledger.LedgerClient
 import org.stellar.anchor.ledger.LedgerClientHelper.waitForTransactionAvailable
@@ -21,6 +22,7 @@ import org.stellar.sdk.requests.RequestBuilder
 import org.stellar.sdk.responses.operations.OperationResponse
 import org.stellar.sdk.responses.operations.PathPaymentBaseOperationResponse
 import org.stellar.sdk.responses.operations.PaymentOperationResponse
+import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.SendTransactionStatus
 import org.stellar.sdk.xdr.OperationType
 import org.stellar.sdk.xdr.TransactionEnvelope
 
@@ -39,8 +41,8 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
     const val TEST_PAYMENT_ASSET_CIRCLE_USDC =
       "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
 
-    @Volatile private var sharedTestPaymentValues: List<Pair<String, String>>? = null
-    private val testPaymentLock = Any()
+    private val paymentValuesByClass = ConcurrentHashMap<String, List<Pair<String, String>>>()
+    private val classLocks = ConcurrentHashMap<String, Any>()
   }
 
   fun inject(target: String, vararg replacements: Pair<String, String>): String {
@@ -57,17 +59,19 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
   }
 
   private fun getTestPaymentValues(): List<Pair<String, String>> {
-    sharedTestPaymentValues?.let {
+    val key = this::class.java.simpleName
+    paymentValuesByClass[key]?.let {
       return it
     }
-    synchronized(testPaymentLock) {
-      sharedTestPaymentValues?.let {
+    val lock = classLocks.getOrPut(key) { Any() }
+    synchronized(lock) {
+      paymentValuesByClass[key]?.let {
         return it
       }
       if (isNotEmpty(config.get("stellar_network.rpc_url"))) {
         val ledgerClient = StellarRpc(config.get("stellar_network.rpc_url")!!)
         val ledgerTxn = sendTestPayment(ledgerClient)
-        setTestPaymentsValues(ledgerTxn!!)
+        setTestPaymentsValues(key, ledgerTxn!!)
       } else if (isNotEmpty(config.get("stellar_network.horizon_url"))) {
         val horizonServer = Server(config.get("stellar_network.horizon_url")!!)
         val payment = fetchTestPaymentFromHorizon(horizonServer)
@@ -78,11 +82,11 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
             val ledgerClient = Horizon(config.get("stellar_network.horizon_url")!!)
             sendTestPayment(ledgerClient)
           }
-        setTestPaymentsValues(ledgerTxn!!)
+        setTestPaymentsValues(key, ledgerTxn!!)
       } else {
         throw Exception("None of stellar_network.rpc_url or stellar_network.horizon_url is not set")
       }
-      return sharedTestPaymentValues!!
+      return paymentValuesByClass[key]!!
     }
   }
 
@@ -141,46 +145,54 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
 
   private fun sendTestPayment(ledgerClient: LedgerClient): LedgerTransaction? {
     val destAccount = TEST_PAYMENT_DEST_ACCOUNT
-
-    // send test payment of 1 USDC from distribution account to the test receiver account
     val usdcAsset =
       Asset.create(null, "USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
         as AssetTypeCreditAlphaNum
     val sourceKey = KeyPair.fromSecretSeed(config.get("app..payment.signing.seed"))
-    info(
-      "Create test payment transaction: 1 USDC from distribution account to the test receiver account"
-    )
     val accountId = sourceKey.accountId
-    val account = ledgerClient.getAccount(accountId)
-    val txn =
-      TransactionBuilder(Account(accountId, account.sequenceNumber), Network.TESTNET)
-        .addOperation(
-          PaymentOperation.builder()
-            .sourceAccount(sourceKey.accountId)
-            .destination(destAccount)
-            .asset(usdcAsset)
-            .amount(BigDecimal("0.0002"))
-            .build()
-        )
-        .addMemo(Memo.text(TEST_PAYMENT_MEMO)) // Add memo
-        .addPreconditions(
-          TransactionPreconditions.builder().timeBounds(TimeBounds.expiresAfter(180)).build()
-        )
-        .setBaseFee(Transaction.MIN_BASE_FEE)
-        .build()
-    // Sign the transaction
-    txn.sign(sourceKey)
 
-    val response = ledgerClient.submitTransaction(txn)
-    return waitForTransactionAvailable(ledgerClient, response.hash, 60, 60)
+    for (attempt in 1..5) {
+      info("sendTestPayment attempt $attempt/5 (class=${this::class.java.simpleName})")
+      val account = ledgerClient.getAccount(accountId)
+      val txn =
+        TransactionBuilder(Account(accountId, account.sequenceNumber), Network.TESTNET)
+          .addOperation(
+            PaymentOperation.builder()
+              .sourceAccount(sourceKey.accountId)
+              .destination(destAccount)
+              .asset(usdcAsset)
+              .amount(BigDecimal("0.0002"))
+              .build()
+          )
+          .addMemo(Memo.text(TEST_PAYMENT_MEMO))
+          .addPreconditions(
+            TransactionPreconditions.builder().timeBounds(TimeBounds.expiresAfter(180)).build()
+          )
+          .setBaseFee(Transaction.MIN_BASE_FEE)
+          .build()
+      txn.sign(sourceKey)
+
+      val response = ledgerClient.submitTransaction(txn)
+      val accepted =
+        response.status == SendTransactionStatus.PENDING ||
+          response.status == SendTransactionStatus.DUPLICATE
+      if (accepted) {
+        val result = waitForTransactionAvailable(ledgerClient, response.hash, 60, 60)
+        if (result != null) return result
+      }
+      info("sendTestPayment attempt $attempt failed (status=${response.status}). Retrying in 3s...")
+      Thread.sleep(3000)
+    }
+    throw Exception(
+      "sendTestPayment failed after 5 attempts (class=${this::class.java.simpleName})"
+    )
   }
 
-  private fun setTestPaymentsValues(ledgerTxn: LedgerTransaction) {
+  private fun setTestPaymentsValues(key: String, ledgerTxn: LedgerTransaction) {
     val txnEnv = TransactionEnvelope.fromXdrBase64(ledgerTxn.envelopeXdr)
     val paymentOp = txnEnv.v1.tx.operations[0].body.paymentOp
     if (paymentOp != null) {
-      // initialize the test payment value pairs for injection
-      sharedTestPaymentValues =
+      paymentValuesByClass[key] =
         listOf(
           Pair(
             "%TESTPAYMENT_ID%",

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PlatformAPITestBase.kt
@@ -177,10 +177,19 @@ open class PlatformAPITestBase(config: TestConfig) : IntegrationTestBase(config)
         response.status == SendTransactionStatus.PENDING ||
           response.status == SendTransactionStatus.DUPLICATE
       if (accepted) {
-        val result = waitForTransactionAvailable(ledgerClient, response.hash, 60, 60)
-        if (result != null) return result
+        try {
+          return waitForTransactionAvailable(ledgerClient, response.hash, 60, 60)
+        } catch (e: Exception) {
+          info(
+            "sendTestPayment attempt $attempt: transaction not confirmed within timeout." +
+              " Retrying in 3s..."
+          )
+        }
+      } else {
+        info(
+          "sendTestPayment attempt $attempt rejected (status=${response.status}). Retrying in 3s..."
+        )
       }
-      info("sendTestPayment attempt $attempt failed (status=${response.status}). Retrying in 3s...")
       Thread.sleep(3000)
     }
     throw Exception(

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/PaymentClient.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/PaymentClient.kt
@@ -8,6 +8,7 @@ import org.stellar.sdk.contract.AssembledTransaction
 import org.stellar.sdk.exception.BadRequestException
 import org.stellar.sdk.operations.InvokeHostFunctionOperation
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse
+import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse
 import org.stellar.sdk.scval.Scv
 import org.stellar.sdk.xdr.SCVal
 import org.stellar.sdk.xdr.SCValType
@@ -100,7 +101,7 @@ class PaymentClient(
     simulationResponse.results.forEach {
       it.auth.forEach { entryXdr ->
         val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
-        val validUntilLedgerSeq = simulationResponse.latestLedger + 10
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 60
         val signedEntry = authorizeEntry(entry, keyPair, validUntilLedgerSeq, Network.TESTNET)
         signedAuthEntries.add(signedEntry)
       }
@@ -127,6 +128,11 @@ class PaymentClient(
     preparedTransaction.sign(keyPair)
 
     val transactionResponse = rpc.sendTransaction(preparedTransaction)
+    if (transactionResponse.status == SendTransactionResponse.SendTransactionStatus.ERROR) {
+      throw RuntimeException(
+        "sendTransaction rejected: errorResultXdr=${transactionResponse.errorResultXdr}"
+      )
+    }
 
     return transactionResponse.hash
   }

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/PaymentClient.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/client/PaymentClient.kt
@@ -101,7 +101,7 @@ class PaymentClient(
     simulationResponse.results.forEach {
       it.auth.forEach { entryXdr ->
         val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
-        val validUntilLedgerSeq = simulationResponse.latestLedger + 60
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 10
         val signedEntry = authorizeEntry(entry, keyPair, validUntilLedgerSeq, Network.TESTNET)
         signedAuthEntries.add(signedEntry)
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -360,7 +360,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
 
     if (isEmpty(cursor)) {
       long latestLedger = getLatestLedger();
-      return GetEventsRequest.builder().filters(filters).startLedger(latestLedger - 1).build();
+      return GetEventsRequest.builder().filters(filters).startLedger(latestLedger - 5).build();
     } else {
       return GetEventsRequest.builder()
           .filters(filters)

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -360,7 +360,8 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
 
     if (isEmpty(cursor)) {
       long latestLedger = getLatestLedger();
-      return GetEventsRequest.builder().filters(filters).startLedger(latestLedger - 5).build();
+      long startLedger = Math.max(1, latestLedger - 5);
+      return GetEventsRequest.builder().filters(filters).startLedger(startLedger).build();
     } else {
       return GetEventsRequest.builder()
           .filters(filters)

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -24,6 +24,7 @@ import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.platform.HealthCheckResult;
 import org.stellar.anchor.api.platform.HealthCheckStatus;
 import org.stellar.anchor.asset.AssetService;
+import org.stellar.anchor.ledger.LedgerClientHelper;
 import org.stellar.anchor.ledger.LedgerTransaction;
 import org.stellar.anchor.ledger.LedgerTransaction.LedgerOperation;
 import org.stellar.anchor.ledger.LedgerTransaction.LedgerPathPaymentOperation;
@@ -174,7 +175,9 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
   private void processTransferEvent(ShouldProcessResult result) {
     debug("Processing transfer event: {}", GsonUtils.getInstance().toJson(result.event));
     try {
-      LedgerTransaction txn = stellarRpc.getTransaction(result.event.getTransactionHash());
+      LedgerTransaction txn =
+          LedgerClientHelper.waitForTransactionAvailable(
+              stellarRpc, result.event.getTransactionHash());
       String wantedOpId =
           String.valueOf(
               new TOID(

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.LedgerException;
-import org.stellar.anchor.api.exception.NotFoundException;
 import org.stellar.anchor.api.exception.rpc.InternalErrorException;
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
@@ -28,6 +27,7 @@ import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.ledger.LedgerClient;
+import org.stellar.anchor.ledger.LedgerClientHelper;
 import org.stellar.anchor.ledger.LedgerTransaction;
 import org.stellar.anchor.ledger.LedgerTransaction.LedgerPayment;
 import org.stellar.anchor.metrics.MetricsService;
@@ -164,11 +164,8 @@ public class NotifyOnchainFundsReceivedHandler
       JdbcSepTransaction txn, NotifyOnchainFundsReceivedRequest request) throws AnchorException {
     String stellarTxnId = request.getStellarTransactionId();
     try {
-      LedgerTransaction ledgerTxn = ledgerClient.getTransaction(stellarTxnId);
-      if (ledgerTxn == null) {
-        throw new NotFoundException(String.format("Transaction (hash=%s) not found", stellarTxnId));
-      }
-
+      LedgerTransaction ledgerTxn =
+          LedgerClientHelper.waitForTransactionAvailable(ledgerClient, stellarTxnId);
       addStellarTransaction(sacToAssetMapper, ledgerTxn, txn);
 
       if (Sep.SEP_31.equals(Sep.from(txn.getProtocol()))) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandler.java
@@ -6,7 +6,6 @@ import static org.stellar.anchor.api.rpc.method.RpcMethod.NOTIFY_ONCHAIN_FUNDS_R
 import static org.stellar.anchor.api.sep.SepTransactionStatus.*;
 import static org.stellar.anchor.platform.utils.PaymentHelper.addStellarTransaction;
 import static org.stellar.anchor.platform.utils.PaymentHelper.getLedgerPayment;
-import static org.stellar.anchor.util.Log.errorEx;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
@@ -15,7 +14,7 @@ import java.util.Set;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.LedgerException;
-import org.stellar.anchor.api.exception.rpc.InternalErrorException;
+import org.stellar.anchor.api.exception.NotFoundException;
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException;
 import org.stellar.anchor.api.platform.PlatformTransactionData.Kind;
@@ -180,11 +179,7 @@ public class NotifyOnchainFundsReceivedHandler
         if (payment != null) txn31.setFromAccount(payment.getFrom());
       }
     } catch (LedgerException ex) {
-      errorEx(String.format("Failed to retrieve stellar transaction by ID[%s]", stellarTxnId), ex);
-      throw new InternalErrorException(
-          String.format(
-              "Failed to retrieve Stellar transaction by ID[%s]: %s",
-              stellarTxnId, ex.getMessage()));
+      throw new NotFoundException(String.format("Transaction (hash=%s) not found", stellarTxnId));
     }
 
     if (request.getAmountIn() != null) {

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandler.java
@@ -24,6 +24,7 @@ import org.stellar.anchor.api.sep.SepTransactionStatus;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.ledger.LedgerClient;
+import org.stellar.anchor.ledger.LedgerClientHelper;
 import org.stellar.anchor.ledger.LedgerTransaction;
 import org.stellar.anchor.metrics.MetricsService;
 import org.stellar.anchor.platform.data.JdbcSep24Transaction;
@@ -111,11 +112,8 @@ public class NotifyOnchainFundsSentHandler
 
     String stellarTxnId = request.getStellarTransactionId();
     try {
-      LedgerTransaction ledgerTxn = ledgerClient.getTransaction(stellarTxnId);
-      if (ledgerTxn == null) {
-        throw new InternalErrorException(
-            String.format("Failed to retrieve Stellar transaction by ID[%s]", stellarTxnId));
-      }
+      LedgerTransaction ledgerTxn =
+          LedgerClientHelper.waitForTransactionAvailable(ledgerClient, stellarTxnId);
       addStellarTransaction(sacToAssetMapper, ledgerTxn, txn);
     } catch (LedgerException ex) {
       errorEx(String.format("Failed to retrieve stellar transaction by ID[%s]", stellarTxnId), ex);

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -664,6 +664,53 @@ class StellarRpcPaymentObserverTest {
     assertEquals("CURSOR_SUBINVOKE", observer.cursor)
   }
 
+  @Test
+  fun `processTransferEvent retries getTransaction when RPC events index races ahead of transactions index`() {
+    val fromAccount = KeyPair.random().accountId
+    val toAccount = KeyPair.random().accountId
+    val amount = BigInteger.valueOf(1_000_000L)
+    val txHash = "txHashRaceCondition"
+    val seqNum = 400L
+    val appOrder = 1
+    val paymentOpId = TOID(seqNum.toInt(), appOrder, 1).toInt64().toString()
+
+    setupTransferEvent(fromAccount, toAccount, amount, txHash, operationIndex = 0L, "CURSOR_RACE")
+
+    val paymentOp =
+      LedgerTransaction.LedgerPaymentOperation().apply {
+        from = fromAccount
+        to = toAccount
+        asset = Asset.createNativeAsset().toXdr()
+        this.amount = amount
+        id = paymentOpId
+      }
+    val op =
+      LedgerOperation().apply {
+        type = OperationType.PAYMENT
+        paymentOperation = paymentOp
+      }
+    val txn =
+      LedgerTransaction.builder()
+        .hash(txHash)
+        .sequenceNumber(seqNum)
+        .applicationOrder(appOrder)
+        .operations(listOf(op))
+        .build()
+
+    every { stellarRpc.getTransaction(txHash) } returnsMany listOf(null, txn)
+
+    val capturedEvent = slot<PaymentTransferEvent>()
+    every { observer["handleEvent"](capture(capturedEvent)) } answers {}
+
+    observer.fetchEvents()
+
+    verify(exactly = 2) { stellarRpc.getTransaction(txHash) }
+    assertEquals(txHash, capturedEvent.captured.txHash)
+    assertEquals(fromAccount, capturedEvent.captured.from)
+    assertEquals(toAccount, capturedEvent.captured.to)
+    assertEquals("CURSOR_RACE", observer.cursor)
+  }
+
   private fun mockPoisonResponse(
     valueBase64: String,
     fromAccount: String = KeyPair.random().accountId,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -20,7 +20,7 @@ import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_STATUS_CHANGED
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.LedgerException
-import org.stellar.anchor.api.exception.rpc.InternalErrorException
+import org.stellar.anchor.api.exception.NotFoundException
 import org.stellar.anchor.api.exception.rpc.InvalidParamsException
 import org.stellar.anchor.api.exception.rpc.InvalidRequestException
 import org.stellar.anchor.api.platform.GetTransactionResponse
@@ -596,11 +596,8 @@ class NotifyOnchainFundsReceivedHandlerTest {
     every { ledgerClient.getTransaction(any()) } throws
       LedgerException("Invalid stellar transaction")
 
-    val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals(
-      "Failed to retrieve Stellar transaction by ID[stellarTxId]: Invalid stellar transaction",
-      ex.message
-    )
+    val ex = assertThrows<NotFoundException> { handler.handle(request) }
+    assertEquals("Transaction (hash=stellarTxId) not found", ex.message)
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
@@ -1287,11 +1284,8 @@ class NotifyOnchainFundsReceivedHandlerTest {
     every { ledgerClient.getTransaction(any()) } throws
       LedgerException("Invalid stellar transaction")
 
-    val ex = assertThrows<InternalErrorException> { handler.handle(request) }
-    assertEquals(
-      "Failed to retrieve Stellar transaction by ID[stellarTxId]: Invalid stellar transaction",
-      ex.message
-    )
+    val ex = assertThrows<NotFoundException> { handler.handle(request) }
+    assertEquals("Transaction (hash=stellarTxId) not found", ex.message)
 
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }


### PR DESCRIPTION
### Description

Fix a family of RPC race conditions. All changes address the same root cause: one RPC call observes a
state that a subsequent call on a different node hasn't indexed yet.

1. **`StellarRpcPaymentObserver`** — replace bare `getTransaction()` with `waitForTransactionAvailable()` so the observer retries before giving up and losing the event
2. **`NotifyOnchainFundsSentHandler`** — same retry wrapper for the deposit path
3. **`NotifyOnchainFundsReceivedHandler`** — same retry wrapper for the withdrawal/SEP-31 path
4. **`StellarRpcPaymentObserver`** — change initial cursor offset from `latestLedger - 1` to `latestLedger - 5` to prevent startup loop when `getLatestLedger` and `getEvents` hit nodes at different ledgers
5. **`WalletClient` / `PaymentClient`** — surface `sendTransaction` errors immediately instead of silently returning a hash for a rejected transaction
6. **`PlatformAPITestBase`** — per-class payment map with retry loop to fix both sequence number collisions between parallel test classes and cross-class payment hash isolation

### Context

[ANCHOR-1231](https://stellarorg.atlassian.net/browse/ANCHOR-1231)

**Observer race (`StellarRpcPaymentObserver` / RPC handlers)**

`getEvents` and `getTransaction(hash)` hit different nodes. The events index is ahead of the transactions index → `getTransaction` returns `null` → exception swallowed → cursor advances → event permanently lost. Confirmed in CI logs: `getEvents` returned the SAC transfer event at `13:41:36.443`, `getTransaction` returned null 44 ms later at `13:41:36.487`.

Fix: `LedgerClientHelper.waitForTransactionAvailable` polls `getTransaction` up to 10 × 1 s.

**Observer startup cursor loop (`StellarRpcPaymentObserver`)**

On a null cursor (startup or reset), the observer calls `getLatestLedger()` and then `getEvents(startLedger = latestLedger - 1)`. These hit different nodes. If the second node is even one ledger behind, it returns `startLedger out of range`. With a null cursor, the observer loops on startup forever and processes no events. This caused all observer-dependent tests (SEP-6, SEP-24, SEP-31 full flows) to fail simultaneously.

Fix: use `latestLedger - 5` as the initial offset. Tolerates up to 5 ledgers of inter-node lag.

**Test parallel sequence number collision (`PlatformAPITestBase`)**

`testPaymentValues` was an instance-level `lateinit var`. Four test subclasses running in parallel all called `sendTestPayment()` from the same signing key, all read the same sequence number before any transaction landed, and three got `txBAD_SEQ`.

Fix: shared companion object with double-checked locking — only one payment is submitted per JVM.

### Testing

```shell
./gradlew :platform:test --tests \
  "org.stellar.anchor.platform.observer.stellar.StellarRpcPaymentObserverTest"

./gradlew :platform:test

./gradlew :core:test

./gradlew runEssentialTests
```

The new unit test (`processTransferEvent retries getTransaction when RPC events index races ahead of transactions index`) mocks `getTransaction` to return `null` on the first call and a valid transaction on the second, asserts exactly two calls were made, and verifies the event was still delivered to the listener.

### Documentation
N/A

### Known limitations

- The retry window in `waitForTransactionAvailable` is 10 × 1 s. An unusually slow node could still exceed it; in that case the event is logged as a warning and the cursor advances (same behavior as before the fix — no regression).

```
./gradlew runEssentialTests
...
For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 12m 41s
71 actionable tasks: 10 executed, 61 up-to-date
```

[ANCHOR-1231]: https://stellarorg.atlassian.net/browse/ANCHOR-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ