### PR TITLE
[ANCHOR-1224]: Missing JWT audience/type binding in JwtService → SEP-10 user token usable as Platform-API admin credential under JWT secret reuse

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -98,7 +98,6 @@ public class JwtService {
             .subject(token.getSub())
             .issuedAt(from(timeIat))
             .expiration(from(timeExp))
-            .subject(token.getSub())
             .audience()
             .add(aud)
             .and();

--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -11,6 +11,7 @@ import java.security.Security;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -37,6 +38,14 @@ public class JwtService {
   public static final String CLIENT_DOMAIN = "client_domain";
   public static final String HOME_DOMAIN = "home_domain";
   public static final String CLIENT_NAME = "client_name";
+
+  public static final String AUD_SEP10 = "sep10";
+  public static final String AUD_SEP45 = "sep45";
+  public static final String AUD_SEP24_INTERACTIVE = "sep24_interactive";
+  public static final String AUD_SEP6_MORE_INFO = "sep6_more_info";
+  public static final String AUD_SEP24_MORE_INFO = "sep24_more_info";
+  public static final String AUD_CALLBACK_API = "callback_api";
+  public static final String AUD_PLATFORM_API = "platform_api";
 
   String sep6MoreInfoUrlJwtSecret;
   String sep10JwtSecret;
@@ -80,6 +89,7 @@ public class JwtService {
   public <T extends WebAuthJwt> String encode(T token) {
     Instant timeExp = Instant.ofEpochSecond(token.getExp());
     Instant timeIat = Instant.ofEpochSecond(token.getIat());
+    String aud = (token instanceof Sep45Jwt) ? AUD_SEP45 : AUD_SEP10;
 
     JwtBuilder builder =
         jwtsBuilder()
@@ -88,7 +98,10 @@ public class JwtService {
             .subject(token.getSub())
             .issuedAt(from(timeIat))
             .expiration(from(timeExp))
-            .subject(token.getSub());
+            .subject(token.getSub())
+            .audience()
+            .add(aud)
+            .and();
 
     if (token.getClientDomain() != null) {
       builder.claim(CLIENT_DOMAIN, token.getClientDomain());
@@ -107,10 +120,17 @@ public class JwtService {
 
   public String encode(MoreInfoUrlJwt token) throws InvalidConfigException {
     var secret = getMoreInfoUrlSecret(token);
+    String aud = (token instanceof Sep6MoreInfoUrlJwt) ? AUD_SEP6_MORE_INFO : AUD_SEP24_MORE_INFO;
 
     Instant timeExp = Instant.ofEpochSecond(token.getExp());
     JwtBuilder builder =
-        jwtsBuilder().id(token.getJti()).expiration(from(timeExp)).subject(token.getSub());
+        jwtsBuilder()
+            .id(token.getJti())
+            .expiration(from(timeExp))
+            .subject(token.getSub())
+            .audience()
+            .add(aud)
+            .and();
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
     }
@@ -136,7 +156,13 @@ public class JwtService {
     }
     Instant timeExp = Instant.ofEpochSecond(token.getExp());
     JwtBuilder builder =
-        jwtsBuilder().id(token.getJti()).expiration(from(timeExp)).subject(token.getSub());
+        jwtsBuilder()
+            .id(token.getJti())
+            .expiration(from(timeExp))
+            .subject(token.getSub())
+            .audience()
+            .add(AUD_SEP24_INTERACTIVE)
+            .and();
     for (Map.Entry<String, Object> claim : token.claims.entrySet()) {
       builder.claim(claim.getKey(), claim.getValue());
     }
@@ -149,14 +175,14 @@ public class JwtService {
   }
 
   public String encode(CallbackAuthJwt token) throws InvalidConfigException {
-    return encode(token, callbackAuthSecret);
+    return encode(token, callbackAuthSecret, AUD_CALLBACK_API);
   }
 
   public String encode(PlatformAuthJwt token) throws InvalidConfigException {
-    return encode(token, platformAuthSecret);
+    return encode(token, platformAuthSecret, AUD_PLATFORM_API);
   }
 
-  private String encode(ApiAuthJwt token, String secret) throws InvalidConfigException {
+  private String encode(ApiAuthJwt token, String secret, String aud) throws InvalidConfigException {
     if (secret == null) {
       throw new InvalidConfigException(
           "Please provide the secret before encoding JWT for API Authentication");
@@ -164,7 +190,8 @@ public class JwtService {
 
     Instant timeExp = Instant.ofEpochSecond(token.getExp());
     Instant timeIat = Instant.ofEpochSecond(token.getIat());
-    JwtBuilder builder = jwtsBuilder().issuedAt(from(timeIat)).expiration(from(timeExp));
+    JwtBuilder builder =
+        jwtsBuilder().issuedAt(from(timeIat)).expiration(from(timeExp)).audience().add(aud).and();
 
     return builder.signWith(KeyUtil.toSecretKeySpecOrNull(secret), Jwts.SIG.HS256).compact();
   }
@@ -177,26 +204,40 @@ public class JwtService {
           InstantiationException,
           IllegalAccessException {
     String secret;
+    String expectedAud;
     if (cls.equals(Sep6MoreInfoUrlJwt.class)) {
       secret = sep6MoreInfoUrlJwtSecret;
+      expectedAud = AUD_SEP6_MORE_INFO;
     } else if (cls.equals(Sep10Jwt.class)) {
       secret = sep10JwtSecret;
+      expectedAud = AUD_SEP10;
     } else if (cls.equals(Sep45Jwt.class)) {
       secret = sep45JwtSecret;
+      expectedAud = AUD_SEP45;
     } else if (cls.equals(Sep24InteractiveUrlJwt.class)) {
       secret = sep24InteractiveUrlJwtSecret;
+      expectedAud = AUD_SEP24_INTERACTIVE;
     } else if (cls.equals(Sep24MoreInfoUrlJwt.class)) {
       secret = sep24MoreInfoUrlJwtSecret;
+      expectedAud = AUD_SEP24_MORE_INFO;
     } else if (cls.equals(CallbackAuthJwt.class)) {
       secret = callbackAuthSecret;
+      expectedAud = AUD_CALLBACK_API;
     } else if (cls.equals(PlatformAuthJwt.class)) {
       secret = platformAuthSecret;
+      expectedAud = AUD_PLATFORM_API;
     } else {
       throw new NotSupportedException(
           String.format("The Jwt class:[%s] is not supported", cls.getName()));
     }
 
     Jwt jwt = jwtsParser().verifyWith(KeyUtil.toSecretKeySpecOrNull(secret)).build().parse(cipher);
+
+    Claims tokenClaims = (Claims) jwt.getBody();
+    Set<String> tokenAudience = tokenClaims.getAudience();
+    if (tokenAudience == null || !tokenAudience.contains(expectedAud)) {
+      throw new JwtException("Invalid token audience: expected " + expectedAud);
+    }
 
     if (cls.equals(Sep6MoreInfoUrlJwt.class)) {
       return (T) Sep6MoreInfoUrlJwt.class.getConstructor(Jwt.class).newInstance(jwt);

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.auth
 
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.MalformedJwtException
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.stellar.anchor.TestConstants.Companion.TEST_CLIENT_NAME
 import org.stellar.anchor.TestConstants.Companion.TEST_HOME_DOMAIN
+import org.stellar.anchor.auth.ApiAuthJwt.PlatformAuthJwt
 import org.stellar.anchor.auth.JwtService.*
 import org.stellar.anchor.auth.MoreInfoUrlJwt.Sep24MoreInfoUrlJwt
 import org.stellar.anchor.config.SecretConfig
@@ -121,5 +123,46 @@ internal class JwtServiceTest {
     assertThrows<MalformedJwtException> {
       jwtService.decode("This is a bad cipher", Sep10Jwt::class.java)
     }
+  }
+
+  @Test
+  fun `sep10 token is rejected when decoded as PlatformAuthJwt even when secrets collide`() {
+    val sharedSecret = "shared_secret_collision_test_32_chars__"
+    val collidingService =
+      JwtService(
+        "sep6_more_info_unique_secret_32_chars__",
+        sharedSecret,
+        "sep45_unique_secret_value_32_chars_____",
+        "sep24_interactive_unique_secret_32_chars",
+        "sep24_more_info_unique_secret_32_chars__",
+        "callback_unique_secret_value_32_chars___",
+        sharedSecret,
+      )
+
+    val sep10Token =
+      Sep10Jwt(TEST_ISS, TEST_SUB, TEST_IAT, TEST_EXP, TEST_JTI, TEST_CLIENT_DOMAIN, null)
+    val sep10Cipher = collidingService.encode(sep10Token)
+
+    assertThrows<JwtException> { collidingService.decode(sep10Cipher, PlatformAuthJwt::class.java) }
+  }
+
+  @Test
+  fun `platform token is rejected when decoded as Sep10Jwt even when secrets collide`() {
+    val sharedSecret = "shared_secret_collision_test_32_chars__"
+    val collidingService =
+      JwtService(
+        "sep6_more_info_unique_secret_32_chars__",
+        sharedSecret,
+        "sep45_unique_secret_value_32_chars_____",
+        "sep24_interactive_unique_secret_32_chars",
+        "sep24_more_info_unique_secret_32_chars__",
+        "callback_unique_secret_value_32_chars___",
+        sharedSecret,
+      )
+
+    val platformToken = PlatformAuthJwt(TEST_IAT, TEST_EXP)
+    val platformCipher = collidingService.encode(platformToken)
+
+    assertThrows<JwtException> { collidingService.decode(platformCipher, Sep10Jwt::class.java) }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
@@ -2,6 +2,10 @@ package org.stellar.anchor.platform.config;
 
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -105,6 +109,44 @@ public class PropertySecretConfig implements SecretConfig, Validator {
 
     if (!isEmpty(config.getSep45JwtSecretKey())) {
       KeyUtil.rejectWeakJWTSecret(config.getSep45JwtSecretKey(), errors, "secret.sep45.jwt_secret");
+    }
+
+    Map<String, String> jwtSecrets = new LinkedHashMap<>();
+    addSecretIfPresent(jwtSecrets, SECRET_PLATFORM_API_AUTH_SECRET, config.getPlatformAuthSecret());
+    addSecretIfPresent(jwtSecrets, SECRET_CALLBACK_API_AUTH_SECRET, config.getCallbackAuthSecret());
+    addSecretIfPresent(jwtSecrets, SECRET_SEP_10_JWT_SECRET, config.getSep10JwtSecretKey());
+    addSecretIfPresent(jwtSecrets, SECRET_SEP_45_JWT_SECRET, config.getSep45JwtSecretKey());
+    addSecretIfPresent(
+        jwtSecrets,
+        SECRET_SEP_24_INTERACTIVE_URL_JWT_SECRET,
+        config.getSep24InteractiveUrlJwtSecret());
+    addSecretIfPresent(
+        jwtSecrets, SECRET_SEP_24_MORE_INFO_URL_JWT_SECRET, config.getSep24MoreInfoUrlJwtSecret());
+    addSecretIfPresent(
+        jwtSecrets, SECRET_SEP_6_MORE_INFO_URL_JWT_SECRET, config.getSep6MoreInfoUrlJwtSecret());
+
+    List<String> keys = new ArrayList<>(jwtSecrets.keySet());
+    for (int i = 0; i < keys.size(); i++) {
+      for (int j = i + 1; j < keys.size(); j++) {
+        String keyA = keys.get(i);
+        String keyB = keys.get(j);
+
+        if (jwtSecrets.get(keyA).equals(jwtSecrets.get(keyB))) {
+          errors.reject(
+              "secrets.jwt.must_be_unique",
+              String.format(
+                  "JWT secrets must be distinct: [%s] and [%s] share the same value."
+                      + " Colliding secrets collapse the token type boundary and allow"
+                      + " token type confusion attacks.",
+                  keyA, keyB));
+        }
+      }
+    }
+  }
+
+  private static void addSecretIfPresent(Map<String, String> map, String key, String value) {
+    if (!isEmpty(value)) {
+      map.put(key, value);
     }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
@@ -48,4 +48,46 @@ class SecretConfigTest {
     config.validate(config, errors)
     assertFalse(errors.hasErrors())
   }
+
+  @Test
+  fun `test secret collision between platform api and sep10 is rejected`() {
+    val sharedSecret = "shared_secret_value_that_is_long_enough_"
+    every { secretManager.get(PropertySecretConfig.SECRET_PLATFORM_API_AUTH_SECRET) } returns
+      sharedSecret
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_10_JWT_SECRET) } returns sharedSecret
+
+    config.validate(config, errors)
+
+    assertEquals(1, errors.errorCount)
+    assertEquals("secrets.jwt.must_be_unique", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test multiple secret collisions are all reported`() {
+    val sharedSecret = "shared_secret_value_that_is_long_enough_"
+    every { secretManager.get(PropertySecretConfig.SECRET_PLATFORM_API_AUTH_SECRET) } returns
+      sharedSecret
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_10_JWT_SECRET) } returns sharedSecret
+    every { secretManager.get(PropertySecretConfig.SECRET_CALLBACK_API_AUTH_SECRET) } returns
+      sharedSecret
+
+    config.validate(config, errors)
+
+    assertEquals(3, errors.errorCount)
+    assert(errors.allErrors.all { it.code == "secrets.jwt.must_be_unique" })
+  }
+
+  @Test
+  fun `test distinct jwt secrets pass validation`() {
+    every { secretManager.get(PropertySecretConfig.SECRET_PLATFORM_API_AUTH_SECRET) } returns
+      "platform_secret_unique_value_32_chars___"
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_10_JWT_SECRET) } returns
+      "sep10_secret_unique_value_32_chars______"
+    every { secretManager.get(PropertySecretConfig.SECRET_CALLBACK_API_AUTH_SECRET) } returns
+      "callback_secret_unique_value_32_chars___"
+
+    config.validate(config, errors)
+
+    assertFalse(errors.hasErrors())
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -74,7 +75,7 @@ class SecretConfigTest {
     config.validate(config, errors)
 
     assertEquals(3, errors.errorCount)
-    assert(errors.allErrors.all { it.code == "secrets.jwt.must_be_unique" })
+    assertTrue(errors.allErrors.all { it.code == "secrets.jwt.must_be_unique" })
   }
 
   @Test


### PR DESCRIPTION
### Description

The platform issues 7 functionally distinct JWT types (`Sep10Jwt`, `Sep45Jwt`, `Sep24InteractiveUrlJwt`, `Sep24MoreInfoUrlJwt`, `Sep6MoreInfoUrlJwt`, `CallbackAuthJwt`, `PlatformAuthJwt`), each signed with a separate HMAC secret. Tokens carried no `aud` claim - the only thing distinguishing a platform admin token from a user SEP-10 session token was which secret signed it. `JwtService.decode` selected the secret by the requested Java class and verified signature and expiry only; if any two secrets shared the same value, a token from one context was byte-for-byte valid in the other. `PropertySecretConfig.validate()` checked only the SEP-45 secret for cryptographic weakness and never checked whether any two secrets were equal, so the collapse went undetected at startup. The canonical `dev.env` example reused identical placeholder strings across distinct secret slots, normalising the dangerous configuration.

If an operator set any two of the 7 secrets to the same value, a token the attacker already held - any completed SEP-10 login, or a SEP-24 interactive URL handed to the user's browser — became a valid Platform API admin credential: read all customer transactions, forge money-movement events (`request_offchain_funds`, `notify_offchain_funds_received`), and drive transactions to terminal states.

The fix adds two independent, layered defences: audience binding closes the vulnerability regardless of configuration; the startup equality check makes the dangerous configuration impossible to deploy.

**Changes**
- [x] `JwtService`: added 7 `AUD_*` string constants, one per token type (`"sep10"`, `"sep45"`, `"sep24_interactive"`, `"sep24_more_info"`, `"sep6_more_info"`, `"callback_api"`, `"platform_api"`).
- [x] `JwtService.encode(WebAuthJwt)`: stamps `aud=sep10` or `aud=sep45` via `.audience().add(aud).and()` before signing.
- [x] `JwtService.encode(MoreInfoUrlJwt)`: stamps `aud=sep6_more_info` or `aud=sep24_more_info` based on token type.
- [x] `JwtService.encode(Sep24InteractiveUrlJwt)`: stamps `aud=sep24_interactive`.
- [x] `JwtService.encode(ApiAuthJwt, String, String)`: private method gains an `aud` parameter; `encode(CallbackAuthJwt)` and `encode(PlatformAuthJwt)` pass `AUD_CALLBACK_API` and `AUD_PLATFORM_API` respectively.
- [x] `JwtService.decode`: tracks `expectedAud` per class alongside `secret` in the existing dispatch chain; after signature verification, extracts `Claims.getAudience()` and throws `JwtException` if the set is null or does not contain `expectedAud`.
- [x] `PropertySecretConfig.validate()`: collects all 7 configured JWT secrets into a map (skipping null/empty), checks every pair for equality, and rejects with error code `secrets.jwt.must_be_unique` on any collision, naming both config keys in the message.

**Acceptance Criteria**
- [x] A `Sep10Jwt` encoded and decoded as `Sep10Jwt` round-trips correctly (all existing roundtrip tests pass unchanged).
- [x] A `Sep10Jwt` cipher is rejected when decoded as `PlatformAuthJwt`, even when `sep10JwtSecret == platformAuthSecret`.
- [x] A `PlatformAuthJwt` cipher is rejected when decoded as `Sep10Jwt`, even when secrets collide.
- [x] `PropertySecretConfig.validate()` emits `secrets.jwt.must_be_unique` for every colliding pair when any two secrets share a value.
- [x] `PropertySecretConfig.validate()` passes without error when all 7 configured secrets are distinct.

### Context

#3810399

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.auth.JwtServiceTest"`
- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.config.SecretConfigTest"`
- Full suites: `./gradlew :core:test` and `./gradlew :platform:test`

### Documentation
N/A

### Known limitations

Tokens issued before this change (no `aud` claim) will be rejected by the updated `decode`. All platform JWT types are short-lived so no active tokens survive a server restart.
