### PR TITLE
[ANCHOR-1248]: Legacy SEP-31 customer ids are attacker-claimable, reopening the KYC IDOR for pre-upgrade customers

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -138,9 +138,7 @@ public class Sep12Service {
 
       boolean owned =
           customerIdOwnerStore.verifyOrClaim(
-              updatedCustomer.getId(),
-              clientName != null ? clientName : ownerAccount,
-              clientName != null ? null : ownerMemo);
+              updatedCustomer.getId(), clientName != null ? clientName : ownerAccount, ownerMemo);
 
       if (!owned) {
         throw new SepNotAuthorizedException(

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -183,7 +183,7 @@ public class Sep31Service {
       ownerClientName = null;
     }
     String ownerAccount = ownerClientName != null ? ownerClientName : webAuthJwt.getOwnerAccount();
-    String ownerMemo = ownerClientName != null ? null : webAuthJwt.getOwnerMemo();
+    String ownerMemo = webAuthJwt.getOwnerMemo();
 
     for (String customerId : Arrays.asList(request.getSenderId(), request.getReceiverId())) {
       if (customerId != null

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -565,6 +565,31 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer keeps muxed id distinct per sub-user even when a client name resolves`() {
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder()
+        .id("new-muxed-receiver-id")
+        .status(Sep12Status.ACCEPTED.name)
+        .build()
+    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns "vibrant"
+
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .type("sep31-receiver")
+        .memo(TEST_MEMO)
+        .memoType("id")
+        .firstName("Jane")
+        .build()
+    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-muxed-receiver-id", "vibrant", TEST_MEMO)
+    }
+  }
+
+  @Test
   fun `Test put customer publishes event with null clientName and logs warning when client is not authorized`() {
     val kycUpdateEventSlot = slot<AnchorEvent>()
     every { customerIntegration.putCustomer(any()) } returns

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -544,6 +544,27 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer keeps memo distinct per sub-user even when a client name resolves`() {
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("new-receiver-id").status(Sep12Status.ACCEPTED.name).build()
+    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns "vibrant"
+
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .type("sep31-receiver")
+        .memo(TEST_MEMO)
+        .firstName("Jane")
+        .build()
+    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-receiver-id", "vibrant", TEST_MEMO)
+    }
+  }
+
+  @Test
   fun `Test put customer publishes event with null clientName and logs warning when client is not authorized`() {
     val kycUpdateEventSlot = slot<AnchorEvent>()
     every { customerIntegration.putCustomer(any()) } returns

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -892,6 +892,34 @@ class Sep31ServiceTest {
   }
 
   @Test
+  fun `test postTransaction keeps memo distinct per sub-user even when a client name resolves`() {
+    useQuotesNotSupportedAssetService()
+
+    every { txnStore.save(any()) } answers
+      {
+        firstArg<Sep31Transaction>().also { it.id = "ABC-123" }
+      }
+
+    val subUserA =
+      TestHelper.createWebAuthJwt(
+        account = TestHelper.TEST_ACCOUNT,
+        accountMemo = TestHelper.TEST_MEMO,
+      )
+    every { clientFinder.getClientName(subUserA) } returns "vibrant"
+    sep31Service.postTransaction(subUserA, ownershipTestRequest(receiverId = "sub-user-a-id"))
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("sub-user-a-id", "vibrant", TestHelper.TEST_MEMO)
+    }
+
+    val subUserB = TestHelper.createMuxedWebAuthJwt(muxedId = 99L)
+    every { clientFinder.getClientName(subUserB) } returns "vibrant"
+    sep31Service.postTransaction(subUserB, ownershipTestRequest(receiverId = "sub-user-b-id"))
+
+    verify(exactly = 1) { customerIdOwnerStore.verifyOrClaim("sub-user-b-id", "vibrant", "99") }
+  }
+
+  @Test
   fun `test postTransaction skips ownership check when sender_id and receiver_id are absent`() {
     useQuotesNotSupportedAssetService()
     val postTxRequest = ownershipTestRequest()

--- a/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
+++ b/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
@@ -1,0 +1,55 @@
+package db.migration;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.stellar.sdk.MuxedAccount;
+
+public class V30__backfill_muxed_sep31_customer_id_owner extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+
+    String findWinningMuxedReferences =
+        "SELECT DISTINCT ON (customer_id) customer_id, creator ->> 'account' AS muxed_account "
+            + "FROM ("
+            + "  SELECT receiver_id AS customer_id, creator::jsonb AS creator, started_at, id "
+            + "    FROM sep31_transaction WHERE receiver_id IS NOT NULL "
+            + "  UNION ALL "
+            + "  SELECT sender_id AS customer_id, creator::jsonb AS creator, started_at, id "
+            + "    FROM sep31_transaction WHERE sender_id IS NOT NULL "
+            + ") refs "
+            + "WHERE creator ->> 'account' LIKE 'M%' "
+            + "ORDER BY customer_id, started_at ASC, id ASC";
+
+    String repairMemo =
+        "UPDATE sep31_customer_id_owner SET creator_memo = ? "
+            + "WHERE customer_id = ? AND creator_memo IS NULL";
+
+    try (PreparedStatement select = connection.prepareStatement(findWinningMuxedReferences);
+        ResultSet rs = select.executeQuery();
+        PreparedStatement update = connection.prepareStatement(repairMemo)) {
+      while (rs.next()) {
+        String customerId = rs.getString("customer_id");
+        String muxedAddress = rs.getString("muxed_account");
+
+        String muxedId;
+        try {
+          BigInteger id = new MuxedAccount(muxedAddress).getMuxedId();
+          if (id == null) continue;
+          muxedId = id.toString();
+        } catch (RuntimeException e) {
+          continue;
+        }
+
+        update.setString(1, muxedId);
+        update.setString(2, customerId);
+        update.executeUpdate();
+      }
+    }
+  }
+}

--- a/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
+++ b/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
@@ -24,7 +24,7 @@ public class V30__backfill_muxed_sep31_customer_id_owner extends BaseJavaMigrati
             + "    FROM sep31_transaction WHERE sender_id IS NOT NULL "
             + ") refs "
             + "WHERE creator ->> 'account' LIKE 'M%' "
-            + "ORDER BY customer_id, started_at ASC, id ASC";
+            + "ORDER BY customer_id, started_at ASC NULLS LAST, id ASC";
 
     String repairMemo =
         "UPDATE sep31_customer_id_owner SET creator_memo = ? "

--- a/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
+++ b/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
@@ -20,5 +20,5 @@ SELECT DISTINCT ON (customer_id)
      WHERE sender_id IS NOT NULL
   ) refs
  WHERE COALESCE(client_name, creator::jsonb ->> 'account') IS NOT NULL
- ORDER BY customer_id, started_at ASC, id ASC
+ ORDER BY customer_id, started_at ASC NULLS LAST, id ASC
 ON CONFLICT (customer_id) DO NOTHING;

--- a/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
+++ b/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
@@ -4,3 +4,21 @@ CREATE TABLE sep31_customer_id_owner (
     creator_memo    VARCHAR(255),
     created_at      TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()
 );
+
+INSERT INTO sep31_customer_id_owner (customer_id, creator_account, creator_memo)
+SELECT DISTINCT ON (customer_id)
+       customer_id,
+       COALESCE(client_name, creator::jsonb ->> 'account') AS creator_account,
+       creator::jsonb ->> 'memo' AS creator_memo
+  FROM (
+    SELECT receiver_id AS customer_id, creator, client_name, started_at, id
+      FROM sep31_transaction
+     WHERE receiver_id IS NOT NULL
+    UNION ALL
+    SELECT sender_id AS customer_id, creator, client_name, started_at, id
+      FROM sep31_transaction
+     WHERE sender_id IS NOT NULL
+  ) refs
+ WHERE COALESCE(client_name, creator::jsonb ->> 'account') IS NOT NULL
+ ORDER BY customer_id, started_at ASC, id ASC
+ON CONFLICT (customer_id) DO NOTHING;


### PR DESCRIPTION
### Description

The ANCHOR-1237 fix (commit 063e435e, #3827576) introduced `sep31_customer_id_owner` to stop a caller from naming another customer's SEP-12 id as `sender_id`/`receiver_id`. It relies on claim-on-first-reference to cover customers that already existed when an operator deploys the fix: `V29__sep31_customer_id_owner.sql` creates the table empty, and `verifyOrClaim` hands an id with no owner row to whoever references it first. That only protects a pre-existing id if its true owner happens to reference it again after upgrading - and a customer that's simply read, updated, or named as receiver by its own anchor never re-claims its id, since only *creating* a brand-new SEP-31 customer claims one (`Sep12Service.putCustomer`'s `isNewSep31Customer` gate). So every customer id that existed before an operator deploys ANCHOR-1237, and isn't re-referenced by its owner first, is claimable by an attacker who knows the id - reopening the exact read/overwrite chain #3827576 fixed, for the entire pre-upgrade customer catalogue.

V29 has never shipped in a tagged release (its only commit is on `develop`; the latest release, 4.5.0, doesn't contain it), so no deployment has it applied. This implements a SQL backfill added directly to V29, plus a small companion Java migration for the one case plain SQL can't handle.

The one part SQL can't do alone: `creator` is stored as a JSON blob in a `VARCHAR` column, and for muxed-account (M...) callers its `memo` field is always null — the sub-account id is embedded only in the M-address's StrKey encoding. A pure-SQL backfill would leave these rows at `creator_memo = NULL`, and since `Sep31Service.postTransaction` computes a muxed caller's memo as their decoded sub-id (never null), the legitimate owner referencing their own legacy id again would fail the ownership check and get locked out. `V30` decodes it using the same `MuxedAccount` class `WebAuthJwt` already relies on.

Separately, and independent of the backfill, `ClientFinder.getClientName` resolves by client domain/signing key only, never consulting the account memo. Both ownership call sites nulled the memo whenever a client name resolved, collapsing distinct sub-users authenticated under one registered client's signing key (different memos or muxed ids) to the same ownership identity. Fixed by keeping the memo always, regardless of whether a client name resolves.

**Changes**
- [x] `V29__sep31_customer_id_owner.sql`: adds a backfill insert after the `CREATE TABLE`, seeding `sep31_customer_id_owner` from `sep31_transaction` history. For each customer id ever named as `sender_id`/`receiver_id`, `DISTINCT ON (customer_id)` ordered by `started_at, id` picks the earliest referencing transaction, and its recorded `client_name` (if attributed) or raw `creator` account/memo becomes the owner. Rows with no recoverable identity (`creator` null and no `client_name`) are excluded rather than violating the `creator_account NOT NULL` constraint.
- [x] `V30__backfill_muxed_sep31_customer_id_owner.java` (new): a `BaseJavaMigration` that re-derives the same "earliest transaction per customer id" set, filters to muxed-account creators, decodes the sub-id via `org.stellar.sdk.MuxedAccount`, and updates `creator_memo` only where it's still `NULL` - so it can never overwrite a distinct owner.
- [x] `Sep31Service.postTransaction`: `ownerMemo` is now always `webAuthJwt.getOwnerMemo()`, not nulled when a client name resolves.
- [x] `Sep12Service.putCustomer`: same change to the `verifyOrClaim` call in the `isNewSep31Customer` branch - memo is always passed through, no longer nulled when a client name resolves.
- [x] `Sep31ServiceTest`, `Sep12ServiceTest`: new tests asserting memo stays distinct per sub-user (one plain-memo, one muxed) even when both resolve to the same client name.

**Acceptance Criteria**
- [x] A customer id that existed before this fix, was referenced in a transaction created by its true owner, and has not been referenced since, cannot be claimed by a different caller after upgrading — `sep31_customer_id_owner` already has the correct owner row before any post-upgrade request arrives.
- [x] The above holds for owners identified by plain account+memo, by registered client name, and by muxed account, without locking out the legitimate owner on their next reference.
- [x] Re-running the migration (or booting against an already-migrated database) is a no-op — verified manually (see Testing).
- [x] Two sub-users authenticated under the same registered client's signing key with distinct memos/muxed ids no longer collapse to one ownership identity.
- [x] A customer id with no transaction history and no `client_name` is skipped by the backfill, not inserted with a null account.

### Context

[HackerOne #3852332](https://hackerone.com/reports/3852332)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep12.Sep12ServiceTest"`
- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep31.Sep31ServiceTest"`
- Manual: seeded a throwaway local Postgres 16 with `sep31_transaction` rows covering a base-account owner referenced by two different transactions (confirming the earliest wins, not the latest), a client-name-resolved owner with a non-null memo, a muxed-account owner, and a transaction with no creator recorded (confirming it's skipped). Ran V29's backfill and V30's decode-and-repair against it directly: all three recoverable identities backfilled correctly, the orphan was skipped, and re-running both migrations against the already-migrated state was a no-op.

### Documentation
N/A

### Known limitations

A SEP-12 customer created via `putCustomer` before this fix shipped but never named on any SEP-31 transaction has no recoverable owner anywhere in the platform database - there's no signal linking it to a caller identity, so it remains claimable by whoever references it first after this migration runs. Closing this would require an operator-facing reclaim workflow (e.g., letting an owner explicitly establish ownership of an id they can otherwise prove is theirs), which is out of scope here.

Also deliberately not addressed: if an attacker already claimed a legacy id in the wild before an operator applies this fix, the backfill enshrines that prior claim as legitimate (it can't distinguish a malicious first-reference from a genuine one). Operators who suspect prior exploitation should audit `sep31_transaction` history for a legacy id's first referencing caller before applying this migration, rather than relying on it as a retroactive remedy.
