### PR TITLE
[ANCHOR-1249]: Payment observer as asset check warn only, non-native withdrawal is credited when the user sends native XLM

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -285,7 +285,7 @@ public class DefaultPaymentListener implements PaymentListener {
       JdbcSepTransaction sepTransaction)
       throws AnchorException, IOException {
 
-    if (!checkAssetAmountSufficient(ledgerTransaction, ledgerPayment, sepTransaction)) {
+    if (!checkAssetAmountSufficient(ledgerTransaction, ledgerPayment, sepTransaction, true)) {
       return;
     }
 
@@ -314,10 +314,12 @@ public class DefaultPaymentListener implements PaymentListener {
       JdbcSepTransaction sepTransaction)
       throws AnchorException, IOException {
 
-    if (!checkAssetAmountSufficient(ledgerTransaction, ledgerPayment, sepTransaction)) {
+    JdbcSep24Transaction sep24Txn = (JdbcSep24Transaction) sepTransaction;
+    boolean isWithdrawal = WITHDRAWAL.getKind().equals(sep24Txn.getKind());
+    if (!checkAssetAmountSufficient(
+        ledgerTransaction, ledgerPayment, sepTransaction, isWithdrawal)) {
       return;
     }
-    JdbcSep24Transaction sep24Txn = (JdbcSep24Transaction) sepTransaction;
 
     if (DEPOSIT.getKind().equals(sep24Txn.getKind())) {
       platformApiClient.notifyOnchainFundsSent(
@@ -353,11 +355,15 @@ public class DefaultPaymentListener implements PaymentListener {
       JdbcSepTransaction sepTransaction)
       throws AnchorException, IOException {
 
-    if (!checkAssetAmountSufficient(ledgerTransaction, ledgerPayment, sepTransaction)) {
+    JdbcSep6Transaction sep6Txn = (JdbcSep6Transaction) sepTransaction;
+    boolean isWithdrawal =
+        WITHDRAWAL.getKind().equals(sep6Txn.getKind())
+            || WITHDRAWAL_EXCHANGE.getKind().equals(sep6Txn.getKind());
+    if (!checkAssetAmountSufficient(
+        ledgerTransaction, ledgerPayment, sepTransaction, isWithdrawal)) {
       return;
     }
 
-    JdbcSep6Transaction sep6Txn = (JdbcSep6Transaction) sepTransaction;
     if (DEPOSIT.getKind().equals(sep6Txn.getKind())
         || DEPOSIT_EXCHANGE.getKind().equals(sep6Txn.getKind())) {
       platformApiClient.notifyOnchainFundsSent(
@@ -438,10 +444,23 @@ public class DefaultPaymentListener implements PaymentListener {
   boolean checkAssetAmountSufficient(
       LedgerTransaction ledgerTransaction,
       LedgerPayment ledgerPayment,
-      JdbcSepTransaction sepTransaction) {
-    // Compare asset code
+      JdbcSepTransaction sepTransaction,
+      boolean enforceAssetMatch) {
     String paymentAssetName = "stellar:" + getSep11AssetName(ledgerPayment.getAsset());
     if (!sepTransaction.getAmountInAsset().equals(paymentAssetName)) {
+      if (enforceAssetMatch) {
+        errorF(
+            "Rejecting incoming payment for SEP-{} transaction: asset did not match. "
+                + "sepTxn.id={}, ledgerTxn.id={}, expected={}, received={}",
+            sepTransaction.getProtocol(),
+            sepTransaction.getId(),
+            ledgerTransaction.getHash(),
+            sepTransaction.getAmountInAsset(),
+            paymentAssetName);
+        Metrics.counter(AnchorMetrics.PAYMENT_OBSERVER_AMOUNT_ASSET_MISMATCH.toString())
+            .increment();
+        return false;
+      }
       debugF(
           "Payment asset {} does not match the expected asset {}.",
           paymentAssetName,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -7,6 +7,7 @@ import io.mockk.impl.annotations.MockK
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.platform.PlatformTransactionData
@@ -562,13 +563,13 @@ class DefaultPaymentListenerTest {
     testJdbcSepTransaction.id = "123"
 
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     } returns true
 
     paymentListener.handleSep31Transaction(testTxn, testPayment, testJdbcSepTransaction)
 
     verify(exactly = 1) {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     }
 
     verify(exactly = 1) {
@@ -596,7 +597,12 @@ class DefaultPaymentListenerTest {
     Metrics.addRegistry(registry)
     try {
       val sufficient =
-        paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+        paymentListener.checkAssetAmountSufficient(
+          testTxn,
+          testPayment,
+          testJdbcSepTransaction,
+          true,
+        )
 
       assertFalse(sufficient)
       assertEquals(
@@ -609,6 +615,61 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
+  fun `test checkAssetAmountSufficient rejects a withdrawal paid in the wrong asset even when the amount is sufficient`() {
+    val event = createTestTransferEvent()
+    val testTxn = event.ledgerTransaction
+    val testPayment = testTxn.operations[0].paymentOperation
+
+    val testJdbcSepTransaction = JdbcSep31Transaction()
+    testJdbcSepTransaction.id = "123"
+    testJdbcSepTransaction.amountInAsset = "stellar:SRT:GISSUER"
+    testJdbcSepTransaction.amountExpected = fromXdrAmount(testPayment.amount)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      val sufficient =
+        paymentListener.checkAssetAmountSufficient(
+          testTxn,
+          testPayment,
+          testJdbcSepTransaction,
+          true,
+        )
+
+      assertFalse(sufficient)
+      assertEquals(
+        1.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMOUNT_ASSET_MISMATCH.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
+  fun `test checkAssetAmountSufficient does not reject a deposit despite the on-chain vs off-chain asset representations differing`() {
+    val event = createTestTransferEvent()
+    val testTxn = event.ledgerTransaction
+    val testPayment = testTxn.operations[0].paymentOperation
+
+    val testJdbcSepTransaction = JdbcSep24Transaction()
+    testJdbcSepTransaction.id = "123"
+    testJdbcSepTransaction.kind = PlatformTransactionData.Kind.DEPOSIT.kind
+    testJdbcSepTransaction.amountInAsset = "iso4217:USD"
+    testJdbcSepTransaction.amountExpected = fromXdrAmount(testPayment.amount)
+
+    val sufficient =
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false
+      )
+
+    assertTrue(sufficient)
+  }
+
+  @Test
   fun `test handleSep31Transaction does not notify onchain funds received when the payment is insufficient`() {
     val event = createTestTransferEvent()
     val testTxn = event.ledgerTransaction
@@ -618,7 +679,7 @@ class DefaultPaymentListenerTest {
     testJdbcSepTransaction.id = "123"
 
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     } returns false
 
     paymentListener.handleSep31Transaction(testTxn, testPayment, testJdbcSepTransaction)
@@ -636,13 +697,13 @@ class DefaultPaymentListenerTest {
     testJdbcSepTransaction.id = "123"
     testJdbcSepTransaction.kind = PlatformTransactionData.Kind.WITHDRAWAL.kind
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     } returns true
 
     paymentListener.handleSep24Transaction(testTxn, testPayment, testJdbcSepTransaction)
 
     verify(exactly = 1) {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     }
     verify(exactly = 1) {
       platformApiClient.notifyOnchainFundsReceived(
@@ -665,13 +726,23 @@ class DefaultPaymentListenerTest {
     testJdbcSepTransaction.kind = PlatformTransactionData.Kind.DEPOSIT.kind
 
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
     } returns true
 
     paymentListener.handleSep24Transaction(testTxn, testPayment, testJdbcSepTransaction)
 
     verify(exactly = 1) {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
     }
     verify(exactly = 1) { platformApiClient.notifyOnchainFundsSent("123", testTxn.hash, any()) }
   }
@@ -685,17 +756,16 @@ class DefaultPaymentListenerTest {
     val testJdbcSepTransaction = JdbcSep6Transaction()
     testJdbcSepTransaction.id = "123"
 
-    // Test WITHDRAWAL
     testJdbcSepTransaction.kind = PlatformTransactionData.Kind.WITHDRAWAL.kind
 
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     } returns true
 
     paymentListener.handleSep6Transaction(testTxn, testPayment, testJdbcSepTransaction)
 
     verify(exactly = 1) {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
     }
     verify(exactly = 1) {
       platformApiClient.notifyOnchainFundsReceived(
@@ -715,17 +785,26 @@ class DefaultPaymentListenerTest {
     val testJdbcSepTransaction = JdbcSep6Transaction()
     testJdbcSepTransaction.id = "123"
 
-    // Test WITHDRAWAL
     testJdbcSepTransaction.kind = PlatformTransactionData.Kind.DEPOSIT.kind
 
     every {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
     } returns true
 
     paymentListener.handleSep6Transaction(testTxn, testPayment, testJdbcSepTransaction)
 
     verify(exactly = 1) {
-      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction)
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
     }
     verify(exactly = 1) { platformApiClient.notifyOnchainFundsSent("123", testTxn.hash, any()) }
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -810,6 +810,101 @@ class DefaultPaymentListenerTest {
   }
 
   @Test
+  fun `test handleSep6Transaction WITHDRAWAL_EXCHANGE`() {
+    val event = createTestTransferEvent()
+    val testTxn = event.ledgerTransaction
+
+    val testPayment = testTxn.operations[0].paymentOperation
+    val testJdbcSepTransaction = JdbcSep6Transaction()
+    testJdbcSepTransaction.id = "123"
+
+    testJdbcSepTransaction.kind = PlatformTransactionData.Kind.WITHDRAWAL_EXCHANGE.kind
+
+    every {
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
+    } returns true
+
+    paymentListener.handleSep6Transaction(testTxn, testPayment, testJdbcSepTransaction)
+
+    verify(exactly = 1) {
+      paymentListener.checkAssetAmountSufficient(testTxn, testPayment, testJdbcSepTransaction, true)
+    }
+    verify(exactly = 1) {
+      platformApiClient.notifyOnchainFundsReceived(
+        "123",
+        testTxn.hash,
+        fromXdrAmount(testPayment.amount).toString(),
+        any(),
+      )
+    }
+  }
+
+  @Test
+  fun `test handleSep6Transaction DEPOSIT_EXCHANGE`() {
+    val event = createTestTransferEvent()
+    val testTxn = event.ledgerTransaction
+    val testPayment = testTxn.operations[0].paymentOperation
+    val testJdbcSepTransaction = JdbcSep6Transaction()
+    testJdbcSepTransaction.id = "123"
+
+    testJdbcSepTransaction.kind = PlatformTransactionData.Kind.DEPOSIT_EXCHANGE.kind
+
+    every {
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
+    } returns true
+
+    paymentListener.handleSep6Transaction(testTxn, testPayment, testJdbcSepTransaction)
+
+    verify(exactly = 1) {
+      paymentListener.checkAssetAmountSufficient(
+        testTxn,
+        testPayment,
+        testJdbcSepTransaction,
+        false,
+      )
+    }
+    verify(exactly = 1) { platformApiClient.notifyOnchainFundsSent("123", testTxn.hash, any()) }
+  }
+
+  @Test
+  fun `test checkAssetAmountSufficient rejects a withdrawal exchange paid in the wrong asset even when the amount is sufficient`() {
+    val event = createTestTransferEvent()
+    val testTxn = event.ledgerTransaction
+    val testPayment = testTxn.operations[0].paymentOperation
+
+    val testJdbcSepTransaction = JdbcSep6Transaction()
+    testJdbcSepTransaction.id = "123"
+    testJdbcSepTransaction.kind = PlatformTransactionData.Kind.WITHDRAWAL_EXCHANGE.kind
+    testJdbcSepTransaction.amountInAsset = "stellar:SRT:GISSUER"
+    testJdbcSepTransaction.amountExpected = fromXdrAmount(testPayment.amount)
+
+    val registry = SimpleMeterRegistry()
+    Metrics.addRegistry(registry)
+    try {
+      val sufficient =
+        paymentListener.checkAssetAmountSufficient(
+          testTxn,
+          testPayment,
+          testJdbcSepTransaction,
+          true,
+        )
+
+      assertFalse(sufficient)
+      assertEquals(
+        1.0,
+        registry.counter(AnchorMetrics.PAYMENT_OBSERVER_AMOUNT_ASSET_MISMATCH.toString()).count(),
+      )
+    } finally {
+      Metrics.removeRegistry(registry)
+    }
+  }
+
+  @Test
   fun `test ambiguous SEP-24 routing does not route payment and increments metric`() {
     val event = createTestTransferEvent()
     val ledgerTransaction = event.ledgerTransaction


### PR DESCRIPTION
### Description

`DefaultPaymentListener.checkAssetAmountSufficient` is the only gate before a SEP-6/24/31 transaction is credited from an observed on-chain payment. ANCHOR-1225 (#3819378's sibling) turned the amount comparison in this method into a hard reject, but left the asset comparison a few lines above it as a debug-only log that falls through. A withdrawal denominated in a non-native asset (e.g. USDC) was credited in full by a payment of the same numeric amount in native XLM instead - the asset never actually arrived, but nothing after this method sees the asset, only the amount.

Fixing this with an unconditional hard reject on any asset mismatch would break every deposit: `checkAssetAmountSufficient` is shared across deposit and withdrawal handling for all three SEPs, and for a deposit, `amountInAsset` holds the off-chain currency the customer paid (e.g. `iso4217:USD`), which can never equal an on-chain Stellar asset name - the comparison is structurally a "mismatch" for every legitimate deposit. That's why the check was left advisory in the first place rather than an oversight scoped to withdrawals alone. The fix has to reject only when the transaction is withdrawal-shaped (SEP-31 is always this shape; SEP-6/24 only when `kind` is `WITHDRAWAL`/`WITHDRAWAL_EXCHANGE`), not blanket-reject every asset mismatch.

**Changes**
- [x] `DefaultPaymentListener.checkAssetAmountSufficient`: added an `enforceAssetMatch` parameter. When the asset comparison fails and `enforceAssetMatch` is true, logs `errorF`, increments the existing `PAYMENT_OBSERVER_AMOUNT_ASSET_MISMATCH` metric (already used by the sibling event/ledger cross-check in `processAndDispatchLedgerPayment`), and returns `false`. When false, behavior is unchanged (debug log, falls through to the amount check).
- [x] `DefaultPaymentListener.handleSep31Transaction`: passes `true` — SEP-31 has no deposit/withdrawal distinction; every transaction it handles is a receive-and-credit flow, so the asset check always applies.
- [x] `DefaultPaymentListener.handleSep24Transaction`: casts to `JdbcSep24Transaction` and computes `WITHDRAWAL.getKind().equals(sep24Txn.getKind())` before calling `checkAssetAmountSufficient` (previously the cast happened after), passing that as `enforceAssetMatch`.
- [x] `DefaultPaymentListener.handleSep6Transaction`: same reordering, `enforceAssetMatch` is true for `WITHDRAWAL` or `WITHDRAWAL_EXCHANGE` kind.
- [x] `DefaultPaymentListenerTest`: updated all existing `checkAssetAmountSufficient` call sites for the new parameter; added `checkAssetAmountSufficient rejects a withdrawal paid in the wrong asset even when the amount is sufficient` (the reported scenario — SRT expected, native XLM sent, sufficient amount, asserts rejection and the metric increment) and `checkAssetAmountSufficient does not reject a deposit despite the on-chain vs off-chain asset representations differing` (guards against regressing deposits).

**Acceptance Criteria**
- [x] A SEP-31, SEP-24, or SEP-6 withdrawal expecting a non-native asset, paid on-chain in native XLM (or any other wrong asset) at a sufficient numeric amount, is rejected and not credited.
- [x] The rejection increments `PAYMENT_OBSERVER_AMOUNT_ASSET_MISMATCH`.
- [x] A SEP-24/SEP-6 deposit is unaffected — it still credits normally despite `amountInAsset` (an off-chain currency) never matching the on-chain asset name.
- [x] Existing amount-insufficient behavior (the ANCHOR-1225 fix) is unchanged.

### Context

[HackerOne #3856257](https://hackerone.com/reports/3856257)

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.observer.stellar.DefaultPaymentListenerTest"`
- Full platform suite: `./gradlew :platform:test`

### Documentation
N/A

### Known limitations
N/A