### PR TITLE
[ANCHOR-1252]: SEP-6 deposit-exchange lets a quote_id bypass the per-asset deposit limit 

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -225,6 +225,12 @@ public class Sep6Service {
       amounts =
           exchangeAmountsCalculator.calculateFromQuote(
               request.getQuoteId(), sellAsset, buyAsset, request.getAmount());
+      requestValidator.validateAmount(
+          amounts.getAmountOut(),
+          buyAsset.getCode(),
+          buyAsset.getSignificantDecimals(),
+          buyAsset.getSep6().getDeposit().getMinAmount(),
+          buyAsset.getSep6().getDeposit().getMaxAmount());
     } else {
       // TODO(philip): remove this
       // If a quote is not provided, set the fee and out amounts to 0.

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -211,11 +211,7 @@ public class Sep6Service {
     requestValidator.validateTypes(
         fundingMethod, buyAsset.getCode(), buyAsset.getSep6().getDeposit().getMethods());
     requestValidator.validateAmount(
-        request.getAmount(),
-        buyAsset.getCode(),
-        buyAsset.getSignificantDecimals(),
-        buyAsset.getSep6().getDeposit().getMinAmount(),
-        buyAsset.getSep6().getDeposit().getMaxAmount());
+        request.getAmount(), sellAsset.getCode(), sellAsset.getSignificantDecimals(), null, null);
     String destinationAccount =
         StringHelper.isEmpty(request.getAccount()) ? token.getAccount() : request.getAccount();
     requestValidator.validateDestinationAccount(token, destinationAccount);

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -1976,4 +1976,96 @@ class Sep6ServiceTest {
     assertNotNull(response.id)
     verify(exactly = 1) { txnStore.save(any()) }
   }
+
+  @Test
+  fun `test depositExchange rejects a quote whose credited amount exceeds max_amount`() {
+    every {
+      exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any(), any())
+    } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset("iso4217:USD")
+        .amountOut("1000000")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .feeDetails(FeeDetails("0", TEST_ASSET_SEP38_FORMAT))
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .fundingMethod("SWIFT")
+        .build()
+
+    val ex =
+      assertThrows<SepValidationException> {
+        sep6ServiceWithRealValidator.depositExchange(token, request)
+      }
+    assert(ex.message!!.contains("invalid amount 1000000 for asset $TEST_ASSET"))
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test depositExchange rejects a quote whose credited amount is below min_amount`() {
+    every {
+      exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any(), any())
+    } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset("iso4217:USD")
+        .amountOut("0.5")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .feeDetails(FeeDetails("0", TEST_ASSET_SEP38_FORMAT))
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .fundingMethod("SWIFT")
+        .build()
+
+    val ex =
+      assertThrows<SepValidationException> {
+        sep6ServiceWithRealValidator.depositExchange(token, request)
+      }
+    assert(ex.message!!.contains("invalid amount 0.5 for asset $TEST_ASSET"))
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test depositExchange succeeds when the credited amount is within limits`() {
+    every { txnStore.save(any()) } returns null
+    every { eventSession.publish(any()) } returns Unit
+    every {
+      exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any(), any())
+    } returns
+      Amounts.builder()
+        .amountIn("100")
+        .amountInAsset("iso4217:USD")
+        .amountOut("98")
+        .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
+        .feeDetails(FeeDetails("2", TEST_ASSET_SEP38_FORMAT))
+        .build()
+
+    val request =
+      StartDepositExchangeRequest.builder()
+        .destinationAsset(TEST_ASSET)
+        .sourceAsset("iso4217:USD")
+        .quoteId(TEST_QUOTE_ID)
+        .amount("100")
+        .account(TEST_ACCOUNT)
+        .fundingMethod("SWIFT")
+        .build()
+
+    val response = sep6ServiceWithRealValidator.depositExchange(token, request)
+    assertNotNull(response.id)
+    verify(exactly = 1) { txnStore.save(any()) }
+  }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -503,6 +503,7 @@ class Sep6ServiceTest {
         .account(TEST_ACCOUNT)
         .fundingMethod("SWIFT")
         .build()
+    val usdAsset = assetService.getAssetById(sourceAsset)
     val response = sep6Service.depositExchange(token, request)
 
     // Verify validations
@@ -513,10 +514,10 @@ class Sep6ServiceTest {
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
-        asset.code,
-        asset.significantDecimals,
-        asset.sep6.deposit.minAmount,
-        asset.sep6.deposit.maxAmount,
+        usdAsset.code,
+        usdAsset.significantDecimals,
+        null,
+        null
       )
     }
     verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
@@ -623,6 +624,7 @@ class Sep6ServiceTest {
         .account(TEST_ACCOUNT)
         .fundingMethod("SWIFT")
         .build()
+    val usdAsset = assetService.getAssetById(sourceAsset)
     val response = sep6Service.depositExchange(token, request)
 
     // Verify validations
@@ -633,10 +635,10 @@ class Sep6ServiceTest {
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
-        asset.code,
-        asset.significantDecimals,
-        asset.sep6.deposit.minAmount,
-        asset.sep6.deposit.maxAmount,
+        usdAsset.code,
+        usdAsset.significantDecimals,
+        null,
+        null
       )
     }
     verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
@@ -749,6 +751,7 @@ class Sep6ServiceTest {
     val sourceAsset = "iso4217:USD"
     val destinationAsset = TEST_ASSET
     val badAmount = "100"
+    val usdAsset = assetService.getAssetById(sourceAsset)
 
     val request =
       StartDepositExchangeRequest.builder()
@@ -758,7 +761,7 @@ class Sep6ServiceTest {
         .account(TEST_ACCOUNT)
         .fundingMethod("SWIFT")
         .build()
-    every { requestValidator.validateAmount(badAmount, TEST_ASSET, any(), any(), any()) } throws
+    every { requestValidator.validateAmount(badAmount, usdAsset.code, any(), any(), any()) } throws
       SepValidationException("bad amount")
 
     assertThrows<SepValidationException> { sep6Service.depositExchange(token, request) }
@@ -771,10 +774,10 @@ class Sep6ServiceTest {
     verify(exactly = 1) {
       requestValidator.validateAmount(
         badAmount,
-        TEST_ASSET,
-        asset.significantDecimals,
-        asset.sep6.deposit.minAmount,
-        asset.sep6.deposit.maxAmount,
+        usdAsset.code,
+        usdAsset.significantDecimals,
+        null,
+        null,
       )
     }
 
@@ -791,14 +794,16 @@ class Sep6ServiceTest {
     val slotEvent = slot<AnchorEvent>()
     every { eventSession.publish(capture(slotEvent)) } returns Unit
 
+    val sourceAsset = "iso4217:USD"
     val request =
       StartDepositExchangeRequest.builder()
         .destinationAsset(TEST_ASSET)
-        .sourceAsset("iso4217:USD")
+        .sourceAsset(sourceAsset)
         .amount("100")
         .account(TEST_ACCOUNT)
         .fundingMethod("SWIFT")
         .build()
+    val usdAsset = assetService.getAssetById(sourceAsset)
     assertThrows<java.lang.RuntimeException> { sep6Service.depositExchange(token, request) }
 
     // Verify validations
@@ -809,10 +814,10 @@ class Sep6ServiceTest {
     verify(exactly = 1) {
       requestValidator.validateAmount(
         "100",
-        asset.code,
-        asset.significantDecimals,
-        asset.sep6.deposit.minAmount,
-        asset.sep6.deposit.maxAmount,
+        usdAsset.code,
+        usdAsset.significantDecimals,
+        null,
+        null
       )
     }
     verify(exactly = 1) { requestValidator.validateDestinationAccount(token, TEST_ACCOUNT) }
@@ -2041,13 +2046,16 @@ class Sep6ServiceTest {
 
   @Test
   fun `test depositExchange succeeds when the credited amount is within limits`() {
+    // The source amount (10001) is outside the destination asset's [1, 10000] deposit range, but
+    // the request is denominated in the source asset, and the quoted, credited destination amount
+    // (98) is within range — this must succeed, not be rejected on the source/destination mismatch.
     every { txnStore.save(any()) } returns null
     every { eventSession.publish(any()) } returns Unit
     every {
       exchangeAmountsCalculator.calculateFromQuote(TEST_QUOTE_ID, any(), any(), any())
     } returns
       Amounts.builder()
-        .amountIn("100")
+        .amountIn("10001")
         .amountInAsset("iso4217:USD")
         .amountOut("98")
         .amountOutAsset(TEST_ASSET_SEP38_FORMAT)
@@ -2059,7 +2067,7 @@ class Sep6ServiceTest {
         .destinationAsset(TEST_ASSET)
         .sourceAsset("iso4217:USD")
         .quoteId(TEST_QUOTE_ID)
-        .amount("100")
+        .amount("10001")
         .account(TEST_ACCOUNT)
         .fundingMethod("SWIFT")
         .build()


### PR DESCRIPTION
### Description

`Sep6Service.depositExchange` validated `request.getAmount()` — the source (off-chain) asset amount — against the *destination* asset's deposit `min_amount`/`max_amount`. That's a units mismatch: the amount actually credited on a quoted deposit is `quote.getBuyAmount()` (the destination-asset amount computed by `ExchangeAmountsCalculator.calculateFromQuote`), and nothing in the call chain ever checked that value against the destination asset's own limits. Whenever the exchange rate made the deposited amount larger than the source amount (e.g. CAD→USDC at 0.74, or USD→JPYC at 0.0083 — both already present in the stock asset config), a source amount inside the cap yielded a credited amount above it, and the deposit was accepted.

This is the deposit-side counterpart of the bug ANCHOR-1228 fixed for SEP-24: that fix's commit message claims "SEP-6's exchange endpoints were never affected — they call the min/max-checking `validateAmount` unconditionally, before the quote is ever applied." That's true about *unconditionality* but not about *correctness* — the unconditional check validated the wrong asset's amount against the wrong asset's limit. `withdrawExchange` doesn't have this problem: its source asset is the Stellar asset leaving the anchor, so checking the source amount against that same asset's own withdraw limits is correct by construction. `depositExchange`'s source asset is the off-chain currency the customer pays, so the existing check was never going to catch an over-limit credited amount.

**First-pass fix, and a review finding against it:** the initial fix added a second check — `amounts.getAmountOut()` against the destination asset's limits — but *left the original, wrong-asset unconditional check in place* (rationalized at the time as "matching the ANCHOR-1228 SEP-24 pattern of adding a check alongside the existing one"). Review correctly flagged that this reintroduces the same units mismatch in the opposite direction: a quoted deposit whose *destination* amount is well within range can still be wrongly rejected because its *source* amount happens to be outside the *destination* asset's range (e.g. `amount_in=10001`, `amount_out=98` against a destination `max_amount` of `10000` — the destination amount is fine, but the unconditional check on the source amount rejects it anyway). The success-path regression test didn't catch this because it used the same value range for both the source and destination amounts, so the mismatch never had a chance to manifest.

**Fix:** the unconditional check on `request.getAmount()` is no longer validated against the *destination* asset's limits. It now validates against the *source* asset's own decimal precision — `requestValidator.validateAmount(request.getAmount(), sellAsset.getCode(), sellAsset.getSignificantDecimals(), null, null)` — with no min/max, since off-chain (fiat) assets carry no SEP-6 deposit/withdraw limit config in this codebase's asset model; only `AssetInfo.getSignificantDecimals()` is meaningful for them. The destination-limit check on the quote's actual credited amount (`amounts.getAmountOut()` vs. `buyAsset`'s deposit limits), added in the first pass, is unchanged and remains the only place destination limits are enforced.

**Changes**
- [x] `Sep6Service.depositExchange`: the unconditional `request.getAmount()` validation now checks it against `sellAsset` (source-asset code, decimals, no min/max) instead of `buyAsset` (destination-asset code, decimals, deposit min/max). The quote-specific check validating `amounts.getAmountOut()` against `buyAsset`'s deposit limits (inside the `quoteId != null` branch) is unchanged. `withdrawExchange` is unchanged — it already validates the correct side.
- [x] `Sep6ServiceTest`: updated the four existing `depositExchange` tests that asserted the old (destination-asset) call signature for the unconditional check — `test deposit-exchange with quote`, `test deposit-exchange without quote`, `test deposit-exchange with bad amount`, `test deposit-exchange does not send event if transaction fails` — to assert the new source-asset-based call instead. Rewrote `test depositExchange succeeds when the credited amount is within limits` to use a source amount (`10001`) outside the destination asset's `[1, 10000]` range and a credited destination amount (`98`) within it, so the regression actually exercises the source-vs-destination distinction the original version of this test failed to cover.

**Acceptance Criteria**
- [x] `POST /sep6/deposit-exchange` with a `quote_id` whose `buy_amount` is above the destination asset's `max_amount` is rejected, even when the request's source-asset `amount` is within the destination asset's limit range.
- [x] Same rejection for a `buy_amount` below `min_amount`.
- [x] A quoted deposit whose credited (destination) amount is within limits succeeds, even when its source amount falls outside the destination asset's range — proving the source amount is no longer validated against destination-asset limits.
- [x] `withdrawExchange` behavior is unchanged.

### Context

[HackerOne #3862075](https://hackerone.com/reports/3862075)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep6.Sep6ServiceTest"` — 64 tests, 0 failures.
- Full suite: `./gradlew :core:test :platform:test`

### Documentation
N/A

### Known limitations
N/A
