### PR TITLE
[ANCHOR-1254]: V30 backfill builds an owner row from two transactions, locking out legacy owners and enabling a co-tenant KYC claim

### DIFF
--- a/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
+++ b/platform/src/main/java/db/migration/V30__backfill_muxed_sep31_customer_id_owner.java
@@ -14,32 +14,33 @@ public class V30__backfill_muxed_sep31_customer_id_owner extends BaseJavaMigrati
   public void migrate(Context context) throws Exception {
     Connection connection = context.getConnection();
 
-    String findWinningMuxedReferences =
-        "SELECT DISTINCT ON (customer_id) customer_id, creator ->> 'account' AS muxed_account "
+    String findWinningReferences =
+        "SELECT DISTINCT ON (customer_id) customer_id, creator ->> 'account' AS winning_account "
             + "FROM ("
-            + "  SELECT receiver_id AS customer_id, creator::jsonb AS creator, started_at, id "
+            + "  SELECT receiver_id AS customer_id, creator::jsonb AS creator, client_name, started_at, id "
             + "    FROM sep31_transaction WHERE receiver_id IS NOT NULL "
             + "  UNION ALL "
-            + "  SELECT sender_id AS customer_id, creator::jsonb AS creator, started_at, id "
+            + "  SELECT sender_id AS customer_id, creator::jsonb AS creator, client_name, started_at, id "
             + "    FROM sep31_transaction WHERE sender_id IS NOT NULL "
             + ") refs "
-            + "WHERE creator ->> 'account' LIKE 'M%' "
+            + "WHERE COALESCE(client_name, creator ->> 'account') IS NOT NULL "
             + "ORDER BY customer_id, started_at ASC NULLS LAST, id ASC";
 
     String repairMemo =
         "UPDATE sep31_customer_id_owner SET creator_memo = ? "
             + "WHERE customer_id = ? AND creator_memo IS NULL";
 
-    try (PreparedStatement select = connection.prepareStatement(findWinningMuxedReferences);
+    try (PreparedStatement select = connection.prepareStatement(findWinningReferences);
         ResultSet rs = select.executeQuery();
         PreparedStatement update = connection.prepareStatement(repairMemo)) {
       while (rs.next()) {
         String customerId = rs.getString("customer_id");
-        String muxedAddress = rs.getString("muxed_account");
+        String winningAccount = rs.getString("winning_account");
+        if (winningAccount == null || !winningAccount.startsWith("M")) continue;
 
         String muxedId;
         try {
-          BigInteger id = new MuxedAccount(muxedAddress).getMuxedId();
+          BigInteger id = new MuxedAccount(winningAccount).getMuxedId();
           if (id == null) continue;
           muxedId = id.toString();
         } catch (RuntimeException e) {


### PR DESCRIPTION
### Description

`V29__sep31_customer_id_owner.sql` backfills `sep31_customer_id_owner` by picking, per customer id, the earliest historical reference (any caller type) and recording that caller's account and JSON `memo` field. `V30__backfill_muxed_sep31_customer_id_owner.java` then repairs the memo for muxed callers, since a muxed sub-account id lives in the StrKey `account` field, not the JSON `memo` field, and SQL alone can't decode it.

The bug: V30 selected its own "winning" reference independently — the earliest reference *among muxed references only* — instead of checking whether the same transaction V29 already chose as the owner happened to be muxed. For a customer id whose earliest reference was a bare, non-muxed caller (so V29 leaves `creator_memo` null) but which also has any later muxed reference, V30's independent query found that later reference, decoded its muxed id, and wrote it onto the row V29 built from the earlier, different transaction — producing an owner row combining one caller's account with a different caller's memo. That row matched neither the real owner nor the later caller, so the real owner's own requests failed the ownership check (`SepNotAuthorizedException`), and a co-tenant sub-account sharing the real owner's client name could pass the check for a customer id it didn't own.

**Fix:** V30 now runs the identical reference-selection query V29 uses (same `refs` union, same `COALESCE(client_name, account) IS NOT NULL` filter, same `ORDER BY customer_id, started_at ASC NULLS LAST, id ASC` tie-break) instead of a muxed-only variant, so it always lands on the exact same winning transaction per customer id that V29 already chose. It only decodes and sets a memo when *that* winning transaction's own account is muxed (`startsWith("M")`) — never from a different, independently-selected reference.

**Changes**
- [x] `V30__backfill_muxed_sep31_customer_id_owner.java`: `findWinningMuxedReferences` (muxed-only `WHERE` clause) replaced with `findWinningReferences`, an unfiltered-by-muxedness query identical to V29's own winner-selection logic; the muxed check (`winningAccount.startsWith("M")`) now happens in Java, after selecting the same per-customer-id winner V29 selected, not before.
- [x] `V29__sep31_customer_id_owner.sql`: unchanged.

**Acceptance Criteria**
- [x] A customer id whose earliest reference is bare/non-muxed and which also has a later muxed reference (from any caller) backfills to `(client_or_account, null)` — the earliest transaction's own identity — not a hybrid of two different transactions.
- [x] The real owner of that customer id passes `verifyOrClaim` after the migration; a co-tenant presenting a different, later muxed sub-account id does not.
- [x] A customer id whose earliest reference is itself muxed still backfills with that transaction's own decoded muxed id (the existing correct case is unaffected).
- [x] A customer id with only bare, non-muxed references is unaffected (memo stays null).

### Context

[HackerOne #3866121](https://hackerone.com/reports/3866121)

### Testing

- Manual: re-ran the report's reproduction scenario against a throwaway Postgres instance, running the verbatim V29 SQL followed by the fixed V30 query/decode/update, decoding with the real `org.stellar.sdk.MuxedAccount` class. 
- Full suite: `./gradlew :core:test :platform:test` — BUILD SUCCESSFUL.

### Documentation
N/A

### Known limitations
N/A
