### PR TITLE
fix(migration): revert V29 to its released checksum, move SEP-31 owner backfill to V31

### DIFF
--- a/platform/src/main/java/db/migration/V31__backfill_sep31_customer_id_owner.java
+++ b/platform/src/main/java/db/migration/V31__backfill_sep31_customer_id_owner.java
@@ -1,0 +1,39 @@
+package db.migration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+public class V31__backfill_sep31_customer_id_owner extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+
+    String backfill =
+        "INSERT INTO sep31_customer_id_owner (customer_id, creator_account, creator_memo) "
+            + "SELECT DISTINCT ON (customer_id) "
+            + "       customer_id, "
+            + "       COALESCE(client_name, creator::jsonb ->> 'account') AS creator_account, "
+            + "       creator::jsonb ->> 'memo' AS creator_memo "
+            + "  FROM ("
+            + "    SELECT receiver_id AS customer_id, creator, client_name, started_at, id "
+            + "      FROM sep31_transaction "
+            + "     WHERE receiver_id IS NOT NULL "
+            + "    UNION ALL "
+            + "    SELECT sender_id AS customer_id, creator, client_name, started_at, id "
+            + "      FROM sep31_transaction "
+            + "     WHERE sender_id IS NOT NULL "
+            + "  ) refs "
+            + " WHERE COALESCE(client_name, creator::jsonb ->> 'account') IS NOT NULL "
+            + " ORDER BY customer_id, started_at ASC NULLS LAST, id ASC "
+            + "ON CONFLICT (customer_id) DO NOTHING";
+
+    try (PreparedStatement insert = connection.prepareStatement(backfill)) {
+      insert.executeUpdate();
+    }
+
+    new V30__backfill_muxed_sep31_customer_id_owner().migrate(context);
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/DataBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/DataBeans.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.component.share;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.stellar.anchor.platform.configurator.FlywayChecksumCompatibilityCallback;
 import org.stellar.anchor.platform.data.*;
 import org.stellar.anchor.platform.observer.stellar.JdbcStellarPaymentStreamerCursorStore;
 import org.stellar.anchor.platform.observer.stellar.PaymentObservingAccountStore;
@@ -10,6 +11,11 @@ import org.stellar.anchor.sep38.Sep38QuoteStore;
 
 @Configuration
 public class DataBeans {
+  @Bean
+  FlywayChecksumCompatibilityCallback flywayChecksumCompatibilityCallback() {
+    return new FlywayChecksumCompatibilityCallback();
+  }
+
   @Bean
   JdbcSep6TransactionStore sep6TransactionStore(JdbcSep6TransactionRepo sep6TransactionRepo) {
     return new JdbcSep6TransactionStore(sep6TransactionRepo);

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/FlywayChecksumCompatibilityCallback.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/FlywayChecksumCompatibilityCallback.java
@@ -1,0 +1,59 @@
+package org.stellar.anchor.platform.configurator;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.flywaydb.core.api.callback.BaseCallback;
+import org.flywaydb.core.api.callback.Context;
+import org.flywaydb.core.api.callback.Event;
+import org.springframework.stereotype.Component;
+
+/**
+ * V29 shipped in 4.6.0 with an inline backfill INSERT, then was reverted to its originally released
+ * form to fix a Flyway checksum mismatch. Databases that already booted 4.6.0 successfully recorded
+ * the with-backfill checksum; databases that never got that far still have the original checksum.
+ * Since neither history can be edited by hand, this normalizes the former to the latter before
+ * Flyway validates, so both histories are accepted regardless of which checksum a given database
+ * recorded.
+ */
+@Component
+public class FlywayChecksumCompatibilityCallback extends BaseCallback {
+
+  private static final int ORIGINAL_V29_CHECKSUM = 1190516276;
+  private static final int V4_6_0_BACKFILL_V29_CHECKSUM = 1803170936;
+
+  @Override
+  public boolean supports(Event event, Context context) {
+    return event == Event.BEFORE_VALIDATE;
+  }
+
+  @Override
+  public void handle(Event event, Context context) {
+    Connection connection = context.getConnection();
+    try {
+      if (!schemaHistoryTableExists(connection)) {
+        return; // fresh database; nothing has been applied yet, so nothing to normalize.
+      }
+      String sql =
+          "UPDATE flyway_schema_history SET checksum = ? "
+              + "WHERE version = '29' AND success = true AND checksum = ?";
+      try (PreparedStatement statement = connection.prepareStatement(sql)) {
+        statement.setInt(1, ORIGINAL_V29_CHECKSUM);
+        statement.setInt(2, V4_6_0_BACKFILL_V29_CHECKSUM);
+        statement.executeUpdate();
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException("Failed to normalize V29 checksum in flyway_schema_history", e);
+    }
+  }
+
+  private boolean schemaHistoryTableExists(Connection connection) throws SQLException {
+    DatabaseMetaData metaData = connection.getMetaData();
+    try (ResultSet tables =
+        metaData.getTables(null, null, "flyway_schema_history", new String[] {"TABLE"})) {
+      return tables.next();
+    }
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/FlywayChecksumCompatibilityCallback.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/FlywayChecksumCompatibilityCallback.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import org.flywaydb.core.api.callback.BaseCallback;
 import org.flywaydb.core.api.callback.Context;
 import org.flywaydb.core.api.callback.Event;
-import org.springframework.stereotype.Component;
 
 /**
  * V29 shipped in 4.6.0 with an inline backfill INSERT, then was reverted to its originally released
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Component;
  * Flyway validates, so both histories are accepted regardless of which checksum a given database
  * recorded.
  */
-@Component
 public class FlywayChecksumCompatibilityCallback extends BaseCallback {
 
   private static final int ORIGINAL_V29_CHECKSUM = 1190516276;
@@ -52,7 +50,8 @@ public class FlywayChecksumCompatibilityCallback extends BaseCallback {
   private boolean schemaHistoryTableExists(Connection connection) throws SQLException {
     DatabaseMetaData metaData = connection.getMetaData();
     try (ResultSet tables =
-        metaData.getTables(null, null, "flyway_schema_history", new String[] {"TABLE"})) {
+        metaData.getTables(
+            null, connection.getSchema(), "flyway_schema_history", new String[] {"TABLE"})) {
       return tables.next();
     }
   }

--- a/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
+++ b/platform/src/main/resources/db/migration/V29__sep31_customer_id_owner.sql
@@ -4,21 +4,3 @@ CREATE TABLE sep31_customer_id_owner (
     creator_memo    VARCHAR(255),
     created_at      TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()
 );
-
-INSERT INTO sep31_customer_id_owner (customer_id, creator_account, creator_memo)
-SELECT DISTINCT ON (customer_id)
-       customer_id,
-       COALESCE(client_name, creator::jsonb ->> 'account') AS creator_account,
-       creator::jsonb ->> 'memo' AS creator_memo
-  FROM (
-    SELECT receiver_id AS customer_id, creator, client_name, started_at, id
-      FROM sep31_transaction
-     WHERE receiver_id IS NOT NULL
-    UNION ALL
-    SELECT sender_id AS customer_id, creator, client_name, started_at, id
-      FROM sep31_transaction
-     WHERE sender_id IS NOT NULL
-  ) refs
- WHERE COALESCE(client_name, creator::jsonb ->> 'account') IS NOT NULL
- ORDER BY customer_id, started_at ASC NULLS LAST, id ASC
-ON CONFLICT (customer_id) DO NOTHING;


### PR DESCRIPTION
### Description

`V29__sep31_customer_id_owner.sql` was edited in place after ANCHOR-1248 to add a backfill `INSERT`, on the assumption it had never shipped in a tagged release. That held against the 4.5.0 tag, but not against every deployed environment: at least one already had the original, bare V29 (table creation only) applied before 4.6.0 shipped, so its recorded Flyway checksum no longer matched the file, and the app correctly refused to start.

This reverts V29 to its original, already-released form (bare `CREATE TABLE`), and moves the backfill `INSERT` (ANCHOR-1248) plus the muxed-account decode repair (V30) into a new migration, V31. V31 delegates to V30's existing decode logic instead of duplicating it.

Reverting V29 only fixes environments that still have the original (pre-4.6.0) checksum recorded. Any environment that already booted 4.6.0 successfully recorded the *with-backfill* checksum for V29, and would now fail validation in the opposite direction once V29 is reverted. Since neither history can be edited by hand (no DB access), this PR also adds `FlywayChecksumCompatibilityCallback`, a Flyway `BEFORE_VALIDATE` callback that normalizes the with-backfill checksum back to the original one, in-app, before Flyway validates. It's a no-op for every other case (fresh install, or a database that already has the original checksum), so it's safe to leave in place regardless of which of the two known histories a given environment has.

The callback is registered as a `@Bean` in `DataBeans` (`component.share`), since that's the one config package every Flyway-enabled server (`platform`, `sep`, `observer`, `event-processor`) actually component-scans - each server's `@ComponentScan` is otherwise scoped to its own controller/component packages and excludes `platform.configurator`, so a plain `@Component` there would never reach Spring Boot's `FlywayAutoConfiguration`.

The table-existence check that guards the normalization scopes its metadata lookup to `connection.getSchema()` rather than searching every schema. `data.schema` is configurable, and an unqualified lookup would treat a fresh target schema as already-initialized if any other schema in the same database happened to have a `flyway_schema_history` table - the check would pass, but the subsequent unqualified `UPDATE` (which resolves against the connection's actual current schema) would then fail because that schema's table doesn't exist.

**Changes**
- `V29__sep31_customer_id_owner.sql`: reverted to its original content (byte-identical to the pre-ANCHOR-1248 commit).
- `V31__backfill_sep31_customer_id_owner.java` (new): runs the same backfill `INSERT` that used to live in V29, then delegates to `V30__backfill_muxed_sep31_customer_id_owner`'s existing `migrate()` for the muxed-account repair.
- `FlywayChecksumCompatibilityCallback.java` (new): Flyway callback that rewrites V29's recorded checksum from the 4.6.0 with-backfill value back to the original value, only when the with-backfill value is actually present in the connection's current schema.
- `DataBeans.java`: registers the callback as a `@Bean` so every Flyway-enabled server picks it up.

### Context

Production incident: the `event-processor` service failed to start after the 4.6.0 release with `FlywayValidateException: Migration checksum mismatch for migration version 29` - `Applied to database: 1190516276` (the bare, pre-backfill V29) vs. `Resolved locally: 1803170936` (the with-backfill V29 shipped in 4.6.0).

### Testing

- `./gradlew :core:test :platform:test` - BUILD SUCCESSFUL.
- Manual, against a live Postgres 16 instance:
  1. Fresh install: ran the actual Flyway engine through the full V1-V31 chain on an empty database with seeded `sep31_transaction` history (plain and muxed callers) - applies cleanly in order, `sep31_customer_id_owner` ends up fully and correctly backfilled. The new callback is a verified no-op here (`flyway_schema_history` doesn't exist yet at `BEFORE_VALIDATE` time; the callback detects that and returns early instead of erroring).
  2. Already-broken environment (reported incident): simulated the exact reported state (bare V29 applied, V30/V31 never run) and ran V31 directly - produces the identical, correct result.
  3. The environment this fix is actually for - one that already booted 4.6.0 and recorded the with-backfill checksum for V29: seeded `flyway_schema_history` with that exact checksum (1803170936) via a real migrate run against the old with-backfill V29 file, then ran Flyway again against the reverted V29 with the callback registered - validation succeeds and the recorded checksum is rewritten to 1190516276. Confirmed as a negative control that the same scenario without the callback throws the checksum mismatch (in the reverse direction from the original incident, as expected).
  4. Cross-schema false-positive: with `public` already holding an initialized `flyway_schema_history`, pointed a fresh, never-migrated `fresh_target` schema (via `currentSchema=fresh_target`) at the same database and confirmed it migrates cleanly - i.e. `public` having history doesn't fool the check into skipping/misinterpreting `fresh_target`'s own state.
  5. Re-ran in all scenarios to confirm idempotency.

### Documentation
N/A

### Known limitations

This normalizes exactly the two checksums known from this incident (the original V29 and the 4.6.0 with-backfill V29). It does not attempt to handle a third, unknown checksum for V29 - that would still fail validation and require a manual `flyway repair`. Any environment currently crash-looping on this checksum mismatch, in either direction, can redeploy directly once this ships - no manual DB access needed.
