### PR TITLE
[ANCHOR-1251]: Permanent DoS of Stellar-RPC Payment Observer via Broken Fault-Recovery

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
@@ -130,6 +130,9 @@ public abstract class AbstractPaymentObserver implements HealthCheckable {
     } catch (TransactionException tex) {
       errorEx("Error restarting stream.", tex);
       setStatus(DATABASE_ERROR);
+    } catch (RuntimeException rex) {
+      errorEx("Error restarting observer.", rex);
+      setStatus(STREAM_ERROR);
     }
   }
 
@@ -187,6 +190,15 @@ public abstract class AbstractPaymentObserver implements HealthCheckable {
   }
 
   void checkStatus() {
+    try {
+      checkStatusInternal();
+    } catch (RuntimeException rex) {
+      errorEx("Unexpected error in observer supervisor; shutting down", rex);
+      setStatus(NEEDS_SHUTDOWN);
+    }
+  }
+
+  private void checkStatusInternal() {
     switch (status) {
       case NEEDS_SHUTDOWN:
         infoF("shut down the observer");

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -75,6 +75,9 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
   @Override
   void startInternal() {
     info("Starting Soroban RPC payment observer");
+    if (executorService == null || executorService.isShutdown()) {
+      executorService = Executors.newSingleThreadScheduledExecutor();
+    }
     task =
         executorService.scheduleAtFixedRate(
             this::fetchEvents, 0, 1, java.util.concurrent.TimeUnit.SECONDS);

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverRecoveryE2ETest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverRecoveryE2ETest.kt
@@ -1,0 +1,99 @@
+package org.stellar.anchor.platform.observer.stellar
+
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.asset.StellarAssetInfo
+import org.stellar.anchor.api.platform.HealthCheckStatus
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.ledger.StellarRpc
+import org.stellar.anchor.platform.config.PaymentObserverConfig.StellarPaymentObserverConfig
+import org.stellar.anchor.platform.observer.PaymentListener
+import org.stellar.sdk.KeyPair
+import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.exception.NetworkException
+import org.stellar.sdk.responses.sorobanrpc.GetEventsResponse
+
+class StellarRpcPaymentObserverRecoveryE2ETest {
+
+  @Test
+  fun `observer resumes polling after a transient RPC outage instead of permanently dying`() {
+    val config =
+      StellarPaymentObserverConfig().apply {
+        silenceCheckInterval = 1
+        silenceTimeout = 2
+        silenceTimeoutRetries = 5
+        initialStreamBackoffTime = 1
+        maxStreamBackoffTime = 2
+        initialEventBackoffTime = 1
+        maxEventBackoffTime = 2
+      }
+
+    val sorobanServer = mockk<SorobanServer>(relaxed = true)
+    val stellarRpc = mockk<StellarRpc>(relaxed = true)
+    every { stellarRpc.sorobanServer } returns sorobanServer
+    every { stellarRpc.getSorobanServer() } returns sorobanServer
+    every { sorobanServer.getLatestLedger() } returns mockk { every { sequence } returns 100 }
+
+    val assetService = mockk<AssetService>(relaxed = true)
+    every { assetService.stellarAssets } returns
+      listOf(StellarAssetInfo().apply { distributionAccount = KeyPair.random().accountId })
+
+    val cursorStore = mockk<StellarPaymentStreamerCursorStore>(relaxed = true)
+    val accountsManager = mockk<PaymentObservingAccountsManager>(relaxed = true)
+
+    val pollCount = AtomicInteger(0)
+    val outageActive = AtomicBoolean(false)
+    every { sorobanServer.getEvents(any()) } answers
+      {
+        if (outageActive.get()) {
+          throw NetworkException(503, "simulated transient RPC outage")
+        }
+        pollCount.incrementAndGet()
+        mockk<GetEventsResponse> {
+          every { events } returns emptyList()
+          every { latestLedger } returns 100L
+          every { cursor } returns "CUR"
+        }
+      }
+
+    val observer =
+      StellarRpcPaymentObserver(
+        stellarRpc,
+        config,
+        emptyList<PaymentListener>(),
+        accountsManager,
+        cursorStore,
+        MockSacToAssetMapper(),
+        assetService,
+      )
+
+    try {
+      observer.start()
+      Thread.sleep(2500)
+      val baselinePolls = pollCount.get()
+      assertTrue(baselinePolls > 0, "observer never polled successfully before the induced outage")
+
+      outageActive.set(true)
+      Thread.sleep(6000)
+
+      outageActive.set(false)
+      val pollsAtRecoveryStart = pollCount.get()
+      Thread.sleep(3000)
+
+      assertTrue(
+        pollCount.get() > pollsAtRecoveryStart,
+        "observer never resumed polling after the outage ended - permanently dead, exactly report 3857031",
+      )
+      assertTrue(
+        observer.check().status == HealthCheckStatus.GREEN,
+        "observer health did not return to GREEN after recovery",
+      )
+    } finally {
+      observer.shutdown()
+    }
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverRecoveryE2ETest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverRecoveryE2ETest.kt
@@ -77,8 +77,20 @@ class StellarRpcPaymentObserverRecoveryE2ETest {
       val baselinePolls = pollCount.get()
       assertTrue(baselinePolls > 0, "observer never polled successfully before the induced outage")
 
+      val executorBeforeOutage = observer.executorService
       outageActive.set(true)
-      Thread.sleep(6000)
+
+      val deadline = System.currentTimeMillis() + 10_000
+      while (
+        observer.executorService === executorBeforeOutage && System.currentTimeMillis() < deadline
+      ) {
+        Thread.sleep(200)
+      }
+      assertTrue(
+        observer.executorService !== executorBeforeOutage,
+        "restartInternal() never replaced the executor - the observer's own recovery path never ran",
+      )
+      assertTrue(executorBeforeOutage.isShutdown, "the original executor was never shut down")
 
       outageActive.set(false)
       val pollsAtRecoveryStart = pollCount.get()
@@ -86,7 +98,7 @@ class StellarRpcPaymentObserverRecoveryE2ETest {
 
       assertTrue(
         pollCount.get() > pollsAtRecoveryStart,
-        "observer never resumed polling after the outage ended - permanently dead, exactly report 3857031",
+        "observer never resumed polling on the new executor after the outage ended",
       )
       assertTrue(
         observer.check().status == HealthCheckStatus.GREEN,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -295,9 +295,12 @@ class StellarRpcPaymentObserverTest {
   @Test
   fun `restartInternal swallows a failed restart instead of propagating it to the supervisor`() {
     observer.setStatus(ObserverStatus.RUNNING)
+    justRun { observer.shutdownInternal() }
     every { observer.startInternal() } throws RejectedExecutionException("executor terminated")
 
     assertDoesNotThrow { observer.restartInternal() }
+
+    verify { observer.startInternal() }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserverTest.kt
@@ -8,9 +8,12 @@ import io.mockk.spyk
 import io.mockk.verify
 import java.io.IOException
 import java.math.BigInteger
+import java.util.concurrent.RejectedExecutionException
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.asset.StellarAssetInfo
@@ -248,6 +251,65 @@ class StellarRpcPaymentObserverTest {
     assertEquals("txHashInvoke", event.txHash)
     assertEquals(opId, event.operationId)
     assertEquals(ledgerTxn, event.ledgerTransaction)
+  }
+
+  @Test
+  fun `startInternal recreates the executor after shutdown instead of throwing RejectedExecutionException`() {
+    observer.startInternal()
+    assertFalse(observer.executorService.isShutdown)
+
+    observer.shutdownInternal()
+    assertTrue(observer.executorService.isShutdown)
+
+    assertDoesNotThrow { observer.startInternal() }
+
+    assertFalse(observer.executorService.isShutdown)
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+
+    observer.shutdownInternal()
+  }
+
+  @Test
+  fun `restartInternal resumes polling after the executor was shut down`() {
+    val response = mockk<GetEventsResponse>()
+    every { observer.buildEventRequest(any()) } returns mockk()
+    every { response.events } returns emptyList()
+    every { response.latestLedger } returns 1L
+    every { response.cursor } returns "CUR"
+    every { sorobanServer.getEvents(any()) } returns response
+    justRun { paymentStreamerCursorStore.saveStellarRpcCursor(any()) }
+
+    observer.startInternal()
+    observer.shutdownInternal()
+    assertTrue(observer.executorService.isShutdown)
+
+    assertDoesNotThrow { observer.restartInternal() }
+
+    assertEquals(ObserverStatus.RUNNING, observer.getStatus())
+    assertFalse(observer.executorService.isShutdown)
+    verify(timeout = 2000, atLeast = 1) { sorobanServer.getEvents(any()) }
+
+    observer.shutdownInternal()
+  }
+
+  @Test
+  fun `restartInternal swallows a failed restart instead of propagating it to the supervisor`() {
+    observer.setStatus(ObserverStatus.RUNNING)
+    every { observer.startInternal() } throws RejectedExecutionException("executor terminated")
+
+    assertDoesNotThrow { observer.restartInternal() }
+  }
+
+  @Test
+  fun `checkStatus never lets an unexpected exception kill the supervisor task`() {
+    observer.setStatus(ObserverStatus.NEEDS_SHUTDOWN)
+    every { observer.shutdownInternal() } throws IllegalStateException("unexpected bug")
+
+    assertDoesNotThrow { observer.checkStatus() }
+
+    assertEquals(ObserverStatus.NEEDS_SHUTDOWN, observer.getStatus())
+
+    assertDoesNotThrow { observer.checkStatus() }
   }
 
   @Test


### PR DESCRIPTION
### Description

`StellarRpcPaymentObserver` reuses a single-shot `ScheduledExecutorService` across restarts. `shutdownInternal()` calls `executorService.shutdownNow()`, which terminates it permanently, but the field is never reassigned. The first time any transient fault (RPC disconnect, a silence timeout, a DB hiccup, an event-publisher error) triggers `AbstractPaymentObserver.restartInternal()`, `startInternal()` tries to reschedule onto that already-terminated executor and throws `RejectedExecutionException`. That exception was only ever caught as `TransactionException` in `restartInternal()`, and `checkStatus()` — the body of the `statusWatcher`'s `scheduleWithFixedDelay` task — had no guard around it at all, so the exception escaped both. Per `ScheduledExecutorService`'s contract, an uncaught exception in a fixed-delay task permanently suppresses every future execution of that task. The result: one ordinary transient fault permanently and silently halts all on-chain payment detection until a manual process restart.

Fixing only the executor reuse isn't sufficient on its own. `restartInternal()` and `checkStatus()` are shared by both `StellarRpcPaymentObserver` and `HorizonPaymentObserver` — Horizon isn't vulnerable to *this specific* trigger only because it happens to build a fresh `SSEStream` on every restart, not because the supervisor itself is hardened. A future change to Horizon's own lifecycle could reintroduce this same class of failure there. The supervisor loop itself needed to become crash-proof, independent of which subclass or which fault caused the failure.

**Changes**
- [x] `StellarRpcPaymentObserver.startInternal`: recreates `executorService` when it's null or already shut down, instead of always scheduling onto the same single-shot instance created at construction. This is the actual root-cause fix — restarts no longer hit a terminated executor.
- [x] `AbstractPaymentObserver.restartInternal`: broadened the catch from `TransactionException` only to also catch `RuntimeException`, setting `STREAM_ERROR`. This status choice is deliberate: `restartInternal()` is only ever called from within `checkStatusInternal()`'s own `STREAM_ERROR`/`SILENCE_ERROR`/`PUBLISHER_ERROR`/`DATABASE_ERROR` branches, each of which has its own bounded backoff-then-shutdown logic (`streamBackoffTimer.isTimerMaxed()`, `silenceTimeoutCount`, etc). `STREAM_ERROR` is a no-op when set from the `STREAM_ERROR` branch itself and a rejected, harmless transition from the other three (per `ObserverStatus.stateTransition`, which only allows `STREAM_ERROR` from `RUNNING`) — either way, control returns with the original error status intact, so each branch's own retry count/timer still advances normally on the next tick instead of being short-circuited.
- [x] `AbstractPaymentObserver.checkStatus`: split into a thin wrapper around the renamed `checkStatusInternal()`, catching any `RuntimeException` as a last-resort backstop so the supervisor task itself can never die. Falls back to `NEEDS_SHUTDOWN` rather than `STREAM_ERROR` here, since `NEEDS_SHUTDOWN` is the only status reachable from every error state in the transition table — `STREAM_ERROR` would be silently rejected in most of them, leaving the failure invisible instead of converging to a clean, observable stop.
- [x] `StellarRpcPaymentObserverTest.kt`: added regression tests — executor recreation after shutdown, `restartInternal` genuinely resuming polling (verified via `sorobanServer.getEvents` actually being invoked again), `restartInternal` swallowing the exact `RejectedExecutionException` the defect throws, and `checkStatus`'s backstop converging to `NEEDS_SHUTDOWN` when something unexpected throws.
- [x] `StellarRpcPaymentObserverRecoveryE2ETest.kt` (new): drives the observer's real `start()` lifecycle — actual `executorService`/`silenceWatcher`/`statusWatcher` threads on real wall-clock timing, only the `SorobanServer` network boundary mocked — through an induced transient outage past `silence_timeout` and back, asserting polling genuinely resumes and health returns to `GREEN`.

**Acceptance Criteria**
- [x] After a transient RPC/DB/publisher fault triggers `restartInternal()`, the observer resumes polling and its health check returns to `GREEN`, with no process restart required.
- [x] `StellarRpcPaymentObserver.startInternal()` never throws `RejectedExecutionException` after `shutdownInternal()` has run.
- [x] An unexpected `RuntimeException` anywhere in `checkStatus()`'s switch body never permanently stops the status watcher's scheduled task.
- [x] Existing bounded backoff-then-shutdown behavior (`streamBackoffTimer.isTimerMaxed()`, `silenceTimeoutCount` vs `silenceTimeoutRetries`, etc.) is unchanged for restarts that succeed normally.

### Context

[HackerOne #3857031](https://hackerone.com/reports/3857031)

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.observer.stellar.StellarRpcPaymentObserverTest"`
- Integration: `./gradlew :platform:test --tests "org.stellar.anchor.platform.observer.stellar.StellarRpcPaymentObserverRecoveryE2ETest"`

### Documentation
N/A

### Known limitations
N/A
