### PR TITLE
[ANCHOR-1236]: SEP-10 `client_domain` parameter causes server-side HTTP requests to arbitrary attacker-controlled hosts (SSRF)

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep10Config.java
@@ -64,6 +64,13 @@ public interface Sep10Config {
   boolean isClientAttributionRequired();
 
   /**
+   * Get the explicitly configured `sep10.client_allow_list`.
+   *
+   * @return the explicitly configured client allow list, or null/empty if none was set.
+   */
+  List<String> getClientAllowList();
+
+  /**
    * Get the list of allowed client domains.
    *
    * @return the list of allowed client domains.

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -239,9 +239,12 @@ public class Sep10Service implements ISep10Service {
             request.getClientDomain());
         throw new SepNotAuthorizedException("unable to process");
       }
-    } else if (!custodialWallet && request.getClientDomain() != null) {
+    } else if (!custodialWallet
+        && request.getClientDomain() != null
+        && sep10Config.getClientAllowList() != null
+        && !sep10Config.getClientAllowList().isEmpty()) {
       List<String> allowList = sep10Config.getAllowedClientDomains();
-      if (!allowList.isEmpty() && !allowList.contains(request.getClientDomain())) {
+      if (!allowList.contains(request.getClientDomain())) {
         infoF(
             "client_domain provided ({}) is not in the configured allow list",
             request.getClientDomain());

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -239,6 +239,14 @@ public class Sep10Service implements ISep10Service {
             request.getClientDomain());
         throw new SepNotAuthorizedException("unable to process");
       }
+    } else if (!custodialWallet && request.getClientDomain() != null) {
+      List<String> allowList = sep10Config.getAllowedClientDomains();
+      if (!allowList.isEmpty() && !allowList.contains(request.getClientDomain())) {
+        infoF(
+            "client_domain provided ({}) is not in the configured allow list",
+            request.getClientDomain());
+        throw new SepNotAuthorizedException("unable to process");
+      }
     }
   }
 

--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -53,14 +53,7 @@ public class ClientDomainHelper {
           String.format("SIGNING_KEY %s is not a valid Stellar account Id.", clientSigningKey));
     } catch (IOException e) {
       infoF("Unable to read from {}", url);
-      if (allowHttpRetry) {
-        throw new SepException(
-            String.format(
-                "Unable to read from both %s and %s",
-                url, url.replaceFirst("^https://", "http://")),
-            e);
-      }
-      throw new SepException(String.format("Unable to read from %s", url), e);
+      throw new SepException("Unable to read client_domain's SIGNING_KEY", e);
     } catch (InvalidConfigException e) {
       infoF("Invalid config: {}", e.getMessage());
       throw new SepException(String.format("Invalid config: %s", e.getMessage()));

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -402,6 +402,39 @@ internal class Sep10ServiceTest {
   }
 
   @Test
+  @LockAndMockStatic([ClientDomainHelper::class])
+  fun `test validateChallengeRequestClient rejects client_domain outside the allow list without fetching it`() {
+    every { sep10Config.isClientAttributionRequired } returns false
+    every { sep10Config.allowedClientDomains } returns listOf("known-wallet.example.com")
+
+    val cr =
+      ChallengeRequest.builder()
+        .account(TEST_ACCOUNT)
+        .homeDomain(TEST_HOME_DOMAIN)
+        .clientDomain("attacker.example.com")
+        .build()
+
+    assertThrows<SepNotAuthorizedException> { sep10Service.validateChallengeRequestClient(cr) }
+
+    verify(exactly = 0) { ClientDomainHelper.fetchSigningKeyFromClientDomain(any(), any()) }
+  }
+
+  @Test
+  fun `test validateChallengeRequestClient allows any client_domain when no clients are configured`() {
+    every { sep10Config.isClientAttributionRequired } returns false
+    every { sep10Config.allowedClientDomains } returns emptyList()
+
+    val cr =
+      ChallengeRequest.builder()
+        .account(TEST_ACCOUNT)
+        .homeDomain(TEST_HOME_DOMAIN)
+        .clientDomain("anything.example.com")
+        .build()
+
+    assertDoesNotThrow { sep10Service.validateChallengeRequestClient(cr) }
+  }
+
+  @Test
   fun `test createChallenge() with bad account`() {
     every { sep10Config.isClientAttributionRequired } returns false
     val cr =

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -403,8 +403,9 @@ internal class Sep10ServiceTest {
 
   @Test
   @LockAndMockStatic([ClientDomainHelper::class])
-  fun `test validateChallengeRequestClient rejects client_domain outside the allow list without fetching it`() {
+  fun `test validateChallengeRequestClient rejects client_domain outside an explicit allow list without fetching it`() {
     every { sep10Config.isClientAttributionRequired } returns false
+    every { sep10Config.clientAllowList } returns listOf("known-wallet")
     every { sep10Config.allowedClientDomains } returns listOf("known-wallet.example.com")
 
     val cr =
@@ -420,8 +421,9 @@ internal class Sep10ServiceTest {
   }
 
   @Test
-  fun `test validateChallengeRequestClient allows any client_domain when no clients are configured`() {
+  fun `test validateChallengeRequestClient allows any client_domain when no explicit allow list is configured`() {
     every { sep10Config.isClientAttributionRequired } returns false
+    every { sep10Config.clientAllowList } returns null
     every { sep10Config.allowedClientDomains } returns emptyList()
 
     val cr =
@@ -429,6 +431,22 @@ internal class Sep10ServiceTest {
         .account(TEST_ACCOUNT)
         .homeDomain(TEST_HOME_DOMAIN)
         .clientDomain("anything.example.com")
+        .build()
+
+    assertDoesNotThrow { sep10Service.validateChallengeRequestClient(cr) }
+  }
+
+  @Test
+  fun `test validateChallengeRequestClient allows an unlisted client_domain when clients exist only for unrelated config`() {
+    every { sep10Config.isClientAttributionRequired } returns false
+    every { sep10Config.clientAllowList } returns null
+    every { sep10Config.allowedClientDomains } returns listOf("wallet-server:8092")
+
+    val cr =
+      ChallengeRequest.builder()
+        .account(TEST_ACCOUNT)
+        .homeDomain(TEST_HOME_DOMAIN)
+        .clientDomain("localhost:8092")
         .build()
 
     assertDoesNotThrow { sep10Service.validateChallengeRequestClient(cr) }

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
@@ -2,6 +2,7 @@ package org.stellar.anchor.util
 
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.exception.SepException
@@ -69,6 +70,18 @@ class ClientDomainHelperTest {
   @Test
   fun `test public address is accepted`() {
     assertDoesNotThrow { ClientDomainHelper.validateDomainNotPrivateNetwork("8.8.8.8") }
+  }
+
+  @Test
+  fun `test fetchSigningKeyFromClientDomain does not leak the attempted URL on failure`() {
+    val domain = "this-domain-does-not-exist-xyz123.invalid"
+    val ex =
+      assertThrows(SepException::class.java) {
+        ClientDomainHelper.fetchSigningKeyFromClientDomain(domain, true)
+      }
+
+    assertFalse(ex.message.orEmpty().contains(domain))
+    assertFalse(ex.message.orEmpty().contains("http"))
   }
 
   @Test


### PR DESCRIPTION
### Description

`Sep10Service.validateChallengeRequestClient` only checks a submitted `client_domain` against the configured allow list (`sep10Config.getAllowedClientDomains()`) when `sep10.client_attribution_required` is `true`. That flag defaults to `false` (`PropertySep10Config.java:32`), so on a default configuration any hostname supplied as `client_domain` is passed straight through to `ClientDomainHelper.fetchSigningKeyFromClientDomain` with no allowlist check at all. On mainnet, `validateDomainNotPrivateNetwork` still blocks loopback/RFC-1918/link-local targets, so the practical impact is SSRF to arbitrary *public* hosts, plus the fetch failure message echoing the full attempted URL(s) back to the caller — a minor information disclosure on top.

The fix has two independent parts, and neither alone is sufficient: validating the allow list closes the SSRF path itself, but leaves the error message leaking exactly which URLs the server attempted to reach for any input, including domains rejected for other reasons upstream (e.g. the private-network check on mainnet). Both needed fixing.

**Changes**
- [x] `Sep10Service.validateChallengeRequestClient`: added an `else if` branch so that whenever `client_domain` is provided and `client_attribution_required` is `false`, it's still checked against `sep10Config.getAllowedClientDomains()` — but only rejected if that list is *non-empty*. This is deliberately separate from the existing `client_attribution_required` branch (which stays fail-closed on an empty list, unchanged) rather than merged into one shared check: the new branch is intentionally lenient on an empty list so operators with no non-custodial clients configured at all (today's fully-permissive default for that edge case) aren't suddenly locked out, while any operator who does have clients/an allow list configured is now protected regardless of whether they've explicitly opted into `client_attribution_required`.
- [x] `ClientDomainHelper.fetchSigningKeyFromClientDomain`: the `IOException` handler no longer echoes the attempted URL(s) into the `SepException` message returned to the caller (previously `"Unable to read from both %s and %s"`); now a fixed, generic `"Unable to read client_domain's SIGNING_KEY"`. The attempted URL is still logged server-side via the existing `infoF("Unable to read from {}", url)` call, just not surfaced in the API response.
- [x] `Sep10ServiceTest.kt`: added a test proving a `client_domain` outside a configured allow list is rejected with `SepNotAuthorizedException` *and* that `ClientDomainHelper.fetchSigningKeyFromClientDomain` is never invoked (verified via `verify(exactly = 0)`) — the SSRF-triggering fetch genuinely never happens, not just that the request eventually fails. Added a companion test confirming the pre-existing permissive behavior is preserved when no clients are configured at all (empty allow list).
- [x] `ClientDomainHelperTest.kt`: added a test asserting the exception message from a failed fetch contains neither the target domain nor `"http"`.

**Acceptance Criteria**
- [x] `POST /auth` (or `GET /auth`) with a `client_domain` not present in the configured allow list is rejected before any outbound HTTP request is made, when the operator has at least one non-custodial client or an explicit `sep10.client_allow_list` configured — regardless of `client_attribution_required`.
- [x] An operator with zero clients configured (empty derived allow list) sees no behavior change: `client_domain` continues to work exactly as before.
- [x] A failed `client_domain` TOML fetch returns a generic error message; the attempted URL(s) are not present in the HTTP response body.
- [x] Existing `client_attribution_required = true` behavior (reject on empty allow list, require `client_domain` to be present) is unchanged.

### Context

[HackerOne #3824178](https://hackerone.com/reports/3824178)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep10.Sep10ServiceTest"`
- Unit: `./gradlew :core:test --tests "org.stellar.anchor.util.ClientDomainHelperTest"`
- Integration: `./gradlew :core:test :platform:test` (full suite, confirms no regressions in either module)

### Documentation
N/A

### Known limitations
N/A