### PR TITLE
[ANCHOR-1261]: SEP-6/24/31-only deployments fail to start due to missing bean dependencies

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -198,7 +198,7 @@ public class SepBeans {
   }
 
   @Bean
-  @OnAllSepsEnabled(seps = {"sep6", "sep24", "sep31"})
+  @OnAnySepsEnabled(seps = {"sep6", "sep24", "sep31"})
   ExchangeAmountsCalculator exchangeAmountsCalculator(
       Sep38QuoteStore sep38QuoteStore, Clock clock) {
     return new ExchangeAmountsCalculator(sep38QuoteStore, clock);

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -121,7 +121,7 @@ public class SepBeans {
   }
 
   @Bean
-  @OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24"})
+  @OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24", "sep31"})
   ClientFinder clientFinder(Sep10Config sep10Config, ClientService clientService) {
     return new ClientFinder(sep10Config, clientService);
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansConditionalRegistrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansConditionalRegistrationTest.kt
@@ -1,0 +1,160 @@
+package org.stellar.anchor.platform.component
+
+import io.mockk.mockk
+import java.time.Clock
+import java.util.function.Supplier
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.stellar.anchor.MoreInfoUrlConstructor
+import org.stellar.anchor.api.callback.CustomerIntegration
+import org.stellar.anchor.api.callback.RateIntegration
+import org.stellar.anchor.asset.AssetService
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.client.ClientFinder
+import org.stellar.anchor.client.ClientService
+import org.stellar.anchor.config.LanguageConfig
+import org.stellar.anchor.config.SecretConfig
+import org.stellar.anchor.config.Sep6Config
+import org.stellar.anchor.config.StellarNetworkConfig
+import org.stellar.anchor.event.EventService
+import org.stellar.anchor.platform.component.sep.SepBeans
+import org.stellar.anchor.platform.config.CallbackApiConfig
+import org.stellar.anchor.platform.config.PropertySep24Config
+import org.stellar.anchor.platform.config.PropertySep31Config
+import org.stellar.anchor.sep24.Sep24TransactionStore
+import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore
+import org.stellar.anchor.sep31.Sep31TransactionStore
+import org.stellar.anchor.sep38.Sep38QuoteStore
+import org.stellar.anchor.sep6.Sep6TransactionStore
+import org.stellar.anchor.util.ExchangeAmountsCalculator
+import org.stellar.anchor.util.SepRequestValidator
+
+class SepBeansConditionalRegistrationTest {
+
+  companion object {
+    @JvmStatic
+    fun singleSepEnabledScenarios() =
+      listOf(
+        arrayOf("sep6.enabled", "true", "sep24.enabled", "false", "sep31.enabled", "false"),
+        arrayOf("sep6.enabled", "false", "sep24.enabled", "true", "sep31.enabled", "false"),
+        arrayOf("sep6.enabled", "false", "sep24.enabled", "false", "sep31.enabled", "true"),
+      )
+  }
+
+  private fun baseRunner(): ApplicationContextRunner =
+    ApplicationContextRunner()
+      .withConfiguration(
+        AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration::class.java)
+      )
+      .withBean(
+        StellarNetworkConfig::class.java,
+        Supplier { mockk<StellarNetworkConfig>(relaxed = true) },
+      )
+      .withBean(SecretConfig::class.java, Supplier { mockk<SecretConfig>(relaxed = true) })
+      .withBean(ClientService::class.java, Supplier { mockk<ClientService>(relaxed = true) })
+      .withBean(
+        CallbackApiConfig::class.java,
+        Supplier { mockk<CallbackApiConfig>(relaxed = true) },
+      )
+      .withBean(JwtService::class.java, Supplier { mockk<JwtService>(relaxed = true) })
+      .withBean(AssetService::class.java, Supplier { mockk<AssetService>(relaxed = true) })
+      .withBean(
+        CustomerIntegration::class.java,
+        Supplier { mockk<CustomerIntegration>(relaxed = true) },
+      )
+      .withBean(
+        PropertySep24Config::class.java,
+        Supplier { mockk<PropertySep24Config>(relaxed = true) },
+      )
+      .withBean(LanguageConfig::class.java, Supplier { mockk<LanguageConfig>(relaxed = true) })
+      .withBean(Sep38QuoteStore::class.java, Supplier { mockk<Sep38QuoteStore>(relaxed = true) })
+      .withBean(EventService::class.java, Supplier { mockk<EventService>(relaxed = true) })
+      .withBean(Sep6Config::class.java, Supplier { mockk<Sep6Config>(relaxed = true) })
+      .withBean(
+        Sep6TransactionStore::class.java,
+        Supplier { mockk<Sep6TransactionStore>(relaxed = true) },
+      )
+      .withBean(
+        "sep6MoreInfoUrlConstructor",
+        MoreInfoUrlConstructor::class.java,
+        Supplier { mockk<MoreInfoUrlConstructor>(relaxed = true) },
+      )
+      .withBean(
+        Sep24TransactionStore::class.java,
+        Supplier { mockk<Sep24TransactionStore>(relaxed = true) },
+      )
+      .withBean(
+        "sep24MoreInfoUrlConstructor",
+        MoreInfoUrlConstructor::class.java,
+        Supplier { mockk<MoreInfoUrlConstructor>(relaxed = true) },
+      )
+      .withBean(
+        PropertySep31Config::class.java,
+        Supplier { mockk<PropertySep31Config>(relaxed = true) },
+      )
+      .withBean(
+        Sep31TransactionStore::class.java,
+        Supplier { mockk<Sep31TransactionStore>(relaxed = true) },
+      )
+      .withBean(RateIntegration::class.java, Supplier { mockk<RateIntegration>(relaxed = true) })
+      .withBean(
+        Sep31CustomerIdOwnerStore::class.java,
+        Supplier { mockk<Sep31CustomerIdOwnerStore>(relaxed = true) },
+      )
+      .withBean(Clock::class.java, Supplier { Clock.systemUTC() })
+      .withPropertyValues(
+        "sep10.enabled=false",
+        "sep10.home_domains=example.com",
+        "sep45.enabled=false",
+        "sep45.home_domains=example.com",
+      )
+      .withUserConfiguration(SepBeans::class.java)
+
+  @ParameterizedTest
+  @MethodSource("singleSepEnabledScenarios")
+  fun `context exposes exactly one ExchangeAmountsCalculator when exactly one of sep6, sep24, sep31 is enabled`(
+    sep6Key: String,
+    sep6Value: String,
+    sep24Key: String,
+    sep24Value: String,
+    sep31Key: String,
+    sep31Value: String,
+  ) {
+    baseRunner()
+      .withPropertyValues("$sep6Key=$sep6Value", "$sep24Key=$sep24Value", "$sep31Key=$sep31Value")
+      .run { context ->
+        assert(context.startupFailure == null) {
+          "context failed to start with $sep6Key=$sep6Value, $sep24Key=$sep24Value, " +
+            "$sep31Key=$sep31Value: ${context.startupFailure}"
+        }
+        assert(context.getBeanNamesForType(ExchangeAmountsCalculator::class.java).size == 1) {
+          "expected exactly one ExchangeAmountsCalculator bean with $sep6Key=$sep6Value, " +
+            "$sep24Key=$sep24Value, $sep31Key=$sep31Value"
+        }
+      }
+  }
+
+  @Test
+  fun `context exposes no ExchangeAmountsCalculator and no ClientFinder or SepRequestValidator when none of sep6, sep24, sep31 are enabled`() {
+    baseRunner()
+      .withPropertyValues("sep6.enabled=false", "sep24.enabled=false", "sep31.enabled=false")
+      .run { context ->
+        assert(context.startupFailure == null) {
+          "context failed to start with sep6/sep24/sep31 all disabled: ${context.startupFailure}"
+        }
+        assert(context.getBeanNamesForType(ExchangeAmountsCalculator::class.java).isEmpty()) {
+          "expected no ExchangeAmountsCalculator bean when sep6/sep24/sep31 are all disabled"
+        }
+        assert(context.getBeanNamesForType(ClientFinder::class.java).isEmpty()) {
+          "expected no ClientFinder bean when sep6/sep10/sep24/sep31 are all disabled"
+        }
+        assert(context.getBeanNamesForType(SepRequestValidator::class.java).isEmpty()) {
+          "expected no SepRequestValidator bean when sep6/sep24 are both disabled"
+        }
+      }
+  }
+}


### PR DESCRIPTION
### Description

`SepBeans` has two bean-gating bugs of the same shape: a bean is annotated with a `@Conditional` narrower than what its unconditionally-required consumers actually need, so a config enabling only one of SEP-6/24/31 fails to boot.

**1. `exchangeAmountsCalculator`** was gated with `@OnAllSepsEnabled(seps = {"sep6", "sep24", "sep31"})`, requiring all three SEPs to be enabled before the bean is registered. But each of the three consumers (`sep6Service`, `sep24Service`, `sep31Service`) is independently gated on only its own SEP being enabled, and each calls `exchangeAmountsCalculator(...)` unconditionally in its constructor arguments. Since `SepBeans` is a plain `@Configuration` class (default `proxyBeanMethods = true`), that in-class method call is intercepted by Spring's CGLIB proxy and resolved as a real bean lookup, not a plain Java call - so it's subject to the bean's own condition. Any deployment running SEP-24 without also running SEP-6 and SEP-31 hit this at startup: `Sep24Service`'s own gate (`sep24.enabled`) passes, but the `exchangeAmountsCalculator` bean it depends on didn't exist.

**2. `clientFinder`** was gated with `@OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24"})`, omitting `"sep31"` - but `sep31Service` takes `ClientFinder clientFinder` directly as a constructor parameter. A SEP-31-only deployment (SEP-6/10/24 all disabled) hit the identical failure mode for this bean instead.

`ExchangeAmountsCalculator` itself has no SEP-6/24/31-specific logic - it's a generic `(Sep38QuoteStore, Clock)` quote-amount calculator shared across all three. Both fixes widen the respective bean's condition to match what its consumers actually require, following the same `@OnAnySepsEnabled` pattern already used elsewhere in this file for other shared beans.

Also added a parameterized Spring-context test (`SepBeansConditionalRegistrationTest`) that boots a real `ApplicationContextRunner` against the actual `SepBeans` class - the existing `SepBeansTest` only calls bean methods directly as plain Java calls, which never exercises Spring's `@Conditional` evaluation and would not have caught either of these regressions, or a future reintroduction of either.

**Changes**
- [x] `SepBeans.exchangeAmountsCalculator`: `@OnAllSepsEnabled(seps = {"sep6", "sep24", "sep31"})` → `@OnAnySepsEnabled(seps = {"sep6", "sep24", "sep31"})`.
- [x] `SepBeans.clientFinder`: `@OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24"})` → `@OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24", "sep31"})`.
- [x] `SepBeansConditionalRegistrationTest.kt` (new): a real Spring `ApplicationContextRunner` test, parameterized across SEP-6-only / SEP-24-only / SEP-31-only, asserting the context starts successfully and exposes exactly one `ExchangeAmountsCalculator` bean in each case; a fourth case asserts zero `ExchangeAmountsCalculator`/`ClientFinder`/`SepRequestValidator` beans when none of the three are enabled.

**Acceptance Criteria**
- [x] A SEP server configured with only `sep24.enabled: true` (SEP-6 and SEP-31 disabled) starts successfully and serves `GET /sep24/info`.
- [x] The same holds symmetrically for a SEP-6-only or SEP-31-only configuration.
- [x] A SEP server with any combination of SEP-6/24/31 enabled together continues to start and share a single `exchangeAmountsCalculator` instance, unchanged from today.
- [x] A SEP server with none of SEP-6/24/31 enabled does not register the `ExchangeAmountsCalculator`, `ClientFinder`, or `SepRequestValidator` beans, unchanged from today.
- [x] CI fails if either bean's condition is narrowed again in a way that breaks a single-SEP deployment.

### Context

Reported by an operator upgrading to 4.6.1: their service failed to start with SEP-24 enabled unless SEP-6 and SEP-31 were also enabled (with inert settings, purely to satisfy the bean condition), despite having no business logic or ops process behind those two protocols. Tracked as ANCHOR-1261. The `clientFinder`/SEP-31 gap was found while verifying the fix live across all three single-SEP configurations, ahead of writing the regression test.

### Testing

- `./gradlew :core:test :platform:test` - BUILD SUCCESSFUL.
- Manual, against a real Postgres instance and the built `service-runner` jar: booted the actual `--sep-server` process independently with `SEP24_ENABLED=true`/`SEP6_ENABLED=true`/`SEP31_ENABLED=true` (each alone, other two disabled) - all three start cleanly and serve requests (`GET /sep24/info` confirmed for the SEP-24 case).
- Negative control, both fixes independently: reverted each bean's condition back to its buggy form, rebuilt, and confirmed the exact reported failure reproduces verbatim (`... required a bean named 'exchangeAmountsCalculator' that could not be found` / `... required a bean of type 'org.stellar.anchor.client.ClientFinder' that could not be found`); confirmed the new automated test fails in exactly the corresponding case and no other; restored both fixes and confirmed clean passes.

### Documentation
N/A

### Known limitations
N/A